### PR TITLE
Fallback to default home page when remote home page is missing

### DIFF
--- a/crates/server/src/config/server.rs
+++ b/crates/server/src/config/server.rs
@@ -93,7 +93,8 @@ pub struct ServerConfig {
     /// Optional homepage content source for `GET /`.
     ///
     /// If this is a local path, palpo serves that file directly.
-    /// If this starts with `https://`, palpo fetches the remote HTML at request time.
+    /// If this starts with `http://` or `https://`, palpo fetches the remote HTML
+    /// at request time.
     /// When the remote fetch fails, palpo logs a warning and falls back to the built-in default
     /// page.
     pub home_page: Option<String>,

--- a/crates/server/src/routing.rs
+++ b/crates/server/src/routing.rs
@@ -16,6 +16,9 @@ use crate::core::client::discovery::support::{Contact, SupportResBody};
 use crate::core::federation::directory::ServerResBody;
 use crate::{AppResult, JsonResult, config, hoops, json_ok, sending};
 
+const DEFAULT_HOME_PAGE_CONTENT_TYPE: &str = "text/html; charset=utf-8";
+const DEFAULT_HOME_PAGE_BODY: &str = "Palpo works";
+
 pub mod prelude {
     pub use salvo::prelude::*;
 
@@ -77,12 +80,7 @@ async fn home(req: &mut Request, res: &mut Response) {
         }
     }
 
-    res.status_code(StatusCode::OK);
-    res.headers_mut().insert(
-        CONTENT_TYPE,
-        HeaderValue::from_static("text/html; charset=utf-8"),
-    );
-    let _ = res.write_body("Hello Palpo");
+    render_default_home_page(res);
 }
 
 enum HomePageSource<'a> {
@@ -92,12 +90,25 @@ enum HomePageSource<'a> {
 
 impl<'a> HomePageSource<'a> {
     fn from_config(value: &'a str) -> Self {
-        if value.starts_with("https://") {
+        if is_remote_home_page_url(value) {
             Self::Remote(value)
         } else {
             Self::Local(value)
         }
     }
+}
+
+fn is_remote_home_page_url(value: &str) -> bool {
+    value.starts_with("http://") || value.starts_with("https://")
+}
+
+fn render_default_home_page(res: &mut Response) {
+    res.status_code(StatusCode::OK);
+    res.headers_mut().insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static(DEFAULT_HOME_PAGE_CONTENT_TYPE),
+    );
+    let _ = res.write_body(DEFAULT_HOME_PAGE_BODY);
 }
 
 async fn fetch_remote_home_page(url: &str) -> Option<(Bytes, String)> {
@@ -224,12 +235,20 @@ fn well_known_support() -> JsonResult<SupportResBody> {
 
 #[cfg(test)]
 mod tests {
-    use super::HomePageSource;
+    use super::{DEFAULT_HOME_PAGE_BODY, HomePageSource};
 
     #[test]
     fn home_page_classifies_https_urls_as_remote() {
         assert!(matches!(
             HomePageSource::from_config("https://example.com/index.html"),
+            HomePageSource::Remote(_)
+        ));
+    }
+
+    #[test]
+    fn home_page_classifies_http_urls_as_remote() {
+        assert!(matches!(
+            HomePageSource::from_config("http://example.com/index.html"),
             HomePageSource::Remote(_)
         ));
     }
@@ -244,6 +263,11 @@ mod tests {
             HomePageSource::from_config("/data/workspace/index.html"),
             HomePageSource::Local(_)
         ));
+    }
+
+    #[test]
+    fn default_home_page_matches_expected_text() {
+        assert_eq!(DEFAULT_HOME_PAGE_BODY, "Palpo works");
     }
 }
 


### PR DESCRIPTION
## What changed
- classify both `http://` and `https://` `home_page` values as remote sources
- fall back to the built-in home page content instead of surfacing a 404 when the remote home page cannot be fetched
- unify the built-in fallback text as `Palpo works`
- add routing tests covering remote URL classification and the fallback text constant

## Why
When `home_page` was configured with a remote URL that did not exist, the home page could still return a 404 instead of the built-in fallback. The root cause was that only `https://` values were treated as remote; `http://` values were interpreted as local file paths and went through the file-serving path.

## Impact
Users now see the default `Palpo works` home page when a configured remote home page is missing or unreachable, instead of a 404 response from the local file path handling.

## Validation
- `cargo test -p palpo routing::tests -- --nocapture`
