### PR TITLE
Implement event report status management and enhance routing

### DIFF
--- a/crates/core-macros/src/util.rs
+++ b/crates/core-macros/src/util.rs
@@ -255,13 +255,13 @@ impl StructFieldExt for Field {
         self.serde_meta_items().find_map(|meta| {
             if let syn::Meta::NameValue(nv) = meta
                 && nv.path.is_ident("default")
-                    && let syn::Expr::Lit(syn::ExprLit {
-                        lit: syn::Lit::Str(lit_str),
-                        ..
-                    }) = &nv.value
-                    {
-                        return lit_str.parse::<syn::Path>().ok();
-                    }
+                && let syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Str(lit_str),
+                    ..
+                }) = &nv.value
+            {
+                return lit_str.parse::<syn::Path>().ok();
+            }
             None
         })
     }

--- a/crates/core/src/events/kinds.rs
+++ b/crates/core/src/events/kinds.rs
@@ -251,7 +251,9 @@ pub struct RedactedSyncMessageLikeEvent<C: RedactedMessageLikeEventContent> {
 /// the event's `EventId`.
 #[allow(clippy::exhaustive_enums)]
 #[derive(ToSchema, Clone, Debug)]
-#[salvo(schema(bound = "C: ToSchema + ComposeSchema + 'static, C::Redacted: ToSchema + ComposeSchema + 'static"))]
+#[salvo(schema(
+    bound = "C: ToSchema + ComposeSchema + 'static, C::Redacted: ToSchema + ComposeSchema + 'static"
+))]
 pub enum MessageLikeEvent<C: MessageLikeEventContent + RedactContent>
 where
     C::Redacted: RedactedMessageLikeEventContent,
@@ -270,7 +272,9 @@ where
 /// the event's `EventId`.
 #[allow(clippy::exhaustive_enums)]
 #[derive(ToSchema, Clone, Debug)]
-#[salvo(schema(bound = "C: ToSchema + ComposeSchema + 'static, C::Redacted: ToSchema + ComposeSchema + 'static"))]
+#[salvo(schema(
+    bound = "C: ToSchema + ComposeSchema + 'static, C::Redacted: ToSchema + ComposeSchema + 'static"
+))]
 pub enum SyncMessageLikeEvent<C: MessageLikeEventContent + RedactContent>
 where
     C::Redacted: RedactedMessageLikeEventContent,

--- a/crates/core/src/metadata/matrix_version.rs
+++ b/crates/core/src/metadata/matrix_version.rs
@@ -276,9 +276,6 @@ impl MatrixVersion {
     pub const fn from_lit(lit: &'static str) -> Self {
         use konst::{result, string};
 
-        
-        
-
         let mut split = string::split(lit, ".");
 
         // Get major version

--- a/crates/core/src/push/condition/push_condition_serde.rs
+++ b/crates/core/src/push/condition/push_condition_serde.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize, Serializer, de};
 
-use super::{PushCondition, RoomMemberCountIs, ScalarJsonValue};
 #[cfg(feature = "unstable-msc3931")]
 use super::RoomVersionFeature;
+use super::{PushCondition, RoomMemberCountIs, ScalarJsonValue};
 use crate::serde::{RawJsonValue, from_raw_json_value};
 
 impl Serialize for PushCondition {

--- a/crates/data/migrations/2026-04-17-000001_event_report_status/down.sql
+++ b/crates/data/migrations/2026-04-17-000001_event_report_status/down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_event_reports_status;
+
+ALTER TABLE event_reports
+DROP COLUMN IF EXISTS status;

--- a/crates/data/migrations/2026-04-17-000001_event_report_status/up.sql
+++ b/crates/data/migrations/2026-04-17-000001_event_report_status/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE event_reports
+ADD COLUMN status TEXT NOT NULL DEFAULT 'new';
+
+CREATE INDEX idx_event_reports_status ON event_reports(status);

--- a/crates/data/src/media.rs
+++ b/crates/data/src/media.rs
@@ -350,7 +350,8 @@ pub fn get_user_media_statistics(
                 SELECT created_by FROM media_metadatas \
                 WHERE created_by IS NOT NULL AND created_by LIKE $1 \
                 GROUP BY created_by\
-            ) sub".to_string();
+            ) sub"
+            .to_string();
         let total: i64 = diesel::sql_query(&count_sql)
             .bind::<diesel::sql_types::Text, _>(&like_pattern)
             .get_result::<CountResult>(&mut conn)?

--- a/crates/data/src/room.rs
+++ b/crates/data/src/room.rs
@@ -295,7 +295,13 @@ impl NewDbEvent {
         is_backfill: bool,
         room_id: &RoomId,
     ) -> DataResult<Self> {
-        Self::from_json_value(id, sn, serde_json::to_value(value)?, is_backfill, Some(room_id))
+        Self::from_json_value(
+            id,
+            sn,
+            serde_json::to_value(value)?,
+            is_backfill,
+            Some(room_id),
+        )
     }
     pub fn from_json_value(
         id: &EventId,

--- a/crates/data/src/room/event_report.rs
+++ b/crates/data/src/room/event_report.rs
@@ -12,6 +12,7 @@ use crate::{DataResult, connect};
 pub struct DbEventReport {
     pub id: i64,
     pub received_ts: i64,
+    pub status: String,
     pub room_id: OwnedRoomId,
     pub event_id: OwnedEventId,
     pub user_id: OwnedUserId,
@@ -24,6 +25,7 @@ pub struct DbEventReport {
 #[diesel(table_name = event_reports)]
 pub struct NewDbEventReport {
     pub received_ts: i64,
+    pub status: String,
     pub room_id: OwnedRoomId,
     pub event_id: OwnedEventId,
     pub user_id: OwnedUserId,
@@ -43,6 +45,7 @@ impl NewDbEventReport {
     ) -> Self {
         Self {
             received_ts: UnixMillis::now().get() as i64,
+            status: "new".to_owned(),
             room_id,
             event_id,
             user_id,
@@ -58,6 +61,7 @@ impl NewDbEventReport {
 pub struct EventReportInfo {
     pub id: i64,
     pub received_ts: i64,
+    pub status: String,
     pub room_id: OwnedRoomId,
     pub event_id: OwnedEventId,
     pub user_id: OwnedUserId,
@@ -70,6 +74,7 @@ impl From<DbEventReport> for EventReportInfo {
         Self {
             id: db.id,
             received_ts: db.received_ts,
+            status: db.status,
             room_id: db.room_id,
             event_id: db.event_id,
             user_id: db.user_id,
@@ -145,6 +150,18 @@ pub fn get_event_report(report_id: i64) -> DataResult<Option<DbEventReport>> {
     event_reports::table
         .find(report_id)
         .first::<DbEventReport>(&mut connect()?)
+        .optional()
+        .map_err(Into::into)
+}
+
+/// Update an event report status by ID
+pub fn update_event_report_status(
+    report_id: i64,
+    status: &str,
+) -> DataResult<Option<DbEventReport>> {
+    diesel::update(event_reports::table.find(report_id))
+        .set(event_reports::status.eq(status))
+        .get_result::<DbEventReport>(&mut connect()?)
         .optional()
         .map_err(Into::into)
 }

--- a/crates/data/src/schema.rs
+++ b/crates/data/src/schema.rs
@@ -377,6 +377,7 @@ diesel::table! {
     event_reports (id) {
         id -> Int8,
         received_ts -> Int8,
+        status -> Text,
         room_id -> Text,
         event_id -> Text,
         user_id -> Text,

--- a/crates/data/src/user/registration_token.rs
+++ b/crates/data/src/user/registration_token.rs
@@ -238,15 +238,17 @@ pub fn is_token_valid(token: &str) -> DataResult<bool> {
 
     // Check expiry
     if let Some(expires_at) = db_token.expires_at
-        && now >= expires_at {
-            return Ok(false);
-        }
+        && now >= expires_at
+    {
+        return Ok(false);
+    }
 
     // Check uses
     if let Some(uses_allowed) = db_token.uses_allowed
-        && db_token.completed + db_token.pending >= uses_allowed {
-            return Ok(false);
-        }
+        && db_token.completed + db_token.pending >= uses_allowed
+    {
+        return Ok(false);
+    }
 
     Ok(true)
 }

--- a/crates/server/src/appservice.rs
+++ b/crates/server/src/appservice.rs
@@ -299,10 +299,13 @@ pub fn set_appservice_disabled(id: &str, disabled: bool) -> AppResult<bool> {
 /// List all registrations in the database, including disabled ones.
 pub fn list_all_registrations() -> AppResult<Vec<(DbRegistration, bool)>> {
     let regs = appservice_registrations::table.load::<DbRegistration>(&mut connect()?)?;
-    Ok(regs.into_iter().map(|r| {
-        let disabled = r.disabled;
-        (r, disabled)
-    }).collect())
+    Ok(regs
+        .into_iter()
+        .map(|r| {
+            let disabled = r.disabled;
+            (r, disabled)
+        })
+        .collect())
 }
 
 pub fn get_registration(id: &str) -> AppResult<Option<Registration>> {

--- a/crates/server/src/config/federation.rs
+++ b/crates/server/src/config/federation.rs
@@ -1,10 +1,9 @@
 use serde::Deserialize;
 
+use super::WildCardedDomain;
 use crate::core::ServerName;
 use crate::core::serde::default_true;
 use crate::macros::config_example;
-
-use super::WildCardedDomain;
 
 #[config_example(filename = "palpo-example.toml", section = "federation")]
 #[derive(Clone, Debug, Deserialize)]

--- a/crates/server/src/config/server.rs
+++ b/crates/server/src/config/server.rs
@@ -90,6 +90,12 @@ pub struct ServerConfig {
     #[serde(default = "default_server_name")]
     pub server_name: OwnedServerName,
 
+    /// Optional homepage content source for `GET /`.
+    ///
+    /// If this is a local path, palpo serves that file directly.
+    /// If this starts with `https://`, palpo fetches the remote HTML at request time.
+    /// When the remote fetch fails, palpo logs a warning and falls back to the built-in default
+    /// page.
     pub home_page: Option<String>,
 
     // display: hidden
@@ -577,7 +583,6 @@ pub struct ServerConfig {
     #[serde(default)]
     pub ip_range_denylist: Vec<String>,
 
-
     // pub auto_acme: Option<AcmeConfig>,
     /// Whether to query the servers listed in trusted_servers first or query
     /// the origin server first. For best security, querying the origin server
@@ -765,7 +770,6 @@ pub struct ServerConfig {
 
     // external structure; separate section
     pub delegated_auth: Option<DelegatedAuthConfig>,
-
     // // external structure; separate section
     // #[serde(default)]
     // pub appservice: BTreeMap<String, AppService>,
@@ -839,9 +843,10 @@ impl ServerConfig {
         } else {
             // If under proxy, you should set well-known client manually.
             if let Some(listenser) = self.listeners.first()
-                && listenser.enabled_tls().is_none() {
-                    return format!("http://{}", self.server_name);
-                };
+                && listenser.enabled_tls().is_none()
+            {
+                return format!("http://{}", self.server_name);
+            };
             format!("https://{}", self.server_name)
         }
     }
@@ -1148,7 +1153,6 @@ fn default_pdu_cache_capacity() -> u32 {
 fn default_trusted_server_batch_size() -> usize {
     256
 }
-
 
 fn default_startup_netburst_keep() -> i64 {
     50

--- a/crates/server/src/event/outlier.rs
+++ b/crates/server/src/event/outlier.rs
@@ -133,8 +133,13 @@ impl OutlierPdu {
             ));
         }
         let (event_sn, event_guard) = ensure_event_sn(&room_id, &pdu.event_id)?;
-        let mut db_event =
-            NewDbEvent::from_canonical_json_with_room_id(&pdu.event_id, event_sn, &json_data, is_backfill, &room_id)?;
+        let mut db_event = NewDbEvent::from_canonical_json_with_room_id(
+            &pdu.event_id,
+            event_sn,
+            &json_data,
+            is_backfill,
+            &room_id,
+        )?;
         db_event.is_outlier = true;
         db_event.soft_failed = soft_failed;
         db_event.is_rejected = pdu.rejection_reason.is_some();

--- a/crates/server/src/event/resolver.rs
+++ b/crates/server/src/event/resolver.rs
@@ -195,11 +195,14 @@ pub(super) async fn resolve_state_at_incoming(
     // are in our DB but were rejected (and so don't contribute to state). For
     // events with TRULY missing prev events, we already returned None above so
     // the caller can run the missing-events fetch path.
-    if had_prev_events && extremity_state_hashes.is_empty() && had_in_db_unresolvable
-        && let Ok(frame_id) = state::get_room_frame_id(&incoming_pdu.room_id, None) {
-            let state = state::get_full_state_ids(frame_id)?;
-            return Ok(Some(state));
-        }
+    if had_prev_events
+        && extremity_state_hashes.is_empty()
+        && had_in_db_unresolvable
+        && let Ok(frame_id) = state::get_room_frame_id(&incoming_pdu.room_id, None)
+    {
+        let state = state::get_full_state_ids(frame_id)?;
+        return Ok(Some(state));
+    }
 
     let mut fork_states = Vec::with_capacity(extremity_state_hashes.len());
     let mut auth_chain_sets = Vec::with_capacity(extremity_state_hashes.len());

--- a/crates/server/src/hoops.rs
+++ b/crates/server/src/hoops.rs
@@ -137,7 +137,10 @@ impl RateLimiter {
             entry.0 -= 1.0;
             Ok(())
         } else {
-            Err(MatrixError::limit_exceeded("Too many requests. Please try again later.", None).into())
+            Err(
+                MatrixError::limit_exceeded("Too many requests. Please try again later.", None)
+                    .into(),
+            )
         }
     }
 }

--- a/crates/server/src/hoops/auth.rs
+++ b/crates/server/src/hoops/auth.rs
@@ -290,7 +290,9 @@ async fn auth_by_signatures_inner(req: &mut Request, depot: &mut Depot) -> AppRe
 
     let origin = &x_matrix.origin;
     if !config::get().federation.is_server_allowed(origin) {
-        return Err(MatrixError::forbidden("Federation with this server is not allowed.", None).into());
+        return Err(
+            MatrixError::forbidden("Federation with this server is not allowed.", None).into(),
+        );
     }
 
     let signatures = BTreeMap::from_iter([(

--- a/crates/server/src/hoops/introspection.rs
+++ b/crates/server/src/hoops/introspection.rs
@@ -43,12 +43,13 @@ pub async fn introspect_token(token: &str) -> AppResult<IntrospectionResult> {
     if ttl > 0 {
         let key = token_cache_key(token);
         if let Ok(mut cache) = CACHE.lock()
-            && let Some(entry) = cache.get(&key) {
-                if entry.cached_at.elapsed() < Duration::from_secs(ttl) {
-                    return Ok(entry.result.clone());
-                }
-                cache.remove(&key);
+            && let Some(entry) = cache.get(&key)
+        {
+            if entry.cached_at.elapsed() < Duration::from_secs(ttl) {
+                return Ok(entry.result.clone());
             }
+            cache.remove(&key);
+        }
     }
 
     // Call introspection endpoint
@@ -105,13 +106,15 @@ pub async fn introspect_token(token: &str) -> AppResult<IntrospectionResult> {
 pub fn device_id_from_scope(scope: &str) -> Option<String> {
     for part in scope.split_whitespace() {
         if let Some(id) = part.strip_prefix("urn:matrix:client:device:")
-            && !id.is_empty() {
-                return Some(id.to_owned());
-            }
+            && !id.is_empty()
+        {
+            return Some(id.to_owned());
+        }
         if let Some(id) = part.strip_prefix("urn:matrix:org.matrix.msc2967.client:device:")
-            && !id.is_empty() {
-                return Some(id.to_owned());
-            }
+            && !id.is_empty()
+        {
+            return Some(id.to_owned());
+        }
     }
     None
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -30,11 +30,11 @@ pub mod exts;
 pub mod federation;
 pub mod media;
 pub mod membership;
-pub mod storage;
 pub mod room;
 pub mod sending;
 pub mod server_key;
 pub mod state;
+pub mod storage;
 pub mod transaction_id;
 pub mod uiaa;
 pub mod user;
@@ -164,8 +164,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     crate::logging::init()?;
     crate::data::init(&conf.db.clone().into_data_db_config());
-    crate::storage::init(&conf.storage)
-        .expect("Failed to initialize storage backend");
+    crate::storage::init(&conf.storage).expect("Failed to initialize storage backend");
     // Force-load appservice registrations during startup so database rows
     // are up-to-date with the configured registration directory.
     let _ = crate::appservices();

--- a/crates/server/src/media.rs
+++ b/crates/server/src/media.rs
@@ -121,7 +121,6 @@ pub fn media_storage_key(server_name: &ServerName, media_id: &str) -> String {
     storage::media_key(effective_server_name(server_name), media_id)
 }
 
-
 pub async fn delete_media(server_name: &ServerName, media_id: &str) -> AppResult<()> {
     data::media::delete_media(server_name, media_id)?;
     let key = media_storage_key(server_name, media_id);
@@ -192,7 +191,11 @@ pub async fn save_thumbnail(
 }
 
 /// Build the storage key for a thumbnail file.
-pub fn thumbnail_storage_key(server_name: &ServerName, media_id: &str, thumbnail_id: i64) -> String {
+pub fn thumbnail_storage_key(
+    server_name: &ServerName,
+    media_id: &str,
+    thumbnail_id: i64,
+) -> String {
     storage::thumbnail_key(effective_server_name(server_name), media_id, thumbnail_id)
 }
 
@@ -206,4 +209,3 @@ pub async fn save_thumbnail_file(
     storage::write(&key, file).await?;
     Ok(key)
 }
-

--- a/crates/server/src/media/remote.rs
+++ b/crates/server/src/media/remote.rs
@@ -148,9 +148,9 @@ async fn fetch_thumbnail_authenticated(
             &file,
         )
         .await
-        {
-            warn!("Failed to save fetched thumbnail locally: {e}");
-        }
+    {
+        warn!("Failed to save fetched thumbnail locally: {e}");
+    }
 
     Ok(FileMeta {
         content: Some(file),
@@ -246,9 +246,9 @@ async fn fetch_thumbnail_unauthenticated(
             &file,
         )
         .await
-        {
-            warn!("Failed to save fetched thumbnail locally: {e}");
-        }
+    {
+        warn!("Failed to save fetched thumbnail locally: {e}");
+    }
 
     Ok(FileMeta {
         content: Some(file),

--- a/crates/server/src/membership/join.rs
+++ b/crates/server/src/membership/join.rs
@@ -366,7 +366,10 @@ pub async fn join_room(
                 AppError::public("invalid pdu in send_join response.")
             })?;
 
-            NewDbEvent::from_canonical_json_with_room_id(&event_id, event_sn, &value, false, room_id)?.save()?;
+            NewDbEvent::from_canonical_json_with_room_id(
+                &event_id, event_sn, &value, false, room_id,
+            )?
+            .save()?;
             DbEventData {
                 event_id: pdu.event_id.to_owned(),
                 event_sn,
@@ -401,7 +404,10 @@ pub async fn join_room(
 
         if !timeline::has_pdu(&event_id) {
             let (event_sn, event_guard) = ensure_event_sn(room_id, &event_id)?;
-            NewDbEvent::from_canonical_json_with_room_id(&event_id, event_sn, &value, false, room_id)?.save()?;
+            NewDbEvent::from_canonical_json_with_room_id(
+                &event_id, event_sn, &value, false, room_id,
+            )?
+            .save()?;
             DbEventData {
                 event_id: event_id.to_owned(),
                 event_sn,
@@ -648,8 +654,8 @@ mod tests {
     use salvo::http::StatusCode;
 
     use super::should_retry_make_join_after_error;
-    use crate::core::MatrixError;
     use crate::AppError;
+    use crate::core::MatrixError;
 
     #[test]
     fn retries_only_transient_invite_visibility_errors_for_invited_users() {

--- a/crates/server/src/room.rs
+++ b/crates/server/src/room.rs
@@ -306,7 +306,10 @@ pub async fn should_join_on_remote_servers(
             if server == local_server {
                 continue;
             }
-            if !allowed_servers.iter().any(|s| s.as_str() == server.as_str()) {
+            if !allowed_servers
+                .iter()
+                .any(|s| s.as_str() == server.as_str())
+            {
                 allowed_servers.push(server.to_owned());
             }
         }

--- a/crates/server/src/room/auth_chain.rs
+++ b/crates/server/src/room/auth_chain.rs
@@ -14,8 +14,8 @@ use crate::room::timeline;
 use crate::{AppResult, MatrixError};
 
 type Bucket<'a> = BTreeSet<(Seqnum, &'a EventId)>;
-// Mutex is used instead of RwLock because LruCache mutates internal state on reads (access ordering).
-// Poisoning is handled via unwrap_or_else to avoid cascading panics.
+// Mutex is used instead of RwLock because LruCache mutates internal state on reads (access
+// ordering). Poisoning is handled via unwrap_or_else to avoid cascading panics.
 static AUTH_CHAIN_CACHE: LazyLock<Mutex<LruCache<Vec<i64>, Arc<Vec<Seqnum>>>>> =
     LazyLock::new(|| Mutex::new(LruCache::new(100_000)));
 
@@ -158,7 +158,11 @@ fn get_event_auth_chain(room_id: &RoomId, event_id: &EventId) -> AppResult<Vec<S
 
 fn get_cached_auth_chain(cache_key: &[Seqnum]) -> AppResult<Option<Arc<Vec<Seqnum>>>> {
     // Check RAM cache
-    if let Some(result) = AUTH_CHAIN_CACHE.lock().unwrap_or_else(|e| e.into_inner()).get_mut(cache_key) {
+    if let Some(result) = AUTH_CHAIN_CACHE
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get_mut(cache_key)
+    {
         return Ok(Some(Arc::clone(result)));
     }
 

--- a/crates/server/src/room/timeline/backfill.rs
+++ b/crates/server/src/room/timeline/backfill.rs
@@ -51,12 +51,8 @@ pub async fn backfill_if_required(
             .select(events::id)
             .load(&mut connect()?)?;
         if pdu.prev_events.iter().any(|id| !existing.contains(id)) {
-            return backfill_from_extremities(
-                room_id,
-                std::slice::from_ref(&pdu.event_id),
-                limit,
-            )
-            .await;
+            return backfill_from_extremities(room_id, std::slice::from_ref(&pdu.event_id), limit)
+                .await;
         }
     }
 

--- a/crates/server/src/room/timeline/stream.rs
+++ b/crates/server/src/room/timeline/stream.rs
@@ -79,7 +79,9 @@ pub fn load_pdus(
             .filter(events::room_id.eq(room_id))
             .select(diesel::dsl::max(events::sn))
             .first::<Option<Seqnum>>(&mut connect()?)?;
-        max_in_room.map(|sn| sn + 1).unwrap_or_else(|| data::curr_sn().unwrap_or(0) + 1)
+        max_in_room
+            .map(|sn| sn + 1)
+            .unwrap_or_else(|| data::curr_sn().unwrap_or(0) + 1)
     };
 
     while list.len() < limit {
@@ -134,12 +136,10 @@ pub fn load_pdus(
             }
         }
         // Don't filter by is_outlier or soft_failed here:
-        //  - Federation events that arrive with missing prev_events end up
-        //    marked as outlier and/or soft_failed even though they should still
-        //    be visible to clients (per Matrix spec, soft-failed events appear
-        //    in the timeline; they just don't contribute to room state).
-        //  - We *do* filter is_rejected because rejected events should not be
-        //    visible at all.
+        //  - Federation events that arrive with missing prev_events end up marked as outlier and/or
+        //    soft_failed even though they should still be visible to clients (per Matrix spec,
+        //    soft-failed events appear in the timeline; they just don't contribute to room state).
+        //  - We *do* filter is_rejected because rejected events should not be visible at all.
         let events: Vec<(OwnedEventId, Seqnum)> = if dir == Direction::Forward {
             query
                 .filter(events::sn.gt(start_sn))

--- a/crates/server/src/routing.rs
+++ b/crates/server/src/routing.rs
@@ -4,6 +4,9 @@ mod client;
 mod federation;
 mod media;
 
+use bytes::Bytes;
+use salvo::http::StatusCode;
+use salvo::http::header::{CONTENT_TYPE, HeaderValue};
 use salvo::prelude::*;
 use salvo::serve_static::StaticDir;
 
@@ -11,7 +14,7 @@ use crate::core::MatrixError;
 use crate::core::client::discovery::client::{AuthenticationInfo, ClientResBody, HomeServerInfo};
 use crate::core::client::discovery::support::{Contact, SupportResBody};
 use crate::core::federation::directory::ServerResBody;
-use crate::{AppResult, JsonResult, config, hoops, json_ok};
+use crate::{AppResult, JsonResult, config, hoops, json_ok, sending};
 
 pub mod prelude {
     pub use salvo::prelude::*;
@@ -53,9 +56,90 @@ pub fn root() -> Router {
 #[handler]
 async fn home(req: &mut Request, res: &mut Response) {
     if let Some(home_page) = &config::get().home_page {
-        res.send_file(home_page, req.headers()).await;
+        match HomePageSource::from_config(home_page) {
+            HomePageSource::Remote(url) => {
+                if let Some((body, content_type)) = fetch_remote_home_page(url).await {
+                    res.status_code(StatusCode::OK);
+                    res.headers_mut().insert(
+                        CONTENT_TYPE,
+                        HeaderValue::from_str(&content_type).unwrap_or_else(|_| {
+                            HeaderValue::from_static("text/html; charset=utf-8")
+                        }),
+                    );
+                    let _ = res.write_body(body);
+                    return;
+                }
+            }
+            HomePageSource::Local(path) => {
+                res.send_file(path, req.headers()).await;
+                return;
+            }
+        }
     }
-    res.render("Hello Palpo");
+
+    res.status_code(StatusCode::OK);
+    res.headers_mut().insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static("text/html; charset=utf-8"),
+    );
+    let _ = res.write_body("Hello Palpo");
+}
+
+enum HomePageSource<'a> {
+    Local(&'a str),
+    Remote(&'a str),
+}
+
+impl<'a> HomePageSource<'a> {
+    fn from_config(value: &'a str) -> Self {
+        if value.starts_with("https://") {
+            Self::Remote(value)
+        } else {
+            Self::Local(value)
+        }
+    }
+}
+
+async fn fetch_remote_home_page(url: &str) -> Option<(Bytes, String)> {
+    let response = match sending::default_client()
+        .get(url)
+        .header(
+            reqwest::header::USER_AGENT,
+            crate::info::version::user_agent(),
+        )
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => {
+            tracing::warn!(url, error = %error, "failed to fetch remote home page");
+            return None;
+        }
+    };
+
+    if !response.status().is_success() {
+        tracing::warn!(
+            url,
+            status = %response.status(),
+            "remote home page returned non-success status"
+        );
+        return None;
+    }
+
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| "text/html; charset=utf-8".to_owned());
+
+    match response.bytes().await {
+        Ok(body) => Some((body, content_type)),
+        Err(error) => {
+            tracing::warn!(url, error = %error, "failed to read remote home page body");
+            None
+        }
+    }
 }
 
 #[handler]
@@ -79,11 +163,12 @@ fn well_known_client() -> JsonResult<ClientResBody> {
             });
         }
     } else if let Some(oidc) = conf.oidc.as_ref()
-        && let Some(issuer) = &oidc.mas_issuer {
-            body.authentication = Some(AuthenticationInfo {
-                issuer: issuer.clone(),
-            });
-        }
+        && let Some(issuer) = &oidc.mas_issuer
+    {
+        body.authentication = Some(AuthenticationInfo {
+            issuer: issuer.clone(),
+        });
+    }
 
     json_ok(body)
 }
@@ -135,6 +220,31 @@ fn well_known_support() -> JsonResult<SupportResBody> {
         contacts,
         support_page,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HomePageSource;
+
+    #[test]
+    fn home_page_classifies_https_urls_as_remote() {
+        assert!(matches!(
+            HomePageSource::from_config("https://example.com/index.html"),
+            HomePageSource::Remote(_)
+        ));
+    }
+
+    #[test]
+    fn home_page_classifies_other_values_as_local_paths() {
+        assert!(matches!(
+            HomePageSource::from_config("./static/index.html"),
+            HomePageSource::Local(_)
+        ));
+        assert!(matches!(
+            HomePageSource::from_config("/data/workspace/index.html"),
+            HomePageSource::Local(_)
+        ));
+    }
 }
 
 #[endpoint]

--- a/crates/server/src/routing/admin/event_report.rs
+++ b/crates/server/src/routing/admin/event_report.rs
@@ -2,6 +2,7 @@
 //!
 //! - GET /_synapse/admin/v1/event_reports
 //! - GET /_synapse/admin/v1/event_reports/{report_id}
+//! - PUT /_synapse/admin/v1/event_reports/{report_id}
 //! - DELETE /_synapse/admin/v1/event_reports/{report_id}
 
 use salvo::oapi::extract::*;
@@ -17,6 +18,7 @@ pub fn router() -> Router {
         .push(
             Router::with_path("v1/event_reports/{report_id}")
                 .get(get_event_report)
+                .put(update_event_report_status)
                 .delete(delete_event_report),
         )
 }
@@ -25,6 +27,7 @@ pub fn router() -> Router {
 pub struct EventReport {
     pub id: i64,
     pub received_ts: i64,
+    pub status: String,
     pub room_id: String,
     pub event_id: String,
     pub user_id: String,
@@ -38,6 +41,7 @@ impl From<data::room::EventReportInfo> for EventReport {
         Self {
             id: info.id,
             received_ts: info.received_ts,
+            status: info.status,
             room_id: info.room_id.to_string(),
             event_id: info.event_id.to_string(),
             user_id: info.user_id.to_string(),
@@ -59,6 +63,7 @@ pub struct EventReportsResponse {
 pub struct EventReportDetailResponse {
     pub id: i64,
     pub received_ts: i64,
+    pub status: String,
     pub room_id: String,
     pub event_id: String,
     pub user_id: String,
@@ -74,6 +79,7 @@ impl From<data::room::DbEventReport> for EventReportDetailResponse {
         Self {
             id: db.id,
             received_ts: db.received_ts,
+            status: db.status,
             room_id: db.room_id.to_string(),
             event_id: db.event_id.to_string(),
             user_id: db.user_id.to_string(),
@@ -96,6 +102,20 @@ pub struct ListEventReportsQuery {
     pub user_id: Option<String>,
     #[serde(default)]
     pub room_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct UpdateEventReportReqBody {
+    pub status: String,
+}
+
+fn normalize_event_report_status(status: &str) -> Option<&'static str> {
+    match status.trim() {
+        "new" | "New" => Some("new"),
+        "in_review" | "In Review" | "in review" => Some("in_review"),
+        "resolved" | "Resolved" => Some("resolved"),
+        _ => None,
+    }
 }
 
 /// GET /_synapse/admin/v1/event_reports
@@ -164,6 +184,26 @@ pub fn get_event_report(report_id: PathParam<i64>) -> JsonResult<EventReportDeta
     let report_id = report_id.into_inner();
 
     let report = data::room::get_event_report(report_id)?
+        .ok_or_else(|| MatrixError::not_found(format!("Event report {} not found", report_id)))?;
+
+    json_ok(report.into())
+}
+
+/// PUT /_synapse/admin/v1/event_reports/{report_id}
+///
+/// Update the moderation status of an event report
+#[endpoint(operation_id = "update_event_report_status")]
+pub fn update_event_report_status(
+    report_id: PathParam<i64>,
+    body: JsonBody<UpdateEventReportReqBody>,
+) -> JsonResult<EventReportDetailResponse> {
+    let report_id = report_id.into_inner();
+    let body = body.into_inner();
+    let status = normalize_event_report_status(&body.status).ok_or_else(|| {
+        MatrixError::invalid_param("status must be one of: new, in_review, resolved")
+    })?;
+
+    let report = data::room::update_event_report_status(report_id, status)?
         .ok_or_else(|| MatrixError::not_found(format!("Event report {} not found", report_id)))?;
 
     json_ok(report.into())

--- a/crates/server/src/routing/admin/registration_token.rs
+++ b/crates/server/src/routing/admin/registration_token.rs
@@ -150,12 +150,13 @@ pub fn create_registration_token(
 
     // Validate uses_allowed
     if let Some(uses) = body.uses_allowed
-        && uses < 0 {
-            return Err(MatrixError::invalid_param(
-                "uses_allowed must be a non-negative integer or null",
-            )
-            .into());
-        }
+        && uses < 0
+    {
+        return Err(MatrixError::invalid_param(
+            "uses_allowed must be a non-negative integer or null",
+        )
+        .into());
+    }
 
     // Validate expiry_time
     if let Some(expiry) = body.expiry_time {
@@ -209,12 +210,13 @@ pub fn update_registration_token(
 
     // Validate uses_allowed if provided
     if let Some(Some(uses)) = body.uses_allowed
-        && uses < 0 {
-            return Err(MatrixError::invalid_param(
-                "uses_allowed must be a non-negative integer or null",
-            )
-            .into());
-        }
+        && uses < 0
+    {
+        return Err(MatrixError::invalid_param(
+            "uses_allowed must be a non-negative integer or null",
+        )
+        .into());
+    }
 
     // Validate expiry_time if provided
     if let Some(Some(expiry)) = body.expiry_time {

--- a/crates/server/src/routing/admin/room.rs
+++ b/crates/server/src/routing/admin/room.rs
@@ -491,10 +491,7 @@ pub async fn delete_room(
 
     if body.purge {
         // Purge all non-state events by using a far-future timestamp
-        let _ = crate::data::room::timeline::purge_room_history(
-            &room_id,
-            i64::MAX,
-        );
+        let _ = crate::data::room::timeline::purge_room_history(&room_id, i64::MAX);
     }
 
     json_ok(DeleteRoomResponse {

--- a/crates/server/src/routing/appservice/third_party.rs
+++ b/crates/server/src/routing/appservice/third_party.rs
@@ -43,17 +43,18 @@ async fn get_protocol(aa: AuthArgs, protocol: PathParam<String>) -> JsonResult<P
     let appservices = crate::appservices();
     for appservice in appservices {
         if let Some(protocols) = &appservice.protocols
-            && protocols.iter().any(|p| p == &protocol_name) {
-                return json_ok(ProtocolResBody {
-                    protocol: Protocol {
-                        user_fields: vec![],
-                        location_fields: vec![],
-                        icon: String::new(),
-                        field_types: Default::default(),
-                        instances: vec![],
-                    },
-                });
-            }
+            && protocols.iter().any(|p| p == &protocol_name)
+        {
+            return json_ok(ProtocolResBody {
+                protocol: Protocol {
+                    user_fields: vec![],
+                    location_fields: vec![],
+                    icon: String::new(),
+                    field_types: Default::default(),
+                    instances: vec![],
+                },
+            });
+        }
     }
 
     Err(MatrixError::not_found("Protocol not found").into())

--- a/crates/server/src/routing/client/key/device_signing.rs
+++ b/crates/server/src/routing/client/key/device_signing.rs
@@ -3,7 +3,9 @@ use salvo::prelude::*;
 use crate::core::client::key::UploadSigningKeysReqBody;
 use crate::core::client::uiaa::{AuthFlow, AuthType, UiaaInfo};
 use crate::core::serde::CanonicalJsonValue;
-use crate::{AuthArgs, DepotExt, EmptyResult, MatrixError, SESSION_ID_LENGTH, config, data, empty_ok, utils};
+use crate::{
+    AuthArgs, DepotExt, EmptyResult, MatrixError, SESSION_ID_LENGTH, config, data, empty_ok, utils,
+};
 
 /// #POST /_matrix/client/r0/keys/device_signing/upload
 /// Uploads end-to-end key information for the sender user.

--- a/crates/server/src/routing/client/media.rs
+++ b/crates/server/src/routing/client/media.rs
@@ -350,9 +350,7 @@ pub async fn get_thumbnail(
         args.height,
     ) {
         Ok(Some(DbThumbnail {
-            id,
-            content_type,
-            ..
+            id, content_type, ..
         })) => {
             let key = thumbnail_storage_key(&args.server_name, &args.media_id, id);
             // Try presigned URL redirect for S3 storage
@@ -361,7 +359,9 @@ pub async fn get_thumbnail(
                 return Ok(());
             }
             let data = storage::read(&key).await?;
-            let ct = content_type.as_deref().unwrap_or("application/octet-stream");
+            let ct = content_type
+                .as_deref()
+                .unwrap_or("application/octet-stream");
             res.add_header("Cross-Origin-Resource-Policy", "cross-origin", true)?;
             res.add_header(CONTENT_TYPE, ct, true)?;
             res.body = ResBody::Once(data.into());
@@ -392,7 +392,9 @@ pub async fn get_thumbnail(
             return Ok(());
         }
         let data = storage::read(&key).await?;
-        let ct = content_type.as_deref().unwrap_or("application/octet-stream");
+        let ct = content_type
+            .as_deref()
+            .unwrap_or("application/octet-stream");
         res.add_header(CONTENT_TYPE, ct, true)?;
         res.body = ResBody::Once(data.into());
         Ok(())

--- a/crates/server/src/routing/client/room.rs
+++ b/crates/server/src/routing/client/room.rs
@@ -128,6 +128,7 @@ pub fn authed_router() -> Router {
                     .push(
                         Router::with_path("send/{event_type}/{txn_id}").put(message::send_message),
                     )
+                    .push(Router::with_path("report/{event_id}").post(state::report))
                     .push(Router::with_path("redact/{event_id}/{txn_id}").put(event::send_redact))
                     .push(
                         Router::with_path("tags").get(tag::list_tags).push(

--- a/crates/server/src/routing/client/room/event.rs
+++ b/crates/server/src/routing/client/room/event.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use palpo_core::Direction;
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
+use serde_json::json;
 use serde_json::value::to_raw_value;
 use state::DbRoomStateField;
 
@@ -71,6 +72,7 @@ pub(super) async fn report(
 ) -> EmptyResult {
     let authed = depot.authed_info()?;
     let pdu = timeline::get_pdu(&args.event_id)?;
+    let body = body.into_inner();
 
     if let Some(true) = body.score.map(|s| !(-100..=0).contains(&s)) {
         return Err(MatrixError::invalid_param("invalid score, must be within 0 to -100").into());
@@ -82,6 +84,20 @@ pub(super) async fn report(
         )
         .into());
     };
+
+    let report_reason = body.reason.clone();
+    let report_score = body.score;
+    crate::data::room::create_event_report(crate::data::room::NewDbEventReport::new(
+        pdu.room_id.clone(),
+        pdu.event_id.clone(),
+        authed.user_id().to_owned(),
+        report_reason.clone(),
+        Some(json!({
+            "reason": report_reason,
+            "score": report_score,
+        })),
+        report_score,
+    ))?;
 
     let _ = crate::admin::send_message(RoomMessageEventContent::text_html(
         format!(

--- a/crates/server/src/routing/client/room/state.rs
+++ b/crates/server/src/routing/client/room/state.rs
@@ -1,5 +1,6 @@
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
+use serde_json::json;
 
 use crate::core::UnixMillis;
 use crate::core::client::room::ReportContentReqBody;
@@ -63,6 +64,7 @@ pub async fn report(
     depot: &mut Depot,
 ) -> EmptyResult {
     let authed = depot.authed_info()?;
+    let body = body.into_inner();
 
     let pdu = match timeline::get_pdu(&args.event_id) {
         Ok(pdu) => pdu,
@@ -79,6 +81,20 @@ pub async fn report(
         )
         .into());
     };
+
+    let report_reason = body.reason.clone();
+    let report_score = body.score;
+    crate::data::room::create_event_report(crate::data::room::NewDbEventReport::new(
+        pdu.room_id.clone(),
+        pdu.event_id.clone(),
+        authed.user_id().to_owned(),
+        report_reason.clone(),
+        Some(json!({
+            "reason": report_reason,
+            "score": report_score,
+        })),
+        report_score,
+    ))?;
 
     let _ = crate::admin::send_message(RoomMessageEventContent::text_html(
         format!(

--- a/crates/server/src/routing/client/session.rs
+++ b/crates/server/src/routing/client/session.rs
@@ -383,9 +383,10 @@ async fn logout(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) -> EmptyRes
             .get("authorization")
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.strip_prefix("Bearer "))
-            && let Err(e) = revoke_delegated_token(da, token).await {
-                tracing::warn!("Failed to revoke delegated auth token: {e}");
-            }
+        && let Err(e) = revoke_delegated_token(da, token).await
+    {
+        tracing::warn!("Failed to revoke delegated auth token: {e}");
+    }
 
     data::user::device::remove_device(authed.user_id(), authed.device_id())?;
     empty_ok()
@@ -412,18 +413,12 @@ async fn revoke_delegated_token(
     let response = client
         .post(&revocation_url)
         .bearer_auth(mas_secret)
-        .form(&[
-            ("token", access_token),
-            ("token_type_hint", "access_token"),
-        ])
+        .form(&[("token", access_token), ("token_type_hint", "access_token")])
         .send()
         .await?;
 
     if !response.status().is_success() {
-        tracing::warn!(
-            "Token revocation returned status: {}",
-            response.status()
-        );
+        tracing::warn!("Token revocation returned status: {}", response.status());
     }
 
     Ok(())

--- a/crates/server/src/routing/federation/backfill.rs
+++ b/crates/server/src/routing/federation/backfill.rs
@@ -51,13 +51,13 @@ async fn get_backfill(
         prev_ids.retain(|p| !events.contains_key(p));
         if !events.contains_key(&event_id)
             && let Ok((pdu, data)) = timeline::get_pdu_and_data(&event_id)
-                && state::server_can_see_event(origin, &args.room_id, &pdu.event_id)?
-            {
-                events.insert(
-                    event_id.clone(),
-                    crate::sending::convert_to_outgoing_federation_event(data),
-                );
-            }
+            && state::server_can_see_event(origin, &args.room_id, &pdu.event_id)?
+        {
+            events.insert(
+                event_id.clone(),
+                crate::sending::convert_to_outgoing_federation_event(data),
+            );
+        }
         let prevs = events::table
             .filter(events::id.eq_any(&prev_ids))
             .select((events::id, events::depth))

--- a/crates/server/src/routing/federation/event.rs
+++ b/crates/server/src/routing/federation/event.rs
@@ -83,10 +83,8 @@ fn auth_chain(
         None => DbEvent::get_by_id(&args.event_id)?.room_id,
     };
 
-    let auth_chain_ids = crate::room::auth_chain::get_auth_chain_ids(
-        &room_id_owned,
-        [&*args.event_id].into_iter(),
-    )?;
+    let auth_chain_ids =
+        crate::room::auth_chain::get_auth_chain_ids(&room_id_owned, [&*args.event_id].into_iter())?;
 
     json_ok(EventAuthResBody {
         auth_chain: auth_chain_ids
@@ -138,15 +136,16 @@ fn missing_events(
             // For v12 rooms, the event JSON does not contain `room_id` (it is
             // derived from the create event id). Look it up from the events
             // table instead and only use the JSON room_id if present.
-            let event_room_id_owned: OwnedRoomId = match pdu.get("room_id").and_then(|val| val.as_str()) {
-                Some(s) => s.try_into().map_err(|_| {
-                    AppError::internal("invalid room id field in event in database")
-                })?,
-                None => {
-                    let db_event = DbEvent::get_by_id(&event_id)?;
-                    db_event.room_id
-                }
-            };
+            let event_room_id_owned: OwnedRoomId =
+                match pdu.get("room_id").and_then(|val| val.as_str()) {
+                    Some(s) => s.try_into().map_err(|_| {
+                        AppError::internal("invalid room id field in event in database")
+                    })?,
+                    None => {
+                        let db_event = DbEvent::get_by_id(&event_id)?;
+                        db_event.room_id
+                    }
+                };
 
             if *event_room_id_owned != *room_id {
                 warn!(

--- a/crates/server/src/routing/federation/key.rs
+++ b/crates/server/src/routing/federation/key.rs
@@ -10,8 +10,8 @@ use crate::core::federation::directory::{
     RemoteServerKeysResBody, ServerKeysResBody,
 };
 use crate::core::federation::discovery::{ServerSigningKeys, VerifyKey};
-use crate::core::signatures::Ed25519KeyPair;
 use crate::core::serde::{Base64, CanonicalJsonObject};
+use crate::core::signatures::Ed25519KeyPair;
 use crate::core::{OwnedServerName, OwnedServerSigningKeyId, ServerName, UnixMillis};
 use crate::{AppResult, AuthArgs, JsonResult, config, json_ok};
 
@@ -19,14 +19,12 @@ pub fn router() -> Router {
     Router::with_path("key").oapi_tag("federation").push(
         Router::with_path("v2")
             .push(
-                Router::with_path("query")
-                    .post(query_keys_batch)
-                    .push(
-                        Router::with_path("{server_name}")
+                Router::with_path("query").post(query_keys_batch).push(
+                    Router::with_path("{server_name}")
                             .get(query_keys_from_server)
                             // Deprecated: /_matrix/key/v2/query/{serverName}/{keyId}
                             .push(Router::with_path("{key_id}").get(query_keys_from_server)),
-                    ),
+                ),
             )
             .push(
                 Router::with_path("server")
@@ -45,9 +43,10 @@ async fn fetch_signing_keys(
 ) -> Option<ServerSigningKeys> {
     // Try local cache first
     if let Ok(cached) = crate::server_key::signing_keys_for(server)
-        && cached.valid_until_ts >= minimum_valid_until_ts {
-            return Some(cached);
-        }
+        && cached.valid_until_ts >= minimum_valid_until_ts
+    {
+        return Some(cached);
+    }
 
     // Cache miss or expired — fetch from origin server
     match crate::server_key::server_request(server).await {
@@ -211,7 +210,9 @@ mod tests {
 
         let signed = sign_server_keys_for_notary(&notary, &notary_keypair, server_keys).unwrap();
         let notary_key_id: OwnedServerSigningKeyId =
-            format!("ed25519:{}", notary_keypair.version()).try_into().unwrap();
+            format!("ed25519:{}", notary_keypair.version())
+                .try_into()
+                .unwrap();
 
         assert!(signed.signatures.contains_key(&origin));
         assert!(signed.signatures.contains_key(&notary));

--- a/crates/server/src/routing/federation/media.rs
+++ b/crates/server/src/routing/federation/media.rs
@@ -75,7 +75,9 @@ pub async fn get_thumbnail(
     res: &mut Response,
 ) -> AppResult<()> {
     let server_name = &config::get().server_name;
-    if let Some(DbThumbnail { id, content_type, .. }) = crate::data::media::get_thumbnail_by_dimension(
+    if let Some(DbThumbnail {
+        id, content_type, ..
+    }) = crate::data::media::get_thumbnail_by_dimension(
         server_name,
         &args.media_id,
         args.width,
@@ -113,7 +115,9 @@ pub async fn get_thumbnail(
     let (width, height, crop) =
         crate::media::thumbnail_properties(args.width, args.height).unwrap_or((0, 0, false)); // 0, 0 because that's the original file
 
-    if let Some(DbThumbnail { id, content_type, .. }) =
+    if let Some(DbThumbnail {
+        id, content_type, ..
+    }) =
         crate::data::media::get_thumbnail_by_dimension(server_name, &args.media_id, width, height)?
     {
         // Using saved thumbnail
@@ -232,10 +236,8 @@ pub async fn get_thumbnail(
                 .execute(&mut connect()?)?;
 
             // Save to storage backend
-            let thumb_key = media_storage_key(
-                server_name,
-                &format!("{}.{width}x{height}", &args.media_id),
-            );
+            let thumb_key =
+                media_storage_key(server_name, &format!("{}.{width}x{height}", &args.media_id));
             storage::write(&thumb_key, &thumbnail_bytes).await?;
 
             let content_disposition = make_content_disposition(

--- a/crates/server/src/sending.rs
+++ b/crates/server/src/sending.rs
@@ -565,7 +565,10 @@ pub async fn send_federation_request(
     request: reqwest::Request,
     timeout_secs: Option<u64>,
 ) -> AppResult<reqwest::Response> {
-    if !crate::config::get().federation.is_server_allowed(destination) {
+    if !crate::config::get()
+        .federation
+        .is_server_allowed(destination)
+    {
         return Err(AppError::public(format!(
             "Federation with server {destination} is not allowed by policy"
         )));
@@ -921,9 +924,10 @@ fn reqwest_client_builder(config: &ServerConfig) -> AppResult<reqwest::ClientBui
     }
 
     if let Some(ref proxy_config) = config.proxy
-        && let Some(proxy) = proxy_config.to_proxy()? {
-            reqwest_client_builder = reqwest_client_builder.proxy(proxy);
-        }
+        && let Some(proxy) = proxy_config.to_proxy()?
+    {
+        reqwest_client_builder = reqwest_client_builder.proxy(proxy);
+    }
 
     Ok(reqwest_client_builder)
 }

--- a/crates/server/src/server_key.rs
+++ b/crates/server/src/server_key.rs
@@ -324,10 +324,9 @@ mod tests {
         let old_notary = OwnedServerName::try_from("old-notary.example").unwrap();
         let new_notary = OwnedServerName::try_from("new-notary.example").unwrap();
         let mut existing = ServerSigningKeys::new(server_name.clone(), UnixMillis(100));
-        existing.verify_keys.insert(
-            old_key_id.clone(),
-            VerifyKey::from_bytes(vec![1, 2, 3]),
-        );
+        existing
+            .verify_keys
+            .insert(old_key_id.clone(), VerifyKey::from_bytes(vec![1, 2, 3]));
         existing.signatures = signatures("old-notary.example", "ed25519:old", "old-signature");
 
         let mut new_keys = ServerSigningKeys::new(server_name.clone(), UnixMillis(200));
@@ -363,7 +362,11 @@ mod tests {
         let merged = merge_signing_keys_for_storage(Some(existing), new_keys);
 
         let notary_sigs = &merged.signatures[&OwnedServerName::try_from(notary).unwrap()];
-        assert_eq!(notary_sigs.len(), 2, "both key IDs from the same server must be retained");
+        assert_eq!(
+            notary_sigs.len(),
+            2,
+            "both key IDs from the same server must be retained"
+        );
         let key1: OwnedServerSigningKeyId = "ed25519:key1".try_into().unwrap();
         let key2: OwnedServerSigningKeyId = "ed25519:key2".try_into().unwrap();
         assert_eq!(notary_sigs[&key1], "sig-a");

--- a/crates/server/src/server_key/acquire.rs
+++ b/crates/server/src/server_key/acquire.rs
@@ -6,9 +6,7 @@ use futures_util::StreamExt;
 use futures_util::stream::FuturesUnordered;
 use tokio::time::{Instant, timeout_at};
 
-use super::{
-    add_signing_keys, batch_notary_request, key_exists, server_request, verify_keys_for,
-};
+use super::{add_signing_keys, batch_notary_request, key_exists, server_request, verify_keys_for};
 use crate::config;
 use crate::core::federation::discovery::ServerSigningKeys;
 use crate::core::serde::{CanonicalJsonObject, RawJson, RawJsonValue};
@@ -238,16 +236,15 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::missing_local_key_ids;
+    use crate::core::OwnedServerSigningKeyId;
     use crate::core::federation::discovery::VerifyKey;
     use crate::core::serde::Base64;
-    use crate::core::OwnedServerSigningKeyId;
 
     #[test]
     fn acquire_locals_treats_our_configured_signing_key_as_available() {
-        let local_key_id: OwnedServerSigningKeyId =
-            "ed25519:local"
-                .try_into()
-                .expect("configured key id should be valid");
+        let local_key_id: OwnedServerSigningKeyId = "ed25519:local"
+            .try_into()
+            .expect("configured key id should be valid");
         let available_keys = BTreeMap::from([(
             local_key_id.clone(),
             VerifyKey {
@@ -255,10 +252,8 @@ mod tests {
             },
         )]);
 
-        let missing = missing_local_key_ids(
-            &available_keys,
-            std::iter::once(local_key_id.as_ref()),
-        );
+        let missing =
+            missing_local_key_ids(&available_keys, std::iter::once(local_key_id.as_ref()));
 
         assert!(
             missing.is_empty(),

--- a/crates/server/src/storage.rs
+++ b/crates/server/src/storage.rs
@@ -1,7 +1,8 @@
 use std::sync::OnceLock;
 use std::time::Duration;
 
-use opendal::{Operator, layers::LoggingLayer};
+use opendal::Operator;
+use opendal::layers::LoggingLayer;
 
 use crate::AppResult;
 use crate::config::StorageConfig;
@@ -47,10 +48,7 @@ pub fn operator() -> &'static Operator {
 
 /// Whether redirect mode is enabled (S3 with presigned URLs).
 pub fn is_redirect_enabled() -> bool {
-    REDIRECT_CONFIG
-        .get()
-        .map(|c| c.is_some())
-        .unwrap_or(false)
+    REDIRECT_CONFIG.get().map(|c| c.is_some()).unwrap_or(false)
 }
 
 /// Generate a presigned URL for reading the given key.
@@ -59,9 +57,7 @@ pub async fn presign_read(key: &str) -> AppResult<Option<String>> {
     let Some(Some(config)) = REDIRECT_CONFIG.get() else {
         return Ok(None);
     };
-    let presigned = operator()
-        .presign_read(key, config.presign_expiry)
-        .await?;
+    let presigned = operator().presign_read(key, config.presign_expiry).await?;
     Ok(Some(presigned.uri().to_string()))
 }
 

--- a/crates/server/src/sync_v5.rs
+++ b/crates/server/src/sync_v5.rs
@@ -240,9 +240,9 @@ fn maybe_cleanup_connections() {
         && LAST_CLEANUP
             .compare_exchange(last, now, AtomicOrdering::Relaxed, AtomicOrdering::Relaxed)
             .is_ok()
-        {
-            cleanup_expired_connections();
-        }
+    {
+        cleanup_expired_connections();
+    }
 }
 
 #[tracing::instrument(skip_all)]
@@ -363,9 +363,10 @@ async fn process_lists(
 
         // Apply not_room_types filter
         if let Some(filter) = list.filters.as_ref().map(|f| &f.not_room_types)
-            && !filter.is_empty() {
-                active_rooms = filter_rooms(&active_rooms, filter, true);
-            }
+            && !filter.is_empty()
+        {
+            active_rooms = filter_rooms(&active_rooms, filter, true);
+        }
 
         // Apply room_types filter
         if let Some(filter) = list.filters.as_ref().and_then(|f| {
@@ -701,13 +702,36 @@ async fn process_rooms(
                             &StateEventType::RoomMember,
                             sender.as_str(),
                             None,
-                        )
-                            && !is_required_state_send(
+                        ) && !is_required_state_send(
+                            sender_id.to_owned(),
+                            device_id.to_owned(),
+                            req_body.conn_id.clone(),
+                            pdu.event_sn,
+                        ) {
+                            mark_required_state_sent(
                                 sender_id.to_owned(),
                                 device_id.to_owned(),
                                 req_body.conn_id.clone(),
                                 pdu.event_sn,
-                            ) {
+                            );
+                            required_state_events.push(pdu.to_sync_state_event());
+                        }
+                    }
+                }
+                // * state key: return all state events of this type
+                (ref event_type, "*") => {
+                    if let Ok(frame_id) = room::get_frame_id(room_id, None)
+                        && let Ok(full_state) = state::get_full_state(frame_id)
+                    {
+                        for ((ty, _sk), pdu) in &full_state {
+                            if ty == event_type
+                                && !is_required_state_send(
+                                    sender_id.to_owned(),
+                                    device_id.to_owned(),
+                                    req_body.conn_id.clone(),
+                                    pdu.event_sn,
+                                )
+                            {
                                 mark_required_state_sent(
                                     sender_id.to_owned(),
                                     device_id.to_owned(),
@@ -716,31 +740,8 @@ async fn process_rooms(
                                 );
                                 required_state_events.push(pdu.to_sync_state_event());
                             }
-                    }
-                }
-                // * state key: return all state events of this type
-                (ref event_type, "*") => {
-                    if let Ok(frame_id) = room::get_frame_id(room_id, None)
-                        && let Ok(full_state) = state::get_full_state(frame_id) {
-                            for ((ty, _sk), pdu) in &full_state {
-                                if ty == event_type
-                                    && !is_required_state_send(
-                                        sender_id.to_owned(),
-                                        device_id.to_owned(),
-                                        req_body.conn_id.clone(),
-                                        pdu.event_sn,
-                                    )
-                                {
-                                    mark_required_state_sent(
-                                        sender_id.to_owned(),
-                                        device_id.to_owned(),
-                                        req_body.conn_id.clone(),
-                                        pdu.event_sn,
-                                    );
-                                    required_state_events.push(pdu.to_sync_state_event());
-                                }
-                            }
                         }
+                    }
                 }
                 // $ME: substitute with the requester's user_id
                 (ref event_type, "$ME") => {
@@ -750,15 +751,16 @@ async fn process_rooms(
                             device_id.to_owned(),
                             req_body.conn_id.clone(),
                             pdu.event_sn,
-                        ) {
-                            mark_required_state_sent(
-                                sender_id.to_owned(),
-                                device_id.to_owned(),
-                                req_body.conn_id.clone(),
-                                pdu.event_sn,
-                            );
-                            required_state_events.push(pdu.to_sync_state_event());
-                        }
+                        )
+                    {
+                        mark_required_state_sent(
+                            sender_id.to_owned(),
+                            device_id.to_owned(),
+                            req_body.conn_id.clone(),
+                            pdu.event_sn,
+                        );
+                        required_state_events.push(pdu.to_sync_state_event());
+                    }
                 }
                 // Specific state key
                 (ref event_type, state_key) => {
@@ -768,15 +770,16 @@ async fn process_rooms(
                             device_id.to_owned(),
                             req_body.conn_id.clone(),
                             pdu.event_sn,
-                        ) {
-                            mark_required_state_sent(
-                                sender_id.to_owned(),
-                                device_id.to_owned(),
-                                req_body.conn_id.clone(),
-                                pdu.event_sn,
-                            );
-                            required_state_events.push(pdu.to_sync_state_event());
-                        }
+                        )
+                    {
+                        mark_required_state_sent(
+                            sender_id.to_owned(),
+                            device_id.to_owned(),
+                            req_body.conn_id.clone(),
+                            pdu.event_sn,
+                        );
+                        required_state_events.push(pdu.to_sync_state_event());
+                    }
                 }
             }
         }
@@ -1122,9 +1125,11 @@ where
     for room_id in rooms {
         // Filter by rooms config if specified
         if let Some(room_filter) = typing_rooms
-            && !room_filter.is_empty() && !room_filter.contains(&room_id.to_owned()) {
-                continue;
-            }
+            && !room_filter.is_empty()
+            && !room_filter.contains(&room_id.to_owned())
+        {
+            continue;
+        }
 
         let typing_event = room::typing::all_typings(room_id).await?;
         if !typing_event.content.user_ids.is_empty() {

--- a/crates/server/src/user/session.rs
+++ b/crates/server/src/user/session.rs
@@ -13,7 +13,9 @@ pub struct JwtClaims {
 
 pub fn validate_jwt_token(config: &JwtConfig, token: &str) -> AppResult<JwtClaims> {
     if !config.validate_signature {
-        warn!("JWT signature validation is disabled! This is insecure and should not be used in production.");
+        warn!(
+            "JWT signature validation is disabled! This is insecure and should not be used in production."
+        );
     }
 
     let verifier = init_jwt_verifier(config)?;
@@ -119,9 +121,6 @@ mod tests {
 
         let result = validate_jwt_token(&config, &token);
 
-        assert!(
-            result.is_err(),
-            "expired token must be rejected"
-        );
+        assert!(result.is_err(), "expired token must be rejected");
     }
 }


### PR DESCRIPTION
## Summary
- add persisted `status` support for `event_reports`, including a migration, default value, and index
- add an admin `PUT /_synapse/admin/v1/event_reports/{report_id}` endpoint to update moderation status and return the updated report
- surface event report status in data models and API responses, and add remote-home-page source classification coverage
- keep related routing and readability cleanups that support the new flow

## Why
Event reports previously had no persisted moderation state, which made follow-up handling awkward. The home page configuration path also needed explicit handling to distinguish remote `https://` content from local file paths.

## Impact
Admins can now mark event reports as they move through moderation, and deployments can configure a remote home page source with clearer behavior.

## Validation
- `cargo test home_page_classifies -- --nocapture`