### PR TITLE
Implement custom profile field routes and federation settings

### DIFF
--- a/crates/core/src/user.rs
+++ b/crates/core/src/user.rs
@@ -1,8 +1,11 @@
+use std::collections::BTreeMap;
+
 use salvo::oapi::{ToParameters, ToSchema};
 use serde::{Deserialize, Serialize};
 
 use crate::events::GlobalAccountDataEventType;
 pub use crate::profile::ProfileFieldName as ProfileField;
+use crate::serde::JsonValue;
 use crate::{OwnedMxcUri, OwnedRoomId, OwnedUserId};
 
 #[derive(ToParameters, Deserialize, Debug)]
@@ -103,6 +106,11 @@ pub struct ProfileResBody {
         skip_serializing_if = "Option::is_none"
     )]
     pub blurhash: Option<String>,
+
+    /// Additional custom profile fields.
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    #[salvo(schema(value_type = Object, additional_properties = true))]
+    pub fields: BTreeMap<String, JsonValue>,
 }
 impl ProfileResBody {
     /// Creates a new `Response` with the given avatar URL and display name.
@@ -111,6 +119,7 @@ impl ProfileResBody {
             avatar_url,
             display_name,
             blurhash: None,
+            fields: BTreeMap::new(),
         }
     }
 }

--- a/crates/data/migrations/2026-04-25-000001_user_profile_fields/down.sql
+++ b/crates/data/migrations/2026-04-25-000001_user_profile_fields/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_profiles DROP COLUMN IF EXISTS fields;

--- a/crates/data/migrations/2026-04-25-000001_user_profile_fields/up.sql
+++ b/crates/data/migrations/2026-04-25-000001_user_profile_fields/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_profiles ADD COLUMN fields JSONB NOT NULL DEFAULT '{}'::jsonb;

--- a/crates/data/src/schema.rs
+++ b/crates/data/src/schema.rs
@@ -942,6 +942,7 @@ diesel::table! {
         display_name -> Nullable<Text>,
         avatar_url -> Nullable<Text>,
         blurhash -> Nullable<Text>,
+        fields -> Jsonb,
     }
 }
 

--- a/crates/data/src/user/profile.rs
+++ b/crates/data/src/user/profile.rs
@@ -2,6 +2,7 @@ use diesel::prelude::*;
 
 use crate::core::OwnedMxcUri;
 use crate::core::identifiers::*;
+use crate::core::serde::{JsonObject, JsonValue};
 use crate::schema::*;
 use crate::{DataResult, connect};
 
@@ -15,6 +16,7 @@ pub struct DbProfile {
     pub display_name: Option<String>,
     pub avatar_url: Option<OwnedMxcUri>,
     pub blurhash: Option<String>,
+    pub fields: JsonValue,
 }
 
 #[derive(Insertable, Debug, Clone)]
@@ -43,4 +45,48 @@ pub fn get_profile(user_id: &UserId, room_id: Option<&RoomId>) -> DataResult<Opt
             .optional()?
     };
     Ok(profile)
+}
+
+pub fn profile_fields(user_id: &UserId) -> DataResult<JsonObject> {
+    let fields = user_profiles::table
+        .filter(user_profiles::user_id.eq(user_id))
+        .filter(user_profiles::room_id.is_null())
+        .select(user_profiles::fields)
+        .first::<JsonValue>(&mut connect()?)?;
+
+    Ok(fields.as_object().cloned().unwrap_or_default())
+}
+
+pub fn profile_field(user_id: &UserId, field: &str) -> DataResult<Option<JsonValue>> {
+    Ok(profile_fields(user_id)?.remove(field))
+}
+
+pub fn set_profile_field(user_id: &UserId, field: &str, value: JsonValue) -> DataResult<()> {
+    let mut fields = profile_fields(user_id)?;
+    fields.insert(field.to_owned(), value);
+
+    diesel::update(
+        user_profiles::table
+            .filter(user_profiles::user_id.eq(user_id))
+            .filter(user_profiles::room_id.is_null()),
+    )
+    .set(user_profiles::fields.eq(JsonValue::Object(fields)))
+    .execute(&mut connect()?)?;
+
+    Ok(())
+}
+
+pub fn delete_profile_field(user_id: &UserId, field: &str) -> DataResult<()> {
+    let mut fields = profile_fields(user_id)?;
+    fields.remove(field);
+
+    diesel::update(
+        user_profiles::table
+            .filter(user_profiles::user_id.eq(user_id))
+            .filter(user_profiles::room_id.is_null()),
+    )
+    .set(user_profiles::fields.eq(JsonValue::Object(fields)))
+    .execute(&mut connect()?)?;
+
+    Ok(())
 }

--- a/crates/data/src/user/profile.rs
+++ b/crates/data/src/user/profile.rs
@@ -1,8 +1,9 @@
 use diesel::prelude::*;
+use diesel::sql_types::{Jsonb, Text};
 
-use crate::core::OwnedMxcUri;
 use crate::core::identifiers::*;
 use crate::core::serde::{JsonObject, JsonValue};
+use crate::core::{MatrixError, OwnedMxcUri};
 use crate::schema::*;
 use crate::{DataResult, connect};
 
@@ -61,32 +62,37 @@ pub fn profile_field(user_id: &UserId, field: &str) -> DataResult<Option<JsonVal
     Ok(profile_fields(user_id)?.remove(field))
 }
 
-pub fn set_profile_field(user_id: &UserId, field: &str, value: JsonValue) -> DataResult<()> {
-    let mut fields = profile_fields(user_id)?;
-    fields.insert(field.to_owned(), value);
-
-    diesel::update(
-        user_profiles::table
-            .filter(user_profiles::user_id.eq(user_id))
-            .filter(user_profiles::room_id.is_null()),
-    )
-    .set(user_profiles::fields.eq(JsonValue::Object(fields)))
-    .execute(&mut connect()?)?;
+fn ensure_profile_updated(updated: usize) -> DataResult<()> {
+    if updated == 0 {
+        return Err(MatrixError::not_found("Profile not found.").into());
+    }
 
     Ok(())
 }
 
-pub fn delete_profile_field(user_id: &UserId, field: &str) -> DataResult<()> {
-    let mut fields = profile_fields(user_id)?;
-    fields.remove(field);
-
-    diesel::update(
-        user_profiles::table
-            .filter(user_profiles::user_id.eq(user_id))
-            .filter(user_profiles::room_id.is_null()),
+pub fn set_profile_field(user_id: &UserId, field: &str, value: JsonValue) -> DataResult<()> {
+    let updated = diesel::sql_query(
+        "UPDATE user_profiles \
+         SET fields = fields || jsonb_build_object($2, $3::jsonb) \
+         WHERE user_id = $1 AND room_id IS NULL",
     )
-    .set(user_profiles::fields.eq(JsonValue::Object(fields)))
+    .bind::<Text, _>(user_id.as_str())
+    .bind::<Text, _>(field)
+    .bind::<Jsonb, _>(value)
     .execute(&mut connect()?)?;
 
-    Ok(())
+    ensure_profile_updated(updated)
+}
+
+pub fn delete_profile_field(user_id: &UserId, field: &str) -> DataResult<()> {
+    let updated = diesel::sql_query(
+        "UPDATE user_profiles \
+         SET fields = fields - $2 \
+         WHERE user_id = $1 AND room_id IS NULL",
+    )
+    .bind::<Text, _>(user_id.as_str())
+    .bind::<Text, _>(field)
+    .execute(&mut connect()?)?;
+
+    ensure_profile_updated(updated)
 }

--- a/crates/data/src/user/profile.rs
+++ b/crates/data/src/user/profile.rs
@@ -53,9 +53,14 @@ pub fn profile_fields(user_id: &UserId) -> DataResult<JsonObject> {
         .filter(user_profiles::user_id.eq(user_id))
         .filter(user_profiles::room_id.is_null())
         .select(user_profiles::fields)
-        .first::<JsonValue>(&mut connect()?)?;
+        .first::<JsonValue>(&mut connect()?)
+        .optional()?;
 
-    Ok(fields.as_object().cloned().unwrap_or_default())
+    Ok(fields
+        .as_ref()
+        .and_then(JsonValue::as_object)
+        .cloned()
+        .unwrap_or_default())
 }
 
 pub fn profile_field(user_id: &UserId, field: &str) -> DataResult<Option<JsonValue>> {

--- a/crates/server/src/routing/client/profile.rs
+++ b/crates/server/src/routing/client/profile.rs
@@ -1,7 +1,10 @@
+use std::collections::BTreeMap;
+
 use diesel::prelude::*;
 use palpo_core::UnixMillis;
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
+use serde::{Deserialize, Serialize};
 use serde_json::{from_value as from_json_value, value::to_raw_value};
 
 use crate::core::client::profile::*;
@@ -12,6 +15,7 @@ use crate::core::federation::query::{
 };
 use crate::core::identifiers::*;
 use crate::core::profile::ProfileFieldName;
+use crate::core::serde::{JsonObject, JsonValue};
 use crate::core::user::ProfileResBody;
 use crate::data::schema::*;
 use crate::data::user::{DbProfile, NewDbPresence};
@@ -28,17 +32,49 @@ pub fn public_router() -> Router {
         .get(get_profile)
         .push(Router::with_path("avatar_url").get(get_avatar_url))
         .push(Router::with_path("displayname").get(get_display_name))
+        .push(Router::with_path("{field}").get(get_profile_field))
 }
 pub fn authed_router() -> Router {
     Router::with_path("profile/{user_id}")
         .hoop(hoops::limit_rate)
         .push(Router::with_path("avatar_url").put(set_avatar_url))
         .push(Router::with_path("displayname").put(set_display_name))
+        .push(
+            Router::with_path("{field}")
+                .put(set_profile_field)
+                .delete(delete_profile_field),
+        )
+}
+
+#[derive(ToSchema, Serialize, Deserialize, Debug, Default)]
+struct ProfileFieldBody {
+    #[serde(flatten)]
+    #[salvo(schema(value_type = Object, additional_properties = true))]
+    fields: JsonObject,
+}
+
+impl ProfileFieldBody {
+    fn single(field: impl Into<String>, value: JsonValue) -> Self {
+        let mut fields = JsonObject::new();
+        fields.insert(field.into(), value);
+        Self { fields }
+    }
 }
 
 fn profile_from_federation_response(
     profile: FederationProfileResBody,
 ) -> serde_json::Result<ProfileResBody> {
+    let fields = profile
+        .iter()
+        .filter(|(field, _)| {
+            !matches!(
+                field.as_str(),
+                "avatar_url" | "displayname" | "xyz.amorgan.blurhash"
+            )
+        })
+        .map(|(field, value)| (field.clone(), value.clone()))
+        .collect();
+
     Ok(ProfileResBody {
         avatar_url: profile
             .get("avatar_url")
@@ -53,7 +89,46 @@ fn profile_from_federation_response(
         blurhash: profile
             .get("xyz.amorgan.blurhash")
             .and_then(|value| value.as_str().map(ToOwned::to_owned)),
+        fields,
     })
+}
+
+fn custom_profile_fields(fields: JsonValue) -> BTreeMap<String, JsonValue> {
+    fields
+        .as_object()
+        .map(|fields| {
+            fields
+                .iter()
+                .map(|(field, value)| (field.clone(), value.clone()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn ensure_custom_profile_field(field: &str) -> Result<(), MatrixError> {
+    if matches!(field, "avatar_url" | "displayname" | "xyz.amorgan.blurhash") {
+        return Err(MatrixError::invalid_param(
+            "Use the dedicated profile endpoint for this field.",
+        ));
+    }
+
+    Ok(())
+}
+
+fn ensure_profile_update_allowed(
+    authed: &crate::AuthedInfo,
+    user_id: &UserId,
+) -> Result<(), MatrixError> {
+    let is_allowed = authed.user_id() == user_id
+        || authed
+            .appservice()
+            .is_some_and(|appservice| appservice.is_user_match(user_id));
+
+    if !is_allowed {
+        return Err(MatrixError::forbidden("forbidden", None));
+    }
+
+    Ok(())
 }
 
 /// #GET /_matrix/client/r0/profile/{user_id}
@@ -87,6 +162,7 @@ async fn get_profile(_aa: AuthArgs, user_id: PathParam<OwnedUserId>) -> JsonResu
         blurhash,
         avatar_url,
         display_name,
+        fields,
         ..
     }) = user_profiles::table
         .filter(user_profiles::user_id.eq(&user_id))
@@ -97,6 +173,7 @@ async fn get_profile(_aa: AuthArgs, user_id: PathParam<OwnedUserId>) -> JsonResu
             avatar_url: None,
             blurhash: None,
             display_name: Some(user_id.localpart().to_owned()),
+            fields: BTreeMap::new(),
         });
     };
 
@@ -104,7 +181,50 @@ async fn get_profile(_aa: AuthArgs, user_id: PathParam<OwnedUserId>) -> JsonResu
         avatar_url,
         blurhash,
         display_name,
+        fields: custom_profile_fields(fields),
     })
+}
+
+/// #GET /_matrix/client/v3/profile/{user_id}/{field}
+/// Returns one custom profile field.
+#[endpoint]
+async fn get_profile_field(
+    _aa: AuthArgs,
+    user_id: PathParam<OwnedUserId>,
+    field: PathParam<String>,
+) -> JsonResult<ProfileFieldBody> {
+    let user_id = user_id.into_inner();
+    let field = field.into_inner();
+    ensure_custom_profile_field(&field)?;
+
+    if user_id.is_remote() {
+        let server_name = user_id.server_name().to_owned();
+        let request = profile_request(
+            &server_name.origin().await,
+            ProfileReqArgs {
+                user_id,
+                field: Some(field.as_str().into()),
+            },
+        )?
+        .into_inner();
+
+        let profile = crate::sending::send_federation_request(&server_name, request, None)
+            .await?
+            .json::<FederationProfileResBody>()
+            .await?;
+
+        let value = profile
+            .get(&field)
+            .cloned()
+            .ok_or_else(|| MatrixError::not_found("Profile field not found."))?;
+
+        return json_ok(ProfileFieldBody::single(field, value));
+    }
+
+    let value = data::user::profile_field(&user_id, &field)?
+        .ok_or_else(|| MatrixError::not_found("Profile field not found."))?;
+
+    json_ok(ProfileFieldBody::single(field, value))
 }
 
 /// #GET /_matrix/client/r0/profile/{user_id}/avatar_url
@@ -166,14 +286,7 @@ async fn set_avatar_url(
 
     // Allow if the user is updating their own profile, or if an appservice is updating
     // a user within its namespace
-    let is_allowed = authed.user_id() == user_id
-        || authed
-            .appservice()
-            .is_some_and(|appservice| appservice.is_user_match(&user_id));
-
-    if !is_allowed {
-        return Err(MatrixError::forbidden("forbidden", None).into());
-    }
+    ensure_profile_update_allowed(authed, &user_id)?;
 
     let SetAvatarUrlReqBody {
         avatar_url,
@@ -305,14 +418,7 @@ async fn set_display_name(
 
     // Allow if the user is updating their own profile, or if an appservice is updating
     // a user within its namespace
-    let is_allowed = authed.user_id() == user_id
-        || authed
-            .appservice()
-            .is_some_and(|appservice| appservice.is_user_match(&user_id));
-
-    if !is_allowed {
-        return Err(MatrixError::forbidden("forbidden", None).into());
-    }
+    ensure_profile_update_allowed(authed, &user_id)?;
     let SetDisplayNameReqBody { display_name } = body.into_inner();
 
     if let Some(display_name) = display_name.as_deref() {
@@ -371,6 +477,55 @@ async fn set_display_name(
             true,
         )?;
     }
+
+    empty_ok()
+}
+
+/// #PUT /_matrix/client/v3/profile/{user_id}/{field}
+/// Updates one custom profile field.
+#[endpoint]
+async fn set_profile_field(
+    _aa: AuthArgs,
+    user_id: PathParam<OwnedUserId>,
+    field: PathParam<String>,
+    body: JsonBody<ProfileFieldBody>,
+    depot: &mut Depot,
+) -> EmptyResult {
+    let user_id = user_id.into_inner();
+    let field = field.into_inner();
+    ensure_custom_profile_field(&field)?;
+
+    let authed = depot.authed_info()?;
+    ensure_profile_update_allowed(authed, &user_id)?;
+
+    let mut body = body.into_inner();
+    let value = body
+        .fields
+        .remove(&field)
+        .ok_or_else(|| MatrixError::bad_json("Profile field body does not match path field."))?;
+
+    data::user::set_profile_field(&user_id, &field, value)?;
+
+    empty_ok()
+}
+
+/// #DELETE /_matrix/client/v3/profile/{user_id}/{field}
+/// Deletes one custom profile field.
+#[endpoint]
+async fn delete_profile_field(
+    _aa: AuthArgs,
+    user_id: PathParam<OwnedUserId>,
+    field: PathParam<String>,
+    depot: &mut Depot,
+) -> EmptyResult {
+    let user_id = user_id.into_inner();
+    let field = field.into_inner();
+    ensure_custom_profile_field(&field)?;
+
+    let authed = depot.authed_info()?;
+    ensure_profile_update_allowed(authed, &user_id)?;
+
+    data::user::delete_profile_field(&user_id, &field)?;
 
     empty_ok()
 }

--- a/crates/server/src/routing/federation/query.rs
+++ b/crates/server/src/routing/federation/query.rs
@@ -36,6 +36,14 @@ pub async fn get_edu_types() -> JsonResult<EduTypesResBody> {
 /// Gets information on a profile.
 #[endpoint]
 async fn get_profile(_aa: AuthArgs, args: ProfileReqArgs) -> JsonResult<ProfileResBody> {
+    if !config::get().federation.allow_inbound_profile_lookup {
+        return Err(MatrixError::forbidden(
+            "Profile lookup over federation is disabled on this homeserver",
+            None,
+        )
+        .into());
+    }
+
     if args.user_id.server_name().is_remote() {
         return Err(MatrixError::invalid_param("User does not belong to this server.").into());
     }

--- a/crates/server/src/routing/federation/query.rs
+++ b/crates/server/src/routing/federation/query.rs
@@ -52,6 +52,7 @@ async fn get_profile(_aa: AuthArgs, args: ProfileReqArgs) -> JsonResult<ProfileR
 
     let profile = data::user::get_profile(&args.user_id, None)?
         .ok_or(MatrixError::not_found("Profile not found."))?;
+    let custom_fields = profile.fields.as_object().cloned().unwrap_or_default();
 
     match args.field.as_ref().map(|field| field.as_str()) {
         Some("displayname") => {
@@ -72,7 +73,11 @@ async fn get_profile(_aa: AuthArgs, args: ProfileReqArgs) -> JsonResult<ProfileR
                 response.set("xyz.amorgan.blurhash", blurhash.into());
             }
         }
-        Some(_) => {}
+        Some(field) => {
+            if let Some(value) = custom_fields.get(field) {
+                response.set(field, value.clone());
+            }
+        }
         None => {
             if let Some(display_name) = profile.display_name {
                 response.extend([ProfileFieldValue::DisplayName(display_name)]);
@@ -83,6 +88,7 @@ async fn get_profile(_aa: AuthArgs, args: ProfileReqArgs) -> JsonResult<ProfileR
             if let Some(blurhash) = profile.blurhash {
                 response.set("xyz.amorgan.blurhash", blurhash.into());
             }
+            response.extend(custom_fields);
         }
     }
 


### PR DESCRIPTION
This pull request adds support for custom user profile fields, allowing users and clients to store, retrieve, update, and delete arbitrary extra fields in user profiles. The implementation includes changes to the database schema, backend logic, and client/server APIs, as well as federation support for these custom fields.

**Database and Data Model Changes:**

- Added a new `fields` column of type `JSONB` to the `user_profiles` table, with corresponding migration scripts for both up and down migrations. The `DbProfile` struct and schema are updated to include this new field, and it is now part of the `ProfileResBody` response. [[1]](diffhunk://#diff-5fae23b9a41373b9c28bf6218644fe53e8946681d092f24e05a24be3ac9ab53fR1) [[2]](diffhunk://#diff-3f4b3d29d803088bec58b3adba6003c53905c42088850e960fb995e83f2c7984R1) [[3]](diffhunk://#diff-dabdcb9df15c6e3131e96e447640a8bce2adcaba3545a1057cdc950ae8827025R945) [[4]](diffhunk://#diff-21560600503adfb0d14d5b2a349caaa2d2b8ecdd66e23e99b4c796044a440859R19) [[5]](diffhunk://#diff-31a10da8c746fc4e458485eb738c68492e1c467355749a647a33c91542886054R109-R113) [[6]](diffhunk://#diff-31a10da8c746fc4e458485eb738c68492e1c467355749a647a33c91542886054R122)

**Backend Logic:**

- Implemented functions to get, set, and delete individual custom profile fields in `crates/data/src/user/profile.rs`. These functions operate on the new `fields` JSON object in the database.

**API and Routing:**

- Extended the client and server profile API routes to support GET, PUT, and DELETE for individual custom profile fields via new endpoints (e.g., `/_matrix/client/v3/profile/{user_id}/{field}`). Added request/response types and validation to ensure reserved fields cannot be manipulated through the custom field endpoints. [[1]](diffhunk://#diff-73d8e462e27408d26205e8c00b1f03f168dfbca547e239e6d64270a190718609R35-R77) [[2]](diffhunk://#diff-73d8e462e27408d26205e8c00b1f03f168dfbca547e239e6d64270a190718609R165) [[3]](diffhunk://#diff-73d8e462e27408d26205e8c00b1f03f168dfbca547e239e6d64270a190718609R176-R229) [[4]](diffhunk://#diff-73d8e462e27408d26205e8c00b1f03f168dfbca547e239e6d64270a190718609R483-R531)

**Federation Support:**

- Updated the federation profile query endpoint to include custom fields in responses and to allow querying individual custom fields over federation, respecting configuration for inbound profile lookups. [[1]](diffhunk://#diff-66481ab8090527ac7907eaf0b945da17367cddb93176baf645f79fc3f06a2deeR39-R46) [[2]](diffhunk://#diff-66481ab8090527ac7907eaf0b945da17367cddb93176baf645f79fc3f06a2deeR55) [[3]](diffhunk://#diff-66481ab8090527ac7907eaf0b945da17367cddb93176baf645f79fc3f06a2deeL67-R80) [[4]](diffhunk://#diff-66481ab8090527ac7907eaf0b945da17367cddb93176baf645f79fc3f06a2deeR91)

**Validation and Security:**

- Added helper functions to ensure only allowed users (themselves or appservices) can update custom profile fields, and to prevent manipulation of reserved fields (`avatar_url`, `displayname`, `xyz.amorgan.blurhash`) through the custom field API. [[1]](diffhunk://#diff-73d8e462e27408d26205e8c00b1f03f168dfbca547e239e6d64270a190718609R92-R133) [[2]](diffhunk://#diff-73d8e462e27408d26205e8c00b1f03f168dfbca547e239e6d64270a190718609L169-R289) [[3]](diffhunk://#diff-73d8e462e27408d26205e8c00b1f03f168dfbca547e239e6d64270a190718609L308-R421)

**Most important changes:**

**Database and Data Model:**
- Added a `fields` JSONB column to the `user_profiles` table and updated the `DbProfile` and `ProfileResBody` structs to include custom fields. [[1]](diffhunk://#diff-5fae23b9a41373b9c28bf6218644fe53e8946681d092f24e05a24be3ac9ab53fR1) [[2]](diffhunk://#diff-3f4b3d29d803088bec58b3adba6003c53905c42088850e960fb995e83f2c7984R1) [[3]](diffhunk://#diff-dabdcb9df15c6e3131e96e447640a8bce2adcaba3545a1057cdc950ae8827025R945) [[4]](diffhunk://#diff-21560600503adfb0d14d5b2a349caaa2d2b8ecdd66e23e99b4c796044a440859R19) [[5]](diffhunk://#diff-31a10da8c746fc4e458485eb738c68492e1c467355749a647a33c91542886054R109-R113) [[6]](diffhunk://#diff-31a10da8c746fc4e458485eb738c68492e1c467355749a647a33c91542886054R122)

**Backend Logic:**
- Implemented functions for getting, setting, and deleting individual custom profile fields in the backend.

**API and Routing:**
- Added new endpoints to the client API for retrieving, updating, and deleting custom profile fields, with validation to prevent misuse of reserved fields. [[1]](diffhunk://#diff-73d8e462e27408d26205e8c00b1f03f168dfbca547e239e6d64270a190718609R35-R77) [[2]](diffhunk://#diff-73d8e462e27408d26205e8c00b1f03f168dfbca547e239e6d64270a190718609R165) [[3]](diffhunk://#diff-73d8e462e27408d26205e8c00b1f03f168dfbca547e239e6d64270a190718609R176-R229) [[4]](diffhunk://#diff-73d8e462e27408d26205e8c00b1f03f168dfbca547e239e6d64270a190718609R483-R531) [[5]](diffhunk://#diff-73d8e462e27408d26205e8c00b1f03f168dfbca547e239e6d64270a190718609R92-R133)

**Federation:**
- Enhanced the federation profile query to support custom fields and allow querying them individually, with configuration to restrict inbound federation lookups. [[1]](diffhunk://#diff-66481ab8090527ac7907eaf0b945da17367cddb93176baf645f79fc3f06a2deeR39-R46) [[2]](diffhunk://#diff-66481ab8090527ac7907eaf0b945da17367cddb93176baf645f79fc3f06a2deeR55) [[3]](diffhunk://#diff-66481ab8090527ac7907eaf0b945da17367cddb93176baf645f79fc3f06a2deeL67-R80) [[4]](diffhunk://#diff-66481ab8090527ac7907eaf0b945da17367cddb93176baf645f79fc3f06a2deeR91)

**Validation and Security:**
- Centralized and improved authorization checks and field validation to ensure only authorized users/appservices can update fields and that reserved fields are not manipulated via the custom field endpoints. [[1]](diffhunk://#diff-73d8e462e27408d26205e8c00b1f03f168dfbca547e239e6d64270a190718609R92-R133) [[2]](diffhunk://#diff-73d8e462e27408d26205e8c00b1f03f168dfbca547e239e6d64270a190718609L169-R289) [[3]](diffhunk://#diff-73d8e462e27408d26205e8c00b1f03f168dfbca547e239e6d64270a190718609L308-R421)