### PR TITLE
Apply ignored user timeline filtering

### DIFF
--- a/crates/data/src/user.rs
+++ b/crates/data/src/user.rs
@@ -137,6 +137,15 @@ pub fn joined_rooms(user_id: &UserId) -> DataResult<Vec<OwnedRoomId>> {
         })
         .collect::<Vec<_>>())
 }
+
+pub fn ignored_users(user_id: &UserId) -> DataResult<Vec<OwnedUserId>> {
+    user_ignores::table
+        .filter(user_ignores::user_id.eq(user_id))
+        .select(user_ignores::ignored_id)
+        .load::<OwnedUserId>(&mut connect()?)
+        .map_err(Into::into)
+}
+
 /// Returns an iterator over all rooms a user was invited to.
 pub fn invited_rooms(
     user_id: &UserId,

--- a/crates/server/src/event.rs
+++ b/crates/server/src/event.rs
@@ -311,23 +311,16 @@ pub fn ignored_filter(item: PdusIterItem, user_id: &UserId) -> bool {
     !is_ignored_pdu(pdu, user_id)
 }
 
-pub fn is_ignored_pdu(pdu: &SnPduEvent, _user_id: &UserId) -> bool {
+pub fn is_ignored_pdu(pdu: &SnPduEvent, user_id: &UserId) -> bool {
     // exclude Synapse's dummy events from bloating up response bodies. clients
     // don't need to see this.
     if pdu.event_ty.to_string() == "org.matrix.dummy_event" {
         return true;
     }
 
-    // TODO: fixme
-    // let ignored_type = IGNORED_MESSAGE_TYPES.binary_search(&pdu.kind).is_ok();
+    is_ignored_sender_pdu(pdu, user_id)
+}
 
-    // let ignored_server = crate::config::get()
-    //     .forbidden_remote_server_names
-    //     .contains(pdu.sender().server_name());
-
-    // if ignored_type && (crate::user::user_is_ignored(&pdu.sender, user_id).await) {
-    //     return true;
-    // }
-
-    false
+pub fn is_ignored_sender_pdu(pdu: &SnPduEvent, user_id: &UserId) -> bool {
+    pdu.state_key.is_none() && crate::user::user_is_ignored(&pdu.sender, user_id)
 }

--- a/crates/server/src/event.rs
+++ b/crates/server/src/event.rs
@@ -7,6 +7,8 @@ pub use batch_token::*;
 pub use pdu::*;
 mod outlier;
 pub mod search;
+use std::collections::BTreeSet;
+
 use diesel::prelude::*;
 pub use outlier::*;
 
@@ -311,16 +313,41 @@ pub fn ignored_filter(item: PdusIterItem, user_id: &UserId) -> bool {
     !is_ignored_pdu(pdu, user_id)
 }
 
+#[inline]
+pub fn ignored_filter_with_ignored_users(
+    item: PdusIterItem,
+    ignored_users: &BTreeSet<OwnedUserId>,
+) -> bool {
+    let (_, pdu) = item;
+    !is_ignored_pdu_by_ignored_users(pdu, ignored_users)
+}
+
 pub fn is_ignored_pdu(pdu: &SnPduEvent, user_id: &UserId) -> bool {
+    let ignored_users = crate::user::ignored_users(user_id);
+    is_ignored_pdu_by_ignored_users(pdu, &ignored_users)
+}
+
+pub fn is_ignored_pdu_by_ignored_users(
+    pdu: &SnPduEvent,
+    ignored_users: &BTreeSet<OwnedUserId>,
+) -> bool {
     // exclude Synapse's dummy events from bloating up response bodies. clients
     // don't need to see this.
     if pdu.event_ty.to_string() == "org.matrix.dummy_event" {
         return true;
     }
 
-    is_ignored_sender_pdu(pdu, user_id)
+    is_ignored_sender_pdu_by_ignored_users(pdu, ignored_users)
 }
 
 pub fn is_ignored_sender_pdu(pdu: &SnPduEvent, user_id: &UserId) -> bool {
-    pdu.state_key.is_none() && crate::user::user_is_ignored(&pdu.sender, user_id)
+    let ignored_users = crate::user::ignored_users(user_id);
+    is_ignored_sender_pdu_by_ignored_users(pdu, &ignored_users)
+}
+
+pub fn is_ignored_sender_pdu_by_ignored_users(
+    pdu: &SnPduEvent,
+    ignored_users: &BTreeSet<OwnedUserId>,
+) -> bool {
+    pdu.state_key.is_none() && ignored_users.contains(&pdu.sender)
 }

--- a/crates/server/src/room/timeline/stream.rs
+++ b/crates/server/src/room/timeline/stream.rs
@@ -184,6 +184,11 @@ pub fn load_pdus(
                     {
                         continue;
                     }
+                    if let Some(user_id) = user_id
+                        && crate::event::is_ignored_pdu(&pdu, user_id)
+                    {
+                        continue;
+                    }
                     if let Some(user_id) = user_id {
                         if pdu.sender != user_id {
                             pdu.remove_transaction_id()?;

--- a/crates/server/src/room/timeline/stream.rs
+++ b/crates/server/src/room/timeline/stream.rs
@@ -69,6 +69,8 @@ pub fn load_pdus(
     dir: Direction,
 ) -> AppResult<IndexMap<Seqnum, SnPduEvent>> {
     let mut list: IndexMap<Seqnum, SnPduEvent> = IndexMap::with_capacity(limit.clamp(10, 100));
+    let ignored_users = user_id.map(crate::user::ignored_users);
+    let mut offset = 0;
     let mut start_sn = if dir == Direction::Forward {
         0
     } else {
@@ -145,6 +147,7 @@ pub fn load_pdus(
                 .filter(events::sn.gt(start_sn))
                 .filter(events::is_rejected.eq(false))
                 .order(events::stream_ordering.desc())
+                .offset(offset)
                 .limit(utils::usize_to_i64(limit))
                 .select((events::id, events::sn))
                 .load::<(OwnedEventId, Seqnum)>(&mut connect()?)?
@@ -165,17 +168,16 @@ pub fn load_pdus(
         if events.is_empty() {
             break;
         }
-        start_sn = if dir == Direction::Forward {
-            if let Some(sn) = events.iter().map(|(_, sn)| sn).max() {
+        let count = events.len();
+        if dir == Direction::Forward {
+            offset += count as i64;
+        } else {
+            start_sn = if let Some(sn) = events.iter().map(|(_, sn)| sn).min() {
                 *sn
             } else {
                 break;
-            }
-        } else if let Some(sn) = events.iter().map(|(_, sn)| sn).min() {
-            *sn
-        } else {
-            break;
-        };
+            };
+        }
         for (event_id, event_sn) in events {
             match super::get_pdu(&event_id) {
                 Ok(mut pdu) => {
@@ -184,8 +186,8 @@ pub fn load_pdus(
                     {
                         continue;
                     }
-                    if let Some(user_id) = user_id
-                        && crate::event::is_ignored_pdu(&pdu, user_id)
+                    if let Some(ignored_users) = &ignored_users
+                        && crate::event::is_ignored_pdu_by_ignored_users(&pdu, ignored_users)
                     {
                         continue;
                     }
@@ -208,6 +210,9 @@ pub fn load_pdus(
                     );
                 }
             }
+        }
+        if dir == Direction::Forward && count < limit {
+            break;
         }
     }
     Ok(list)

--- a/crates/server/src/room/timeline/topolo.rs
+++ b/crates/server/src/room/timeline/topolo.rs
@@ -60,6 +60,7 @@ pub fn load_pdus(
     dir: Direction,
 ) -> AppResult<IndexMap<Seqnum, SnPduEvent>> {
     let mut list: IndexMap<Seqnum, SnPduEvent> = IndexMap::with_capacity(limit.clamp(10, 100));
+    let ignored_users = user_id.map(crate::user::ignored_users);
     let mut offset = 0;
     while list.len() < limit {
         let mut query = events::table
@@ -211,7 +212,9 @@ pub fn load_pdus(
                     if !pdu.user_can_see(user_id)? {
                         continue;
                     }
-                    if crate::event::is_ignored_pdu(&pdu, user_id) {
+                    if let Some(ignored_users) = &ignored_users
+                        && crate::event::is_ignored_pdu_by_ignored_users(&pdu, ignored_users)
+                    {
                         continue;
                     }
                     if pdu.sender != user_id {

--- a/crates/server/src/room/timeline/topolo.rs
+++ b/crates/server/src/room/timeline/topolo.rs
@@ -211,6 +211,9 @@ pub fn load_pdus(
                     if !pdu.user_can_see(user_id)? {
                         continue;
                     }
+                    if crate::event::is_ignored_pdu(&pdu, user_id) {
+                        continue;
+                    }
                     if pdu.sender != user_id {
                         pdu.remove_transaction_id()?;
                     }

--- a/crates/server/src/routing/client/room/event.rs
+++ b/crates/server/src/routing/client/room/event.rs
@@ -54,6 +54,16 @@ pub(super) fn get_room_event(
     if !state::user_can_see_event(authed.user_id(), &args.event_id)? {
         return Err(MatrixError::not_found("event not found").into());
     }
+    if crate::event::is_ignored_sender_pdu(&event, authed.user_id()) {
+        return Err(MatrixError::sender_ignored(
+            "the sender of the requested event is ignored",
+            Some(event.sender.clone()),
+        )
+        .into());
+    }
+    if crate::event::is_ignored_pdu(&event, authed.user_id()) {
+        return Err(MatrixError::not_found("event not found").into());
+    }
 
     let mut event = event.clone();
     event.add_age()?;
@@ -163,6 +173,13 @@ pub(super) fn get_context(
         return Err(
             MatrixError::forbidden("you don't have permission to view this event", None).into(),
         );
+    }
+    if crate::event::is_ignored_sender_pdu(&base_event, sender_id) {
+        return Err(MatrixError::sender_ignored(
+            "the sender of the requested event is ignored",
+            Some(base_event.sender.clone()),
+        )
+        .into());
     }
 
     if !crate::room::lazy_loading::lazy_load_was_sent_before(

--- a/crates/server/src/sync_v5.rs
+++ b/crates/server/src/sync_v5.rs
@@ -20,7 +20,7 @@ use crate::core::identifiers::*;
 use crate::core::{Seqnum, UnixMillis};
 use crate::data::connect;
 use crate::data::schema::*;
-use crate::event::{BatchToken, ignored_filter};
+use crate::event::{BatchToken, ignored_filter_with_ignored_users};
 use crate::room::{self, filter_rooms, state, timeline};
 use crate::sync_v3::{DEFAULT_BUMP_TYPES, TimelineData, share_encrypted_room};
 use crate::{AppResult, data, extract_variant};
@@ -264,6 +264,7 @@ pub async fn sync_events(
     }
 
     let all_joined_rooms = data::user::joined_rooms(sender_id)?;
+    let ignored_users = crate::user::ignored_users(sender_id);
 
     let all_invited_rooms = data::user::invited_rooms(sender_id, 0)?;
     let all_invited_rooms: Vec<&RoomId> = all_invited_rooms.iter().map(|r| r.0.as_ref()).collect();
@@ -330,6 +331,7 @@ pub async fn sync_events(
         sync_info,
         &all_invited_rooms,
         &dm_rooms,
+        &ignored_users,
         &todo_rooms,
         known_rooms,
         &mut res_body,
@@ -535,6 +537,7 @@ async fn process_rooms(
     }: SyncInfo<'_>,
     all_invited_rooms: &[&RoomId],
     dm_rooms: &HashSet<OwnedRoomId>,
+    ignored_users: &BTreeSet<OwnedUserId>,
     todo_rooms: &TodoRooms,
     known_rooms: &KnownRooms,
     response: &mut SyncEventsResBody,
@@ -619,7 +622,7 @@ async fn process_rooms(
             let mut receipts = data::room::receipt::read_receipts(room_id, *room_since_sn)?
                 .into_iter()
                 .filter_map(|(read_user, content)| {
-                    if !crate::user::user_is_ignored(&read_user, sender_id) {
+                    if !ignored_users.contains(&read_user) {
                         Some(content)
                     } else {
                         None
@@ -665,7 +668,7 @@ async fn process_rooms(
         let room_events: Vec<_> = timeline
             .events
             .iter()
-            .filter(|item| ignored_filter(*item, sender_id))
+            .filter(|item| ignored_filter_with_ignored_users(*item, &ignored_users))
             .map(|(_, pdu)| pdu.to_sync_room_event())
             .collect();
 

--- a/crates/server/src/user.rs
+++ b/crates/server/src/user.rs
@@ -8,7 +8,7 @@ pub mod presence;
 // mod ldap;
 // pub use ldap::*;
 pub mod session;
-use std::mem;
+use std::{collections::BTreeSet, mem};
 
 use diesel::prelude::*;
 pub use presence::*;
@@ -126,17 +126,24 @@ pub fn clean_signatures<F: Fn(&UserId) -> bool>(
 /// Returns true/false based on whether the recipient/receiving user has
 /// blocked the sender
 pub fn user_is_ignored(sender_id: &UserId, recipient_id: &UserId) -> bool {
+    ignored_users(recipient_id)
+        .iter()
+        .any(|blocked_user| blocked_user == sender_id)
+}
+
+pub fn ignored_users(recipient_id: &UserId) -> BTreeSet<OwnedUserId> {
+    let ignored_user_ids = data::user::ignored_users(recipient_id).unwrap_or_default();
+    if !ignored_user_ids.is_empty() {
+        return ignored_user_ids.into_iter().collect();
+    }
+
     if let Ok(Some(ignored)) = data::user::get_global_data::<IgnoredUserListEvent>(
         recipient_id,
         &GlobalAccountDataEventType::IgnoredUserList.to_string(),
     ) {
-        ignored
-            .content
-            .ignored_users
-            .keys()
-            .any(|blocked_user| blocked_user == sender_id)
+        ignored.content.ignored_users.keys().cloned().collect()
     } else {
-        false
+        BTreeSet::new()
     }
 }
 


### PR DESCRIPTION
This pull request improves how ignored events and senders are filtered from responses and event lookups, making the handling of ignored users more consistent and robust across the codebase. The main changes involve updating the logic to check if an event or its sender should be ignored, and applying these checks in various event loading and retrieval functions.

**Event filtering and ignored user handling:**

* Refactored `is_ignored_pdu` and added `is_ignored_sender_pdu` in `crates/server/src/event.rs` to consistently check if a PDU or its sender should be ignored, using `user_is_ignored` logic. The new implementation ensures ignored events are filtered out early.

* Applied ignored event and sender checks in event loading functions (`load_pdus`) in both `crates/server/src/room/timeline/stream.rs` and `crates/server/src/room/timeline/topolo.rs`, ensuring ignored events are skipped when loading timelines. [[1]](diffhunk://#diff-03366c0438c58c0cc7f8493f84b65fd06298c7bc6c92667b92569e69b51d9aaeR187-R191) [[2]](diffhunk://#diff-5f93c904cf25d222385fcd003f648f7de480f5d6a21c3476f7f21bc5ebc913aeR214-R216)

**API response changes:**

* Updated `get_room_event` and `get_context` in `crates/server/src/routing/client/room/event.rs` to return appropriate errors if the event or its sender is ignored, improving client feedback and privacy. [[1]](diffhunk://#diff-8b277cdeb6efcf6700d9796b0a65d66cf1246c5521bf46317a6af77fb7f0d25fR57-R66) [[2]](diffhunk://#diff-8b277cdeb6efcf6700d9796b0a65d66cf1246c5521bf46317a6af77fb7f0d25fR177-R183)