### PR TITLE
add policy server discovery endpoint

### DIFF
--- a/crates/core/src/client/discovery.rs
+++ b/crates/core/src/client/discovery.rs
@@ -3,5 +3,6 @@ pub mod auth_metadata;
 pub mod capabilities;
 pub mod client;
 pub mod homeserver;
+pub mod policy_server;
 pub mod support;
 pub mod versions;

--- a/crates/core/src/client/discovery/policy_server.rs
+++ b/crates/core/src/client/discovery/policy_server.rs
@@ -1,0 +1,79 @@
+//! `GET /.well-known/matrix/policy_server`
+//!
+//! Discovery information for a policy server.
+
+use std::collections::BTreeMap;
+
+use salvo::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::SigningKeyAlgorithm;
+use crate::serde::Base64;
+
+/// Request type for the `policy_server` endpoint.
+#[derive(ToSchema, Clone, Debug, Default, Deserialize, Serialize)]
+pub struct PolicyServerReqBody {}
+
+impl PolicyServerReqBody {
+    /// Creates an empty `PolicyServerReqBody`.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+/// Response type for the `policy_server` endpoint.
+#[derive(ToSchema, Clone, Debug, Deserialize, Serialize)]
+pub struct PolicyServerResBody {
+    /// Public signing keys for the policy server.
+    ///
+    /// The response must contain at least one `ed25519` key.
+    pub public_keys: BTreeMap<SigningKeyAlgorithm, Base64>,
+}
+
+impl PolicyServerResBody {
+    /// Creates a new `PolicyServerResBody` with the given Ed25519 public key.
+    pub fn new(ed25519_public_key: Base64) -> Self {
+        Self {
+            public_keys: [(SigningKeyAlgorithm::Ed25519, ed25519_public_key)].into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+    use super::PolicyServerResBody;
+    use crate::SigningKeyAlgorithm;
+    use crate::serde::Base64;
+
+    #[test]
+    fn policy_server_response_serializes_ed25519_key() {
+        let response = PolicyServerResBody::new(Base64::new(vec![1, 2, 3]));
+
+        assert_eq!(
+            to_json_value(&response).unwrap(),
+            json!({
+                "public_keys": {
+                    "ed25519": "AQID"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn policy_server_response_deserializes_ed25519_key() {
+        let response: PolicyServerResBody = from_json_value(json!({
+            "public_keys": {
+                "ed25519": "AQID"
+            }
+        }))
+        .unwrap();
+
+        let ed25519_key = response
+            .public_keys
+            .get(&SigningKeyAlgorithm::Ed25519)
+            .expect("ed25519 key is present");
+        assert_eq!(ed25519_key.as_bytes(), &[1, 2, 3]);
+    }
+}

--- a/crates/server/src/routing.rs
+++ b/crates/server/src/routing.rs
@@ -12,8 +12,10 @@ use salvo::serve_static::StaticDir;
 
 use crate::core::MatrixError;
 use crate::core::client::discovery::client::{AuthenticationInfo, ClientResBody, HomeServerInfo};
+use crate::core::client::discovery::policy_server::PolicyServerResBody;
 use crate::core::client::discovery::support::{Contact, SupportResBody};
 use crate::core::federation::directory::ServerResBody;
+use crate::core::serde::Base64;
 use crate::{AppResult, JsonResult, config, hoops, json_ok, sending};
 
 const DEFAULT_HOME_PAGE_CONTENT_TYPE: &str = "text/html; charset=utf-8";
@@ -52,6 +54,7 @@ pub fn root() -> Router {
         .push(
             Router::with_path(".well-known/matrix")
                 .push(Router::with_path("client").get(well_known_client))
+                .push(Router::with_path("policy_server").get(well_known_policy_server))
                 .push(Router::with_path("support").get(well_known_support))
                 .push(Router::with_path("server").get(well_known_server)),
         )
@@ -245,6 +248,13 @@ fn well_known_support() -> JsonResult<SupportResBody> {
         contacts,
         support_page,
     })
+}
+
+#[endpoint]
+fn well_known_policy_server() -> JsonResult<PolicyServerResBody> {
+    json_ok(PolicyServerResBody::new(Base64::new(
+        config::keypair().public_key().to_vec(),
+    )))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This pull request introduces support for a new `.well-known` endpoint to advertise policy server information, specifically its public signing keys. The main changes include implementing the data structures and endpoint handler for `/.well-known/matrix/policy_server`, integrating it into the server routing, and adding comprehensive tests for serialization and deserialization.

**New Policy Server Discovery Endpoint:**

* Added a new module `policy_server` with request/response types for the `/.well-known/matrix/policy_server` endpoint, including serialization, deserialization, and tests for public key handling.
* Integrated the new `policy_server` module into the client discovery module by updating the module imports.

**Server Routing and Handler Integration:**

* Registered the `well_known_policy_server` handler under the `.well-known/matrix/policy_server` path in the server routing configuration.
* Implemented the `well_known_policy_server` endpoint handler to return the server's Ed25519 public key in the expected response format.
* Updated imports in the server routing module to support the new endpoint and response types.