### PR TITLE
[codex] Fix guest flag handling for real users

### DIFF
--- a/crates/data/src/user.rs
+++ b/crates/data/src/user.rs
@@ -305,6 +305,21 @@ pub fn is_deactivated(user_id: &UserId) -> DataResult<bool> {
     Ok(deactivated_at.is_some())
 }
 
+pub fn is_guest(user_id: &UserId) -> DataResult<bool> {
+    users::table
+        .filter(users::id.eq(user_id))
+        .select(users::is_guest)
+        .first::<bool>(&mut connect()?)
+        .map_err(Into::into)
+}
+
+pub fn set_guest(user_id: &UserId, is_guest: bool) -> DataResult<()> {
+    diesel::update(users::table.find(user_id))
+        .set(users::is_guest.eq(is_guest))
+        .execute(&mut connect()?)?;
+    Ok(())
+}
+
 pub fn all_device_ids(user_id: &UserId) -> DataResult<Vec<OwnedDeviceId>> {
     user_devices::table
         .filter(user_devices::user_id.eq(user_id))

--- a/crates/server/src/hoops/auth.rs
+++ b/crates/server/src/hoops/auth.rs
@@ -159,10 +159,14 @@ async fn auth_by_delegated_token(token: &str, aa: &AuthArgs, depot: &mut Depot) 
         .map_err(|_| MatrixError::unknown_token("Invalid username in token", true))?;
 
     // User should already be provisioned by the auth service via MAS admin endpoints
-    let user = users::table
+    let mut user = users::table
         .find(&user_id)
         .first::<DbUser>(&mut connect()?)
         .map_err(|_| MatrixError::unknown_token("User not found (not yet provisioned?)", true))?;
+    if user.is_guest {
+        crate::data::user::set_guest(&user_id, false)?;
+        user.is_guest = false;
+    }
 
     // Extract device_id from introspection response, scope, or query param
     let device_id_str = result

--- a/crates/server/src/routing/admin/mas.rs
+++ b/crates/server/src/routing/admin/mas.rs
@@ -151,6 +151,8 @@ pub async fn provision_user(
     if !exists {
         user::create_user(user_id.clone(), None)?;
         res.status_code(salvo::http::StatusCode::CREATED);
+    } else {
+        data::user::set_guest(&user_id, false)?;
     }
     if let Some(displayname) = &body.set_displayname {
         data::user::set_display_name(&user_id, displayname)?;

--- a/crates/server/src/routing/client/account.rs
+++ b/crates/server/src/routing/client/account.rs
@@ -85,7 +85,7 @@ async fn whoami(_aa: AuthArgs, depot: &mut Depot) -> JsonResult<WhoamiResBody> {
     json_ok(WhoamiResBody {
         user_id: authed.user_id().to_owned(),
         device_id: Some(authed.device_id().to_owned()),
-        is_guest: false,
+        is_guest: authed.user.is_guest,
     })
 }
 

--- a/crates/server/src/routing/client/oidc.rs
+++ b/crates/server/src/routing/client/oidc.rs
@@ -1109,8 +1109,12 @@ async fn create_or_get_user(
     let exist_user = users::table
         .filter(users::id.eq(&parsed_user_id))
         .first::<DbUser>(&mut connect()?);
-    if let Ok(exist_user) = exist_user {
+    if let Ok(mut exist_user) = exist_user {
         tracing::debug!("Found existing user account: {}", user_id);
+        if exist_user.is_guest {
+            data::user::set_guest(&exist_user.id, false)?;
+            exist_user.is_guest = false;
+        }
 
         // Note: We intentionally do NOT update the profile for existing users
         // to preserve any changes the user made in Matrix (like custom display names).

--- a/crates/server/src/routing/client/register.rs
+++ b/crates/server/src/routing/client/register.rs
@@ -152,14 +152,12 @@ async fn register(
         }
     }
 
-    let password = if is_guest {
-        None
-    } else {
-        body.password.as_deref()
-    };
-
     // Create user
-    let db_user = crate::user::create_user(user_id.clone(), password)?;
+    let db_user = if is_guest {
+        crate::user::create_guest_user(user_id.clone())?
+    } else {
+        crate::user::create_user(user_id.clone(), body.password.as_deref())?
+    };
 
     // Presence update
     crate::data::user::set_presence(

--- a/crates/server/src/routing/client/room/summary.rs
+++ b/crates/server/src/routing/client/room/summary.rs
@@ -206,7 +206,7 @@ where
     match sender_id {
         Some(sender_id) => {
             let user_can_see_events = state::user_can_see_events(sender_id, room_id)?;
-            let is_guest = data::user::is_deactivated(sender_id).unwrap_or(false);
+            let is_guest = data::user::is_guest(sender_id).unwrap_or(false);
             let user_in_allowed_restricted_room = allowed_room_ids
                 .any(|room| room::user::is_joined(sender_id, room).unwrap_or(false));
 

--- a/crates/server/src/user.rs
+++ b/crates/server/src/user.rs
@@ -35,12 +35,24 @@ pub fn is_username_available(username: &str) -> AppResult<bool> {
 }
 
 pub fn create_user(user_id: impl Into<OwnedUserId>, password: Option<&str>) -> AppResult<DbUser> {
+    create_user_inner(user_id, password, false)
+}
+
+pub fn create_guest_user(user_id: impl Into<OwnedUserId>) -> AppResult<DbUser> {
+    create_user_inner(user_id, None, true)
+}
+
+fn create_user_inner(
+    user_id: impl Into<OwnedUserId>,
+    password: Option<&str>,
+    is_guest: bool,
+) -> AppResult<DbUser> {
     let user_id = user_id.into();
     let new_user = NewDbUser {
         id: user_id.clone(),
         ty: None,
         is_admin: false,
-        is_guest: password.is_none(),
+        is_guest,
         is_local: user_id.is_local(),
         localpart: user_id.localpart().to_owned(),
         server_name: user_id.server_name().to_owned(),

--- a/crates/server/src/user/password.rs
+++ b/crates/server/src/user/password.rs
@@ -46,5 +46,8 @@ pub fn set_password(user_id: &UserId, password: &str) -> AppResult<()> {
             created_at: UnixMillis::now(),
         })
         .execute(&mut connect()?)?;
+    diesel::update(users::table.find(user_id))
+        .set(users::is_guest.eq(false))
+        .execute(&mut connect()?)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes real authenticated users being treated as Matrix guests when they were created without a local Matrix password, such as MAS, delegated-auth, or OIDC-provisioned users.

## Root Cause

`create_user(user_id, None)` used the absence of a local password to set `is_guest = true`. That path is also used for real passwordless/auth-provider users, so joins to invited rooms could fail with `guests are not allowed to join this room`.

## Changes

- Split regular user creation from explicit guest user creation.
- Ensure MAS, delegated-auth, and OIDC flows repair previously misclassified real users by clearing `is_guest`.
- Clear the guest flag when setting a password.
- Return the actual `is_guest` value from `whoami`.
- Fix room summary guest-access logic to check `is_guest` instead of `is_deactivated`.

## Validation

- `cargo check -p palpo`
- `git diff --check`