### PR TITLE
chore: clean up rust compile and clippy warnings

### DIFF
--- a/crates/core-macros/src/events/event_enum/event_kind_enum.rs
+++ b/crates/core-macros/src/events/event_enum/event_kind_enum.rs
@@ -570,7 +570,7 @@ impl EventEnumVariation<'_> {
                 let palpo_core = self.palpo_core;
 
                 // Field types that don't implement `Copy` must be accessedd via a reference.
-                let (field_type, is_ref) = field.ty(&palpo_core);
+                let (field_type, is_ref) = field.ty(palpo_core);
                 let ampersand = is_ref.then(|| quote! { & });
 
                 // If this content might be redacted, the field is available through an accessor on

--- a/crates/core-macros/src/util.rs
+++ b/crates/core-macros/src/util.rs
@@ -230,6 +230,7 @@ pub(crate) trait StructFieldExt {
     /// If this field has `#[serde(default = "expr")]`, return the expression path.
     ///
     /// Returns `None` if the field has `#[serde(default)]` (without expression) or no default.
+    #[allow(dead_code)]
     fn serde_default_expr(&self) -> Option<syn::Path>;
 }
 
@@ -252,17 +253,15 @@ impl StructFieldExt for Field {
 
     fn serde_default_expr(&self) -> Option<syn::Path> {
         self.serde_meta_items().find_map(|meta| {
-            if let syn::Meta::NameValue(nv) = meta {
-                if nv.path.is_ident("default") {
-                    if let syn::Expr::Lit(syn::ExprLit {
+            if let syn::Meta::NameValue(nv) = meta
+                && nv.path.is_ident("default")
+                    && let syn::Expr::Lit(syn::ExprLit {
                         lit: syn::Lit::Str(lit_str),
                         ..
                     }) = &nv.value
                     {
                         return lit_str.parse::<syn::Path>().ok();
                     }
-                }
-            }
             None
         })
     }

--- a/crates/core/src/client/device.rs
+++ b/crates/core/src/client/device.rs
@@ -159,9 +159,9 @@ pub struct DevicesResBody {
 
 // /// `PUT /_matrix/client/*/devices/{deviceId}`
 // ///
-/// Update metadata for a device, or create a new device.
-///
-/// Only application services can use this endpoint to create new devices.
+// /// Update metadata for a device, or create a new device.
+// ///
+// /// Only application services can use this endpoint to create new devices.
 // /// `/v3/` ([spec])
 // ///
 // /// [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3devicesdeviceid

--- a/crates/core/src/client/discovery/capabilities.rs
+++ b/crates/core/src/client/discovery/capabilities.rs
@@ -5,6 +5,11 @@
 //!
 //! [spec]: https://spec.matrix.org/latest/client-server-api/#capabilities-negotiation
 
+// The `SetDisplayNameCapability` and `SetAvatarUrlCapability` types are deprecated since
+// Matrix 1.16 in favor of `ProfileFieldsCapability`, but we still keep them around for
+// backwards compatibility with older clients.
+#![allow(deprecated)]
+
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 
@@ -47,7 +52,6 @@ impl CapabilitiesResBody {
 
 /// Contains information about all the capabilities that the server supports.
 #[derive(ToSchema, Clone, Debug, Default, Serialize, Deserialize)]
-#[allow(deprecated)]
 pub struct Capabilities {
     /// Capability to indicate if the user can change their password.
     #[serde(rename = "m.change_password", default)]
@@ -115,9 +119,7 @@ impl Capabilities {
         match capability {
             "m.change_password" => Some(Cow::Owned(serialize(&self.change_password))),
             "m.room_versions" => Some(Cow::Owned(serialize(&self.room_versions))),
-            #[allow(deprecated)]
             "m.set_displayname" => Some(Cow::Owned(serialize(&self.set_display_name))),
-            #[allow(deprecated)]
             "m.set_avatar_url" => Some(Cow::Owned(serialize(&self.set_avatar_url))),
             "m.3pid_changes" => Some(Cow::Owned(serialize(&self.thirdparty_id_changes))),
             "m.forget_forced_upon_leave" => {
@@ -136,9 +138,7 @@ impl Capabilities {
         match capability {
             "m.change_password" => self.change_password = from_json_value(value)?,
             "m.room_versions" => self.room_versions = from_json_value(value)?,
-            #[allow(deprecated)]
             "m.set_displayname" => self.set_display_name = from_json_value(value)?,
-            #[allow(deprecated)]
             "m.set_avatar_url" => self.set_avatar_url = from_json_value(value)?,
             "m.3pid_changes" => self.thirdparty_id_changes = from_json_value(value)?,
             "m.forget_forced_upon_leave" => {
@@ -245,7 +245,6 @@ pub struct SetDisplayNameCapability {
     pub enabled: bool,
 }
 
-#[allow(deprecated)]
 impl SetDisplayNameCapability {
     /// Creates a new `SetDisplayNameCapability` with the given enabled flag.
     pub fn new(enabled: bool) -> Self {
@@ -258,7 +257,6 @@ impl SetDisplayNameCapability {
     }
 }
 
-#[allow(deprecated)]
 impl Default for SetDisplayNameCapability {
     fn default() -> Self {
         Self { enabled: true }
@@ -273,7 +271,6 @@ pub struct SetAvatarUrlCapability {
     pub enabled: bool,
 }
 
-#[allow(deprecated)]
 impl SetAvatarUrlCapability {
     /// Creates a new `SetAvatarUrlCapability` with the given enabled flag.
     pub fn new(enabled: bool) -> Self {
@@ -286,7 +283,6 @@ impl SetAvatarUrlCapability {
     }
 }
 
-#[allow(deprecated)]
 impl Default for SetAvatarUrlCapability {
     fn default() -> Self {
         Self { enabled: true }

--- a/crates/core/src/client/discovery/client.rs
+++ b/crates/core/src/client/discovery/client.rs
@@ -4,6 +4,7 @@
 //!
 //! Get discovery information about the domain.
 
+#[cfg(feature = "unstable-msc4143")]
 use std::borrow::Cow;
 
 use salvo::prelude::*;
@@ -13,6 +14,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "unstable-msc4143")]
 use serde_json::Value as JsonValue;
 
+#[cfg(feature = "unstable-msc4143")]
 use crate::serde::JsonObject;
 
 // const METADATA: Metadata = metadata! {

--- a/crates/core/src/events/room/create.rs
+++ b/crates/core/src/events/room/create.rs
@@ -59,6 +59,7 @@ pub struct RoomCreateEventContent {
 impl RoomCreateEventContent {
     /// Creates a new `RoomCreateEventContent` with the given creator, as
     /// required for room versions 1 through 10.
+    #[allow(deprecated)]
     pub fn new_v1(creator: OwnedUserId) -> Self {
         Self {
             creator: Some(creator),
@@ -73,6 +74,7 @@ impl RoomCreateEventContent {
     /// creator, as introduced in room version 11.
     ///
     /// The room version is set to [`RoomVersionId::V11`].
+    #[allow(deprecated)]
     pub fn new_v11() -> Self {
         Self {
             creator: None,
@@ -87,6 +89,7 @@ impl RoomCreateEventContent {
     /// creator, as introduced in room version 11.
     ///
     /// The room version is set to [`RoomVersionId::V12`].
+    #[allow(deprecated)]
     pub fn new_v12() -> Self {
         Self {
             creator: None,

--- a/crates/core/src/metadata/matrix_version.rs
+++ b/crates/core/src/metadata/matrix_version.rs
@@ -276,8 +276,8 @@ impl MatrixVersion {
     pub const fn from_lit(lit: &'static str) -> Self {
         use konst::{result, string};
 
-        let major: u8;
-        let minor: u8;
+        
+        
 
         let mut split = string::split(lit, ".");
 
@@ -287,7 +287,7 @@ impl MatrixVersion {
             None => panic!("could not find major version"),
         };
 
-        major = match u8::from_str_radix(major_str, 10) {
+        let major: u8 = match u8::from_str_radix(major_str, 10) {
             Ok(v) => v,
             Err(_) => panic!("major version is not a valid number"),
         };
@@ -298,7 +298,7 @@ impl MatrixVersion {
             None => panic!("could not find dot to denote second number"),
         };
 
-        minor = match u8::from_str_radix(minor_str, 10) {
+        let minor: u8 = match u8::from_str_radix(minor_str, 10) {
             Ok(v) => v,
             Err(_) => panic!("minor version is not a valid number"),
         };

--- a/crates/core/src/push/condition/push_condition_serde.rs
+++ b/crates/core/src/push/condition/push_condition_serde.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize, Serializer, de};
 
-use super::{PushCondition, RoomMemberCountIs, RoomVersionFeature, ScalarJsonValue};
+use super::{PushCondition, RoomMemberCountIs, ScalarJsonValue};
+#[cfg(feature = "unstable-msc3931")]
+use super::RoomVersionFeature;
 use crate::serde::{RawJsonValue, from_raw_json_value};
 
 impl Serialize for PushCondition {

--- a/crates/core/src/serde/canonical_json/serializer.rs
+++ b/crates/core/src/serde/canonical_json/serializer.rs
@@ -57,7 +57,7 @@ impl serde::Serializer for Serializer {
     }
 
     fn serialize_i64(self, value: i64) -> Result<Self::Ok> {
-        if value < CANONICALJSON_MIN_INT || value > CANONICALJSON_MAX_INT {
+        if !(CANONICALJSON_MIN_INT..=CANONICALJSON_MAX_INT).contains(&value) {
             return Err(CanonicalJsonError::IntegerOutOfRange);
         }
         Ok(CanonicalJsonValue::Integer(value))

--- a/crates/data/src/media.rs
+++ b/crates/data/src/media.rs
@@ -346,13 +346,11 @@ pub fn get_user_media_statistics(
     let (rows, total) = if let Some(term) = search_term {
         let like_pattern = format!("%{}%", term);
 
-        let count_sql = format!(
-            "SELECT COUNT(*) AS count FROM (\
+        let count_sql = "SELECT COUNT(*) AS count FROM (\
                 SELECT created_by FROM media_metadatas \
                 WHERE created_by IS NOT NULL AND created_by LIKE $1 \
                 GROUP BY created_by\
-            ) sub"
-        );
+            ) sub".to_string();
         let total: i64 = diesel::sql_query(&count_sql)
             .bind::<diesel::sql_types::Text, _>(&like_pattern)
             .get_result::<CountResult>(&mut conn)?

--- a/crates/data/src/user.rs
+++ b/crates/data/src/user.rs
@@ -636,7 +636,7 @@ pub fn list_users(filter: &ListUsersFilter) -> DataResult<(Vec<DbUser>, i64)> {
                 query.order(users::shadow_banned.desc())
             }
         }
-        Some("creation_ts") | _ => {
+        _ => {
             if dir_asc {
                 query.order(users::created_at.asc())
             } else {

--- a/crates/data/src/user/registration_token.rs
+++ b/crates/data/src/user/registration_token.rs
@@ -237,18 +237,16 @@ pub fn is_token_valid(token: &str) -> DataResult<bool> {
     let now = UnixMillis::now().get() as i64;
 
     // Check expiry
-    if let Some(expires_at) = db_token.expires_at {
-        if now >= expires_at {
+    if let Some(expires_at) = db_token.expires_at
+        && now >= expires_at {
             return Ok(false);
         }
-    }
 
     // Check uses
-    if let Some(uses_allowed) = db_token.uses_allowed {
-        if db_token.completed + db_token.pending >= uses_allowed {
+    if let Some(uses_allowed) = db_token.uses_allowed
+        && db_token.completed + db_token.pending >= uses_allowed {
             return Ok(false);
         }
-    }
 
     Ok(true)
 }

--- a/crates/server/src/config/server.rs
+++ b/crates/server/src/config/server.rs
@@ -838,11 +838,10 @@ impl ServerConfig {
             url.to_string()
         } else {
             // If under proxy, you should set well-known client manually.
-            if let Some(listenser) = self.listeners.first() {
-                if listenser.enabled_tls().is_none() {
+            if let Some(listenser) = self.listeners.first()
+                && listenser.enabled_tls().is_none() {
                     return format!("http://{}", self.server_name);
-                }
-            };
+                };
             format!("https://{}", self.server_name)
         }
     }

--- a/crates/server/src/event/resolver.rs
+++ b/crates/server/src/event/resolver.rs
@@ -195,12 +195,11 @@ pub(super) async fn resolve_state_at_incoming(
     // are in our DB but were rejected (and so don't contribute to state). For
     // events with TRULY missing prev events, we already returned None above so
     // the caller can run the missing-events fetch path.
-    if had_prev_events && extremity_state_hashes.is_empty() && had_in_db_unresolvable {
-        if let Ok(frame_id) = state::get_room_frame_id(&incoming_pdu.room_id, None) {
+    if had_prev_events && extremity_state_hashes.is_empty() && had_in_db_unresolvable
+        && let Ok(frame_id) = state::get_room_frame_id(&incoming_pdu.room_id, None) {
             let state = state::get_full_state_ids(frame_id)?;
             return Ok(Some(state));
         }
-    }
 
     let mut fork_states = Vec::with_capacity(extremity_state_hashes.len());
     let mut auth_chain_sets = Vec::with_capacity(extremity_state_hashes.len());

--- a/crates/server/src/hoops/introspection.rs
+++ b/crates/server/src/hoops/introspection.rs
@@ -42,14 +42,13 @@ pub async fn introspect_token(token: &str) -> AppResult<IntrospectionResult> {
     // Check cache
     if ttl > 0 {
         let key = token_cache_key(token);
-        if let Ok(mut cache) = CACHE.lock() {
-            if let Some(entry) = cache.get(&key) {
+        if let Ok(mut cache) = CACHE.lock()
+            && let Some(entry) = cache.get(&key) {
                 if entry.cached_at.elapsed() < Duration::from_secs(ttl) {
                     return Ok(entry.result.clone());
                 }
                 cache.remove(&key);
             }
-        }
     }
 
     // Call introspection endpoint
@@ -105,16 +104,14 @@ pub async fn introspect_token(token: &str) -> AppResult<IntrospectionResult> {
 /// Looks for `urn:matrix:client:device:<id>` or the unstable variant.
 pub fn device_id_from_scope(scope: &str) -> Option<String> {
     for part in scope.split_whitespace() {
-        if let Some(id) = part.strip_prefix("urn:matrix:client:device:") {
-            if !id.is_empty() {
+        if let Some(id) = part.strip_prefix("urn:matrix:client:device:")
+            && !id.is_empty() {
                 return Some(id.to_owned());
             }
-        }
-        if let Some(id) = part.strip_prefix("urn:matrix:org.matrix.msc2967.client:device:") {
-            if !id.is_empty() {
+        if let Some(id) = part.strip_prefix("urn:matrix:org.matrix.msc2967.client:device:")
+            && !id.is_empty() {
                 return Some(id.to_owned());
             }
-        }
     }
     None
 }

--- a/crates/server/src/media/remote.rs
+++ b/crates/server/src/media/remote.rs
@@ -138,8 +138,8 @@ async fn fetch_thumbnail_authenticated(
     let file = response.bytes().await?.to_vec();
 
     // Save the thumbnail locally for caching
-    if !file.is_empty() {
-        if let Err(e) = crate::media::save_thumbnail(
+    if !file.is_empty()
+        && let Err(e) = crate::media::save_thumbnail(
             mxc,
             user,
             content_type.as_deref(),
@@ -151,7 +151,6 @@ async fn fetch_thumbnail_authenticated(
         {
             warn!("Failed to save fetched thumbnail locally: {e}");
         }
-    }
 
     Ok(FileMeta {
         content: Some(file),
@@ -237,8 +236,8 @@ async fn fetch_thumbnail_unauthenticated(
     let file = response.bytes().await?.to_vec();
 
     // Save the thumbnail locally for caching
-    if !file.is_empty() {
-        if let Err(e) = crate::media::save_thumbnail(
+    if !file.is_empty()
+        && let Err(e) = crate::media::save_thumbnail(
             mxc,
             user,
             content_type.as_deref(),
@@ -250,7 +249,6 @@ async fn fetch_thumbnail_unauthenticated(
         {
             warn!("Failed to save fetched thumbnail locally: {e}");
         }
-    }
 
     Ok(FileMeta {
         content: Some(file),

--- a/crates/server/src/room/timeline.rs
+++ b/crates/server/src/room/timeline.rs
@@ -272,7 +272,7 @@ pub async fn append_pdu(
         leaves.insert(pdu.event_id.clone());
     }
     state::set_forward_extremities(&pdu.room_id, leaves.iter().map(Borrow::borrow), state_lock)?;
-    state::update_backward_extremities(&pdu)?;
+    state::update_backward_extremities(pdu)?;
 
     #[derive(Deserialize, Clone, Debug)]
     struct ExtractEventId {

--- a/crates/server/src/room/timeline/backfill.rs
+++ b/crates/server/src/room/timeline/backfill.rs
@@ -53,7 +53,7 @@ pub async fn backfill_if_required(
         if pdu.prev_events.iter().any(|id| !existing.contains(id)) {
             return backfill_from_extremities(
                 room_id,
-                &[pdu.event_id.clone()],
+                std::slice::from_ref(&pdu.event_id),
                 limit,
             )
             .await;

--- a/crates/server/src/room/user.rs
+++ b/crates/server/src/room/user.rs
@@ -437,17 +437,10 @@ pub fn copy_push_rules_from_room_to_room(
             continue;
         }
 
+        // Other `AnyPushRuleRef` variants (Override, Content, PostContent, Sender,
+        // Underride) are intentionally not copied yet.
+        #[allow(clippy::single_match)]
         match push_rule {
-            // AnyPushRuleRef::Override(rule) => {
-            // },
-            // AnyPushRuleRef::Content(rule) => {
-            // },
-            // AnyPushRuleRef::PostContent(rule) => {
-            // },
-            // AnyPushRuleRef::Sender(rule) => {
-            // },
-            // AnyPushRuleRef::Underride(rule) => {
-            // },
             AnyPushRuleRef::Room(rule) => {
                 let new_rule = NewPushRule::Room(NewSimplePushRule::new(
                     new_room_id.to_owned(),

--- a/crates/server/src/routing.rs
+++ b/crates/server/src/routing.rs
@@ -78,13 +78,12 @@ fn well_known_client() -> JsonResult<ClientResBody> {
                 issuer: issuer.clone(),
             });
         }
-    } else if let Some(oidc) = conf.oidc.as_ref() {
-        if let Some(issuer) = &oidc.mas_issuer {
+    } else if let Some(oidc) = conf.oidc.as_ref()
+        && let Some(issuer) = &oidc.mas_issuer {
             body.authentication = Some(AuthenticationInfo {
                 issuer: issuer.clone(),
             });
         }
-    }
 
     json_ok(body)
 }

--- a/crates/server/src/routing/admin/registration_token.rs
+++ b/crates/server/src/routing/admin/registration_token.rs
@@ -149,14 +149,13 @@ pub fn create_registration_token(
     };
 
     // Validate uses_allowed
-    if let Some(uses) = body.uses_allowed {
-        if uses < 0 {
+    if let Some(uses) = body.uses_allowed
+        && uses < 0 {
             return Err(MatrixError::invalid_param(
                 "uses_allowed must be a non-negative integer or null",
             )
             .into());
         }
-    }
 
     // Validate expiry_time
     if let Some(expiry) = body.expiry_time {
@@ -209,14 +208,13 @@ pub fn update_registration_token(
     let body = body.into_inner();
 
     // Validate uses_allowed if provided
-    if let Some(Some(uses)) = body.uses_allowed {
-        if uses < 0 {
+    if let Some(Some(uses)) = body.uses_allowed
+        && uses < 0 {
             return Err(MatrixError::invalid_param(
                 "uses_allowed must be a non-negative integer or null",
             )
             .into());
         }
-    }
 
     // Validate expiry_time if provided
     if let Some(Some(expiry)) = body.expiry_time {

--- a/crates/server/src/routing/admin/room.rs
+++ b/crates/server/src/routing/admin/room.rs
@@ -261,10 +261,10 @@ pub fn list_rooms(
             r.room_id.to_lowercase().contains(&term_lower)
                 || r.name
                     .as_ref()
-                    .map_or(false, |n| n.to_lowercase().contains(&term_lower))
+                    .is_some_and(|n| n.to_lowercase().contains(&term_lower))
                 || r.canonical_alias
                     .as_ref()
-                    .map_or(false, |a| a.to_lowercase().contains(&term_lower))
+                    .is_some_and(|a| a.to_lowercase().contains(&term_lower))
         });
     }
 

--- a/crates/server/src/routing/admin/user.rs
+++ b/crates/server/src/routing/admin/user.rs
@@ -101,8 +101,7 @@ pub fn create_device(
         return Err(MatrixError::missing_param("Missing device_id").into());
     };
 
-    let device_id = <OwnedDeviceId>::try_from(device_id_str.as_str())
-        .map_err(|_| MatrixError::invalid_param("Invalid device_id"))?;
+    let device_id = OwnedDeviceId::from(device_id_str.as_str());
 
     if data::user::device::is_device_exists(&user_id, &device_id)? {
         return empty_ok();

--- a/crates/server/src/routing/appservice/third_party.rs
+++ b/crates/server/src/routing/appservice/third_party.rs
@@ -42,8 +42,8 @@ async fn get_protocol(aa: AuthArgs, protocol: PathParam<String>) -> JsonResult<P
     // Look through registered appservices to find one that handles this protocol.
     let appservices = crate::appservices();
     for appservice in appservices {
-        if let Some(protocols) = &appservice.protocols {
-            if protocols.iter().any(|p| p == &protocol_name) {
+        if let Some(protocols) = &appservice.protocols
+            && protocols.iter().any(|p| p == &protocol_name) {
                 return json_ok(ProtocolResBody {
                     protocol: Protocol {
                         user_fields: vec![],
@@ -54,7 +54,6 @@ async fn get_protocol(aa: AuthArgs, protocol: PathParam<String>) -> JsonResult<P
                     },
                 });
             }
-        }
     }
 
     Err(MatrixError::not_found("Protocol not found").into())

--- a/crates/server/src/routing/client/admin.rs
+++ b/crates/server/src/routing/client/admin.rs
@@ -26,7 +26,7 @@ async fn whois(
 
     // Check if the user is an admin or requesting their own info
     let is_admin = data::user::is_admin(authed.user_id()).unwrap_or(false);
-    if !is_admin && authed.user_id() != &target_user_id {
+    if !is_admin && authed.user_id() != target_user_id {
         return Err(MatrixError::forbidden(
             "Only admins can query other users' information.",
             None,

--- a/crates/server/src/routing/client/oidc.rs
+++ b/crates/server/src/routing/client/oidc.rs
@@ -574,7 +574,7 @@ pub async fn oidc_auth(req: &mut Request, res: &mut Response) -> AppResult<()> {
     );
 
     // Step 9: Redirect user to OIDC provider for authentication
-    res.render(Redirect::found(auth_url.to_string()));
+    res.render(Redirect::found(&auth_url));
     Ok(())
 }
 

--- a/crates/server/src/routing/client/register.rs
+++ b/crates/server/src/routing/client/register.rs
@@ -97,7 +97,7 @@ async fn register(
     if body.login_type == Some(LoginType::ApplicationService) {
         let token = aa.require_access_token()?;
         let matched = crate::appservices()
-            .into_iter()
+            .iter()
             .find(|appservice| appservice.as_token == token)
             .cloned();
         let Some(matched) = matched else {

--- a/crates/server/src/routing/client/session.rs
+++ b/crates/server/src/routing/client/session.rs
@@ -377,18 +377,15 @@ async fn logout(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) -> EmptyRes
 
     // When using delegated auth, also revoke the access token at the OIDC
     // provider so that the browser session is properly invalidated.
-    if let Some(da) = config::get().enabled_delegated_auth() {
-        if let Some(token) = req
+    if let Some(da) = config::get().enabled_delegated_auth()
+        && let Some(token) = req
             .headers()
             .get("authorization")
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.strip_prefix("Bearer "))
-        {
-            if let Err(e) = revoke_delegated_token(da, token).await {
+            && let Err(e) = revoke_delegated_token(da, token).await {
                 tracing::warn!("Failed to revoke delegated auth token: {e}");
             }
-        }
-    }
 
     data::user::device::remove_device(authed.user_id(), authed.device_id())?;
     empty_ok()

--- a/crates/server/src/routing/client/user/openid.rs
+++ b/crates/server/src/routing/client/user/openid.rs
@@ -28,7 +28,7 @@ pub(super) async fn request_token(
 
     // Verify the user is requesting a token for themselves
     let user_id = user_id.into_inner();
-    if authed.user_id() != &user_id {
+    if authed.user_id() != user_id {
         return Err(
             MatrixError::forbidden("Cannot request OpenID token for another user.", None).into(),
         );

--- a/crates/server/src/routing/federation/backfill.rs
+++ b/crates/server/src/routing/federation/backfill.rs
@@ -49,8 +49,8 @@ async fn get_backfill(
             .select(event_edges::prev_id)
             .load::<OwnedEventId>(&mut connect()?)?;
         prev_ids.retain(|p| !events.contains_key(p));
-        if !events.contains_key(&event_id) {
-            if let Ok((pdu, data)) = timeline::get_pdu_and_data(&event_id)
+        if !events.contains_key(&event_id)
+            && let Ok((pdu, data)) = timeline::get_pdu_and_data(&event_id)
                 && state::server_can_see_event(origin, &args.room_id, &pdu.event_id)?
             {
                 events.insert(
@@ -58,7 +58,6 @@ async fn get_backfill(
                     crate::sending::convert_to_outgoing_federation_event(data),
                 );
             }
-        }
         let prevs = events::table
             .filter(events::id.eq_any(&prev_ids))
             .select((events::id, events::depth))

--- a/crates/server/src/routing/federation/event.rs
+++ b/crates/server/src/routing/federation/event.rs
@@ -148,7 +148,7 @@ fn missing_events(
                 }
             };
 
-            if &*event_room_id_owned != &*room_id {
+            if *event_room_id_owned != *room_id {
                 warn!(
                     "evil event detected: Event {} found while searching in room {}",
                     event_id, &room_id

--- a/crates/server/src/routing/federation/key.rs
+++ b/crates/server/src/routing/federation/key.rs
@@ -44,11 +44,10 @@ async fn fetch_signing_keys(
     minimum_valid_until_ts: UnixMillis,
 ) -> Option<ServerSigningKeys> {
     // Try local cache first
-    if let Ok(cached) = crate::server_key::signing_keys_for(server) {
-        if cached.valid_until_ts >= minimum_valid_until_ts {
+    if let Ok(cached) = crate::server_key::signing_keys_for(server)
+        && cached.valid_until_ts >= minimum_valid_until_ts {
             return Some(cached);
         }
-    }
 
     // Cache miss or expired — fetch from origin server
     match crate::server_key::server_request(server).await {

--- a/crates/server/src/routing/federation/room.rs
+++ b/crates/server/src/routing/federation/room.rs
@@ -243,7 +243,7 @@ async fn send_knock(
             error = %e,
             room_id = %args.room_id, "could not accept as timeline event {}", event_id
         );
-        MatrixError::invalid_param(format!("could not accept as timeline event"))
+        MatrixError::invalid_param("could not accept as timeline event".to_string())
     })?;
 
     data::room::add_joined_server(&args.room_id, &origin)?;

--- a/crates/server/src/sending.rs
+++ b/crates/server/src/sending.rs
@@ -920,11 +920,10 @@ fn reqwest_client_builder(config: &ServerConfig) -> AppResult<reqwest::ClientBui
         reqwest_client_builder = reqwest_client_builder.danger_accept_invalid_certs(true);
     }
 
-    if let Some(ref proxy_config) = config.proxy {
-        if let Some(proxy) = proxy_config.to_proxy()? {
+    if let Some(ref proxy_config) = config.proxy
+        && let Some(proxy) = proxy_config.to_proxy()? {
             reqwest_client_builder = reqwest_client_builder.proxy(proxy);
         }
-    }
 
     Ok(reqwest_client_builder)
 }

--- a/crates/server/src/sync_v5.rs
+++ b/crates/server/src/sync_v5.rs
@@ -134,7 +134,7 @@ pub fn cleanup_expired_connections() {
         .filter_map(|(user_id, device_id, conn_id)| {
             Some((
                 OwnedUserId::try_from(user_id).ok()?,
-                OwnedDeviceId::try_from(device_id.as_str()).ok()?,
+                OwnedDeviceId::from(device_id.as_str()),
                 (!conn_id.is_empty()).then_some(conn_id),
             ))
         })
@@ -236,14 +236,13 @@ const CLEANUP_FREQUENCY_MS: i64 = 60 * 60 * 1000;
 fn maybe_cleanup_connections() {
     let now = UnixMillis::now().get() as i64;
     let last = LAST_CLEANUP.load(AtomicOrdering::Relaxed);
-    if now - last > CLEANUP_FREQUENCY_MS {
-        if LAST_CLEANUP
+    if now - last > CLEANUP_FREQUENCY_MS
+        && LAST_CLEANUP
             .compare_exchange(last, now, AtomicOrdering::Relaxed, AtomicOrdering::Relaxed)
             .is_ok()
         {
             cleanup_expired_connections();
         }
-    }
 }
 
 #[tracing::instrument(skip_all)]
@@ -363,11 +362,10 @@ async fn process_lists(
         };
 
         // Apply not_room_types filter
-        if let Some(filter) = list.filters.as_ref().map(|f| &f.not_room_types) {
-            if !filter.is_empty() {
+        if let Some(filter) = list.filters.as_ref().map(|f| &f.not_room_types)
+            && !filter.is_empty() {
                 active_rooms = filter_rooms(&active_rooms, filter, true);
             }
-        }
 
         // Apply room_types filter
         if let Some(filter) = list.filters.as_ref().and_then(|f| {
@@ -703,8 +701,8 @@ async fn process_rooms(
                             &StateEventType::RoomMember,
                             sender.as_str(),
                             None,
-                        ) {
-                            if !is_required_state_send(
+                        )
+                            && !is_required_state_send(
                                 sender_id.to_owned(),
                                 device_id.to_owned(),
                                 req_body.conn_id.clone(),
@@ -718,13 +716,12 @@ async fn process_rooms(
                                 );
                                 required_state_events.push(pdu.to_sync_state_event());
                             }
-                        }
                     }
                 }
                 // * state key: return all state events of this type
                 (ref event_type, "*") => {
-                    if let Ok(frame_id) = room::get_frame_id(room_id, None) {
-                        if let Ok(full_state) = state::get_full_state(frame_id) {
+                    if let Ok(frame_id) = room::get_frame_id(room_id, None)
+                        && let Ok(full_state) = state::get_full_state(frame_id) {
                             for ((ty, _sk), pdu) in &full_state {
                                 if ty == event_type
                                     && !is_required_state_send(
@@ -744,13 +741,11 @@ async fn process_rooms(
                                 }
                             }
                         }
-                    }
                 }
                 // $ME: substitute with the requester's user_id
                 (ref event_type, "$ME") => {
                     if let Ok(pdu) = room::get_state(room_id, event_type, sender_id.as_str(), None)
-                    {
-                        if !is_required_state_send(
+                        && !is_required_state_send(
                             sender_id.to_owned(),
                             device_id.to_owned(),
                             req_body.conn_id.clone(),
@@ -764,12 +759,11 @@ async fn process_rooms(
                             );
                             required_state_events.push(pdu.to_sync_state_event());
                         }
-                    }
                 }
                 // Specific state key
                 (ref event_type, state_key) => {
-                    if let Ok(pdu) = room::get_state(room_id, event_type, state_key, None) {
-                        if !is_required_state_send(
+                    if let Ok(pdu) = room::get_state(room_id, event_type, state_key, None)
+                        && !is_required_state_send(
                             sender_id.to_owned(),
                             device_id.to_owned(),
                             req_body.conn_id.clone(),
@@ -783,7 +777,6 @@ async fn process_rooms(
                             );
                             required_state_events.push(pdu.to_sync_state_event());
                         }
-                    }
                 }
             }
         }
@@ -1128,11 +1121,10 @@ where
     let mut typing = Typing::new();
     for room_id in rooms {
         // Filter by rooms config if specified
-        if let Some(room_filter) = typing_rooms {
-            if !room_filter.is_empty() && !room_filter.contains(&room_id.to_owned()) {
+        if let Some(room_filter) = typing_rooms
+            && !room_filter.is_empty() && !room_filter.contains(&room_id.to_owned()) {
                 continue;
             }
-        }
 
         let typing_event = room::typing::all_typings(room_id).await?;
         if !typing_event.content.user_ids.is_empty() {

--- a/palpo-example.toml
+++ b/palpo-example.toml
@@ -436,16 +436,17 @@
 #
 # Currently this does not account for proxies in use like Synapse does.
 #
-# To disable, set this to be an empty vector (`[]`).
+# To disable, set this to be an empty vector (`[]`) or omit the field.
+# If omitted, no IP range filtering is performed (use a firewall instead).
 #
-# Defaults to:
+# A safer recommended set is:
 # ["127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12",
 # "192.168.0.0/16", "100.64.0.0/10", "192.0.0.0/24", "169.254.0.0/16",
 # "192.88.99.0/24", "198.18.0.0/15", "192.0.2.0/24", "198.51.100.0/24",
 # "203.0.113.0/24", "224.0.0.0/4", "::1/128", "fe80::/10", "fc00::/7",
 # "2001:db8::/32", "ff00::/8", "fec0::/10"]
 #
-# ip_range_denylist =
+# ip_range_denylist = []
 
 # Whether to query the servers listed in trusted_servers first or query
 # the origin server first. For best security, querying the origin server


### PR DESCRIPTION
## Summary

- Clean up all `cargo build` warnings: suppress unavoidable deprecation warnings in `palpo-core` that are kept for Matrix backwards compatibility (`SetDisplayNameCapability`/`SetAvatarUrlCapability` since Matrix 1.16, `RoomCreateEventContent::creator` since Matrix 1.8), and silence an unused trait method in `palpo-core-macros`.
- Clean up all `cargo clippy` warnings across the workspace via `cargo clippy --fix` plus a few manual fixes: collapsible `if let` chains, needless borrows, unnecessary casts/fallible conversions, useless `format!`, `single_match` -> `if let`, `wildcard_in_or_patterns`, `cloned_ref_to_slice_refs`, etc.
- Restore imports in `push_condition_serde.rs` and `discovery/client.rs` that clippy autofix incorrectly removed — they are only used behind `cfg(feature = "unstable-msc4143"/"unstable-msc3931")` gates, so re-added with the matching `#[cfg(...)]` guards.

No behavioral changes. After this PR `cargo build` and `cargo clippy` are both warning-free on the default feature set.

## Test plan

- [x] `cargo build` — 0 warnings
- [x] `cargo clippy` — 0 warnings