### PR TITLE
add policy event signing endpoint

### DIFF
--- a/crates/core/src/federation.rs
+++ b/crates/core/src/federation.rs
@@ -19,6 +19,7 @@ pub mod knock;
 pub mod media;
 pub mod membership;
 pub mod openid;
+pub mod policy;
 pub mod query;
 pub mod room;
 pub mod space;

--- a/crates/core/src/federation/policy.rs
+++ b/crates/core/src/federation/policy.rs
@@ -1,0 +1,5 @@
+//! [Policy Servers] endpoints.
+//!
+//! [Policy Servers]: https://spec.matrix.org/latest/server-server-api/#policy-servers
+
+pub mod sign_event;

--- a/crates/core/src/federation/policy/sign_event.rs
+++ b/crates/core/src/federation/policy/sign_event.rs
@@ -1,0 +1,122 @@
+//! `POST /_matrix/policy/v1/sign`
+//!
+//! Ask the Policy Server to sign an event.
+
+use salvo::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::serde::RawJsonValue;
+use crate::{
+    OwnedServerName, OwnedServerSigningKeyId, ServerName, ServerSignatures, ServerSigningKeyId,
+};
+
+/// Request body for the `sign_event` endpoint.
+#[derive(ToSchema, Serialize, Deserialize, Debug)]
+#[salvo(schema(value_type = Object))]
+pub struct PolicySignEventReqBody(pub Box<RawJsonValue>);
+
+impl PolicySignEventReqBody {
+    /// Creates a new `PolicySignEventReqBody` with the given PDU.
+    pub fn new(pdu: Box<RawJsonValue>) -> Self {
+        Self(pdu)
+    }
+}
+
+crate::json_body_modifier!(PolicySignEventReqBody);
+
+/// Response body for the `sign_event` endpoint.
+#[derive(ToSchema, Clone, Debug, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct PolicySignEventResBody {
+    /// A map containing the Policy Server's signature of the event.
+    #[salvo(schema(value_type = Object, additional_properties = true))]
+    pub signatures: ServerSignatures,
+}
+
+impl PolicySignEventResBody {
+    /// The signing key ID that must be used by the Policy Server for the Ed25519 signature.
+    pub const POLICY_SERVER_ED25519_SIGNING_KEY_ID: &str = "ed25519:policy_server";
+
+    /// Creates a new `PolicySignEventResBody` with the given Policy Server name and signature.
+    pub fn new(server_name: OwnedServerName, ed25519_signature: String) -> Self {
+        let key_id: OwnedServerSigningKeyId = Self::POLICY_SERVER_ED25519_SIGNING_KEY_ID
+            .try_into()
+            .expect("Policy Server default ed25519 signing key ID should be valid");
+
+        Self {
+            signatures: ServerSignatures::from_iter([(server_name, key_id, ed25519_signature)]),
+        }
+    }
+
+    /// Get the signature of the event for the given Policy Server name, if any.
+    pub fn ed25519_signature(&self, server_name: &ServerName) -> Option<&str> {
+        let key_id = <&ServerSigningKeyId>::try_from(Self::POLICY_SERVER_ED25519_SIGNING_KEY_ID)
+            .expect("Policy Server default ed25519 signing key ID should be valid");
+
+        self.signatures
+            .get(server_name)?
+            .get(key_id)
+            .map(String::as_str)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+    use super::{PolicySignEventReqBody, PolicySignEventResBody};
+    use crate::serde::to_raw_json_value;
+    use crate::{owned_server_name, server_name};
+
+    const SIGNATURE: &str =
+        "zLFxllD0pbBuBpfHh8NuHNaICpReF/PAOpUQTsw+bFGKiGfDNAsnhcP7pbrmhhpfbOAxIdLraQLeeiXBryLmBw";
+
+    #[test]
+    fn request_body_serializes_as_raw_pdu() {
+        let request = PolicySignEventReqBody::new(
+            to_raw_json_value(&json!({
+                "type": "m.room.message",
+                "content": { "body": "hello" }
+            }))
+            .unwrap(),
+        );
+
+        assert_eq!(
+            to_json_value(&request).unwrap(),
+            json!({
+                "type": "m.room.message",
+                "content": { "body": "hello" }
+            })
+        );
+    }
+
+    #[test]
+    fn response_serializes_as_signature_map() {
+        let response =
+            PolicySignEventResBody::new(owned_server_name!("policy.example.org"), SIGNATURE.into());
+
+        assert_eq!(
+            to_json_value(&response).unwrap(),
+            json!({
+                "policy.example.org": {
+                    "ed25519:policy_server": SIGNATURE,
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn response_deserializes_and_finds_ed25519_signature() {
+        let response: PolicySignEventResBody = from_json_value(json!({
+            "policy.example.org": {
+                "ed25519:policy_server": SIGNATURE,
+            },
+        }))
+        .unwrap();
+
+        assert_eq!(
+            response.ed25519_signature(server_name!("policy.example.org")),
+            Some(SIGNATURE)
+        );
+    }
+}

--- a/crates/server/src/routing.rs
+++ b/crates/server/src/routing.rs
@@ -3,6 +3,7 @@ mod appservice;
 mod client;
 mod federation;
 mod media;
+mod policy;
 
 use bytes::Bytes;
 use salvo::http::StatusCode;
@@ -46,6 +47,7 @@ pub fn root() -> Router {
                 .push(media::router())
                 .push(federation::router())
                 .push(federation::key::router())
+                .push(policy::router())
                 .push(appservice::router()),
         )
         .push(admin::router())

--- a/crates/server/src/routing/policy.rs
+++ b/crates/server/src/routing/policy.rs
@@ -1,0 +1,79 @@
+use salvo::oapi::extract::*;
+use salvo::prelude::*;
+
+use crate::core::federation::policy::sign_event::{PolicySignEventReqBody, PolicySignEventResBody};
+use crate::core::serde::CanonicalJsonObject;
+use crate::core::signatures::KeyPair;
+use crate::{AppError, AppResult, AuthArgs, JsonResult, MatrixError, config, hoops, json_ok};
+
+pub fn router() -> Router {
+    Router::with_path("policy")
+        .hoop(check_policy_server_enabled)
+        .hoop(hoops::auth_by_signatures)
+        .oapi_tag("policy")
+        .push(Router::with_path("v1/sign").post(sign_event))
+}
+
+#[handler]
+async fn check_policy_server_enabled() -> AppResult<()> {
+    if config::get().enabled_federation().is_none() {
+        Err(AppError::public("Federation is disabled."))
+    } else {
+        Ok(())
+    }
+}
+
+#[endpoint]
+fn sign_event(
+    _aa: AuthArgs,
+    body: JsonBody<PolicySignEventReqBody>,
+) -> JsonResult<PolicySignEventResBody> {
+    let signature = sign_policy_event(&body.0.0)?;
+
+    json_ok(PolicySignEventResBody::new(
+        config::get().server_name.clone(),
+        signature,
+    ))
+}
+
+fn sign_policy_event(pdu: &serde_json::value::RawValue) -> AppResult<String> {
+    let mut object: CanonicalJsonObject = serde_json::from_str(pdu.get()).map_err(|_| {
+        MatrixError::bad_json("Policy Server signing request must be a JSON object")
+    })?;
+
+    if object.get("type").and_then(|value| value.as_str()) == Some("m.room.policy")
+        && object.get("state_key").and_then(|value| value.as_str()) == Some("")
+    {
+        return Err(MatrixError::forbidden(
+            "Policy Server configuration events must not be signed by this endpoint",
+            None,
+        )
+        .into());
+    }
+
+    object.remove("signatures");
+    object.remove("unsigned");
+
+    let canonical_json = serde_json::to_string(&object)?;
+    Ok(config::keypair().sign(canonical_json.as_bytes()).base64())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::sign_policy_event;
+    use crate::core::serde::to_raw_json_value;
+
+    #[test]
+    fn policy_config_event_is_rejected() {
+        let pdu = to_raw_json_value(&json!({
+            "type": "m.room.policy",
+            "state_key": "",
+            "content": {}
+        }))
+        .unwrap();
+
+        assert!(sign_policy_event(&pdu).is_err());
+    }
+}


### PR DESCRIPTION
This pull request introduces support for Matrix Policy Server endpoints, specifically implementing the `POST /_matrix/policy/v1/sign` endpoint. The changes add the necessary routing, request/response types, and logic to allow the server to sign events as a Policy Server, following the Matrix specification.

**Policy Server support and endpoint implementation:**

* Added a new `policy` module to the federation core, with a submodule for the `sign_event` endpoint, including request and response types, signature handling, and tests. [[1]](diffhunk://#diff-2cf2bc495b6ce7efac70666bc38bc45f59b8012dcd48f9cf7c0aba892dd5b1c6R22) [[2]](diffhunk://#diff-de42c0e255bcbf2b55ff7e14642b3f5c8f253ca7682aba62fe0bd273bb4ea2bbR1-R5) [[3]](diffhunk://#diff-6cd389d77684a345ffa108661699cf1a642377a008482853b5bc68cd7b9a07b7R1-R122)
* Implemented the Policy Server router and handler in `crates/server/src/routing/policy.rs`, including endpoint registration, signature logic, and input validation.

**Server routing integration:**

* Registered the new `policy` module in the main server routing, ensuring the endpoint is available under the correct path. [[1]](diffhunk://#diff-1871a2edf3118ffc590e5b1ca7ab276fdeb42d60c7a1032bbba2d8ecb9432d67R6) [[2]](diffhunk://#diff-1871a2edf3118ffc590e5b1ca7ab276fdeb42d60c7a1032bbba2d8ecb9432d67R50)