### PR TITLE
[codex] add arm64 docker image builds

### DIFF
--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -25,9 +25,9 @@ jobs:
           - platform: linux/amd64
             runs_on: ubuntu-latest
             suffix: linux-amd64
-          # - platform: linux/arm64
-          #   runs_on: ubuntu-latest-arm
-          #   suffix: linux-arm64
+          - platform: linux/arm64
+            runs_on: ubuntu-24.04-arm
+            suffix: linux-arm64
     steps:
       - name: Set up Docker Buildx
         id: buildx


### PR DESCRIPTION
## What changed

This PR re-enables the `linux/arm64` build in the Docker image release workflow and updates the ARM runner label to `ubuntu-24.04-arm`.

## Why

`ghcr.io/palpo-im/palpo:latest` currently publishes only a `linux/amd64` image manifest, so pulls on ARM64 hosts fail with:

`no matching manifest for linux/arm64/v8`

The workflow already had the ARM job scaffolded, but it was commented out.

## Impact

After this workflow runs on `main`, image tags such as `latest` can be published as multi-arch manifests including both `linux/amd64` and `linux/arm64`.

## Root cause

The release workflow matrix only built `linux/amd64`, so the merged manifest list never contained an ARM64 image.

## Validation

- Confirmed the current published manifest for `ghcr.io/palpo-im/palpo:latest` only includes `linux/amd64`
- Ran `git diff --check`
- Parsed `.github/workflows/release-docker-images.yml` successfully with PyYAML
