### PR TITLE
Feature/GitHub oauth

### DIFF
--- a/crates/server/palpo.toml
+++ b/crates/server/palpo.toml
@@ -58,7 +58,7 @@ user_prefix = ""
 issuer = "https://accounts.google.com"
 client_id = "your-google-client-id.apps.googleusercontent.com"
 client_secret = "GOCSPX-your-google-client-secret"
-redirect_uri = "http://localhost:6006/_matrix/client/oidc/callback"  # 修正为本地地址
+redirect_uri = "https://your-server.com/_matrix/client/oidc/callback"
 
 [oidc.providers.github]
 issuer = "https://github.com"

--- a/crates/server/palpo.toml
+++ b/crates/server/palpo.toml
@@ -49,9 +49,21 @@ uris = ["turn:turn.matrix.org?transport=udp", "turn:turn.matrix.org?transport=tc
 enable = true
 enable_pkce = true
 session_timeout = 1800
+require_email_verified = false
+allow_registration = true
+default_provider = "github"
+user_prefix = ""
 
 [oidc.providers.google]
 issuer = "https://accounts.google.com"
 client_id = "your-google-client-id.apps.googleusercontent.com"
 client_secret = "GOCSPX-your-google-client-secret"
-redirect_uri = "https://your-domain.com/_matrix/client/oidc/callback"
+redirect_uri = "http://localhost:6006/_matrix/client/oidc/callback"  # 修正为本地地址
+
+[oidc.providers.github]
+issuer = "https://github.com"
+client_id = "your-github-oauth-app-id"
+client_secret = "your-github-oauth-app-secret"
+redirect_uri = "https://your-server.com/_matrix/client/oidc/callback"
+scopes = ["read:user", "user:email"]
+display_name = "Sign in with GitHub"

--- a/palpo-example.toml
+++ b/palpo-example.toml
@@ -1174,7 +1174,14 @@
 # issuer = "https://accounts.google.com"
 # client_id = "your-client-id.apps.googleusercontent.com"
 # client_secret = "your-client-secret"
-# redirect_uri = "https://your-server.com/_matrix/client/v3/oidc/callback/google"
+# redirect_uri = "https://your-server.com/_matrix/client/oidc/callback"
+#
+# [oidc.providers.github]
+# issuer = "https://github.com"
+# client_id = "your-github-oauth-app-id"
+# client_secret = "your-github-oauth-app-secret"
+# redirect_uri = "https://your-server.com/_matrix/client/oidc/callback"
+# scopes = ["read:user", "user:email"]
 #
 # providers = {}
 
@@ -1198,9 +1205,11 @@
 # User ID mapping strategy
 #
 # Controls how Matrix user IDs are generated from OIDC user information:
-# - "email" - Use the email address localpart
-# - "sub" - Use the OIDC subject identifier
+# - "email" - Use the email address localpart (requires public email)
+# - "sub" - Use the OIDC subject identifier (recommended for GitHub)
 # - "preferred_username" - Use the preferred_username claim
+#
+# Note: For GitHub, use "sub" since users may have private emails
 #
 # user_mapping = "email"
 
@@ -1217,6 +1226,9 @@
 #
 # When enabled, only users with verified email addresses can authenticate.
 # The email_verified claim from the OIDC provider is checked.
+#
+# Note: Set to false for GitHub if users have private emails,
+# as private emails will cause authentication to fail.
 #
 # require_email_verified = true
 


### PR DESCRIPTION
# Add GitHub OAuth Support for Matrix Authentication

## Summary

This PR adds GitHub OAuth 2.0 support alongside the existing Google OIDC implementation, enabling users to authenticate with their GitHub accounts.

## Key Changes

### 1. Provider Type Differentiation
- Added `ProviderType` enum to cleanly handle provider-specific logic
- Supports Google (OIDC), GitHub (OAuth 2.0), and Generic providers
- Uses pattern matching instead of if-else chains for better maintainability

### 2. GitHub-Specific OAuth Handling
- **Token Exchange**: Requires `Accept: application/json` header
- **User Info API**: Requires `User-Agent` header
- **Field Mapping**: Maps GitHub's `id` → `sub`, `avatar_url` → `picture`
- **No OIDC Discovery**: Uses hardcoded endpoints (GitHub doesn't support `.well-known/openid-configuration`)

### 3. Authentication Strategy Differences

#### Email Verification
- **Google**: Usually has verified public emails, safe to use `require_email_verified = true`
- **GitHub**: Many users have private emails, requires `require_email_verified = false` to prevent authentication failures

#### Recommended Configuration
```toml
[oidc]
require_email_verified = false  # Critical for GitHub private emails
allow_registration = true
default_provider = "github"
user_prefix = ""  # Clean usernames

[oidc.providers.github]
issuer = "https://github.com"
scopes = ["read:user", "user:email"]  # GitHub-specific scopes
```

### 4. Secure User ID Generation Strategy

**Security Consideration**: GitHub usernames can be transferred when users rename their accounts, creating a potential account takeover risk.

**Solution**: Combine username with provider ID for both readability and security:
- Format: `@username_providerID:server`
- Example: `@octocat_48358093:server`
- Benefits:
  - Readable (shows username)
  - Secure (ID prevents takeover)
  - Unique (even if username changes hands)

**Generation Priority**:
1. Username + ID (GitHub: `login_id`)
2. Email prefix + ID (`john_123456` from john@example.com)
3. Fallback: `user_123456`

### 5. Profile Preservation
- First login: Creates user profile from OAuth provider data
- Subsequent logins: Preserves user's Matrix profile modifications
- Users can customize their display names without OAuth overwriting them

## Testing

### Setup
1. Create GitHub OAuth App with callback URL: `http://your-server/_matrix/client/oidc/callback`
2. Configure `palpo.toml` with GitHub credentials
3. Test authentication flow

### Verified Scenarios
- ✅ GitHub users with public emails
- ✅ GitHub users with private emails (requires `require_email_verified = false`)
- ✅ User profile preservation on re-authentication
- ✅ Concurrent Google and GitHub provider support

## Breaking Changes

None. The changes are backward compatible with existing OIDC configurations.

## Security Considerations

1. **Username Uniqueness**: Addressed by including provider ID in Matrix user ID
2. **Private Emails**: Handled by making email verification optional
3. **PKCE Support**: Maintained for enhanced OAuth security
4. **Session Security**: HTTP-only cookies with configurable timeout

## Documentation

- Updated inline documentation with GitHub-specific requirements
- Added configuration examples for both Google and GitHub
- Clarified the differences between OIDC and pure OAuth 2.0 flows

## Future Improvements

- Support for additional OAuth providers (GitLab, Microsoft, etc.)
- Configurable user ID generation strategies
- Provider-specific attribute mapping

---

**Note for Reviewers**: Pay special attention to the user ID generation strategy and email verification handling, as these differ significantly from standard OIDC providers.