### PR TITLE
Stabilize OAuth device authorization metadata

### DIFF
--- a/crates/core/src/client/discovery/auth_metadata.rs
+++ b/crates/core/src/client/discovery/auth_metadata.rs
@@ -141,7 +141,6 @@ pub struct AuthorizationServerMetadata {
     /// URL of the authorization server's device authorization endpoint ([RFC 8628]).
     ///
     /// [RFC 8628]: https://datatracker.ietf.org/doc/html/rfc8628
-    #[cfg(feature = "unstable-msc4108")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub device_authorization_endpoint: Option<Url>,
 
@@ -205,7 +204,6 @@ impl AuthorizationServerMetadata {
             self.account_management_uri
                 .as_ref()
                 .map(|string| ("account_management_uri", string)),
-            #[cfg(feature = "unstable-msc4108")]
             self.device_authorization_endpoint
                 .as_ref()
                 .map(|string| ("device_authorization_endpoint", string)),
@@ -274,7 +272,6 @@ pub enum GrantType {
     /// The device code grant type ([RFC 8628]).
     ///
     /// [RFC 8628]: https://datatracker.ietf.org/doc/html/rfc8628
-    #[cfg(feature = "unstable-msc4108")]
     #[palpo_enum(rename = "urn:ietf:params:oauth:grant-type:device_code")]
     DeviceCode,
 
@@ -459,13 +456,10 @@ mod tests {
             metadata.insecure_validate_urls().unwrap();
         }
 
-        #[cfg(feature = "unstable-msc4108")]
-        {
-            let mut metadata = original_metadata.clone();
-            metadata.device_authorization_endpoint =
-                Some(Url::parse("http://server.local/device").unwrap());
-            metadata.validate_urls().unwrap_err();
-            metadata.insecure_validate_urls().unwrap();
-        }
+        let mut metadata = original_metadata;
+        metadata.device_authorization_endpoint =
+            Some(Url::parse("http://server.local/device").unwrap());
+        metadata.validate_urls().unwrap_err();
+        metadata.insecure_validate_urls().unwrap();
     }
 }

--- a/crates/core/src/client/discovery/auth_metadata/serde.rs
+++ b/crates/core/src/client/discovery/auth_metadata/serde.rs
@@ -30,7 +30,6 @@ impl<'de> Deserialize<'de> for AuthorizationServerMetadata {
             account_management_uri,
             #[cfg(feature = "unstable-msc4191")]
             account_management_actions_supported,
-            #[cfg(feature = "unstable-msc4108")]
             device_authorization_endpoint,
             prompt_values_supported,
         } = helper;
@@ -109,7 +108,6 @@ impl<'de> Deserialize<'de> for AuthorizationServerMetadata {
             account_management_uri,
             #[cfg(feature = "unstable-msc4191")]
             account_management_actions_supported,
-            #[cfg(feature = "unstable-msc4108")]
             device_authorization_endpoint,
             prompt_values_supported,
         })
@@ -132,7 +130,6 @@ struct AuthorizationServerMetadataDeHelper {
     #[cfg(feature = "unstable-msc4191")]
     #[serde(default)]
     account_management_actions_supported: BTreeSet<AccountManagementAction>,
-    #[cfg(feature = "unstable-msc4108")]
     device_authorization_endpoint: Option<Url>,
     #[serde(default)]
     prompt_values_supported: Vec<Prompt>,
@@ -269,7 +266,30 @@ mod tests {
             );
         }
 
-        #[cfg(feature = "unstable-msc4108")]
+        assert_eq!(
+            metadata
+                .device_authorization_endpoint
+                .as_ref()
+                .map(Url::as_str),
+            Some("https://server.local/device")
+        );
+    }
+
+    #[test]
+    fn metadata_device_authorization_grant_type() {
+        let mut metadata_object = authorization_server_metadata_object();
+        get_mut_array(&mut metadata_object, "grant_types_supported")
+            .push("urn:ietf:params:oauth:grant-type:device_code".into());
+
+        let metadata =
+            from_json_value::<AuthorizationServerMetadata>(metadata_object.into()).unwrap();
+
+        assert_eq!(metadata.grant_types_supported.len(), 3);
+        assert!(
+            metadata
+                .grant_types_supported
+                .contains(&GrantType::DeviceCode)
+        );
         assert_eq!(
             metadata
                 .device_authorization_endpoint
@@ -359,7 +379,6 @@ mod tests {
             assert_eq!(metadata.account_management_actions_supported.len(), 0);
         }
 
-        #[cfg(feature = "unstable-msc4108")]
         assert_eq!(metadata.device_authorization_endpoint, None);
     }
 
@@ -498,7 +517,6 @@ mod tests {
             );
         }
 
-        #[cfg(feature = "unstable-msc4108")]
         assert_eq!(
             metadata
                 .device_authorization_endpoint

--- a/crates/server/src/routing/client.rs
+++ b/crates/server/src/routing/client.rs
@@ -111,6 +111,7 @@ pub fn router() -> Router {
     }
     client
         .push(Router::with_path("versions").get(supported_versions))
+        .push(Router::with_path("v1/auth_metadata").get(unstable::auth_metadata))
         .push(
             Router::with_path("oidc")
                 .push(Router::with_path("status").get(oidc::oidc_status))

--- a/crates/server/src/routing/client/unstable.rs
+++ b/crates/server/src/routing/client/unstable.rs
@@ -66,11 +66,12 @@ async fn auth_issuer(res: &mut Response) -> JsonResult<serde_json::Value> {
 }
 
 /// `GET /_matrix/client/unstable/org.matrix.msc2965/auth_metadata`
+/// `GET /_matrix/client/v1/auth_metadata`
 ///
 /// Returns the OAuth 2.0 authorization server metadata (MSC2965/MSC3861).
 /// Fetches the metadata from the issuer's `/.well-known/openid-configuration` endpoint.
 #[endpoint]
-async fn auth_metadata(res: &mut Response) -> JsonResult<serde_json::Value> {
+pub(super) async fn auth_metadata(res: &mut Response) -> JsonResult<serde_json::Value> {
     res.headers_mut().insert(
         "Cache-Control",
         "public, max-age=600, s-maxage=3600, stale-while-revalidate=600"


### PR DESCRIPTION
This pull request removes the `unstable-msc4108` feature gating from support for the OAuth 2.0 Device Authorization Grant (RFC 8628) in the authorization server metadata. As a result, the device authorization endpoint and related grant type are now always available in the codebase, and the relevant tests are updated accordingly. Additionally, it exposes the `/v1/auth_metadata` endpoint in the client routing.

Key changes:

**Device Authorization Grant Support Un-gated:**

* Removed the `#[cfg(feature = "unstable-msc4108")]` conditional compilation from the `device_authorization_endpoint` field in `AuthorizationServerMetadata`, the `DeviceCode` variant in `GrantType`, and all related logic, making support for the device authorization endpoint and grant type always enabled. [[1]](diffhunk://#diff-8cfcb5a9f1cdaa617bd6b043b39d7e4fd315a6f2bf82e73c5a065f174e36fb03L144) [[2]](diffhunk://#diff-8cfcb5a9f1cdaa617bd6b043b39d7e4fd315a6f2bf82e73c5a065f174e36fb03L277) [[3]](diffhunk://#diff-daedecf46760427bb493a857431b8c02e8e832620e298072bf8081da9726dcd4L33) [[4]](diffhunk://#diff-daedecf46760427bb493a857431b8c02e8e832620e298072bf8081da9726dcd4L112) [[5]](diffhunk://#diff-daedecf46760427bb493a857431b8c02e8e832620e298072bf8081da9726dcd4L135)
* Updated tests to remove feature gating for device authorization endpoint and grant type, ensuring they are always tested. [[1]](diffhunk://#diff-8cfcb5a9f1cdaa617bd6b043b39d7e4fd315a6f2bf82e73c5a065f174e36fb03L462-L471) [[2]](diffhunk://#diff-daedecf46760427bb493a857431b8c02e8e832620e298072bf8081da9726dcd4L272-R292) [[3]](diffhunk://#diff-daedecf46760427bb493a857431b8c02e8e832620e298072bf8081da9726dcd4L362) [[4]](diffhunk://#diff-daedecf46760427bb493a857431b8c02e8e832620e298072bf8081da9726dcd4L501)

**API and Routing Improvements:**

* Added the `/v1/auth_metadata` endpoint to the client router, making the authorization server metadata accessible via a stable path.
* Made the `auth_metadata` handler public within the module to support the new route.