### PR TITLE
add account moderation endpoints

### DIFF
--- a/crates/core/src/client/admin.rs
+++ b/crates/core/src/client/admin.rs
@@ -91,3 +91,129 @@ impl ConnectionInfo {
         Self::default()
     }
 }
+
+/// Request body for the `lock_user` endpoint.
+#[derive(ToSchema, Clone, Debug, Deserialize, Serialize)]
+pub struct LockUserReqBody {
+    /// Whether to lock the target account.
+    pub locked: bool,
+}
+
+impl LockUserReqBody {
+    /// Creates a new `LockUserReqBody` with the given locked status.
+    pub fn new(locked: bool) -> Self {
+        Self { locked }
+    }
+}
+
+/// Response body for the `lock_user` endpoint.
+#[derive(ToSchema, Clone, Debug, Deserialize, Serialize)]
+pub struct LockUserResBody {
+    /// Whether the target account is locked.
+    pub locked: bool,
+}
+
+impl LockUserResBody {
+    /// Creates a new `LockUserResBody` with the given locked status.
+    pub fn new(locked: bool) -> Self {
+        Self { locked }
+    }
+}
+
+/// Response body for the `is_user_locked` endpoint.
+#[derive(ToSchema, Clone, Debug, Deserialize, Serialize)]
+pub struct IsUserLockedResBody {
+    /// Whether the target account is locked.
+    pub locked: bool,
+}
+
+impl IsUserLockedResBody {
+    /// Creates a new `IsUserLockedResBody` with the given locked status.
+    pub fn new(locked: bool) -> Self {
+        Self { locked }
+    }
+}
+
+/// Request body for the `suspend_user` endpoint.
+#[derive(ToSchema, Clone, Debug, Deserialize, Serialize)]
+pub struct SuspendUserReqBody {
+    /// Whether to suspend the target account.
+    pub suspended: bool,
+}
+
+impl SuspendUserReqBody {
+    /// Creates a new `SuspendUserReqBody` with the given suspended status.
+    pub fn new(suspended: bool) -> Self {
+        Self { suspended }
+    }
+}
+
+/// Response body for the `suspend_user` endpoint.
+#[derive(ToSchema, Clone, Debug, Deserialize, Serialize)]
+pub struct SuspendUserResBody {
+    /// Whether the target account is suspended.
+    pub suspended: bool,
+}
+
+impl SuspendUserResBody {
+    /// Creates a new `SuspendUserResBody` with the given suspended status.
+    pub fn new(suspended: bool) -> Self {
+        Self { suspended }
+    }
+}
+
+/// Response body for the `is_user_suspended` endpoint.
+#[derive(ToSchema, Clone, Debug, Deserialize, Serialize)]
+pub struct IsUserSuspendedResBody {
+    /// Whether the target account is suspended.
+    pub suspended: bool,
+}
+
+impl IsUserSuspendedResBody {
+    /// Creates a new `IsUserSuspendedResBody` with the given suspended status.
+    pub fn new(suspended: bool) -> Self {
+        Self { suspended }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, to_value as to_json_value};
+
+    use super::{
+        IsUserLockedResBody, IsUserSuspendedResBody, LockUserReqBody, LockUserResBody,
+        SuspendUserReqBody, SuspendUserResBody,
+    };
+
+    #[test]
+    fn lock_user_bodies_serialize() {
+        assert_eq!(
+            to_json_value(LockUserReqBody::new(true)).unwrap(),
+            json!({ "locked": true })
+        );
+        assert_eq!(
+            to_json_value(LockUserResBody::new(false)).unwrap(),
+            json!({ "locked": false })
+        );
+        assert_eq!(
+            to_json_value(IsUserLockedResBody::new(true)).unwrap(),
+            json!({ "locked": true })
+        );
+    }
+
+    #[test]
+    fn suspend_user_bodies_serialize() {
+        assert_eq!(
+            to_json_value(SuspendUserReqBody::new(true)).unwrap(),
+            json!({ "suspended": true })
+        );
+        assert_eq!(
+            to_json_value(SuspendUserResBody::new(false)).unwrap(),
+            json!({ "suspended": false })
+        );
+        assert_eq!(
+            to_json_value(IsUserSuspendedResBody::new(true)).unwrap(),
+            json!({ "suspended": true })
+        );
+    }
+}

--- a/crates/core/src/client/discovery/capabilities.rs
+++ b/crates/core/src/client/discovery/capabilities.rs
@@ -92,6 +92,15 @@ pub struct Capabilities {
     )]
     pub forget_forced_upon_leave: ForgetForcedUponLeaveCapability,
 
+    /// Capability to indicate if the user can perform account moderation actions via server
+    /// administration endpoints.
+    #[serde(
+        rename = "m.account_moderation",
+        default,
+        skip_serializing_if = "AccountModerationCapability::is_default"
+    )]
+    pub account_moderation: AccountModerationCapability,
+
     /// Any other custom capabilities that the server supports outside of the
     /// specification, labeled using the Java package naming convention and
     /// stored as arbitrary JSON values.
@@ -125,6 +134,7 @@ impl Capabilities {
             "m.forget_forced_upon_leave" => {
                 Some(Cow::Owned(serialize(&self.forget_forced_upon_leave)))
             }
+            "m.account_moderation" => Some(Cow::Owned(serialize(&self.account_moderation))),
             _ => self.custom_capabilities.get(capability).map(Cow::Borrowed),
         }
     }
@@ -143,6 +153,9 @@ impl Capabilities {
             "m.3pid_changes" => self.thirdparty_id_changes = from_json_value(value)?,
             "m.forget_forced_upon_leave" => {
                 self.forget_forced_upon_leave = from_json_value(value)?;
+            }
+            "m.account_moderation" => {
+                self.account_moderation = from_json_value(value)?;
             }
             _ => {
                 self.custom_capabilities
@@ -387,6 +400,30 @@ pub struct ForgetForcedUponLeaveCapability {
     /// This behavior applies irrespective of whether the user has left the room on their own
     /// or has been kicked or banned from the room by another user.
     pub enabled: bool,
+}
+
+/// Information about the `m.account_moderation` capability.
+#[derive(ToSchema, Clone, Debug, Default, Serialize, Deserialize)]
+pub struct AccountModerationCapability {
+    /// Whether the user can suspend accounts via `PUT /admin/suspend/{userId}`.
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
+    pub suspend: bool,
+
+    /// Whether the user can lock accounts via `PUT /admin/lock/{userId}`.
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
+    pub lock: bool,
+}
+
+impl AccountModerationCapability {
+    /// Creates a new `AccountModerationCapability` with the given suspend and lock capabilities.
+    pub fn new(suspend: bool, lock: bool) -> Self {
+        Self { suspend, lock }
+    }
+
+    /// Returns whether all fields have their default value.
+    pub fn is_default(&self) -> bool {
+        !self.suspend && !self.lock
+    }
 }
 
 impl ForgetForcedUponLeaveCapability {

--- a/crates/data/src/user.rs
+++ b/crates/data/src/user.rs
@@ -82,6 +82,14 @@ impl DbUser {
     pub fn is_deactivated(&self) -> bool {
         self.deactivated_at.is_some()
     }
+
+    pub fn is_locked(&self) -> bool {
+        self.locked_at.is_some()
+    }
+
+    pub fn is_suspended(&self) -> bool {
+        self.suspended_at.is_some()
+    }
 }
 
 #[derive(Insertable, AsChangeset, Debug, Clone)]
@@ -303,6 +311,26 @@ pub fn is_deactivated(user_id: &UserId) -> DataResult<bool> {
         .optional()?
         .flatten();
     Ok(deactivated_at.is_some())
+}
+
+pub fn is_locked(user_id: &UserId) -> DataResult<bool> {
+    let locked_at = users::table
+        .filter(users::id.eq(user_id))
+        .select(users::locked_at)
+        .first::<Option<UnixMillis>>(&mut connect()?)
+        .optional()?
+        .flatten();
+    Ok(locked_at.is_some())
+}
+
+pub fn is_suspended(user_id: &UserId) -> DataResult<bool> {
+    let suspended_at = users::table
+        .filter(users::id.eq(user_id))
+        .select(users::suspended_at)
+        .first::<Option<UnixMillis>>(&mut connect()?)
+        .optional()?
+        .flatten();
+    Ok(suspended_at.is_some())
 }
 
 pub fn is_guest(user_id: &UserId) -> DataResult<bool> {

--- a/crates/server/src/hoops/auth.rs
+++ b/crates/server/src/hoops/auth.rs
@@ -73,6 +73,7 @@ async fn auth_by_access_token_inner(aa: AuthArgs, depot: &mut Depot) -> AppResul
             .find(&access_token.user_id)
             .first::<DbUser>(&mut connect()?)
             .map_err(|_| MatrixError::unknown_token("User not found", true))?;
+        ensure_user_account_usable(&user)?;
         let user_device = user_devices::table
             .filter(user_devices::device_id.eq(&access_token.device_id))
             .filter(user_devices::user_id.eq(&user.id))
@@ -128,6 +129,7 @@ async fn auth_by_access_token_inner(aa: AuthArgs, depot: &mut Depot) -> AppResul
                     (user, user_device)
                 };
 
+                ensure_user_account_usable(&user)?;
                 depot.inject(AuthedInfo {
                     user,
                     user_device,
@@ -167,6 +169,7 @@ async fn auth_by_delegated_token(token: &str, aa: &AuthArgs, depot: &mut Depot) 
         crate::data::user::set_guest(&user_id, false)?;
         user.is_guest = false;
     }
+    ensure_user_account_usable(&user)?;
 
     // Extract device_id from introspection response, scope, or query param
     let device_id_str = result
@@ -202,6 +205,22 @@ async fn auth_by_delegated_token(token: &str, aa: &AuthArgs, depot: &mut Depot) 
         access_token_id: None,
         appservice: None,
     });
+    Ok(())
+}
+
+fn ensure_user_account_usable(user: &DbUser) -> AppResult<()> {
+    if user.is_deactivated() {
+        return Err(MatrixError::user_deactivated("the user has been deactivated").into());
+    }
+
+    if user.is_locked() {
+        return Err(MatrixError::user_locked("the user has been locked").into());
+    }
+
+    if user.is_suspended() {
+        return Err(MatrixError::user_suspended("the user has been suspended").into());
+    }
+
     Ok(())
 }
 

--- a/crates/server/src/routing/client.rs
+++ b/crates/server/src/routing/client.rs
@@ -32,8 +32,9 @@ use salvo::prelude::*;
 
 use crate::config;
 use crate::core::client::discovery::capabilities::{
-    Capabilities, CapabilitiesResBody, ChangePasswordCapability, ProfileFieldsCapability,
-    RoomVersionStability, RoomVersionsCapability, ThirdPartyIdChangesCapability,
+    AccountModerationCapability, Capabilities, CapabilitiesResBody, ChangePasswordCapability,
+    ProfileFieldsCapability, RoomVersionStability, RoomVersionsCapability,
+    ThirdPartyIdChangesCapability,
 };
 use crate::core::client::discovery::versions::VersionsResBody;
 use crate::core::client::search::{ResultCategories, SearchReqArgs, SearchReqBody, SearchResBody};
@@ -146,9 +147,11 @@ fn search(
 /// #GET /_matrix/client/r0/capabilities
 /// Get information on the supported feature set and other relevent capabilities of this server.
 #[endpoint]
-fn get_capabilities(_aa: AuthArgs) -> JsonResult<CapabilitiesResBody> {
+fn get_capabilities(_aa: AuthArgs, depot: &mut Depot) -> JsonResult<CapabilitiesResBody> {
     let mut available = BTreeMap::new();
     let conf = crate::config::get();
+    let authed = depot.authed_info()?;
+    let account_moderation = AccountModerationCapability::new(authed.is_admin(), authed.is_admin());
     for room_version in &*config::UNSTABLE_ROOM_VERSIONS {
         available.insert(room_version.clone(), RoomVersionStability::Unstable);
     }
@@ -165,6 +168,7 @@ fn get_capabilities(_aa: AuthArgs) -> JsonResult<CapabilitiesResBody> {
             change_password: ChangePasswordCapability { enabled: true },
             thirdparty_id_changes: ThirdPartyIdChangesCapability { enabled: true },
             profile_fields: Some(ProfileFieldsCapability::new(true)),
+            account_moderation,
             ..Default::default()
         },
     })
@@ -213,6 +217,7 @@ fn supported_versions() -> JsonResult<VersionsResBody> {
             ("uk.tcpip.msc4133".to_owned(), true), /* Extending User Profile API with Key:Value Pairs (https://github.com/matrix-org/matrix-spec-proposals/pull/4133) */
             ("us.cloke.msc4175".to_owned(), true), /* Profile field for user time zone (https://github.com/matrix-org/matrix-spec-proposals/pull/4175) */
             ("org.matrix.simplified_msc3575".to_owned(), true), /* Simplified Sliding sync (https://github.com/matrix-org/matrix-spec-proposals/pull/4186) */
+            ("uk.timedout.msc4323".to_owned(), true),           // Account suspension and locking.
         ]),
     })
 }

--- a/crates/server/src/routing/client/admin.rs
+++ b/crates/server/src/routing/client/admin.rs
@@ -1,14 +1,30 @@
 use std::collections::BTreeMap;
 
-use salvo::oapi::extract::PathParam;
+use salvo::oapi::extract::{JsonBody, PathParam};
 use salvo::prelude::*;
 
+use crate::config;
+use crate::core::client::admin::{
+    IsUserLockedResBody, IsUserSuspendedResBody, LockUserReqBody, LockUserResBody,
+    SuspendUserReqBody, SuspendUserResBody,
+};
 use crate::core::client::server::{ConnectionInfo, DeviceInfo, SessionInfo, UserInfoResBody};
 use crate::core::identifiers::*;
-use crate::{AuthArgs, DepotExt, JsonResult, MatrixError, data, json_ok};
+use crate::{AppResult, AuthArgs, DepotExt, JsonResult, MatrixError, data, json_ok};
 
 pub fn authed_router() -> Router {
-    Router::with_path("admin/whois/{user_id}").get(whois)
+    Router::new()
+        .push(Router::with_path("admin/whois/{user_id}").get(whois))
+        .push(
+            Router::with_path("admin/lock/{user_id}")
+                .get(is_user_locked)
+                .put(lock_user),
+        )
+        .push(
+            Router::with_path("admin/suspend/{user_id}")
+                .get(is_user_suspended)
+                .put(suspend_user),
+        )
 }
 
 /// Get information about a particular user.
@@ -66,4 +82,79 @@ async fn whois(
         user_id: Some(target_user_id),
         devices,
     })
+}
+
+fn require_admin(depot: &mut Depot) -> AppResult<OwnedUserId> {
+    let authed = depot.authed_info()?;
+    if !authed.is_admin() {
+        return Err(MatrixError::forbidden("Requires server admin privileges", None).into());
+    }
+
+    Ok(authed.user_id().to_owned())
+}
+
+fn get_local_user(user_id: &UserId) -> AppResult<data::user::DbUser> {
+    if user_id.server_name() != config::server_name() {
+        return Err(MatrixError::not_found("User not found").into());
+    }
+
+    data::user::get_user(user_id).map_err(|_| MatrixError::not_found("User not found").into())
+}
+
+#[endpoint]
+pub(super) async fn is_user_locked(
+    _aa: AuthArgs,
+    user_id: PathParam<OwnedUserId>,
+    depot: &mut Depot,
+) -> JsonResult<IsUserLockedResBody> {
+    require_admin(depot)?;
+    let target_user_id = user_id.into_inner();
+    let user = get_local_user(&target_user_id)?;
+
+    json_ok(IsUserLockedResBody::new(user.is_locked()))
+}
+
+#[endpoint]
+pub(super) async fn lock_user(
+    _aa: AuthArgs,
+    user_id: PathParam<OwnedUserId>,
+    body: JsonBody<LockUserReqBody>,
+    depot: &mut Depot,
+) -> JsonResult<LockUserResBody> {
+    let admin_user_id = require_admin(depot)?;
+    let target_user_id = user_id.into_inner();
+    get_local_user(&target_user_id)?;
+
+    data::user::set_locked(&target_user_id, body.locked, Some(&admin_user_id))?;
+
+    json_ok(LockUserResBody::new(body.locked))
+}
+
+#[endpoint]
+pub(super) async fn is_user_suspended(
+    _aa: AuthArgs,
+    user_id: PathParam<OwnedUserId>,
+    depot: &mut Depot,
+) -> JsonResult<IsUserSuspendedResBody> {
+    require_admin(depot)?;
+    let target_user_id = user_id.into_inner();
+    let user = get_local_user(&target_user_id)?;
+
+    json_ok(IsUserSuspendedResBody::new(user.is_suspended()))
+}
+
+#[endpoint]
+pub(super) async fn suspend_user(
+    _aa: AuthArgs,
+    user_id: PathParam<OwnedUserId>,
+    body: JsonBody<SuspendUserReqBody>,
+    depot: &mut Depot,
+) -> JsonResult<SuspendUserResBody> {
+    require_admin(depot)?;
+    let target_user_id = user_id.into_inner();
+    get_local_user(&target_user_id)?;
+
+    data::user::set_suspended(&target_user_id, body.suspended)?;
+
+    json_ok(SuspendUserResBody::new(body.suspended))
 }

--- a/crates/server/src/routing/client/unstable.rs
+++ b/crates/server/src/routing/client/unstable.rs
@@ -30,6 +30,16 @@ pub(super) fn router() -> Router {
                 .push(
                     Router::with_path("im.nheko.summary/rooms/{room_id_or_alias}/summary")
                         .get(super::room::summary::get_summary_msc_3266),
+                )
+                .push(
+                    Router::with_path("uk.timedout.msc4323/admin/lock/{user_id}")
+                        .get(super::admin::is_user_locked)
+                        .put(super::admin::lock_user),
+                )
+                .push(
+                    Router::with_path("uk.timedout.msc4323/admin/suspend/{user_id}")
+                        .get(super::admin::is_user_suspended)
+                        .put(super::admin::suspend_user),
                 ),
         )
 }

--- a/crates/server/src/user/password.rs
+++ b/crates/server/src/user/password.rs
@@ -12,6 +12,12 @@ pub fn verify_password(user: &DbUser, password: &str) -> AppResult<()> {
     if user.deactivated_at.is_some() {
         return Err(MatrixError::user_deactivated("the user has been deactivated").into());
     }
+    if user.locked_at.is_some() {
+        return Err(MatrixError::user_locked("the user has been locked").into());
+    }
+    if user.suspended_at.is_some() {
+        return Err(MatrixError::user_suspended("the user has been suspended").into());
+    }
     let hash = crate::user::get_password_hash(&user.id)
         .map_err(|_| MatrixError::unauthorized("wrong username or password."))?;
     if hash.is_empty() {


### PR DESCRIPTION
This pull request introduces account suspension and locking features, allowing server administrators to lock or suspend user accounts via new admin endpoints. It also ensures that locked or suspended users cannot authenticate or use their accounts. Additionally, the server now advertises these capabilities, and the relevant endpoints are exposed under both stable and unstable routes.

**Account Moderation Capabilities and Data Model:**

- Added `AccountModerationCapability` to the `Capabilities` struct, allowing the server to advertise support for account locking and suspension. This includes serialization, deserialization, and integration into the `/capabilities` endpoint, with admin users granted both capabilities. [[1]](diffhunk://#diff-3e217f88efb56480c76a6ca448e530cdacb20a7d2dc2365a3b7a6909742b46ebR95-R103) [[2]](diffhunk://#diff-3e217f88efb56480c76a6ca448e530cdacb20a7d2dc2365a3b7a6909742b46ebR137) [[3]](diffhunk://#diff-3e217f88efb56480c76a6ca448e530cdacb20a7d2dc2365a3b7a6909742b46ebR157-R159) [[4]](diffhunk://#diff-14b779e8702df502bf49f38fdf74fbff103118cb977b2b137ddbe0966919b311L35-R37) [[5]](diffhunk://#diff-14b779e8702df502bf49f38fdf74fbff103118cb977b2b137ddbe0966919b311L149-R154) [[6]](diffhunk://#diff-14b779e8702df502bf49f38fdf74fbff103118cb977b2b137ddbe0966919b311R171)
- Introduced data models and request/response types for locking and suspending users, including tests for serialization.

**Admin Endpoints for Locking and Suspension:**

- Added new admin endpoints for locking (`PUT/GET /admin/lock/{userId}`) and suspending (`PUT/GET /admin/suspend/{userId}`) user accounts, with corresponding handlers and admin checks. These endpoints are also available under unstable MSC4323 routes. [[1]](diffhunk://#diff-66c2a90e2998f6fbeb508fc65c1dcb6c3730f53bbaa5d7ed90e9b4816964d5adL3-R27) [[2]](diffhunk://#diff-66c2a90e2998f6fbeb508fc65c1dcb6c3730f53bbaa5d7ed90e9b4816964d5adR86-R160) [[3]](diffhunk://#diff-9e4e0f0f72cbddd06c155e183ea22a29250e455d20c85d5a8425f99de653c840R33-R42)

**Authentication and Account Usability Enforcement:**

- Updated authentication logic to prevent locked or suspended users from authenticating or using their accounts, by introducing `ensure_user_account_usable` checks in all relevant authentication flows. [[1]](diffhunk://#diff-e27f34f41b985d4b0842e37d16fc6c9a9bcabde26a0fd5efbe5988a5f2406141R76) [[2]](diffhunk://#diff-e27f34f41b985d4b0842e37d16fc6c9a9bcabde26a0fd5efbe5988a5f2406141R132) [[3]](diffhunk://#diff-e27f34f41b985d4b0842e37d16fc6c9a9bcabde26a0fd5efbe5988a5f2406141R172) [[4]](diffhunk://#diff-e27f34f41b985d4b0842e37d16fc6c9a9bcabde26a0fd5efbe5988a5f2406141R211-R226) [[5]](diffhunk://#diff-8bcb82fccf5a147898bb0f9cf81c228b62a1a3fb0e1e30a2a6462f12087f6e8eR15-R20)

**User Data Accessors and Utilities:**

- Added helper methods and queries to check if a user is locked or suspended, both in the data layer and on the `DbUser` struct. [[1]](diffhunk://#diff-66052605b8c436ba476ba0fe0a826801128467683d5638242565d166191305fdR85-R92) [[2]](diffhunk://#diff-66052605b8c436ba476ba0fe0a826801128467683d5638242565d166191305fdR316-R335)

**Spec Compliance and Discovery:**

- Advertised support for MSC4323 (account suspension and locking) in the discovery endpoint.

---

**References:**  
[[1]](diffhunk://#diff-3e217f88efb56480c76a6ca448e530cdacb20a7d2dc2365a3b7a6909742b46ebR95-R103) [[2]](diffhunk://#diff-3e217f88efb56480c76a6ca448e530cdacb20a7d2dc2365a3b7a6909742b46ebR137) [[3]](diffhunk://#diff-3e217f88efb56480c76a6ca448e530cdacb20a7d2dc2365a3b7a6909742b46ebR157-R159) [[4]](diffhunk://#diff-a411a6cb1276897d10048255c0a6557895614b8049c30450a43726caf7e34956R94-R219) [[5]](diffhunk://#diff-66c2a90e2998f6fbeb508fc65c1dcb6c3730f53bbaa5d7ed90e9b4816964d5adL3-R27) [[6]](diffhunk://#diff-66c2a90e2998f6fbeb508fc65c1dcb6c3730f53bbaa5d7ed90e9b4816964d5adR86-R160) [[7]](diffhunk://#diff-9e4e0f0f72cbddd06c155e183ea22a29250e455d20c85d5a8425f99de653c840R33-R42) [[8]](diffhunk://#diff-e27f34f41b985d4b0842e37d16fc6c9a9bcabde26a0fd5efbe5988a5f2406141R76) [[9]](diffhunk://#diff-e27f34f41b985d4b0842e37d16fc6c9a9bcabde26a0fd5efbe5988a5f2406141R132) [[10]](diffhunk://#diff-e27f34f41b985d4b0842e37d16fc6c9a9bcabde26a0fd5efbe5988a5f2406141R172) [[11]](diffhunk://#diff-e27f34f41b985d4b0842e37d16fc6c9a9bcabde26a0fd5efbe5988a5f2406141R211-R226) [[12]](diffhunk://#diff-66052605b8c436ba476ba0fe0a826801128467683d5638242565d166191305fdR85-R92) [[13]](diffhunk://#diff-66052605b8c436ba476ba0fe0a826801128467683d5638242565d166191305fdR316-R335) [[14]](diffhunk://#diff-14b779e8702df502bf49f38fdf74fbff103118cb977b2b137ddbe0966919b311L35-R37) [[15]](diffhunk://#diff-14b779e8702df502bf49f38fdf74fbff103118cb977b2b137ddbe0966919b311L149-R154) [[16]](diffhunk://#diff-14b779e8702df502bf49f38fdf74fbff103118cb977b2b137ddbe0966919b311R171) [[17]](diffhunk://#diff-14b779e8702df502bf49f38fdf74fbff103118cb977b2b137ddbe0966919b311R220) [[18]](diffhunk://#diff-8bcb82fccf5a147898bb0f9cf81c228b62a1a3fb0e1e30a2a6462f12087f6e8eR15-R20)