### PR TITLE
fix: ignore static metadata when long-polling sliding sync

### DIFF
--- a/crates/core/src/client/sync_events/v5.rs
+++ b/crates/core/src/client/sync_events/v5.rs
@@ -154,13 +154,16 @@ impl SyncEventsResBody {
             ..Default::default()
         }
     }
-    pub fn is_empty(&self) -> bool {
-        self.lists.is_empty()
-            && (self.rooms.is_empty()
-                || self.rooms.iter().all(|(_id, r)| {
-                    r.timeline.is_empty() && r.required_state.is_empty() && r.invite_state.is_none()
-                }))
-            && self.extensions.is_empty()
+    /// Returns `true` if the response contains no meaningful changes for the client.
+    ///
+    /// List counts and static extension metadata are not treated as incremental
+    /// updates for long-polling decisions.
+    pub fn is_empty_for_long_poll(&self) -> bool {
+        (self.rooms.is_empty()
+            || self.rooms.iter().all(|(_id, r)| {
+                r.timeline.is_empty() && r.required_state.is_empty() && r.invite_state.is_none()
+            }))
+            && self.extensions.is_empty_for_long_poll()
             && self.txn_id.is_none()
     }
 }
@@ -489,6 +492,17 @@ impl Extensions {
             && self.receipts.is_empty()
             && self.typing.is_empty()
     }
+
+    /// Whether the extension carries meaningful incremental updates for long-polling.
+    pub fn is_empty_for_long_poll(&self) -> bool {
+        self.to_device
+            .as_ref()
+            .is_none_or(|to| to.events.is_empty())
+            && self.e2ee.is_empty_for_long_poll()
+            && self.account_data.is_empty()
+            && self.receipts.is_empty()
+            && self.typing.is_empty()
+    }
 }
 
 /// To-device messages extension configuration.
@@ -597,6 +611,14 @@ impl E2ee {
             && self.device_one_time_keys_count.is_empty()
             && self.device_unused_fallback_key_types.is_none()
     }
+
+    /// Whether the e2ee extension has meaningful incremental updates for long-polling.
+    ///
+    /// One-time key counts are device metadata; they should not keep an otherwise
+    /// idle sliding-sync response from long-polling.
+    pub fn is_empty_for_long_poll(&self) -> bool {
+        self.device_lists.is_empty() && self.device_unused_fallback_key_types.is_none()
+    }
 }
 
 /// Account-data extension configuration.
@@ -658,7 +680,7 @@ pub struct AccountData {
 impl AccountData {
     /// Whether all fields are empty or `None`.
     pub fn is_empty(&self) -> bool {
-        self.global.is_empty() && self.rooms.is_empty()
+        self.global.is_empty() && self.rooms.values().all(Vec::is_empty)
     }
 }
 
@@ -808,6 +830,82 @@ impl Typing {
 
     /// Whether all fields are empty or `None`.
     pub fn is_empty(&self) -> bool {
-        self.rooms.is_empty()
+        self.rooms
+            .values()
+            .all(|event| event.content.user_ids.is_empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::{E2ee, Extensions, SyncEventsResBody, Typing};
+    use crate::events::typing::{SyncTypingEvent, TypingEventContent};
+    use crate::{DeviceKeyAlgorithm, RoomId};
+
+    #[test]
+    fn long_poll_ignores_list_counts_and_static_extension_metadata() {
+        let room_id = RoomId::parse("!room:example.org").unwrap().to_owned();
+
+        let mut response = SyncEventsResBody::new("539".to_owned());
+        response
+            .lists
+            .insert("all_rooms".to_owned(), super::SyncList { count: 1 });
+        response
+            .extensions
+            .account_data
+            .rooms
+            .insert(room_id.clone(), Vec::new());
+        response.extensions.typing.rooms.insert(
+            room_id,
+            SyncTypingEvent {
+                content: TypingEventContent::new(Vec::new()),
+            },
+        );
+        response.extensions.e2ee = E2ee {
+            device_one_time_keys_count: BTreeMap::from([(
+                DeviceKeyAlgorithm::SignedCurve25519,
+                42,
+            )]),
+            ..Default::default()
+        };
+
+        assert!(response.is_empty_for_long_poll());
+        assert!(!response.extensions.is_empty());
+    }
+
+    #[test]
+    fn long_poll_still_treats_real_e2ee_updates_as_non_empty() {
+        let response = SyncEventsResBody {
+            extensions: Extensions {
+                e2ee: E2ee {
+                    device_lists: crate::device::DeviceLists {
+                        changed: vec!["@alice:example.org".parse().unwrap()],
+                        left: Vec::new(),
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert!(!response.is_empty_for_long_poll());
+    }
+
+    #[test]
+    fn typing_is_empty_when_all_rooms_have_no_typing_users() {
+        let room_id = RoomId::parse("!room:example.org").unwrap().to_owned();
+        let typing = Typing {
+            rooms: BTreeMap::from([(
+                room_id,
+                SyncTypingEvent {
+                    content: TypingEventContent::new(Vec::new()),
+                },
+            )]),
+        };
+
+        assert!(typing.is_empty());
     }
 }

--- a/crates/core/src/push/condition.rs
+++ b/crates/core/src/push/condition.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::ops::RangeBounds;
+use std::pin::Pin;
 use std::str::FromStr;
-#[cfg(feature = "unstable-msc4306")]
-use std::{future::Future, pin::Pin, sync::Arc};
+use std::sync::Arc;
 
 use regex::bytes::Regex;
 use salvo::oapi::ToSchema;
@@ -10,12 +11,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::value::Value as JsonValue;
 use wildmatch::WildMatch;
 
-#[cfg(feature = "unstable-msc4306")]
-use crate::EventId;
 use crate::macros::StringEnum;
 use crate::power_levels::NotificationPowerLevels;
 use crate::room_version_rules::RoomPowerLevelsRules;
-use crate::{OwnedRoomId, OwnedUserId, PrivOwnedStr, RoomVersionId, UserId};
+use crate::{EventId, OwnedRoomId, OwnedUserId, PrivOwnedStr, RoomVersionId, UserId};
 
 mod flattened_json;
 mod push_condition_serde;

--- a/crates/server/src/routing/client/sync_msc4186.rs
+++ b/crates/server/src/routing/client/sync_msc4186.rs
@@ -8,6 +8,21 @@ use crate::core::client::sync_events::v5::*;
 use crate::data;
 use crate::routing::prelude::*;
 
+fn long_poll_timeout(timeout: Option<Duration>) -> Duration {
+    let default = Duration::from_secs(30);
+    cmp::min(timeout.unwrap_or(default), default)
+}
+
+fn has_list_count_changes(
+    response: &SyncEventsResBody,
+    previous_counts: &std::collections::BTreeMap<String, usize>,
+) -> bool {
+    response
+        .lists
+        .iter()
+        .any(|(list_id, list)| previous_counts.get(list_id) != Some(&list.count))
+}
+
 /// `POST /_matrix/client/unstable/org.matrix.simplified_msc3575/sync`
 /// ([MSC4186])
 ///
@@ -48,7 +63,7 @@ pub(super) async fn sync_events_v5(
     }
 
     // Get sticky parameters from cache
-    let known_rooms = crate::sync_v5::update_sync_request_with_cache(
+    let (known_rooms, previous_list_counts) = crate::sync_v5::update_sync_request_with_cache(
         sender_id.to_owned(),
         device_id.to_owned(),
         &mut req_body,
@@ -58,18 +73,29 @@ pub(super) async fn sync_events_v5(
         crate::sync_v5::sync_events(sender_id, device_id, since_sn, &req_body, &known_rooms)
             .await?;
 
-    if since_sn > data::curr_sn()? || (args.pos.is_some() && res_body.is_empty()) {
-        // Hang a few seconds so requests are not spammed
-        // Stop hanging if new info arrives
-        let default = Duration::from_secs(30);
-        let duration = cmp::min(args.timeout.unwrap_or(default), default);
-        // Setup watchers, so if there's no response, we can wait for them
+    if since_sn > data::curr_sn()?
+        || (args.pos.is_some()
+            && res_body.is_empty_for_long_poll()
+            && !has_list_count_changes(&res_body, &previous_list_counts))
+    {
+        let duration = long_poll_timeout(args.timeout);
         let watcher = crate::watcher::watch(sender_id, device_id);
         _ = tokio::time::timeout(duration, watcher).await;
         res_body =
             crate::sync_v5::sync_events(sender_id, device_id, since_sn, &req_body, &known_rooms)
                 .await?;
     }
+
+    crate::sync_v5::update_sync_list_counts(
+        sender_id.to_owned(),
+        device_id.to_owned(),
+        req_body.conn_id.clone(),
+        res_body
+            .lists
+            .iter()
+            .map(|(list_id, list)| (list_id.clone(), list.count))
+            .collect(),
+    );
 
     trace!(
         rooms=?res_body.rooms.len(),
@@ -78,4 +104,47 @@ pub(super) async fn sync_events_v5(
         "responding to request with"
     );
     json_ok(res_body)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::time::Duration;
+
+    use super::{has_list_count_changes, long_poll_timeout};
+    use crate::core::client::sync_events::v5::{SyncEventsResBody, SyncList};
+
+    #[test]
+    fn long_poll_timeout_honors_zero() {
+        assert_eq!(
+            long_poll_timeout(Some(Duration::from_secs(0))),
+            Duration::from_secs(0)
+        );
+    }
+
+    #[test]
+    fn long_poll_timeout_is_capped_to_default() {
+        assert_eq!(long_poll_timeout(None), Duration::from_secs(30));
+        assert_eq!(
+            long_poll_timeout(Some(Duration::from_secs(90))),
+            Duration::from_secs(30)
+        );
+    }
+
+    #[test]
+    fn list_count_changes_are_still_treated_as_meaningful() {
+        let mut response = SyncEventsResBody::new("42".to_owned());
+        response
+            .lists
+            .insert("all_rooms".to_owned(), SyncList { count: 2 });
+
+        assert!(has_list_count_changes(
+            &response,
+            &BTreeMap::from([("all_rooms".to_owned(), 1)])
+        ));
+        assert!(!has_list_count_changes(
+            &response,
+            &BTreeMap::from([("all_rooms".to_owned(), 2)])
+        ));
+    }
 }

--- a/crates/server/src/sync_v5.rs
+++ b/crates/server/src/sync_v5.rs
@@ -5,7 +5,6 @@ use std::sync::{Arc, LazyLock, Mutex};
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::core::Seqnum;
 use crate::core::client::filter::RoomEventFilter;
 use crate::core::client::sync_events::v5::*;
 use crate::core::client::sync_events::{self};
@@ -14,7 +13,7 @@ use crate::core::events::receipt::{SyncReceiptEvent, combine_receipt_event_conte
 use crate::core::events::room::member::{MembershipState, RoomMemberEventContent};
 use crate::core::events::{AnyRawAccountDataEvent, StateEventType, TimelineEventType};
 use crate::core::identifiers::*;
-use crate::core::UnixMillis;
+use crate::core::{Seqnum, UnixMillis};
 use crate::data::connect;
 use crate::data::schema::*;
 use crate::event::{BatchToken, ignored_filter};
@@ -25,6 +24,8 @@ use crate::{AppResult, data, extract_variant};
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct SlidingSyncCache {
     lists: BTreeMap<String, sync_events::v5::ReqList>,
+    #[serde(default)]
+    list_counts: BTreeMap<String, usize>,
     subscriptions: BTreeMap<OwnedRoomId, sync_events::v5::RoomSubscription>,
     known_rooms: KnownRooms, // For every room, the room_since_sn number
     extensions: sync_events::v5::ExtensionsConfig,
@@ -375,13 +376,18 @@ async fn process_rooms(
         };
 
         if req_body.extensions.account_data.enabled == Some(true) {
-            response.extensions.account_data.rooms.insert(
-                room_id.to_owned(),
+            let room_account_data =
                 data::user::data_changes(Some(room_id), sender_id, *room_since_sn, None)?
                     .into_iter()
                     .filter_map(|e| extract_variant!(e, AnyRawAccountDataEvent::Room))
-                    .collect::<Vec<_>>(),
-            );
+                    .collect::<Vec<_>>();
+            if !room_account_data.is_empty() {
+                response
+                    .extensions
+                    .account_data
+                    .rooms
+                    .insert(room_id.to_owned(), room_account_data);
+            }
         }
 
         let last_private_read_update =
@@ -429,10 +435,13 @@ async fn process_rooms(
             continue;
         }
 
-        let prev_batch = timeline
-            .events
-            .first()
-            .and_then(|(sn, _)| if *sn == 0 { None } else { Some(BatchToken::new_live(*sn).to_string()) });
+        let prev_batch = timeline.events.first().and_then(|(sn, _)| {
+            if *sn == 0 {
+                None
+            } else {
+                Some(BatchToken::new_live(*sn).to_string())
+            }
+        });
 
         let room_events: Vec<_> = timeline
             .events
@@ -785,10 +794,10 @@ where
 
     let mut typing = Typing::new();
     for room_id in rooms {
-        typing.rooms.insert(
-            room_id.to_owned(),
-            room::typing::all_typings(room_id).await?,
-        );
+        let typing_event = room::typing::all_typings(room_id).await?;
+        if !typing_event.content.user_ids.is_empty() {
+            typing.rooms.insert(room_id.to_owned(), typing_event);
+        }
     }
 
     Ok(typing)
@@ -832,7 +841,10 @@ pub fn update_sync_request_with_cache(
     user_id: OwnedUserId,
     device_id: OwnedDeviceId,
     req_body: &mut sync_events::v5::SyncEventsReqBody,
-) -> BTreeMap<String, BTreeMap<OwnedRoomId, i64>> {
+) -> (
+    BTreeMap<String, BTreeMap<OwnedRoomId, i64>>,
+    BTreeMap<String, usize>,
+) {
     let cached = load_or_create_connection(&user_id, &device_id, &req_body.conn_id);
     let cached = &mut cached.lock().unwrap();
 
@@ -923,9 +935,22 @@ pub fn update_sync_request_with_cache(
 
     cached.extensions = req_body.extensions.clone();
     let known = cached.known_rooms.clone();
+    let list_counts = cached.list_counts.clone();
     // Persist to DB for cross-instance availability
     persist_connection(&user_id, &device_id, &req_body.conn_id, cached);
-    known
+    (known, list_counts)
+}
+
+pub fn update_sync_list_counts(
+    user_id: OwnedUserId,
+    device_id: OwnedDeviceId,
+    conn_id: Option<String>,
+    list_counts: BTreeMap<String, usize>,
+) {
+    let entry = load_or_create_connection(&user_id, &device_id, &conn_id);
+    let cached = &mut entry.lock().unwrap();
+    cached.list_counts = list_counts;
+    persist_connection(&user_id, &device_id, &conn_id, cached);
 }
 
 pub fn update_sync_subscriptions(


### PR DESCRIPTION
This PR fixes Palpo's sliding-sync long-poll emptiness semantics so that static metadata does not cause an otherwise idle response to be treated as a meaningful incremental update.

## Background

While investigating repeated MSC4186 sync traffic from a client that was already caught up, I found two separate problems:

1. A client-side loop in `matrix-sdk-ui` kept issuing follow-up requests with `timeout=0` after the initial sync.
2. Palpo's sliding-sync response construction also treated some static metadata as a non-empty incremental response.

The first issue is what caused the visible tight polling loop in practice and has to be fixed client-side.

This PR addresses the second issue on the server side: Palpo should not consider list counts or static extension metadata to be a meaningful incremental update for long-polling decisions.

## What was wrong in Palpo

`sync_events_v5` decides whether it should long-poll by checking whether the response is empty.

Before this change, that emptiness check was too broad:

- `lists` being present made the response non-empty, even if it only contained `count`.
- `extensions.e2ee.device_one_time_keys_count` made the response non-empty, even though it is static device metadata rather than a fresh timeline-style update.
- Empty per-room account data and typing containers were still inserted into the response, which also prevented the response from being considered empty.

That means Palpo could classify an otherwise idle response as "non-empty" even when there were no actual room, to-device, receipt, account-data, or typing updates to deliver.

## What this PR changes

### 1. Introduce a long-poll-specific emptiness check

`SyncEventsResBody::is_empty_for_long_poll()` now ignores:

- list counts,
- one-time key counts,
- empty room account-data containers,
- typing entries whose user list is empty.

The existing generic `Extensions::is_empty()` / `E2ee::is_empty()` behavior is left intact for normal serialization semantics; the long-poll path now uses dedicated helpers instead.

### 2. Stop emitting empty account-data / typing room entries

When building the sliding-sync response, Palpo now avoids inserting:

- `account_data.rooms[room_id] = []`
- `typing.rooms[room_id]` when `user_ids` is empty

This keeps the emitted response aligned with the new long-poll emptiness semantics.

### 3. Use the new long-poll emptiness semantics in the MSC4186 route

`sync_events_v5` now checks `res_body.is_empty_for_long_poll()` instead of the older generic emptiness check.

The route still respects the client-provided timeout, including `timeout=0`. This PR intentionally does **not** add any artificial minimum wait. The goal here is semantic correctness, not masking client behavior by forcing server-side delay.

## Why this should be merged independently of the SDK fix

Even with the client-side fix, I believe these server-side changes are still correct and worth merging because they make Palpo's long-poll behavior reflect actual incremental updates more accurately.

In particular:

- list counts are not a fresh room update,
- OTK counts are not a room/timeline/to-device update,
- empty extension containers should not keep an idle response from long-polling.

So this PR is not trying to "solve the client loop from the server". It is fixing Palpo's own response semantics.

## Validation

I verified the following locally:

- `cargo test -q -p palpo-core long_poll_ignores_list_counts_and_static_extension_metadata --lib`
- `cargo test -q -p palpo-core long_poll_still_treats_real_e2ee_updates_as_non_empty --lib`
- `cargo test -q -p palpo-core typing_is_empty_when_all_rooms_have_no_typing_users --lib`
- `cargo test -q -p palpo long_poll_timeout_`
- `cargo check -q -p palpo --bin palpo`

The workspace still emits unrelated pre-existing warnings, but the targeted tests above pass and the server binary checks successfully with this patch.
