### PR TITLE
fix(oidc,delegated_auth): security review follow-ups

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,53 @@
+name: Supply chain audit
+
+# Runs cargo-deny to check dependencies for known advisories, license
+# policy violations, banned crates and untrusted sources. The advisory
+# database is refreshed on every run, so the nightly schedule catches
+# new CVEs even on quiet days without code changes.
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      - 'deny.toml'
+      - '.github/workflows/audit.yml'
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      - 'deny.toml'
+      - '.github/workflows/audit.yml'
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cargo-deny:
+    name: cargo-deny (${{ matrix.checks }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        checks:
+          # All four are blocking. The advisory ignore list in deny.toml
+          # absorbs known-accepted findings, so a red run on this job is
+          # always a real, new event that needs attention — either a fresh
+          # CVE, a license-policy drift, a banned/duplicate crate, or a
+          # new git source that hasn't been vetted.
+          - advisories
+          - bans licenses sources
+    steps:
+      - uses: actions/checkout@v6
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check ${{ matrix.checks }}
+          arg: --all-features

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,70 @@
+name: Miri
+
+# Runs Miri (MIR interpreter) to catch undefined behaviour — out-of-bounds
+# access, invalid aliasing, uninitialised reads, data races in unsafe code —
+# that safe-Rust tests and ASan can miss.
+#
+# Scope is deliberately narrow: only crates whose test suites don't touch
+# syscalls, the filesystem, or the network. Miri aborts on anything it can't
+# model, so the server/data crates (tokio, diesel, reqwest) aren't viable.
+# Add a crate to the matrix once its tests are Miri-clean.
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - 'crates/identifiers-validation/**'
+      - '.github/workflows/miri.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'crates/identifiers-validation/**'
+      - '.github/workflows/miri.yml'
+  schedule:
+    - cron: '37 4 * * 1'  # Monday 04:37 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: miri-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Pin the nightly so CI is reproducible; bump deliberately alongside a
+  # local `rustup update nightly && cargo +nightly miri setup` run.
+  RUST_NIGHTLY: nightly-2026-04-23
+  # Miri's default is pedantic; -Zmiri-strict-provenance flags provenance
+  # bugs that the newer aliasing model would also catch. Add more flags
+  # (e.g. -Zmiri-tree-borrows) as desired.
+  MIRIFLAGS: -Zmiri-strict-provenance
+
+jobs:
+  miri:
+    name: cargo miri (${{ matrix.crate }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - crate: palpo-identifiers-validation
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install nightly with miri
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_NIGHTLY }}
+          components: miri, rust-src
+      - name: Cache Miri sysroot and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/miri
+            target/miri
+          key: miri-${{ runner.os }}-${{ env.RUST_NIGHTLY }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            miri-${{ runner.os }}-${{ env.RUST_NIGHTLY }}-
+      - name: Miri setup
+        run: cargo +${{ env.RUST_NIGHTLY }} miri setup
+      - name: Miri test
+        run: cargo +${{ env.RUST_NIGHTLY }} miri test -p ${{ matrix.crate }}

--- a/.github/workflows/quality-control.yml
+++ b/.github/workflows/quality-control.yml
@@ -58,3 +58,28 @@ jobs:
       - name: Cargo test
         timeout-minutes: 40
         run: cargo test --all --all-features --no-fail-fast -- --nocapture
+
+  clippy:
+    name: cargo clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: clippy
+      - name: Install dependencies
+        run: "sudo apt update && sudo apt install -y --no-install-recommends libclang-dev libpq-dev cmake postgresql postgresql-contrib"
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+
+  # Intentionally omitted (see git history for the full snippets):
+  #
+  #   - cargo fmt --check: rustfmt.toml uses unstable features and the
+  #     committed tree fails `cargo +nightly fmt --check`. Running it here
+  #     would paint every PR red without blocking, so it's off until a
+  #     one-shot `cargo +nightly fmt` pass cleans the tree.
+  #
+  #   - cargo machete: reports ~45 "unused" deps in palpo-data alone,
+  #     nearly all false positives from the hub-crate pattern. Would need
+  #     a large [package.metadata.cargo-machete] ignore list per crate
+  #     before it's signal rather than noise.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5291,9 +5291,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/core/src/events/room/message.rs
+++ b/crates/core/src/events/room/message.rs
@@ -874,15 +874,13 @@ pub(crate) fn parse_markdown(text: &str) -> Option<String> {
 
         for event in parser_events.iter().skip(1) {
             match event {
-                Event::Text(s) => {
-                    // If the string does not contain markdown, the only modification that should
-                    // happen is that newlines are converted to hardbreaks. It means that we should
-                    // find all the other characters from the original string in the text events.
-                    // Let's check that by walking the original string.
-                    if text[pos..].starts_with(s.as_ref()) {
-                        pos += s.len();
-                        continue;
-                    }
+                // If the string does not contain markdown, the only modification that should
+                // happen is that newlines are converted to hardbreaks. It means that we should
+                // find all the other characters from the original string in the text events.
+                // Let's check that by walking the original string.
+                Event::Text(s) if text[pos..].starts_with(s.as_ref()) => {
+                    pos += s.len();
+                    continue;
                 }
                 Event::HardBreak => {
                     // A hard break happens when a newline is encountered, which is not necessarily

--- a/crates/core/src/serde/canonical_json.rs
+++ b/crates/core/src/serde/canonical_json.rs
@@ -199,10 +199,10 @@ pub fn validate_canonical_json(json: &CanonicalJsonObject) -> Result<(), Canonic
                     }
                 }
             }
-            CanonicalJsonValue::Integer(value) => {
-                if *value < CANONICALJSON_MIN_INT || *value > CANONICALJSON_MAX_INT {
-                    return Err(CanonicalJsonError::IntegerOutOfRange);
-                }
+            CanonicalJsonValue::Integer(value)
+                if *value < CANONICALJSON_MIN_INT || *value > CANONICALJSON_MAX_INT =>
+            {
+                return Err(CanonicalJsonError::IntegerOutOfRange);
             }
             _ => {}
         }

--- a/crates/core/src/third_party.rs
+++ b/crates/core/src/third_party.rs
@@ -378,8 +378,8 @@ mod tests {
         let third_party_id = ThirdPartyIdentifier {
             address: "monkey@banana.island".into(),
             medium: Medium::Email,
-            validated_at: UnixMillis(1_535_176_800_000_u64.try_into().unwrap()),
-            added_at: UnixMillis(1_535_336_848_756_u64.try_into().unwrap()),
+            validated_at: UnixMillis(1_535_176_800_000_u64),
+            added_at: UnixMillis(1_535_336_848_756_u64),
         };
 
         let third_party_id_serialized = json!({

--- a/crates/server/src/config/delegated_auth.rs
+++ b/crates/server/src/config/delegated_auth.rs
@@ -44,6 +44,22 @@ pub struct DelegatedAuthConfig {
     /// Included in the well-known client response under m.authentication.
     pub account_management_url: Option<String>,
 
+    /// Expected `aud` (audience) value in the introspection response.
+    /// REQUIRED when `enable = true`. Per RFC 7662 §2.2, the relying
+    /// party MUST validate that the token was issued for this resource
+    /// server. Without this, a token issued by the same authorization
+    /// server for a *different* application (a separate Matrix
+    /// homeserver, a web app, anything else registered as a client at
+    /// the same MAS) will introspect as `active: true` and Palpo would
+    /// otherwise accept it.
+    ///
+    /// Set this to the resource indicator (RFC 8707) Palpo registers
+    /// at the upstream authorization server — typically the homeserver's
+    /// canonical URL or the registered `client_id`. The introspection
+    /// `aud` claim must include this exact string (string or array form
+    /// both supported).
+    pub expected_aud: Option<String>,
+
     /// Cache TTL for introspection results in seconds.
     /// Set to 0 to disable caching.
     ///

--- a/crates/server/src/config/delegated_auth.rs
+++ b/crates/server/src/config/delegated_auth.rs
@@ -29,6 +29,17 @@ pub struct DelegatedAuthConfig {
     /// authorization server for SSO login.
     pub client_id: Option<String>,
 
+    /// The OAuth2 client_secret Palpo uses when authenticating to the
+    /// authorization server's introspection (RFC 7662) and revocation
+    /// (RFC 7009) endpoints. When set, Palpo uses HTTP Basic auth with
+    /// `client_id:client_secret`. When unset, Palpo falls back to its
+    /// legacy `Authorization: Bearer <admin.mas_secret>` behavior — only
+    /// safe when the upstream registers Palpo as a public client and
+    /// also accepts the homeserver-admin shared bearer.
+    ///
+    /// Default: None (legacy bearer fallback).
+    pub client_secret: Option<String>,
+
     /// Optional URL for account management UI.
     /// Included in the well-known client response under m.authentication.
     pub account_management_url: Option<String>,

--- a/crates/server/src/config/oidc.rs
+++ b/crates/server/src/config/oidc.rs
@@ -120,6 +120,33 @@ pub struct OidcConfig {
     ///
     /// example: "https://auth.example.com/"
     pub mas_issuer: Option<String>,
+
+    /// Allowed URL prefixes for the `redirectUrl` query parameter on the
+    /// Matrix-standard `/_matrix/client/*/login/sso/redirect[/{idpId}]`
+    /// endpoint.
+    ///
+    /// When a Matrix client initiates SSO via that endpoint, it supplies a
+    /// `redirectUrl` the homeserver should send the browser back to after
+    /// successful authentication — with a short-lived `loginToken` appended.
+    /// Anything the browser can reach becomes a login-token-capture vector
+    /// if we don't validate this value.
+    ///
+    /// The supplied redirectUrl is accepted only if it starts with one of
+    /// the prefixes in this list (byte-level prefix match — the trailing
+    /// slash matters, e.g. `https://app.element.io/` rejects
+    /// `https://app.element.io.attacker.com/`).
+    ///
+    /// An empty list (the default) disables the Matrix-standard SSO flow
+    /// entirely: `/login/sso/redirect` responds 403 and the `m.login.sso`
+    /// login type is advertised but cannot be completed. Clients can still
+    /// start OAuth via the custom `/_matrix/client/oidc/auth` endpoint
+    /// which does not emit a token to a third-party URL.
+    ///
+    /// example: ["https://app.element.io/", "https://element.io/"]
+    ///
+    /// default: [] (fail-closed)
+    #[serde(default)]
+    pub sso_client_whitelist: Vec<String>,
 }
 
 #[derive(Clone, Deserialize)]

--- a/crates/server/src/directory.rs
+++ b/crates/server/src/directory.rs
@@ -137,7 +137,7 @@ fn get_local_public_rooms(
         // We need to collect all, so we can sort by member count
         .collect();
 
-    all_rooms.sort_by(|l, r| r.num_joined_members.cmp(&l.num_joined_members));
+    all_rooms.sort_by_key(|r| std::cmp::Reverse(r.num_joined_members));
 
     let total_room_count_estimate = (all_rooms.len() as u32).into();
 

--- a/crates/server/src/event/fetching.rs
+++ b/crates/server/src/event/fetching.rs
@@ -192,7 +192,7 @@ pub(super) async fn fetch_and_process_missing_state_by_ids(
 
     let mut desired_events = pdu_ids;
     desired_events.push(event_id.to_owned());
-    desired_events.extend(auth_chain_ids.into_iter());
+    desired_events.extend(auth_chain_ids);
 
     let desired_count = desired_events.len();
     let mut failed_missing_events = Vec::new();

--- a/crates/server/src/hoops/auth.rs
+++ b/crates/server/src/hoops/auth.rs
@@ -149,12 +149,42 @@ async fn auth_by_delegated_token(token: &str, aa: &AuthArgs, depot: &mut Depot) 
         return Err(MatrixError::unknown_token("Token is not active", true).into());
     }
 
+    let conf = config::get();
+
+    // RFC 7662 §2.2: validate the `aud` claim to prevent cross-resource-server
+    // token reuse. Without this, a token issued by the same MAS for a different
+    // application (another homeserver, a web app, etc.) would be accepted.
+    let da = conf
+        .enabled_delegated_auth()
+        .ok_or_else(|| MatrixError::unknown_token("Delegated auth not enabled", true))?;
+    let expected_aud = da.expected_aud.as_deref().ok_or_else(|| {
+        tracing::error!(
+            "delegated_auth.expected_aud not configured — refusing to validate tokens \
+             without audience binding (set delegated_auth.expected_aud to the resource \
+             indicator Palpo is registered as at the upstream)"
+        );
+        MatrixError::unknown_token(
+            "Delegated auth misconfigured: expected_aud not set",
+            true,
+        )
+    })?;
+    let aud_value = result.aud.as_ref().ok_or_else(|| {
+        MatrixError::unknown_token("Missing aud in introspection response", true)
+    })?;
+    let aud_matches = match aud_value {
+        serde_json::Value::String(s) => s == expected_aud,
+        serde_json::Value::Array(arr) => arr.iter().any(|v| v.as_str() == Some(expected_aud)),
+        _ => false,
+    };
+    if !aud_matches {
+        return Err(MatrixError::unknown_token("Token audience mismatch", true).into());
+    }
+
     let username = result
         .username
         .as_deref()
         .ok_or_else(|| MatrixError::unknown_token("No username in introspection response", true))?;
 
-    let conf = config::get();
     let user_id = UserId::parse_with_server_name(username, &conf.server_name)
         .map_err(|_| MatrixError::unknown_token("Invalid username in token", true))?;
 

--- a/crates/server/src/hoops/introspection.rs
+++ b/crates/server/src/hoops/introspection.rs
@@ -15,6 +15,10 @@ pub struct IntrospectionResult {
     pub username: Option<String>,
     pub sub: Option<String>,
     pub device_id: Option<String>,
+    /// RFC 7519 `aud` — string or array of strings. Validated by the
+    /// caller against `delegated_auth.expected_aud` to prevent
+    /// cross-resource-server token reuse.
+    pub aud: Option<serde_json::Value>,
 }
 
 struct CachedEntry {

--- a/crates/server/src/hoops/introspection.rs
+++ b/crates/server/src/hoops/introspection.rs
@@ -56,17 +56,39 @@ pub async fn introspect_token(token: &str) -> AppResult<IntrospectionResult> {
     let introspection_url = conf
         .introspection_endpoint()
         .ok_or_else(|| MatrixError::unknown("Delegated auth not configured"))?;
-    let mas_secret = conf
-        .admin
-        .mas_secret
-        .as_ref()
-        .ok_or_else(|| MatrixError::unknown("admin.mas_secret not configured"))?;
+    let da = conf
+        .enabled_delegated_auth()
+        .ok_or_else(|| MatrixError::unknown("Delegated auth not enabled"))?;
 
     let client = sending::default_client();
-    let response = client
-        .post(&introspection_url)
-        .bearer_auth(mas_secret)
-        .form(&[("token", token)])
+    // Three-tier client authentication for the introspection endpoint:
+    //  1. (client_id + client_secret) — RFC 7662 §2.1 / RFC 6749 §2.3.1
+    //     `client_secret_basic`. The right thing for a confidential client.
+    //  2. (client_id only) — RFC 7009 §2.1 public client: send client_id
+    //     in the form body, no Authorization header.
+    //  3. (neither) — legacy fallback to `Authorization: Bearer
+    //     <admin.mas_secret>`. Only safe when the upstream accepts the
+    //     homeserver-admin shared bearer at this endpoint.
+    let mut request = client.post(&introspection_url);
+    let mut form_params: Vec<(&str, &str)> = vec![("token", token)];
+    match (da.client_id.as_deref(), da.client_secret.as_deref()) {
+        (Some(id), Some(secret)) => {
+            request = request.basic_auth(id, Some(secret));
+        }
+        (Some(id), None) => {
+            form_params.push(("client_id", id));
+        }
+        _ => {
+            let mas_secret = conf
+                .admin
+                .mas_secret
+                .as_ref()
+                .ok_or_else(|| MatrixError::unknown("admin.mas_secret not configured"))?;
+            request = request.bearer_auth(mas_secret);
+        }
+    }
+    let response = request
+        .form(&form_params)
         .send()
         .await
         .map_err(|e| {

--- a/crates/server/src/routing/client/oidc.rs
+++ b/crates/server/src/routing/client/oidc.rs
@@ -128,6 +128,7 @@ use crate::{AppResult, JsonResult, data, json_ok};
 /// - CSRF protection via state parameter
 /// - PKCE code verifier for enhanced security
 /// - Provider selection for multi-provider setups
+/// - Optional client redirect URL for the Matrix-standard SSO completion flow
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OidcSession {
     /// CSRF protection state parameter
@@ -138,6 +139,18 @@ pub struct OidcSession {
     pub provider: String,
     /// Session creation timestamp
     pub created_at: u64,
+    /// Client redirect URL for the Matrix-standard SSO completion flow.
+    ///
+    /// Set when the OAuth flow was initiated from
+    /// `/_matrix/client/*/login/sso/redirect[/{idpId}]` with a whitelist-
+    /// validated `redirectUrl`. On successful callback, instead of
+    /// returning a JSON response, we 302 to this URL with a `loginToken`
+    /// query param that the client then redeems via `POST /login`
+    /// (`m.login.token`).
+    ///
+    /// When `None`, the callback returns the legacy JSON response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_redirect_url: Option<String>,
 }
 
 /// OIDC provider discovery information
@@ -509,6 +522,19 @@ pub async fn oidc_auth(req: &mut Request, res: &mut Response) -> AppResult<()> {
         (None, None)
     };
 
+    // Step 4b: Pick up an optional client redirectUrl for the Matrix-standard
+    // SSO completion flow. When this is set, the callback handler redirects
+    // the browser back to this URL with a `loginToken` appended, instead of
+    // returning the legacy JSON response. The URL is allowlist-validated
+    // here (defense in depth — session.rs's redirect/provider_url handlers
+    // validate it first at the edge).
+    let client_redirect_url = req
+        .query::<String>("redirectUrl")
+        .or_else(|| req.query::<String>("redirect_url"));
+    if let Some(ref url) = client_redirect_url {
+        crate::routing::client::session::validate_sso_redirect_url(url)?;
+    }
+
     // Step 5: Create OIDC session for tracking
     let session = OidcSession {
         state: state.clone(),
@@ -518,6 +544,7 @@ pub async fn oidc_auth(req: &mut Request, res: &mut Response) -> AppResult<()> {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs(),
+        client_redirect_url,
     };
 
     // Step 6: Store session in secure cookie
@@ -624,7 +651,7 @@ pub async fn oidc_auth(req: &mut Request, res: &mut Response) -> AppResult<()> {
 /// - Provider communication failures → 502 Bad Gateway
 /// - User creation failures → 500 Internal Server Error
 #[endpoint]
-pub async fn oidc_callback(req: &mut Request) -> JsonResult<OidcLoginResponse> {
+pub async fn oidc_callback(req: &mut Request, res: &mut Response) -> AppResult<()> {
     // Step 1: Handle OAuth error responses first
     if let Some(error) = req.query::<String>("error") {
         let error_description = req
@@ -736,13 +763,38 @@ pub async fn oidc_callback(req: &mut Request) -> JsonResult<OidcLoginResponse> {
         session.provider
     );
 
-    // Step 14: Return Matrix authentication credentials
-    json_ok(OidcLoginResponse {
+    // Step 14: Dispatch on flow type.
+    if let Some(client_url) = session.client_redirect_url.as_deref() {
+        // Matrix-standard SSO completion: issue a short-lived login token and
+        // 302 the browser back to the client URL with ?loginToken=... appended.
+        // The client (e.g. Element) then exchanges the token via
+        // `POST /login` with `m.login.token`.
+        //
+        // Defense-in-depth allowlist check before we emit a token anywhere.
+        crate::routing::client::session::validate_sso_redirect_url(client_url)?;
+
+        let login_token = generate_random_string(32);
+        let parsed_user_id = crate::core::identifiers::UserId::parse(&matrix_user_id)
+            .map_err(|_| MatrixError::unknown("Failed to parse Matrix user ID for login token"))?;
+        crate::user::create_login_token(&parsed_user_id, &login_token)?;
+
+        let mut url = Url::parse(client_url).map_err(|e| {
+            MatrixError::invalid_param(format!("Invalid client redirectUrl: {}", e))
+        })?;
+        url.query_pairs_mut().append_pair("loginToken", &login_token);
+
+        res.render(Redirect::found(url.as_str()));
+        return Ok(());
+    }
+
+    // Legacy JSON response for custom/programmatic clients (unchanged).
+    res.render(Json(OidcLoginResponse {
         user_id: matrix_user_id,
         access_token,
         device_id,
         home_server: config.server_name.to_string(),
-    })
+    }));
+    Ok(())
 }
 
 /// `POST /_matrix/client/*/oidc/login`

--- a/crates/server/src/routing/client/session.rs
+++ b/crates/server/src/routing/client/session.rs
@@ -29,7 +29,7 @@ pub fn public_router() -> Router {
             .push(
                 Router::with_path("sso/redirect")
                     .get(redirect)
-                    .push(Router::with_path("idpId").get(provider_url)),
+                    .push(Router::with_path("{idpId}").get(provider_url)),
             ),
     )
 }
@@ -53,10 +53,31 @@ pub fn authed_router() -> Router {
 /// when logging in.
 #[endpoint]
 async fn login_types(_aa: AuthArgs) -> JsonResult<LoginTypesResBody> {
-    let flows = if config::get().enabled_delegated_auth().is_some() {
+    let conf = config::get();
+    let flows = if conf.enabled_delegated_auth().is_some() {
+        // MSC3861 delegated auth — SSO is the only flow.
         vec![LoginType::Sso(
             crate::core::client::session::SsoLoginType::new(),
         )]
+    } else if let Some(oidc_cfg) = conf.enabled_oidc() {
+        // [oidc] providers configured — advertise m.login.sso with the
+        // provider list, keeping password + appservice as secondary flows
+        // so existing token-gated registration paths still work.
+        let identity_providers: Vec<IdentityProvider> = oidc_cfg
+            .providers
+            .iter()
+            .map(|(id, pc)| {
+                IdentityProvider::new(
+                    id.clone(),
+                    pc.display_name.clone().unwrap_or_else(|| id.clone()),
+                )
+            })
+            .collect();
+        vec![
+            LoginType::Sso(SsoLoginType { identity_providers }),
+            LoginType::password(),
+            LoginType::appservice(),
+        ]
     } else {
         vec![LoginType::password(), LoginType::appservice()]
     };
@@ -491,6 +512,41 @@ fn get_redirect_url(req: &Request) -> Result<String, MatrixError> {
         .ok_or_else(|| MatrixError::bad_json("Missing redirectUrl parameter"))
 }
 
+/// Reject any `redirectUrl` not starting with a configured whitelist prefix.
+/// Defense against login-token theft via attacker-crafted redirectUrl.
+///
+/// Applies only to the `[oidc]` path. The `[delegated_auth]` path does not
+/// emit tokens to the supplied URL (the IdP issuer handles the return), so
+/// this validator is a no-op there and relies on the IdP's own validation
+/// of client redirect URIs.
+///
+/// Made `pub(crate)` so the oidc.rs handler can also defense-in-depth check
+/// the cookie contents it reads on callback.
+pub(crate) fn validate_sso_redirect_url(url: &str) -> Result<(), MatrixError> {
+    let conf = config::get();
+    let Some(oidc_cfg) = conf.enabled_oidc() else {
+        // Non-OIDC path (delegated_auth or unconfigured): skip.
+        return Ok(());
+    };
+    if oidc_cfg.sso_client_whitelist.is_empty() {
+        return Err(MatrixError::forbidden(
+            "SSO redirect rejected: no oidc.sso_client_whitelist configured",
+            None,
+        ));
+    }
+    if !oidc_cfg
+        .sso_client_whitelist
+        .iter()
+        .any(|prefix| url.starts_with(prefix))
+    {
+        return Err(MatrixError::forbidden(
+            "SSO redirect rejected: redirectUrl not in oidc.sso_client_whitelist",
+            None,
+        ));
+    }
+    Ok(())
+}
+
 /// Build the authorization URL for the delegated auth issuer.
 fn build_sso_redirect_url(redirect_url: &str) -> Result<String, MatrixError> {
     let conf = config::get();
@@ -519,10 +575,32 @@ fn build_sso_redirect_url(redirect_url: &str) -> Result<String, MatrixError> {
     Ok(format!("{authorize_url}?{params}"))
 }
 
+/// Decide which backend to redirect to based on which OIDC path is enabled.
+/// `[oidc]` (multi-provider OAuth) takes precedence over `[delegated_auth]`
+/// (MSC3861). For `[oidc]`, we bounce through our own `/oidc/auth` so it can
+/// set the CSRF/PKCE cookie and stash the client's redirectUrl. For
+/// `[delegated_auth]`, we build the IdP authorize URL directly.
+fn build_auth_redirect_url(
+    idp_id: Option<String>,
+    client_redirect_url: &str,
+) -> Result<String, MatrixError> {
+    let conf = config::get();
+    if conf.enabled_oidc().is_some() {
+        let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+        if let Some(id) = idp_id {
+            serializer.append_pair("provider", &id);
+        }
+        serializer.append_pair("redirectUrl", client_redirect_url);
+        return Ok(format!("/_matrix/client/oidc/auth?{}", serializer.finish()));
+    }
+    build_sso_redirect_url(client_redirect_url)
+}
+
 #[endpoint]
 async fn redirect(_aa: AuthArgs, req: &mut Request, res: &mut Response) -> AppResult<()> {
     let redirect_url = get_redirect_url(req)?;
-    let auth_url = build_sso_redirect_url(&redirect_url)?;
+    validate_sso_redirect_url(&redirect_url)?;
+    let auth_url = build_auth_redirect_url(None, &redirect_url)?;
     res.render(salvo::prelude::Redirect::found(auth_url));
     Ok(())
 }
@@ -530,7 +608,9 @@ async fn redirect(_aa: AuthArgs, req: &mut Request, res: &mut Response) -> AppRe
 #[endpoint]
 async fn provider_url(_aa: AuthArgs, req: &mut Request, res: &mut Response) -> AppResult<()> {
     let redirect_url = get_redirect_url(req)?;
-    let auth_url = build_sso_redirect_url(&redirect_url)?;
+    validate_sso_redirect_url(&redirect_url)?;
+    let idp_id = req.param::<String>("idpId");
+    let auth_url = build_auth_redirect_url(idp_id, &redirect_url)?;
     res.render(salvo::prelude::Redirect::found(auth_url));
     Ok(())
 }

--- a/crates/server/src/routing/client/session.rs
+++ b/crates/server/src/routing/client/session.rs
@@ -396,8 +396,12 @@ async fn logout(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) -> EmptyRes
         return empty_ok();
     };
 
-    // When using delegated auth, also revoke the access token at the OIDC
-    // provider so that the browser session is properly invalidated.
+    // When using delegated auth, revoke the access token at the OIDC provider
+    // BEFORE removing the local device. If upstream revocation fails, we
+    // surface that to the caller and leave the local device intact so the
+    // client can retry — otherwise the client believes it logged out while
+    // the upstream OAuth2 session is still live and the token still valid
+    // for any other resource server that trusts MAS-issued tokens.
     if let Some(da) = config::get().enabled_delegated_auth()
         && let Some(token) = req
             .headers()
@@ -406,7 +410,11 @@ async fn logout(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) -> EmptyRes
             .and_then(|v| v.strip_prefix("Bearer "))
         && let Err(e) = revoke_delegated_token(da, token).await
     {
-        tracing::warn!("Failed to revoke delegated auth token: {e}");
+        tracing::error!("Failed to revoke delegated auth token: {e}");
+        return Err(MatrixError::unknown(format!(
+            "Upstream token revocation failed; please retry: {e}"
+        ))
+        .into());
     }
 
     data::user::device::remove_device(authed.user_id(), authed.device_id())?;
@@ -457,7 +465,8 @@ async fn revoke_delegated_token(
     let response = request.form(&form_params).send().await?;
 
     if !response.status().is_success() {
-        tracing::warn!("Token revocation returned status: {}", response.status());
+        let status = response.status();
+        return Err(format!("token revocation returned status {status}").into());
     }
 
     Ok(())
@@ -488,8 +497,13 @@ async fn logout_all(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) -> Empt
     };
 
     // Best-effort revocation of the current device's OAuth2 token at the
-    // upstream provider. Mirrors `logout`'s behavior; see the doc comment
-    // for why other devices' tokens aren't reachable from here.
+    // upstream provider. Unlike `logout`, we proceed with the full local
+    // cleanup even on failure — the user explicitly asked to log out
+    // everywhere, so we honour that locally regardless of upstream state.
+    // Failure is still raised to the caller after local cleanup so the
+    // client can show a "MAS session may still be live, visit account UI"
+    // message rather than a misleading green checkmark.
+    let mut revocation_error: Option<String> = None;
     if let Some(da) = config::get().enabled_delegated_auth()
         && let Some(token) = req
             .headers()
@@ -498,10 +512,20 @@ async fn logout_all(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) -> Empt
             .and_then(|v| v.strip_prefix("Bearer "))
         && let Err(e) = revoke_delegated_token(da, token).await
     {
-        tracing::warn!("Failed to revoke delegated auth token in logout_all: {e}");
+        tracing::error!("Failed to revoke delegated auth token in logout_all: {e}");
+        revocation_error = Some(e.to_string());
     }
 
     data::user::remove_all_devices(authed.user_id())?;
+
+    if let Some(e) = revocation_error {
+        return Err(MatrixError::unknown(format!(
+            "Local sessions cleared but upstream token revocation failed; \
+             visit your account-management UI to verify the upstream session \
+             is also signed out: {e}"
+        ))
+        .into());
+    }
 
     empty_ok()
 }
@@ -552,8 +576,17 @@ fn get_redirect_url(req: &Request) -> Result<String, MatrixError> {
         .ok_or_else(|| MatrixError::bad_json("Missing redirectUrl parameter"))
 }
 
-/// Reject any `redirectUrl` not starting with a configured whitelist prefix.
+/// Reject any `redirectUrl` not matching a configured whitelist entry.
 /// Defense against login-token theft via attacker-crafted redirectUrl.
+///
+/// Match semantics: the input and each whitelist entry are parsed as URLs;
+/// **origins must match exactly** (scheme + host + port) and the input path
+/// must equal or be below the entry's path. Both sides must be `https://`.
+/// Whitespace-only and unparsable whitelist entries are skipped (logged).
+/// Raw byte-prefix matching is intentionally not used — it accepts hostile
+/// inputs like `https://app.example.io.evil.com/` against an entry of
+/// `https://app.example.io` (no trailing slash) and is wildcarded by an
+/// empty-string entry.
 ///
 /// Applies only to the `[oidc]` path. The `[delegated_auth]` path does not
 /// emit tokens to the supplied URL (the IdP issuer handles the return), so
@@ -562,29 +595,162 @@ fn get_redirect_url(req: &Request) -> Result<String, MatrixError> {
 ///
 /// Made `pub(crate)` so the oidc.rs handler can also defense-in-depth check
 /// the cookie contents it reads on callback.
-pub(crate) fn validate_sso_redirect_url(url: &str) -> Result<(), MatrixError> {
+pub(crate) fn validate_sso_redirect_url(input: &str) -> Result<(), MatrixError> {
     let conf = config::get();
     let Some(oidc_cfg) = conf.enabled_oidc() else {
         // Non-OIDC path (delegated_auth or unconfigured): skip.
         return Ok(());
     };
-    if oidc_cfg.sso_client_whitelist.is_empty() {
+    match_sso_redirect_url(input, &oidc_cfg.sso_client_whitelist)
+}
+
+/// Pure helper for `validate_sso_redirect_url`. Extracted so the whitelist
+/// matching logic can be unit-tested without touching the global config.
+fn match_sso_redirect_url(input: &str, whitelist: &[String]) -> Result<(), MatrixError> {
+    if whitelist.is_empty() {
         return Err(MatrixError::forbidden(
             "SSO redirect rejected: no oidc.sso_client_whitelist configured",
             None,
         ));
     }
-    if !oidc_cfg
-        .sso_client_whitelist
-        .iter()
-        .any(|prefix| url.starts_with(prefix))
-    {
+
+    let target = url::Url::parse(input)
+        .map_err(|_| MatrixError::forbidden("redirectUrl is not a valid URL", None))?;
+    if target.scheme() != "https" {
         return Err(MatrixError::forbidden(
-            "SSO redirect rejected: redirectUrl not in oidc.sso_client_whitelist",
+            "redirectUrl must use https scheme",
             None,
         ));
     }
-    Ok(())
+    if target.host_str().is_none() {
+        return Err(MatrixError::forbidden(
+            "redirectUrl is missing a host",
+            None,
+        ));
+    }
+
+    for entry in whitelist {
+        if entry.trim().is_empty() {
+            tracing::warn!("Skipping empty sso_client_whitelist entry");
+            continue;
+        }
+        let allowed = match url::Url::parse(entry) {
+            Ok(u) => u,
+            Err(_) => {
+                tracing::warn!("Skipping malformed sso_client_whitelist entry: {entry:?}");
+                continue;
+            }
+        };
+        if allowed.scheme() != "https" {
+            tracing::warn!("Skipping non-https sso_client_whitelist entry: {entry:?}");
+            continue;
+        }
+        if target.origin() != allowed.origin() {
+            continue;
+        }
+        let allowed_path = allowed.path();
+        let target_path = target.path();
+        // Equal, or target_path begins with allowed_path followed by a '/' boundary.
+        // This prevents `/admin` from allowing `/administrator`.
+        if target_path == allowed_path
+            || target_path.starts_with(allowed_path)
+                && (allowed_path.ends_with('/')
+                    || target_path[allowed_path.len()..].starts_with('/'))
+        {
+            return Ok(());
+        }
+    }
+    Err(MatrixError::forbidden(
+        "SSO redirect rejected: redirectUrl not in oidc.sso_client_whitelist",
+        None,
+    ))
+}
+
+#[cfg(test)]
+mod sso_whitelist_tests {
+    use super::match_sso_redirect_url;
+
+    fn wl(entries: &[&str]) -> Vec<String> {
+        entries.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    #[test]
+    fn allows_exact_origin_match() {
+        let w = wl(&["https://app.element.io/"]);
+        assert!(match_sso_redirect_url("https://app.element.io/", &w).is_ok());
+        assert!(match_sso_redirect_url("https://app.element.io/path", &w).is_ok());
+        assert!(match_sso_redirect_url("https://app.element.io/?x=1", &w).is_ok());
+    }
+
+    #[test]
+    fn rejects_sibling_host_with_missing_trailing_slash() {
+        // The pre-fix prefix-match accepted this for entry "https://app.element.io".
+        let w = wl(&["https://app.element.io"]);
+        assert!(match_sso_redirect_url("https://app.element.io.evil.com/", &w).is_err());
+    }
+
+    #[test]
+    fn rejects_userinfo_smuggling() {
+        let w = wl(&["https://app.element.io/"]);
+        assert!(match_sso_redirect_url("https://app.element.io@evil.com/", &w).is_err());
+    }
+
+    #[test]
+    fn rejects_different_port() {
+        let w = wl(&["https://app.element.io/"]);
+        assert!(match_sso_redirect_url("https://app.element.io:8443/", &w).is_err());
+    }
+
+    #[test]
+    fn rejects_http_scheme_input() {
+        let w = wl(&["https://app.element.io/"]);
+        assert!(match_sso_redirect_url("http://app.element.io/", &w).is_err());
+    }
+
+    #[test]
+    fn rejects_javascript_scheme_input() {
+        let w = wl(&["https://app.element.io/"]);
+        assert!(match_sso_redirect_url("javascript:alert(1)", &w).is_err());
+    }
+
+    #[test]
+    fn empty_string_entry_is_not_a_wildcard() {
+        // The pre-fix prefix-match made [""] match every URL.
+        let w = wl(&["", "https://app.element.io/"]);
+        assert!(match_sso_redirect_url("https://app.element.io/", &w).is_ok());
+        assert!(match_sso_redirect_url("https://evil.com/", &w).is_err());
+    }
+
+    #[test]
+    fn skips_non_https_entry() {
+        let w = wl(&["http://app.element.io/", "https://app.element.io/"]);
+        assert!(match_sso_redirect_url("https://app.element.io/", &w).is_ok());
+        // The http entry must not be promoted to allow http inputs.
+        assert!(match_sso_redirect_url("http://app.element.io/", &w).is_err());
+    }
+
+    #[test]
+    fn empty_whitelist_rejects_all() {
+        let w = wl(&[]);
+        assert!(match_sso_redirect_url("https://app.element.io/", &w).is_err());
+    }
+
+    #[test]
+    fn path_prefix_respects_segment_boundary() {
+        let w = wl(&["https://app.element.io/admin"]);
+        assert!(match_sso_redirect_url("https://app.element.io/admin", &w).is_ok());
+        assert!(match_sso_redirect_url("https://app.element.io/admin/x", &w).is_ok());
+        // Pre-fix would have allowed this; new check rejects.
+        assert!(match_sso_redirect_url("https://app.element.io/administrator", &w).is_err());
+    }
+
+    #[test]
+    fn host_match_is_case_insensitive_via_url_normalization() {
+        // url::Url lowercases hosts on parse, so case differences in input
+        // and entry are handled identically.
+        let w = wl(&["https://APP.Element.IO/"]);
+        assert!(match_sso_redirect_url("https://app.element.io/", &w).is_ok());
+    }
 }
 
 /// Build the authorization URL for the delegated auth issuer.

--- a/crates/server/src/routing/client/session.rs
+++ b/crates/server/src/routing/client/session.rs
@@ -414,6 +414,12 @@ async fn logout(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) -> EmptyRes
 }
 
 /// Call the OIDC provider's revocation endpoint to end the OAuth2 session.
+///
+/// Authenticates per RFC 6749 §2.3.1: prefers HTTP Basic with
+/// `client_id:client_secret` when both are configured (RFC 7009 §2.1's
+/// expected method for confidential clients). Falls back to bearer with
+/// `admin.mas_secret` for back-compat with deployments that register Palpo
+/// as a public client and rely on the homeserver-admin shared bearer.
 async fn revoke_delegated_token(
     da: &config::DelegatedAuthConfig,
     access_token: &str,
@@ -422,21 +428,33 @@ async fn revoke_delegated_token(
         .issuer
         .as_deref()
         .ok_or("delegated auth issuer not configured")?;
-    let mas_secret = config::get()
-        .admin
-        .mas_secret
-        .as_deref()
-        .ok_or("admin.mas_secret not configured")?;
 
     let revocation_url = format!("{}/oauth2/revoke", issuer.trim_end_matches('/'));
 
     let client = crate::sending::default_client();
-    let response = client
-        .post(&revocation_url)
-        .bearer_auth(mas_secret)
-        .form(&[("token", access_token), ("token_type_hint", "access_token")])
-        .send()
-        .await?;
+    let mut request = client.post(&revocation_url);
+    let mut form_params: Vec<(&str, &str)> = vec![
+        ("token", access_token),
+        ("token_type_hint", "access_token"),
+    ];
+    match (da.client_id.as_deref(), da.client_secret.as_deref()) {
+        (Some(id), Some(secret)) => {
+            request = request.basic_auth(id, Some(secret));
+        }
+        (Some(id), None) => {
+            form_params.push(("client_id", id));
+        }
+        _ => {
+            let mas_secret = config::get()
+                .admin
+                .mas_secret
+                .as_deref()
+                .ok_or("admin.mas_secret not configured")?;
+            request = request.bearer_auth(mas_secret);
+        }
+    }
+
+    let response = request.form(&form_params).send().await?;
 
     if !response.status().is_success() {
         tracing::warn!("Token revocation returned status: {}", response.status());
@@ -452,14 +470,36 @@ async fn revoke_delegated_token(
 /// - Deletes all device metadata (device id, device display name, last seen ip, last seen ts)
 /// - Forgets all to-device events
 /// - Triggers device list updates
+/// - With delegated auth: revokes the current OAuth2 token at the auth
+///   provider. Tokens belonging to OTHER devices cannot be revoked from
+///   here — under MSC3861, Palpo doesn't store the upstream tokens; only
+///   the device that initiated this request carries one. Users who want a
+///   true "sign out everywhere" should use MAS's account UI session list,
+///   which has the full upstream session inventory. Tracked as a TODO
+///   upstream: needs MAS admin API for kill-sessions-by-user.
 ///
 /// Note: This is equivalent to calling [`GET /_matrix/client/r0/logout`](fn.logout_route.html)
-/// from each device of this user.
+/// from each device of this user — except for the upstream-revocation gap
+/// noted above.
 #[endpoint]
-async fn logout_all(_aa: AuthArgs, depot: &mut Depot) -> EmptyResult {
+async fn logout_all(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) -> EmptyResult {
     let Ok(authed) = depot.authed_info() else {
         return empty_ok();
     };
+
+    // Best-effort revocation of the current device's OAuth2 token at the
+    // upstream provider. Mirrors `logout`'s behavior; see the doc comment
+    // for why other devices' tokens aren't reachable from here.
+    if let Some(da) = config::get().enabled_delegated_auth()
+        && let Some(token) = req
+            .headers()
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "))
+        && let Err(e) = revoke_delegated_token(da, token).await
+    {
+        tracing::warn!("Failed to revoke delegated auth token in logout_all: {e}");
+    }
 
     data::user::remove_all_devices(authed.user_id())?;
 

--- a/crates/server/src/server_key/acquire.rs
+++ b/crates/server/src/server_key/acquire.rs
@@ -228,7 +228,7 @@ async fn acquire_notary_result(missing: &mut Batch, server_keys: ServerSigningKe
 }
 
 fn keys_count(batch: &Batch) -> usize {
-    batch.iter().flat_map(|(_, key_ids)| key_ids.iter()).count()
+    batch.values().flat_map(|key_ids| key_ids.iter()).count()
 }
 
 #[cfg(test)]

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -55,14 +55,12 @@ fn allowed_to_send_state_event(
             .into());
         }
         // Forbid m.room.encryption if encryption is disabled
-        StateEventType::RoomEncryption => {
-            if !conf.allow_encryption {
-                return Err(MatrixError::forbidden(
-                    "Encryption is disabled on this homeserver.",
-                    None,
-                )
-                .into());
-            }
+        StateEventType::RoomEncryption if !conf.allow_encryption => {
+            return Err(MatrixError::forbidden(
+                "Encryption is disabled on this homeserver.",
+                None,
+            )
+            .into());
         }
         // admin room is a sensitive room, it should not ever be made public
         StateEventType::RoomJoinRules => {

--- a/crates/server/src/sync_v3.rs
+++ b/crates/server/src/sync_v3.rs
@@ -693,22 +693,21 @@ async fn load_joined_room(
                             .membership;
 
                         match new_membership {
-                            MembershipState::Join => {
-                                // A new user joined an encrypted room
-                                // if !share_encrypted_room(sender_id, &user_id, &room_id)? {
+                            // A new user joined an encrypted room
+                            // if !share_encrypted_room(sender_id, &user_id, &room_id)? {
+                            MembershipState::Join
                                 if since_tk.event_sn() <= state_event.event_sn
                                     && !room::user::shared_rooms(vec![
                                         sender_id.to_owned(),
                                         user_id.to_owned(),
                                     ])?
-                                    .is_empty()
-                                {
-                                    // if user_id.is_local() {
-                                    // check for test TestDeviceListsUpdateOverFederation
-                                    // device_list_updates.insert(user_id.clone());
-                                    // }
-                                    joined_users.insert(user_id);
-                                }
+                                    .is_empty() =>
+                            {
+                                // if user_id.is_local() {
+                                // check for test TestDeviceListsUpdateOverFederation
+                                // device_list_updates.insert(user_id.clone());
+                                // }
+                                joined_users.insert(user_id);
                             }
                             MembershipState::Leave => {
                                 // Write down users that have left encrypted rooms we are in

--- a/crates/server/src/sync_v5.rs
+++ b/crates/server/src/sync_v5.rs
@@ -985,11 +985,11 @@ fn collect_e2ee(
 
                             let content: RoomMemberEventContent = pdu.get_content()?;
                             match content.membership {
-                                MembershipState::Join => {
-                                    // A new user joined an encrypted room
-                                    if !share_encrypted_room(sender_id, &user_id, Some(room_id))? {
-                                        device_list_changes.insert(user_id.to_owned());
-                                    }
+                                // A new user joined an encrypted room
+                                MembershipState::Join
+                                    if !share_encrypted_room(sender_id, &user_id, Some(room_id))? =>
+                                {
+                                    device_list_changes.insert(user_id.to_owned());
                                 }
                                 MembershipState::Leave => {
                                     // Write down users that have left encrypted rooms we

--- a/crates/server/src/user/session.rs
+++ b/crates/server/src/user/session.rs
@@ -112,12 +112,14 @@ mod tests {
         )
         .expect("JWT token should be encoded");
 
-        let mut config = JwtConfig::default();
-        config.secret = "test-secret".to_owned();
-        config.format = "HMAC".to_owned();
-        config.algorithm = "HS256".to_owned();
-        config.validate_exp = true;
-        config.require_exp = true;
+        let config = JwtConfig {
+            secret: "test-secret".to_owned(),
+            format: "HMAC".to_owned(),
+            algorithm: "HS256".to_owned(),
+            validate_exp: true,
+            require_exp: true,
+            ..Default::default()
+        };
 
         let result = validate_jwt_token(&config, &token);
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,138 @@
+# cargo-deny configuration — supply-chain, license and advisory policy.
+# Schema reference: https://embarkstudios.github.io/cargo-deny/checks/cfg.html
+#
+# Run locally with:
+#   cargo install --locked cargo-deny
+#   cargo deny check
+
+[graph]
+# Check all targets the workspace actually builds for. Leave empty to check
+# every target (slower, but catches platform-specific advisories).
+all-features = true
+
+[output]
+feature-depth = 1
+
+# ---------------------------------------------------------------------------
+# Advisories — RustSec vulnerability / unmaintained / yanked crate policy.
+# ---------------------------------------------------------------------------
+[advisories]
+version = 2
+# yanked crates are denied by default in v2; unmaintained/vulnerabilities error
+# by default. Add IDs here to temporarily silence a known-acceptable finding.
+# Each entry should come with a comment explaining *why* and, ideally, a
+# tracking issue or removal date.
+ignore = [
+    { id = "RUSTSEC-2023-0071", reason = """
+Marvin Attack timing sidechannel in the `rsa` crate. Pulled in transitively
+via `jsonwebtoken` for RSA-signed JWT verification (OIDC flows).
+
+No fixed release of `rsa` exists; a constant-time rewrite is tracked upstream
+at https://github.com/RustCrypto/RSA/issues/19. Acknowledged risk: a remote
+attacker able to observe precise response-time measurements against the JWT
+verification path could, in theory, mount Marvin against our RSA key. In
+practice the signal is very small behind async/network jitter, but this is
+still a live issue — revisit when `rsa` ships a patched release or we move
+JWT verification off `jsonwebtoken`/`rsa`.
+""" },
+    { id = "RUSTSEC-2026-0111", reason = """
+Diesel SQLite backend UTF-8 corruption. Not reachable: palpo-data enables
+only the `postgres` backend (see crates/data/Cargo.toml), so the affected
+SQLite code path is not compiled into any palpo binary. Revisit if a SQLite
+backend is ever introduced.
+""" },
+    { id = "RUSTSEC-2024-0436", reason = """
+`paste` is unmaintained (author archived the repo). The crate is a tiny
+proc-macro with no known soundness issues; it's pulled in transitively by
+several dependencies. No remote attack surface. Revisit if an exploitable
+advisory is ever published or if we can push upstreams onto `pastey`.
+""" },
+    { id = "RUSTSEC-2026-0105", reason = """
+`core2` unmaintained (all versions yanked). Transitive via image → rav1e →
+ravif → bitstream-io → core2, used only for thumbnailing. Not fixable from
+palpo; waiting on `bitstream-io` to drop or replace core2. No known
+soundness issue, just a maintenance flag.
+""" },
+]
+
+# ---------------------------------------------------------------------------
+# Licenses — what license families we accept from dependencies.
+# ---------------------------------------------------------------------------
+[licenses]
+version = 2
+confidence-threshold = 0.93
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "MIT-0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "0BSD",
+    "BSL-1.0",
+    "CC0-1.0",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "MPL-2.0",
+    "OpenSSL",
+    # Pulled in transitively by deps we already use:
+    "NCSA",                # libfuzzer-sys (via image → rav1e → ravif)
+    "Unlicense",           # rustyline-async — public-domain-equivalent, OSI-approved
+    "CDLA-Permissive-2.0", # webpki-roots / webpki-root-certs
+]
+# Per-crate exceptions for licenses not in the global allow list.
+exceptions = [
+    # { allow = ["OpenSSL"], crate = "ring" },
+]
+# Crates with non-SPDX or ambiguous licensing may need an explicit clarification.
+# [[licenses.clarify]]
+# crate = "ring"
+# expression = "ISC AND MIT AND OpenSSL"
+# license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[licenses.private]
+# Don't lint palpo's own crates — they're Apache-2.0 per workspace metadata.
+ignore = true
+
+# ---------------------------------------------------------------------------
+# Bans — duplicate versions, wildcard deps, disallowed crates.
+# ---------------------------------------------------------------------------
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+# Crates that must not appear in the graph. Example uses:
+#   - force migration off of an abandoned crate
+#   - block a crate you've decided to never pull in (openssl, etc.)
+deny = [
+    # { crate = "openssl", reason = "project uses rustls; openssl is a policy mistake" },
+]
+# Crates where duplicate versions are tolerated (warn-only noise reducers).
+skip = []
+# Whole subtrees where duplicates are tolerated (common for windows-sys,
+# hashbrown, etc. pulled in by transitive deps).
+skip-tree = []
+
+# ---------------------------------------------------------------------------
+# Sources — where dependencies are allowed to come from.
+# ---------------------------------------------------------------------------
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# Git dependencies must come from a vetted org. The salvo-rs patch in the
+# workspace Cargo.toml is the only current git source; add more here if a
+# new one is introduced.
+allow-git = [
+    # cargo-deny normalizes URLs by stripping the trailing ".git", so the
+    # form without the suffix matches both the Cargo.toml patch URL and
+    # what shows up in Cargo.lock.
+    "https://github.com/salvo-rs/salvo",
+]
+
+[sources.allow-org]
+# Alternative form — allow every repo under an org. Prefer allow-git above
+# when the set is small enough to enumerate.
+# github = ["salvo-rs"]


### PR DESCRIPTION
## Summary

Three independent security fixes from focused reviews of `8970cdbc` (SSO bridge / open-redirect mitigation) and `a4874ae0` (RFC 7662/7009 client auth on introspect + revoke):

1. **`oidc.sso_client_whitelist` — structural URL match, not byte prefix.** The previous `url.starts_with(prefix)` check accepted `https://app.example.io.evil.com/` for an entry of `https://app.example.io` (no trailing slash), and treated an empty-string entry as a wildcard. Replaced with `Url::parse` on both sides, exact origin comparison, https-only, and segment-boundary path match. Empty/whitespace and unparsable entries are skipped with a `tracing::warn!`.
2. **Introspection — validate `aud` per RFC 7662 §2.2.** `auth_by_delegated_token` previously consumed the introspection response at face value: any token MAS reported as `active: true` with a `username` was accepted as a Matrix authentication. Whenever the same MAS instance serves more than one resource server (the normal MSC3861 deployment shape), a token issued for a different application would have been accepted. Added `aud` to `IntrospectionResult` (string or array form) and `delegated_auth.expected_aud` config. Missing/mismatched/unset all fail closed with `M_UNKNOWN_TOKEN`.
3. **Logout — propagate upstream revocation failure.** `revoke_delegated_token` now returns `Err` on non-2xx; `logout` returns an error and does not remove the local device on failure (so the client retries instead of believing it logged out while the upstream OAuth2 session is still live); `logout_all` does the full local cleanup (per its semantics) but surfaces upstream failure pointing the user at MAS account UI.

## Breaking change

Anyone running with `delegated_auth.enable = true` **must** add `delegated_auth.expected_aud = "<resource indicator>"` to their config (typically the homeserver's canonical URL or the `client_id` Palpo is registered as upstream). Without it, all delegated-auth requests fail with `M_UNKNOWN_TOKEN`.

## Out of scope (flagged for follow-up)

- `mas_secret` Tier 3 fallback to user-controlled `issuer` URL (defense-in-depth: gate behind explicit `use_admin_bearer_fallback` flag or warn at startup).
- Shared `default_client()` honors `allow_invalid_tls_certificates` for credential-bearing introspect/revoke calls (consider a dedicated `mas_client()` that always verifies certs).
- `OidcSession` cookie is unsigned plain JSON (architectural — server-side state storage or HMAC signing). Not directly exploitable absent another XSS / subdomain cookie-injection vector, but worth fixing as defense-in-depth.

## Test plan

- [x] `cargo check -p palpo` clean
- [x] `cargo clippy -p palpo --all-targets -- -D warnings` clean
- [x] `cargo test -p palpo --bins` — 44 passing (33 existing + 11 new whitelist regression tests)
- [x] New `sso_whitelist_tests` cover: trailing-slash sibling-host bypass, empty-string-as-wildcard, userinfo smuggling, port mismatch, http/javascript scheme rejection, `/admin` vs `/administrator` boundary
- [ ] Staging: verify whitelist accepts a known-good `redirectUrl` and rejects each bypass shape via `/login/sso/redirect?redirectUrl=...`
- [ ] Staging: verify `delegated_auth` flow with `expected_aud` set to the canonical MAS audience works end-to-end (login + introspect + logout)
- [ ] Staging: verify `delegated_auth` with `expected_aud` unset returns `M_UNKNOWN_TOKEN` (fail-closed)
- [ ] Staging: kill the upstream MAS revoke endpoint and confirm `POST /logout` now returns an error rather than 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)