### PR TITLE
Add rendezvous discovery endpoint

### DIFF
--- a/crates/core/src/client/discovery.rs
+++ b/crates/core/src/client/discovery.rs
@@ -3,5 +3,6 @@ pub mod auth_metadata;
 pub mod capabilities;
 pub mod client;
 pub mod homeserver;
+pub mod rendezvous;
 pub mod support;
 pub mod versions;

--- a/crates/core/src/client/discovery/rendezvous.rs
+++ b/crates/core/src/client/discovery/rendezvous.rs
@@ -1,0 +1,62 @@
+//! `GET /_matrix/client/unstable/io.element.msc4388/rendezvous`
+//!
+//! Discover if the rendezvous API is available.
+
+use salvo::prelude::*;
+use serde::{Deserialize, Serialize};
+
+/// Request type for the `discover_rendezvous` endpoint.
+#[derive(ToSchema, Clone, Debug, Default, Deserialize, Serialize)]
+pub struct DiscoverRendezvousReqBody {}
+
+impl DiscoverRendezvousReqBody {
+    /// Creates a new `DiscoverRendezvousReqBody`.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+/// Response type for the `discover_rendezvous` endpoint.
+#[derive(ToSchema, Clone, Debug, Default, Deserialize, Serialize)]
+pub struct DiscoverRendezvousResBody {
+    /// Whether the requester is able to use the create session endpoint.
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
+    pub create_available: bool,
+}
+
+impl DiscoverRendezvousResBody {
+    /// Creates a new `DiscoverRendezvousResBody`.
+    pub fn new(create_available: bool) -> Self {
+        Self { create_available }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+    use super::DiscoverRendezvousResBody;
+
+    #[test]
+    fn rendezvous_discovery_deserializes_old_empty_payload() {
+        let body: DiscoverRendezvousResBody = from_json_value(json!({})).unwrap();
+
+        assert!(!body.create_available);
+    }
+
+    #[test]
+    fn rendezvous_discovery_serializes_available_flag() {
+        assert_eq!(
+            to_json_value(DiscoverRendezvousResBody::new(true)).unwrap(),
+            json!({ "create_available": true })
+        );
+    }
+
+    #[test]
+    fn rendezvous_discovery_omits_unavailable_flag() {
+        assert_eq!(
+            to_json_value(DiscoverRendezvousResBody::new(false)).unwrap(),
+            json!({})
+        );
+    }
+}

--- a/crates/server/src/routing/client/unstable.rs
+++ b/crates/server/src/routing/client/unstable.rs
@@ -1,6 +1,7 @@
 use salvo::prelude::*;
 
 use crate::core::MatrixError;
+use crate::core::client::discovery::rendezvous::DiscoverRendezvousResBody;
 use crate::{JsonResult, config, hoops, json_ok};
 
 pub(super) fn router() -> Router {
@@ -12,6 +13,7 @@ pub(super) fn router() -> Router {
         .push(
             Router::with_path("org.matrix.msc2965/auth_metadata").get(auth_metadata),
         )
+        .push(Router::with_path("io.element.msc4388/rendezvous").get(discover_rendezvous))
         // Authed routes
         .push(
             Router::new()
@@ -32,6 +34,14 @@ pub(super) fn router() -> Router {
                         .get(super::room::summary::get_summary_msc_3266),
                 ),
         )
+}
+
+/// `GET /_matrix/client/unstable/io.element.msc4388/rendezvous`
+///
+/// Discover whether rendezvous sessions can be created on this server.
+#[endpoint]
+async fn discover_rendezvous() -> JsonResult<DiscoverRendezvousResBody> {
+    json_ok(DiscoverRendezvousResBody::new(false))
 }
 
 /// `GET /_matrix/client/unstable/org.matrix.msc2965/auth_issuer`


### PR DESCRIPTION
This pull request introduces support for the experimental Matrix Rendezvous API discovery endpoint, allowing clients to check if rendezvous sessions can be created on the server. The main changes include adding the new endpoint, defining request and response types, and integrating the endpoint into the server's routing.

**Rendezvous API Discovery Support:**

* Added a new module `rendezvous` in `crates/core/src/client/discovery` that defines the request and response types for the rendezvous discovery endpoint, including tests for serialization and deserialization.
* Updated the module exports in `crates/core/src/client/discovery.rs` to include the new `rendezvous` module.

**Server Routing Integration:**

* Registered the new `GET /_matrix/client/unstable/io.element.msc4388/rendezvous` endpoint in the client unstable router, and implemented its handler to return the discovery response (currently always indicating that session creation is unavailable). [[1]](diffhunk://#diff-9e4e0f0f72cbddd06c155e183ea22a29250e455d20c85d5a8425f99de653c840R4) [[2]](diffhunk://#diff-9e4e0f0f72cbddd06c155e183ea22a29250e455d20c85d5a8425f99de653c840R16) [[3]](diffhunk://#diff-9e4e0f0f72cbddd06c155e183ea22a29250e455d20c85d5a8425f99de653c840R49-R56)