### PR TITLE
Add federation education types discovery

### DIFF
--- a/crates/core/src/federation/query.rs
+++ b/crates/core/src/federation/query.rs
@@ -84,6 +84,60 @@ pub fn profile_request(origin: &str, args: ProfileReqArgs) -> SendResult<SendReq
     Ok(crate::sending::get(url))
 }
 
+/// `GET /_matrix/federation/unstable/io.fsky.vel/edutypes`
+///
+/// Determine what types of EDUs a server wishes to receive.
+pub fn edu_types_request(origin: &str) -> SendResult<SendRequest> {
+    let url = Url::parse(&format!(
+        "{origin}/_matrix/federation/unstable/io.fsky.vel/edutypes"
+    ))?;
+    Ok(crate::sending::get(url))
+}
+
+/// Request type for the `edutypes` endpoint.
+#[derive(ToSchema, Clone, Debug, Default, Deserialize, Serialize)]
+pub struct EduTypesReqBody {}
+
+impl EduTypesReqBody {
+    /// Creates a new `EduTypesReqBody`.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+/// Response type for the `edutypes` endpoint.
+#[derive(ToSchema, Clone, Debug, Deserialize, Serialize)]
+pub struct EduTypesResBody {
+    /// Whether presence EDUs should be sent.
+    #[serde(rename = "m.presence", default = "crate::serde::default_true")]
+    pub presence: bool,
+
+    /// Whether read receipt EDUs should be sent.
+    #[serde(rename = "m.receipt", default = "crate::serde::default_true")]
+    pub receipt: bool,
+
+    /// Whether typing EDUs should be sent.
+    #[serde(rename = "m.typing", default = "crate::serde::default_true")]
+    pub typing: bool,
+}
+
+impl EduTypesResBody {
+    /// Creates a new `EduTypesResBody` with all EDU flags set to `true`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for EduTypesResBody {
+    fn default() -> Self {
+        Self {
+            presence: true,
+            receipt: true,
+            typing: true,
+        }
+    }
+}
+
 /// Request type for the `get_profile_information` endpoint.
 
 #[derive(ToParameters, Deserialize, Debug)]
@@ -139,5 +193,39 @@ impl CustomResBody {
     /// Creates a new response with the given body.
     pub fn new(body: JsonValue) -> Self {
         Self(body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+    use super::EduTypesResBody;
+
+    #[test]
+    fn edu_types_default_to_true_when_missing() {
+        let body: EduTypesResBody = from_json_value(json!({})).unwrap();
+
+        assert!(body.presence);
+        assert!(body.receipt);
+        assert!(body.typing);
+    }
+
+    #[test]
+    fn edu_types_use_msc4373_field_names() {
+        let body = EduTypesResBody {
+            presence: true,
+            receipt: false,
+            typing: true,
+        };
+
+        assert_eq!(
+            to_json_value(body).unwrap(),
+            json!({
+                "m.presence": true,
+                "m.receipt": false,
+                "m.typing": true,
+            })
+        );
     }
 }

--- a/crates/server/src/routing.rs
+++ b/crates/server/src/routing.rs
@@ -44,6 +44,7 @@ pub fn root() -> Router {
             Router::with_path("_matrix")
                 .push(client::router())
                 .push(media::router())
+                .push(federation::public_router())
                 .push(federation::router())
                 .push(federation::key::router())
                 .push(appservice::router()),

--- a/crates/server/src/routing/federation.rs
+++ b/crates/server/src/routing/federation.rs
@@ -59,6 +59,13 @@ pub fn router() -> Router {
         .push(Router::with_path("versions").get(get_versions))
 }
 
+pub fn public_router() -> Router {
+    Router::with_path("federation")
+        .hoop(check_federation_enabled)
+        .oapi_tag("federation")
+        .push(Router::with_path("unstable/io.fsky.vel/edutypes").get(query::get_edu_types))
+}
+
 #[handler]
 async fn check_federation_enabled() -> AppResult<()> {
     let conf = config::get();

--- a/crates/server/src/routing/federation/query.rs
+++ b/crates/server/src/routing/federation/query.rs
@@ -4,7 +4,7 @@ use palpo_core::federation::query::ProfileReqArgs;
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
 
-use crate::core::federation::query::RoomInfoResBody;
+use crate::core::federation::query::{EduTypesResBody, RoomInfoResBody};
 use crate::core::identifiers::*;
 use crate::core::user::{ProfileField, ProfileResBody};
 use crate::{
@@ -17,6 +17,19 @@ pub fn router() -> Router {
         .push(Router::with_path("profile").get(get_profile))
         .push(Router::with_path("directory").get(get_directory))
         .push(Router::with_path("{query_type}").get(query_by_type))
+}
+
+/// #GET /_matrix/federation/unstable/io.fsky.vel/edutypes
+/// Determine what types of EDUs this server wishes to receive.
+#[endpoint]
+pub async fn get_edu_types() -> JsonResult<EduTypesResBody> {
+    let conf = config::get();
+
+    json_ok(EduTypesResBody {
+        presence: conf.presence.allow_incoming,
+        receipt: conf.read_receipt.allow_incoming,
+        typing: conf.typing.allow_incoming,
+    })
 }
 
 /// #GET /_matrix/federation/v1/query/profile

--- a/crates/server/src/routing/federation/transaction.rs
+++ b/crates/server/src/routing/federation/transaction.rs
@@ -170,9 +170,9 @@ async fn process_edu_presence(origin: &ServerName, presence: PresenceContent) {
 }
 
 async fn process_edu_receipt(origin: &ServerName, receipt: ReceiptContent) {
-    // if !crate::config::get().allow_incoming_read_receipts() {
-    // 	return;
-    // }
+    if !crate::config::get().read_receipt.allow_incoming {
+        return;
+    }
 
     for (room_id, room_updates) in receipt {
         if handler::acl_check(origin, &room_id).is_err() {
@@ -221,9 +221,9 @@ async fn process_edu_receipt(origin: &ServerName, receipt: ReceiptContent) {
 }
 
 async fn process_edu_typing(origin: &ServerName, typing: TypingContent) {
-    // if !crate::config::get().allow_incoming_typing {
-    //     return;
-    // }
+    if !crate::config::get().typing.allow_incoming {
+        return;
+    }
 
     if typing.user_id.server_name() != origin {
         warn!(


### PR DESCRIPTION
This pull request introduces a new federation endpoint that allows remote servers to discover which types of EDUs (Ephemeral Data Units) this server is willing to receive. It also ensures that the server only processes incoming read receipt and typing EDUs if they are enabled in the configuration. The changes include endpoint implementation, configuration integration, and related tests.

**Federation Endpoint for EDU Types**

* Added a new public endpoint `/_matrix/federation/unstable/io.fsky.vel/edutypes` to advertise which EDU types (presence, receipt, typing) are accepted by this server, with response fields reflecting the current configuration (`EduTypesResBody`). [[1]](diffhunk://#diff-b8e4ae20f85fdb92088e3e2f4726f1d6575595d47eea533a798760f00d6a47a7R87-R140) [[2]](diffhunk://#diff-66481ab8090527ac7907eaf0b945da17367cddb93176baf645f79fc3f06a2deeR22-R34) [[3]](diffhunk://#diff-921af890e16e1ad9f26976a6f208b9973560d2e28afc453177c5bc3207d62f5bR62-R68) [[4]](diffhunk://#diff-1871a2edf3118ffc590e5b1ca7ab276fdeb42d60c7a1032bbba2d8ecb9432d67R50)
* Registered the new endpoint in the federation routing layer, making it publicly accessible. [[1]](diffhunk://#diff-921af890e16e1ad9f26976a6f208b9973560d2e28afc453177c5bc3207d62f5bR62-R68) [[2]](diffhunk://#diff-1871a2edf3118ffc590e5b1ca7ab276fdeb42d60c7a1032bbba2d8ecb9432d67R50)

**Configuration Enforcement for Incoming EDUs**

* Updated the processing logic for incoming read receipt and typing EDUs to respect the server’s configuration (`read_receipt.allow_incoming` and `typing.allow_incoming`), preventing processing if not allowed. [[1]](diffhunk://#diff-fcc4ade3d23837fd39e52201e9f571ebd526d33b9ffb02eebf5aa5f20f3053d1L173-R175) [[2]](diffhunk://#diff-fcc4ade3d23837fd39e52201e9f571ebd526d33b9ffb02eebf5aa5f20f3053d1L224-R226)

**Testing and Serialization**

* Added tests to ensure the new response struct (`EduTypesResBody`) defaults to all `true` values and uses the correct field names for serialization.

**Code Maintenance**

* Updated imports to include the new `EduTypesResBody` type where required.