### PR TITLE
Add no access token authentication scheme

### DIFF
--- a/crates/core/src/auth_scheme.rs
+++ b/crates/core/src/auth_scheme.rs
@@ -41,13 +41,38 @@ pub trait AuthScheme: Sized {
 }
 
 /// No authentication is performed.
-///
-/// This type accepts a [`SendAccessToken`] as input to be able to send it regardless of whether it
-/// is required.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct NoAuthentication;
 
 impl AuthScheme for NoAuthentication {
+    type Input<'a> = ();
+    type AddAuthenticationError = std::convert::Infallible;
+    type Output = ();
+    type ExtractAuthenticationError = std::convert::Infallible;
+
+    fn add_authentication<T: AsRef<[u8]>>(
+        _request: &mut http::Request<T>,
+        _input: (),
+    ) -> Result<(), Self::AddAuthenticationError> {
+        Ok(())
+    }
+
+    /// Since this endpoint doesn't expect any authentication, this is a noop.
+    fn extract_authentication<T: AsRef<[u8]>>(
+        _request: &http::Request<T>,
+    ) -> Result<(), Self::ExtractAuthenticationError> {
+        Ok(())
+    }
+}
+
+/// No authentication is performed on an API that usually relies on access tokens.
+///
+/// Contrary to [`NoAuthentication`], this type accepts a [`SendAccessToken`] as input to be able to
+/// send it regardless of whether it is required.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoAccessToken;
+
+impl AuthScheme for NoAccessToken {
     type Input<'a> = SendAccessToken<'a>;
     type AddAuthenticationError = header::InvalidHeaderValue;
     type Output = ();
@@ -341,4 +366,52 @@ pub enum ExtractTokenError {
     /// Failed to deserialize the query string.
     #[error("failed to deserialize query string: {0}")]
     FromQuery(#[from] serde_html_form::de::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use http::header;
+
+    use super::{AuthScheme, NoAccessToken, NoAuthentication, SendAccessToken};
+
+    const TOKEN: &str = "token";
+
+    fn http_request() -> http::Request<Vec<u8>> {
+        http::Request::builder().uri("/").body(Vec::new()).unwrap()
+    }
+
+    #[test]
+    fn no_authentication_ignores_headers() {
+        let mut request = http_request();
+
+        NoAuthentication::add_authentication(&mut request, ()).unwrap();
+
+        assert!(request.headers().get(header::AUTHORIZATION).is_none());
+    }
+
+    #[test]
+    fn no_access_token_only_sends_for_always() {
+        let mut request = http_request();
+
+        NoAccessToken::add_authentication(&mut request, SendAccessToken::IfRequired(TOKEN))
+            .unwrap();
+        assert!(request.headers().get(header::AUTHORIZATION).is_none());
+
+        NoAccessToken::add_authentication(&mut request, SendAccessToken::Always(TOKEN)).unwrap();
+        assert_eq!(
+            request.headers().get(header::AUTHORIZATION).unwrap(),
+            "Bearer token"
+        );
+    }
+
+    #[test]
+    fn no_access_token_extracts_no_authentication() {
+        let request = http::Request::builder()
+            .uri("/?access_token=token")
+            .header(header::AUTHORIZATION, "NotBearer token")
+            .body(Vec::new())
+            .unwrap();
+
+        NoAccessToken::extract_authentication(&request).unwrap();
+    }
 }

--- a/crates/core/src/client/rendezvous.rs
+++ b/crates/core/src/client/rendezvous.rs
@@ -11,7 +11,7 @@ pub mod unstable {
     #[cfg(feature = "client")]
     use crate::api::error::FromHttpResponseError;
     use crate::{
-        api::{auth_scheme::NoAuthentication, error::HeaderDeserializationError},
+        api::{auth_scheme::NoAccessToken, error::HeaderDeserializationError},
         metadata,
     };
     use serde::{Deserialize, Serialize};
@@ -21,7 +21,7 @@ pub mod unstable {
     metadata! {
         method: POST,
         rate_limited: true,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             unstable("org.matrix.msc4108") => "/_matrix/client/unstable/org.matrix.msc4108/rendezvous",
         }

--- a/crates/core/src/client/rendezvous/create_rendezvous_session.rs
+++ b/crates/core/src/client/rendezvous/create_rendezvous_session.rs
@@ -11,7 +11,7 @@ pub mod unstable {
     #[cfg(feature = "client")]
     use crate::api::error::FromHttpResponseError;
     use crate::{
-        api::{auth_scheme::NoAuthentication, error::HeaderDeserializationError},
+        api::{auth_scheme::NoAccessToken, error::HeaderDeserializationError},
         metadata,
     };
     use serde::{Deserialize, Serialize};
@@ -21,7 +21,7 @@ pub mod unstable {
     metadata! {
         method: POST,
         rate_limited: true,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             unstable("org.matrix.msc4108") => "/_matrix/client/unstable/org.matrix.msc4108/rendezvous",
         }


### PR DESCRIPTION
This pull request introduces a new authentication scheme, `NoAccessToken`, to allow APIs that typically use access tokens to optionally send them, and updates relevant endpoints to use this scheme. It also adds tests to ensure correct authentication behavior. The most important changes are:

### Authentication Scheme Enhancements

* Added a new `NoAccessToken` struct and implemented the `AuthScheme` trait for it, allowing endpoints to accept a `SendAccessToken` and send it only when explicitly required. This is in contrast to the existing `NoAuthentication` scheme, which never sends tokens.
* Updated the `NoAuthentication` implementation to use an empty tuple as input and clarified its behavior as a true "no authentication" scheme.

### Endpoint Updates

* Changed the authentication scheme for the unstable rendezvous endpoints in `rendezvous.rs` and `create_rendezvous_session.rs` from `NoAuthentication` to `NoAccessToken`, aligning with the intended behavior for these APIs. [[1]](diffhunk://#diff-30e17840d0dc4616c9abec53dd2c1130ce8e14f2505ab8dd87773b93c798b694L14-R14) [[2]](diffhunk://#diff-30e17840d0dc4616c9abec53dd2c1130ce8e14f2505ab8dd87773b93c798b694L24-R24)

### Testing Improvements

* Added unit tests for both `NoAuthentication` and `NoAccessToken` to verify that headers are handled as expected and that tokens are only sent when required.