### PR TITLE
Support remote home_page URLs

### DIFF
--- a/crates/server/src/config/server.rs
+++ b/crates/server/src/config/server.rs
@@ -90,6 +90,11 @@ pub struct ServerConfig {
     #[serde(default = "default_server_name")]
     pub server_name: OwnedServerName,
 
+    /// Optional homepage content source for `GET /`.
+    ///
+    /// If this is a local path, palpo serves that file directly.
+    /// If this starts with `https://`, palpo fetches the remote HTML at request time.
+    /// When the remote fetch fails, palpo logs a warning and falls back to the built-in default page.
     pub home_page: Option<String>,
 
     // display: hidden

--- a/crates/server/src/routing.rs
+++ b/crates/server/src/routing.rs
@@ -4,6 +4,9 @@ mod client;
 mod federation;
 mod media;
 
+use bytes::Bytes;
+use salvo::http::StatusCode;
+use salvo::http::header::{CONTENT_TYPE, HeaderValue};
 use salvo::prelude::*;
 use salvo::serve_static::StaticDir;
 
@@ -11,7 +14,7 @@ use crate::core::MatrixError;
 use crate::core::client::discovery::client::{AuthenticationInfo, ClientResBody, HomeServerInfo};
 use crate::core::client::discovery::support::{Contact, SupportResBody};
 use crate::core::federation::directory::ServerResBody;
-use crate::{AppResult, JsonResult, config, hoops, json_ok};
+use crate::{AppResult, JsonResult, config, hoops, json_ok, sending};
 
 pub mod prelude {
     pub use salvo::prelude::*;
@@ -53,9 +56,90 @@ pub fn root() -> Router {
 #[handler]
 async fn home(req: &mut Request, res: &mut Response) {
     if let Some(home_page) = &config::get().home_page {
-        res.send_file(home_page, req.headers()).await;
+        match HomePageSource::from_config(home_page) {
+            HomePageSource::Remote(url) => {
+                if let Some((body, content_type)) = fetch_remote_home_page(url).await {
+                    res.status_code(StatusCode::OK);
+                    res.headers_mut().insert(
+                        CONTENT_TYPE,
+                        HeaderValue::from_str(&content_type).unwrap_or_else(|_| {
+                            HeaderValue::from_static("text/html; charset=utf-8")
+                        }),
+                    );
+                    let _ = res.write_body(body);
+                    return;
+                }
+            }
+            HomePageSource::Local(path) => {
+                res.send_file(path, req.headers()).await;
+                return;
+            }
+        }
     }
-    res.render("Hello Palpo");
+
+    res.status_code(StatusCode::OK);
+    res.headers_mut().insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static("text/html; charset=utf-8"),
+    );
+    let _ = res.write_body("Hello Palpo");
+}
+
+enum HomePageSource<'a> {
+    Local(&'a str),
+    Remote(&'a str),
+}
+
+impl<'a> HomePageSource<'a> {
+    fn from_config(value: &'a str) -> Self {
+        if value.starts_with("https://") {
+            Self::Remote(value)
+        } else {
+            Self::Local(value)
+        }
+    }
+}
+
+async fn fetch_remote_home_page(url: &str) -> Option<(Bytes, String)> {
+    let response = match sending::default_client()
+        .get(url)
+        .header(
+            reqwest::header::USER_AGENT,
+            crate::info::version::user_agent(),
+        )
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => {
+            tracing::warn!(url, error = %error, "failed to fetch remote home page");
+            return None;
+        }
+    };
+
+    if !response.status().is_success() {
+        tracing::warn!(
+            url,
+            status = %response.status(),
+            "remote home page returned non-success status"
+        );
+        return None;
+    }
+
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| "text/html; charset=utf-8".to_owned());
+
+    match response.bytes().await {
+        Ok(body) => Some((body, content_type)),
+        Err(error) => {
+            tracing::warn!(url, error = %error, "failed to read remote home page body");
+            None
+        }
+    }
 }
 
 #[handler]
@@ -135,6 +219,31 @@ fn well_known_support() -> JsonResult<SupportResBody> {
         contacts,
         support_page,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HomePageSource;
+
+    #[test]
+    fn home_page_classifies_https_urls_as_remote() {
+        assert!(matches!(
+            HomePageSource::from_config("https://example.com/index.html"),
+            HomePageSource::Remote(_)
+        ));
+    }
+
+    #[test]
+    fn home_page_classifies_other_values_as_local_paths() {
+        assert!(matches!(
+            HomePageSource::from_config("./static/index.html"),
+            HomePageSource::Local(_)
+        ));
+        assert!(matches!(
+            HomePageSource::from_config("/data/workspace/index.html"),
+            HomePageSource::Local(_)
+        ));
+    }
 }
 
 #[endpoint]


### PR DESCRIPTION
## What changed
- add support for treating `home_page` as a remote `https://` URL
- fetch remote homepage HTML at request time for `/`
- log a warning and fall back to the built-in default page when the fetch fails
- document the new `home_page` behavior in server config

## Why
Palpo previously treated `home_page` only as a local file path. This change allows tenant control planes to publish custom landing pages to object storage and point Palpo at the hosted HTML directly.

## Impact
Servers can now set `home_page = "https://..."` and serve externally hosted landing pages without bundling local static files into the runtime.

## Validation
- `cargo test -p palpo home_page_classifies`
- `cargo check -p palpo`
