### PR TITLE
add support contact pgp key discovery

### DIFF
--- a/crates/core/src/client/discovery/support.rs
+++ b/crates/core/src/client/discovery/support.rs
@@ -74,6 +74,18 @@ pub struct Contact {
     /// At least one of `matrix_id` or `email_address` is required.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub matrix_id: Option<OwnedUserId>,
+
+    /// An optional URI leading to a PGP key that may be used to encrypt messages sent to the
+    /// contact.
+    ///
+    /// This field uses the unstable prefix defined in [MSC4439].
+    ///
+    /// [MSC4439]: https://github.com/matrix-org/matrix-spec-proposals/pull/4439
+    #[serde(
+        rename = "dev.zirco.msc4439.pgp_key",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub pgp_key: Option<String>,
 }
 
 impl Contact {
@@ -83,6 +95,7 @@ impl Contact {
             role,
             email_address: Some(email_address),
             matrix_id: None,
+            pgp_key: None,
         }
     }
 
@@ -92,6 +105,7 @@ impl Contact {
             role,
             email_address: None,
             matrix_id: Some(matrix_id),
+            pgp_key: None,
         }
     }
 }
@@ -120,4 +134,32 @@ pub enum ContactRole {
 
     #[doc(hidden)]
     _Custom(PrivOwnedStr),
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, to_value as to_json_value};
+
+    use super::{Contact, ContactRole, SupportResBody};
+
+    #[test]
+    fn support_contact_serializes_pgp_key() {
+        let contact = Contact {
+            role: ContactRole::Security,
+            email_address: Some("security@example.com".to_owned()),
+            matrix_id: None,
+            pgp_key: Some("https://example.com/security.asc".to_owned()),
+        };
+
+        assert_eq!(
+            to_json_value(SupportResBody::with_contacts(vec![contact])).unwrap(),
+            json!({
+                "contacts": [{
+                    "role": "m.role.security",
+                    "email_address": "security@example.com",
+                    "dev.zirco.msc4439.pgp_key": "https://example.com/security.asc"
+                }]
+            })
+        );
+    }
 }

--- a/crates/server/src/config/well_known.rs
+++ b/crates/server/src/config/well_known.rs
@@ -83,4 +83,11 @@ pub struct WellKnownConfig {
     ///
     /// Example: "@admin:example.com"
     pub support_mxid: Option<OwnedUserId>,
+
+    /// URI to a PGP key for the support contact.
+    ///
+    /// This is exposed as `dev.zirco.msc4439.pgp_key` in `/.well-known/matrix/support`.
+    ///
+    /// Example: "https://example.com/security.asc"
+    pub support_pgp_key: Option<String>,
 }

--- a/crates/server/src/routing.rs
+++ b/crates/server/src/routing.rs
@@ -217,6 +217,7 @@ fn well_known_support() -> JsonResult<SupportResBody> {
     let email_address = conf.well_known.support_email.clone();
 
     let matrix_id = conf.well_known.support_mxid.clone();
+    let pgp_key = conf.well_known.support_pgp_key.clone();
 
     // if a role is specified, an email address or matrix id is required
     if role.is_some() && (email_address.is_none() && matrix_id.is_none()) {
@@ -231,6 +232,7 @@ fn well_known_support() -> JsonResult<SupportResBody> {
             role,
             email_address,
             matrix_id,
+            pgp_key,
         };
 
         contacts.push(contact);

--- a/palpo-example.toml
+++ b/palpo-example.toml
@@ -1267,6 +1267,14 @@
 #
 # support_mxid =
 
+# URI to a PGP key for the support contact.
+#
+# This is exposed as `dev.zirco.msc4439.pgp_key` in `/.well-known/matrix/support`.
+#
+# Example: "https://example.com/security.asc"
+#
+# support_pgp_key =
+
 # [oidc]
 
 # Enable OIDC/OAuth authentication


### PR DESCRIPTION
This pull request introduces support for including a PGP key URI in support contact information, following the proposed MSC4439 specification. The changes enable the server to expose a PGP key for support contacts in its well-known Matrix support endpoint, allow configuration of this key, and add tests to ensure correct serialization.

Support for PGP key in support contact information:

* Added an optional `pgp_key` field to the `Contact` struct, serialized as `dev.zirco.msc4439.pgp_key`, and updated `Contact` constructors to initialize this field. [[1]](diffhunk://#diff-c95720c3081cf5cbfa61fa8c67520d03c77f111da700f55c4227ae5feddbd4b9R77-R88) [[2]](diffhunk://#diff-c95720c3081cf5cbfa61fa8c67520d03c77f111da700f55c4227ae5feddbd4b9R98) [[3]](diffhunk://#diff-c95720c3081cf5cbfa61fa8c67520d03c77f111da700f55c4227ae5feddbd4b9R108)
* Added a test to verify correct serialization of the `pgp_key` field in the support contact JSON.

Configuration and server integration:

* Added a `support_pgp_key` field to the `WellKnownConfig` struct, allowing configuration of the PGP key URI for the support contact.
* Updated the server's support endpoint logic to include the configured PGP key in the contact information, if present. [[1]](diffhunk://#diff-1871a2edf3118ffc590e5b1ca7ab276fdeb42d60c7a1032bbba2d8ecb9432d67R220) [[2]](diffhunk://#diff-1871a2edf3118ffc590e5b1ca7ab276fdeb42d60c7a1032bbba2d8ecb9432d67R235)
* Documented the `support_pgp_key` configuration option in the example configuration file.