### PR TITLE
Implement account state authentication guards

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -209,7 +209,7 @@ impl Scribe for MatrixError {
                     Unauthorized | UnknownToken { .. } | MissingToken => StatusCode::UNAUTHORIZED,
                     NotFound | Unrecognized => StatusCode::NOT_FOUND,
                     LimitExceeded { .. } => StatusCode::TOO_MANY_REQUESTS,
-                    UserDeactivated => StatusCode::FORBIDDEN,
+                    UserDeactivated | UserLocked | UserSuspended => StatusCode::FORBIDDEN,
                     TooLarge => StatusCode::PAYLOAD_TOO_LARGE,
                     CannotOverwriteMedia => StatusCode::CONFLICT,
                     NotYetUploaded => StatusCode::GATEWAY_TIMEOUT,

--- a/crates/server/src/hoops/auth.rs
+++ b/crates/server/src/hoops/auth.rs
@@ -73,7 +73,7 @@ async fn auth_by_access_token_inner(aa: AuthArgs, depot: &mut Depot) -> AppResul
             .find(&access_token.user_id)
             .first::<DbUser>(&mut connect()?)
             .map_err(|_| MatrixError::unknown_token("User not found", true))?;
-        ensure_user_account_usable(&user)?;
+        crate::user::ensure_account_usable(&user)?;
         let user_device = user_devices::table
             .filter(user_devices::device_id.eq(&access_token.device_id))
             .filter(user_devices::user_id.eq(&user.id))
@@ -129,7 +129,7 @@ async fn auth_by_access_token_inner(aa: AuthArgs, depot: &mut Depot) -> AppResul
                     (user, user_device)
                 };
 
-                ensure_user_account_usable(&user)?;
+                crate::user::ensure_account_usable(&user)?;
                 depot.inject(AuthedInfo {
                     user,
                     user_device,
@@ -169,7 +169,7 @@ async fn auth_by_delegated_token(token: &str, aa: &AuthArgs, depot: &mut Depot) 
         crate::data::user::set_guest(&user_id, false)?;
         user.is_guest = false;
     }
-    ensure_user_account_usable(&user)?;
+    crate::user::ensure_account_usable(&user)?;
 
     // Extract device_id from introspection response, scope, or query param
     let device_id_str = result
@@ -205,22 +205,6 @@ async fn auth_by_delegated_token(token: &str, aa: &AuthArgs, depot: &mut Depot) 
         access_token_id: None,
         appservice: None,
     });
-    Ok(())
-}
-
-fn ensure_user_account_usable(user: &DbUser) -> AppResult<()> {
-    if user.is_deactivated() {
-        return Err(MatrixError::user_deactivated("the user has been deactivated").into());
-    }
-
-    if user.is_locked() {
-        return Err(MatrixError::user_locked("the user has been locked").into());
-    }
-
-    if user.is_suspended() {
-        return Err(MatrixError::user_suspended("the user has been suspended").into());
-    }
-
     Ok(())
 }
 

--- a/crates/server/src/routing/client/session.rs
+++ b/crates/server/src/routing/client/session.rs
@@ -8,6 +8,7 @@ use salvo::prelude::*;
 use crate::core::UnixMillis;
 use crate::core::client::session::*;
 use crate::core::client::uiaa::{AuthFlow, AuthType, UiaaInfo, UserIdentifier};
+use crate::core::error::ErrorKind;
 use crate::core::identifiers::*;
 use crate::core::serde::CanonicalJsonValue;
 use crate::data::connect;
@@ -169,8 +170,18 @@ async fn login(
             let Ok(user) = data::user::get_user(&user_id) else {
                 return Err(MatrixError::forbidden("User not found.", None).into());
             };
-            if let Err(_e) = user::verify_password(&user, password) {
+            if let Err(e) = user::verify_password(&user, password) {
                 res.status_code(StatusCode::FORBIDDEN); //for complement testing: TestLogin/parallel/POST_/login_wrong_password_is_rejected
+                if let AppError::Matrix(matrix) = e {
+                    if matches!(
+                        matrix.kind,
+                        ErrorKind::UserDeactivated
+                            | ErrorKind::UserLocked
+                            | ErrorKind::UserSuspended
+                    ) {
+                        return Err(matrix.into());
+                    }
+                }
                 return Err(MatrixError::forbidden("Wrong username or password.", None).into());
             }
             // }
@@ -244,6 +255,10 @@ async fn login(
             return Err(MatrixError::unknown("Unsupported login type.").into());
         }
     };
+
+    let user = data::user::get_user(&user_id)
+        .map_err(|_| MatrixError::forbidden("User not found.", None))?;
+    user::ensure_account_usable(&user)?;
 
     // Generate new device id if the user didn't specify one
     let device_id = body

--- a/crates/server/src/user/password.rs
+++ b/crates/server/src/user/password.rs
@@ -8,7 +8,7 @@ use crate::data::schema::*;
 use crate::data::user::NewDbPassword;
 use crate::{AppResult, MatrixError};
 
-pub fn verify_password(user: &DbUser, password: &str) -> AppResult<()> {
+pub fn ensure_account_usable(user: &DbUser) -> AppResult<()> {
     if user.deactivated_at.is_some() {
         return Err(MatrixError::user_deactivated("the user has been deactivated").into());
     }
@@ -18,6 +18,12 @@ pub fn verify_password(user: &DbUser, password: &str) -> AppResult<()> {
     if user.suspended_at.is_some() {
         return Err(MatrixError::user_suspended("the user has been suspended").into());
     }
+    Ok(())
+}
+
+pub fn verify_password(user: &DbUser, password: &str) -> AppResult<()> {
+    ensure_account_usable(user)?;
+
     let hash = crate::user::get_password_hash(&user.id)
         .map_err(|_| MatrixError::unauthorized("wrong username or password."))?;
     if hash.is_empty() {


### PR DESCRIPTION
This pull request refactors how user account status checks (for deactivation, locking, and suspension) are handled throughout the authentication and login flows. The main improvement is centralizing the logic for checking if a user account is usable into a single function, and ensuring that all relevant authentication paths use this check. Additionally, error handling is improved to return more accurate status codes and error types for locked and suspended users.

**User account usability checks refactor:**

* Moved the `ensure_user_account_usable` function from `auth.rs` to `user/password.rs`, renamed it to `ensure_account_usable`, and updated it to check for deactivated, locked, and suspended user accounts. All authentication and login flows now consistently call this function to verify account status. [[1]](diffhunk://#diff-e27f34f41b985d4b0842e37d16fc6c9a9bcabde26a0fd5efbe5988a5f2406141L76-R76) [[2]](diffhunk://#diff-e27f34f41b985d4b0842e37d16fc6c9a9bcabde26a0fd5efbe5988a5f2406141L132-R132) [[3]](diffhunk://#diff-e27f34f41b985d4b0842e37d16fc6c9a9bcabde26a0fd5efbe5988a5f2406141L172-R172) [[4]](diffhunk://#diff-e27f34f41b985d4b0842e37d16fc6c9a9bcabde26a0fd5efbe5988a5f2406141L211-L226) [[5]](diffhunk://#diff-8bcb82fccf5a147898bb0f9cf81c228b62a1a3fb0e1e30a2a6462f12087f6e8eL11-R11) [[6]](diffhunk://#diff-8bcb82fccf5a147898bb0f9cf81c228b62a1a3fb0e1e30a2a6462f12087f6e8eR21-R26) [[7]](diffhunk://#diff-be245555237f0442ce12f7374bbec516cf12c6574b1f586917fbdcff887ac590R259-R262)

* Updated the `verify_password` function to call `ensure_account_usable` before checking the password, ensuring that locked, suspended, or deactivated users cannot log in even with a correct password.

**Error handling improvements:**

* Improved error handling in the login route to return specific errors for deactivated, locked, or suspended users, rather than a generic forbidden error.

* Updated the `MatrixError` to return `FORBIDDEN` status for all three account states: deactivated, locked, and suspended, ensuring consistent HTTP status codes for these cases.

**Code organization:**

* Removed the old `ensure_user_account_usable` function definition from `auth.rs` and replaced all its usages with the new centralized function.

* Added necessary imports and minor code cleanup to support the refactor.

These changes make the authentication flow more robust and maintainable by ensuring all routes consistently enforce account status checks and return accurate error responses.