### PR TITLE
fix: return 400 M_BAD_JSON for float content in PDU instead of panicking

### DIFF
--- a/crates/server/src/event/pdu.rs
+++ b/crates/server/src/event/pdu.rs
@@ -1006,7 +1006,14 @@ impl PduBuilder {
         event_auth::auth_check(auth_rules, &pdu, &fetch_event, &fetch_state).await?;
 
         // Hash and sign
-        let mut pdu_json = to_canonical_object(&pdu).expect("event is valid, we just created it");
+        // NOTE: `pdu.content` originates from the client request (via `PduBuilder`),
+        // so it may legitimately fail canonical-JSON serialization — e.g. if the
+        // client submitted a float, which the Matrix canonical-JSON spec forbids.
+        // Return a 400 `M_BAD_JSON` rather than panicking the server thread.
+        let mut pdu_json = to_canonical_object(&pdu).map_err(|e| {
+            tracing::warn!(error = ?e, "event content is not valid canonical JSON");
+            MatrixError::bad_json(format!("event content is not valid canonical JSON: {e}"))
+        })?;
 
         pdu_json.remove("event_id");
 


### PR DESCRIPTION
## Summary

`PduBuilder::hash_sign` in `crates/server/src/event/pdu.rs` called
`to_canonical_object(&pdu).expect(\"event is valid, we just created it\")`.
The `expect`'s claim is incorrect: `pdu.content` comes from the client
request (via `PduBuilder`), not the server. The Matrix canonical-JSON
spec forbids floats (see `CANONICALJSON_MAX_INT` / `serialize_f32` in
`crates/core/src/serde/canonical_json/`), so any client submitting a
float inside event `content` — e.g. a weather widget stuffing a
decimal temperature into `org.octos.app.initial_state` — would panic
the server thread instead of receiving an error.

## What changed

- Replace the `.expect(...)` with `map_err(...)?`.
- Map `CanonicalJsonError` to `MatrixError::bad_json` so the client
  receives a 400 `M_BAD_JSON` response.
- Log a `tracing::warn!` with the underlying error for diagnosis.

The rest of the file (including all other similar `.expect` sites) is
deliberately untouched — those have different call contexts and
should be evaluated separately. This PR is strictly about the one
site named in the bug report.

## Rationale — why not just accept floats?

Matrix canonical JSON deliberately forbids floats because events are
signed via SHA-256 of the canonical byte representation, and floats
have no canonical textual form (0.1 vs 0.10 vs 1e-1 all represent the
same value with different bytes; IEEE 754 also makes cross-language
equality unreliable). If palpo accepted a float, the event would be
rejected on federation by every other server (Synapse, Dendrite,
Conduit, tuwunel). The correct client-side encoding is a string
(\`\"12.5\"\`) or a scaled integer (\`125\` meaning tenths).

## Test plan

- [x] `cargo check -p palpo` — compiles, no new warnings.
- [ ] Manual: send an event with a float in `content` via
  \`PUT /_matrix/client/v3/rooms/{roomId}/state/{eventType}/{stateKey}\`
  and confirm the response is 400 \`M_BAD_JSON\` (was: panic).
- [ ] Existing canonical-JSON unit tests still pass.