### PR TITLE
fix(sliding-sync): always emit list count on idle re-poll

### DIFF
--- a/crates/core/src/client/sync_events/v5.rs
+++ b/crates/core/src/client/sync_events/v5.rs
@@ -957,6 +957,52 @@ mod tests {
     }
 
     #[test]
+    fn count_only_list_serializes_count_field() {
+        // Regression guard: an incremental sliding-sync response that has no list
+        // ops must still emit `count`. matrix-rust-sdk's
+        // `SlidingSyncList::update` only calls
+        // `update_request_generator_state(maximum_number_of_rooms)` when the
+        // server-supplied `count` is `Some`. If we serialize a `SyncList` as
+        // bare `{}` the SDK keeps `fully_loaded=false` forever and tight-polls
+        // the server.
+        let list = super::SyncList {
+            count: 2,
+            ops: Vec::new(),
+        };
+
+        let json = serde_json::to_value(&list).unwrap();
+
+        assert_eq!(json["count"], 2);
+        assert!(
+            json.get("ops").is_none(),
+            "ops should be omitted when empty (skip_serializing_if), \
+             but count must remain present, got: {json}"
+        );
+    }
+
+    #[test]
+    fn count_only_response_is_long_poll_empty() {
+        // After the fix the `since_sn > curr_sn` fast path emits a body shaped
+        // like `{ pos, lists: { all_rooms: { count: N } } }`. The handler's
+        // long-poll guard must still treat that body as "no incremental
+        // updates" — otherwise palpo#72's empty-body short-circuit would
+        // regress and idle clients would no longer long-poll.
+        let mut response = SyncEventsResBody::new("200".to_owned());
+        response.lists.insert(
+            "all_rooms".to_owned(),
+            super::SyncList {
+                count: 2,
+                ops: Vec::new(),
+            },
+        );
+
+        assert!(
+            response.is_empty_for_long_poll(),
+            "count-only list should be considered long-poll empty"
+        );
+    }
+
+    #[test]
     fn typing_is_empty_when_all_rooms_have_no_typing_users() {
         let room_id = RoomId::parse("!room:example.org").unwrap().to_owned();
         let typing = Typing {

--- a/crates/server/src/routing/client/sync_msc4186.rs
+++ b/crates/server/src/routing/client/sync_msc4186.rs
@@ -151,4 +151,125 @@ mod tests {
             &BTreeMap::from([("all_rooms".to_owned(), 2)])
         ));
     }
+
+    /// Walks through the full handler-level decision sequence for the bug from
+    /// the field report:
+    ///
+    ///   1. Step 1 – fresh sync: response carries `count + ops`.
+    ///   2. The handler caches `previous_list_counts = { all_rooms: count }`.
+    ///   3. Step 2 – idle re-poll (`since_sn > curr_sn`): server takes the fast-path. After the
+    ///      fix, the response body is shaped like `{ pos, lists: { all_rooms: { count } } }` (no
+    ///      ops).
+    ///   4. The handler must: a. treat the body as long-poll-empty; b. NOT regard it as a
+    ///      list-count change (otherwise long-polling would be skipped); c. write the same `count`
+    ///      back into the cache so subsequent requests stay consistent.
+    ///   5. The serialized JSON must include `count` so a client like matrix-rust-sdk can drive
+    ///      `SlidingSyncList::is_fully_loaded`.
+    ///
+    /// Before the fix, step 3 returned `{ pos }` with no `lists` field, the
+    /// SDK saw `count = None`, and it tight-polled the server.
+    #[test]
+    fn idle_repoll_preserves_count_and_long_poll_semantics() {
+        // Step 1 – fresh sync response.
+        let mut step1 = SyncEventsResBody::new("200".to_owned());
+        step1.lists.insert(
+            "all_rooms".to_owned(),
+            SyncList {
+                count: 2,
+                ops: Vec::new(),
+            },
+        );
+
+        // Cache update that the handler performs after step 1.
+        let cached_counts: BTreeMap<String, usize> = step1
+            .lists
+            .iter()
+            .map(|(id, l)| (id.clone(), l.count))
+            .collect();
+        assert_eq!(cached_counts.get("all_rooms"), Some(&2));
+
+        // Step 2 – fast-path response after the fix (count-only list, no ops,
+        // no rooms, no extension data).
+        let mut step2 = SyncEventsResBody::new("200".to_owned());
+        step2.lists.insert(
+            "all_rooms".to_owned(),
+            SyncList {
+                count: 2,
+                ops: Vec::new(),
+            },
+        );
+
+        // (a) handler treats this as "no incremental updates"
+        assert!(step2.is_empty_for_long_poll());
+        // (b) but recognises it carries no list-count change either, so the
+        //     long-poll guard fires (the request should hang on the watcher
+        //     instead of returning immediately).
+        assert!(!has_list_count_changes(&step2, &cached_counts));
+
+        // (c) cache write after step 2 is idempotent.
+        let cached_counts_after: BTreeMap<String, usize> = step2
+            .lists
+            .iter()
+            .map(|(id, l)| (id.clone(), l.count))
+            .collect();
+        assert_eq!(cached_counts_after, cached_counts);
+
+        // (d) wire shape: `lists.all_rooms.count` is present, ops omitted.
+        let json = serde_json::to_value(&step2).unwrap();
+        assert_eq!(json["lists"]["all_rooms"]["count"], 2);
+        assert!(json["lists"]["all_rooms"].get("ops").is_none());
+        // The pre-fix bug repro: the response would have been `{ "pos": "200" }`
+        // with no `lists` key at all.
+        assert!(
+            json.get("lists")
+                .is_some_and(|v| !v.as_object().unwrap().is_empty())
+        );
+    }
+
+    /// When the user joins (or leaves) a room between two idle re-polls, the
+    /// server-side `count` must reflect the new size and the handler must NOT
+    /// long-poll the request — the count change itself is a meaningful update.
+    /// Mirrors the bug doc's `incremental_sync_count_reflects_real_total_after_join`.
+    #[test]
+    fn count_change_after_room_join_breaks_out_of_long_poll() {
+        let cached_counts = BTreeMap::from([("all_rooms".to_owned(), 2)]);
+
+        // Idle re-poll AFTER the user joined a third room: fast-path emits
+        // count=3 with no ops (ops would arrive on the next non-fast-path
+        // sync, when the client re-issues with a fresh pos).
+        let mut response = SyncEventsResBody::new("201".to_owned());
+        response.lists.insert(
+            "all_rooms".to_owned(),
+            SyncList {
+                count: 3,
+                ops: Vec::new(),
+            },
+        );
+
+        // Long-poll guard: the body is technically empty for long-poll
+        // purposes (no rooms, no extensions), BUT the count change must
+        // promote the response to "meaningful" so we return immediately.
+        assert!(response.is_empty_for_long_poll());
+        assert!(has_list_count_changes(&response, &cached_counts));
+    }
+
+    /// A list that the client just introduced (no entry in the previous
+    /// counts cache) is also a count change and must be returned to the
+    /// client immediately, not hidden behind the long-poll guard.
+    #[test]
+    fn newly_introduced_list_is_treated_as_count_change() {
+        // The cache has counts for an unrelated list only.
+        let cached_counts = BTreeMap::from([("dms".to_owned(), 0)]);
+
+        let mut response = SyncEventsResBody::new("200".to_owned());
+        response.lists.insert(
+            "all_rooms".to_owned(),
+            SyncList {
+                count: 2,
+                ops: Vec::new(),
+            },
+        );
+
+        assert!(has_list_count_changes(&response, &cached_counts));
+    }
 }

--- a/crates/server/src/sync_v5.rs
+++ b/crates/server/src/sync_v5.rs
@@ -25,6 +25,61 @@ use crate::room::{self, filter_rooms, state, timeline};
 use crate::sync_v3::{DEFAULT_BUMP_TYPES, TimelineData, share_encrypted_room};
 use crate::{AppResult, data, extract_variant};
 
+/// Apply a sliding-sync list's filter pipeline to the candidate room sets.
+///
+/// Returns the rooms (in input order) that survive the `is_invite`,
+/// `room_types`, `not_room_types`, `is_dm`, and `is_encrypted` filters from
+/// the request. Used by both `process_lists` (which sorts and slices the
+/// result for ops) and the `since_sn > curr_sn` fast path (which only needs
+/// the count).
+fn compute_active_rooms<'a>(
+    list: &sync_events::v5::ReqList,
+    all_invited_rooms: &[&'a RoomId],
+    all_joined_rooms: &[&'a RoomId],
+    all_rooms: &[&'a RoomId],
+    dm_rooms: &HashSet<OwnedRoomId>,
+) -> Vec<&'a RoomId> {
+    let mut active_rooms: Vec<&'a RoomId> = match list.filters.as_ref().and_then(|f| f.is_invite) {
+        Some(true) => all_invited_rooms.to_vec(),
+        Some(false) => all_joined_rooms.to_vec(),
+        None => all_rooms.to_vec(),
+    };
+
+    // Apply not_room_types filter
+    if let Some(filter) = list.filters.as_ref().map(|f| &f.not_room_types)
+        && !filter.is_empty()
+    {
+        active_rooms = filter_rooms(&active_rooms, filter, true);
+    }
+
+    // Apply room_types filter
+    if let Some(filter) = list.filters.as_ref().and_then(|f| {
+        if f.room_types.is_empty() {
+            None
+        } else {
+            Some(&f.room_types)
+        }
+    }) {
+        active_rooms = filter_rooms(&active_rooms, filter, false);
+    }
+
+    // Apply is_dm filter
+    match list.filters.as_ref().and_then(|f| f.is_dm) {
+        Some(true) => active_rooms.retain(|r| dm_rooms.contains(*r)),
+        Some(false) => active_rooms.retain(|r| !dm_rooms.contains(*r)),
+        None => {}
+    }
+
+    // Apply is_encrypted filter
+    match list.filters.as_ref().and_then(|f| f.is_encrypted) {
+        Some(true) => active_rooms.retain(|r| room::is_encrypted(r)),
+        Some(false) => active_rooms.retain(|r| !room::is_encrypted(r)),
+        None => {}
+    }
+
+    active_rooms
+}
+
 /// Sort rooms by last activity (most recent first) using event sequence numbers.
 fn sort_rooms_by_activity(rooms: &mut [&RoomId]) -> AppResult<()> {
     if rooms.is_empty() {
@@ -259,9 +314,6 @@ pub async fn sync_events(
     let curr_sn = data::curr_sn()?;
     crate::seqnum_reach(curr_sn).await;
     let next_batch = curr_sn + 1;
-    if since_sn > curr_sn {
-        return Ok(SyncEventsResBody::new(next_batch.to_string()));
-    }
 
     let all_joined_rooms = data::user::joined_rooms(sender_id)?;
 
@@ -278,8 +330,8 @@ pub async fn sync_events(
         .chain(all_knocked_rooms.iter().map(AsRef::as_ref))
         .collect();
 
-    let all_joined_rooms = all_joined_rooms.iter().map(AsRef::as_ref).collect();
-    let all_invited_rooms = all_invited_rooms.iter().map(AsRef::as_ref).collect();
+    let all_joined_rooms: Vec<&RoomId> = all_joined_rooms.iter().map(AsRef::as_ref).collect();
+    let all_invited_rooms: Vec<&RoomId> = all_invited_rooms.iter().map(AsRef::as_ref).collect();
 
     // Load DM room set from m.direct account data
     let dm_rooms: HashSet<OwnedRoomId> = data::user::get_data::<DirectEventContent>(
@@ -289,6 +341,35 @@ pub async fn sync_events(
     )
     .map(|direct| direct.0.values().flatten().cloned().collect())
     .unwrap_or_default();
+
+    // Fast path: client's pos is ahead of curr_sn (the typical idle case where
+    // a client immediately re-polls with the pos we just handed it). There are
+    // no new events to deliver, but we still emit each requested list's count
+    // so sliding-sync clients (matrix-rust-sdk in particular) can compute
+    // `fully_loaded` and stop tight-polling. Omitting `count` here makes the
+    // SDK skip `update_request_generator_state`, which keeps `fully_loaded`
+    // permanently false in `Running` mode and produces a `pos=N&timeout=0`
+    // request flood.
+    if since_sn > curr_sn {
+        let mut res = SyncEventsResBody::new(next_batch.to_string());
+        for (list_id, list) in &req_body.lists {
+            let active_rooms = compute_active_rooms(
+                list,
+                &all_invited_rooms,
+                &all_joined_rooms,
+                &all_rooms,
+                &dm_rooms,
+            );
+            res.lists.insert(
+                list_id.clone(),
+                sync_events::v5::SyncList {
+                    count: active_rooms.len(),
+                    ops: Vec::new(),
+                },
+            );
+        }
+        return Ok(res);
+    }
 
     let mut todo_rooms: TodoRooms = BTreeMap::new();
 
@@ -355,43 +436,13 @@ async fn process_lists(
     res_body: &mut SyncEventsResBody,
 ) -> AppResult<()> {
     for (list_id, list) in &req_body.lists {
-        let mut active_rooms: Vec<&RoomId> = match list.filters.as_ref().and_then(|f| f.is_invite) {
-            Some(true) => all_invited_rooms.to_vec(),
-            Some(false) => all_joined_rooms.to_vec(),
-            None => all_rooms.to_vec(),
-        };
-
-        // Apply not_room_types filter
-        if let Some(filter) = list.filters.as_ref().map(|f| &f.not_room_types)
-            && !filter.is_empty()
-        {
-            active_rooms = filter_rooms(&active_rooms, filter, true);
-        }
-
-        // Apply room_types filter
-        if let Some(filter) = list.filters.as_ref().and_then(|f| {
-            if f.room_types.is_empty() {
-                None
-            } else {
-                Some(&f.room_types)
-            }
-        }) {
-            active_rooms = filter_rooms(&active_rooms, filter, false);
-        }
-
-        // Apply is_dm filter
-        match list.filters.as_ref().and_then(|f| f.is_dm) {
-            Some(true) => active_rooms.retain(|r| dm_rooms.contains(*r)),
-            Some(false) => active_rooms.retain(|r| !dm_rooms.contains(*r)),
-            None => {}
-        }
-
-        // Apply is_encrypted filter
-        match list.filters.as_ref().and_then(|f| f.is_encrypted) {
-            Some(true) => active_rooms.retain(|r| room::is_encrypted(r)),
-            Some(false) => active_rooms.retain(|r| !room::is_encrypted(r)),
-            None => {}
-        }
+        let active_rooms = compute_active_rooms(
+            list,
+            all_invited_rooms,
+            all_joined_rooms,
+            all_rooms,
+            dm_rooms,
+        );
 
         // Sort rooms by last activity (most recent first)
         let mut sorted_rooms = active_rooms;
@@ -1356,4 +1407,137 @@ pub fn is_required_state_send(
     let entry = load_or_create_connection(&user_id, &device_id, &conn_id);
     let cached = entry.lock().unwrap();
     cached.required_state.contains(&event_sn)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::compute_active_rooms;
+    use crate::core::client::sync_events::v5::{ReqList, ReqListFilters};
+    use crate::core::identifiers::{OwnedRoomId, RoomId};
+
+    fn rid(s: &str) -> OwnedRoomId {
+        RoomId::parse(s).unwrap().to_owned()
+    }
+
+    fn list_with(filters: ReqListFilters) -> ReqList {
+        ReqList {
+            filters: Some(filters),
+            ..Default::default()
+        }
+    }
+
+    /// Default filter pipeline (no filters set) returns all rooms — this is
+    /// what the typical `lists.all_rooms` config hits, and it's the count
+    /// path exercised by the bug repro.
+    #[test]
+    fn no_filters_returns_all_rooms() {
+        let r1 = rid("!one:example.org");
+        let r2 = rid("!two:example.org");
+        let r3 = rid("!three:example.org");
+        let joined = vec![r1.as_ref(), r2.as_ref()];
+        let invited = vec![r3.as_ref()];
+        let all: Vec<&RoomId> = joined
+            .iter()
+            .copied()
+            .chain(invited.iter().copied())
+            .collect();
+        let dms = HashSet::new();
+
+        let active = compute_active_rooms(&ReqList::default(), &invited, &joined, &all, &dms);
+
+        assert_eq!(active.len(), 3);
+    }
+
+    /// `is_invite=true` selects only the invited subset — this is how an EX
+    /// client renders the invite shelf, and `count` here drives whether the
+    /// client knows there's an invite badge to show.
+    #[test]
+    fn is_invite_true_returns_invited_only() {
+        let joined1 = rid("!j1:example.org");
+        let joined2 = rid("!j2:example.org");
+        let invited1 = rid("!i1:example.org");
+        let joined = vec![joined1.as_ref(), joined2.as_ref()];
+        let invited = vec![invited1.as_ref()];
+        let all: Vec<&RoomId> = joined
+            .iter()
+            .copied()
+            .chain(invited.iter().copied())
+            .collect();
+        let dms = HashSet::new();
+
+        let list = list_with(ReqListFilters {
+            is_invite: Some(true),
+            ..Default::default()
+        });
+        let active = compute_active_rooms(&list, &invited, &joined, &all, &dms);
+
+        assert_eq!(active.len(), 1);
+    }
+
+    #[test]
+    fn is_invite_false_returns_joined_only() {
+        let joined1 = rid("!j1:example.org");
+        let joined2 = rid("!j2:example.org");
+        let invited1 = rid("!i1:example.org");
+        let joined = vec![joined1.as_ref(), joined2.as_ref()];
+        let invited = vec![invited1.as_ref()];
+        let all: Vec<&RoomId> = joined
+            .iter()
+            .copied()
+            .chain(invited.iter().copied())
+            .collect();
+        let dms = HashSet::new();
+
+        let list = list_with(ReqListFilters {
+            is_invite: Some(false),
+            ..Default::default()
+        });
+        let active = compute_active_rooms(&list, &invited, &joined, &all, &dms);
+
+        assert_eq!(active.len(), 2);
+    }
+
+    /// `is_dm=true` retains only rooms that are tagged in `m.direct`.
+    /// This filter doesn't touch the database, so we can exercise it in-process.
+    #[test]
+    fn is_dm_true_keeps_dm_rooms_only() {
+        let r_dm = rid("!dm:example.org");
+        let r_other = rid("!other:example.org");
+        let joined: Vec<&RoomId> = vec![r_dm.as_ref(), r_other.as_ref()];
+        let invited: Vec<&RoomId> = Vec::new();
+        let all: Vec<&RoomId> = joined.clone();
+        let mut dms = HashSet::new();
+        dms.insert(r_dm.clone());
+
+        let list = list_with(ReqListFilters {
+            is_dm: Some(true),
+            ..Default::default()
+        });
+        let active = compute_active_rooms(&list, &invited, &joined, &all, &dms);
+
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0], &*r_dm);
+    }
+
+    #[test]
+    fn is_dm_false_excludes_dm_rooms() {
+        let r_dm = rid("!dm:example.org");
+        let r_other = rid("!other:example.org");
+        let joined: Vec<&RoomId> = vec![r_dm.as_ref(), r_other.as_ref()];
+        let invited: Vec<&RoomId> = Vec::new();
+        let all: Vec<&RoomId> = joined.clone();
+        let mut dms = HashSet::new();
+        dms.insert(r_dm.clone());
+
+        let list = list_with(ReqListFilters {
+            is_dm: Some(false),
+            ..Default::default()
+        });
+        let active = compute_active_rooms(&list, &invited, &joined, &all, &dms);
+
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0], &*r_other);
+    }
 }


### PR DESCRIPTION
## Summary

- The MSC4186 sync handler's fast-path early-return drops `lists.<id>.count` whenever a client polls with a `pos` ahead of `curr_sn`. Since palpo sets `pos = curr_sn + 1` on every response, that condition fires on **every** quiet polling cycle and the response degenerates to `{"pos":"200"}`.
- `matrix-rust-sdk`'s `SlidingSyncList::update` only calls `update_request_generator_state` when `count` is `Some`. Without it `fully_loaded` stays `false` in `Running` mode and the room-list service tight-polls with `timeout=0`. Field report: 8 827 identical `pos=200&timeout=0` requests in 24h on a 2-room test account.
- This PR makes the fast path emit `SyncList { count, ops: vec![] }` for every requested list, matching the behaviour of synapse, conduwuit, and the matrix-org sliding-sync proxy. `is_empty_for_long_poll` already ignores `lists`, so palpo#72's empty-body short-circuit still treats count-only responses as long-poll empty.

## Why this fires every poll, not just edge cases

`sync_events` writes `pos = next_batch = curr_sn + 1`. The next request the client makes carries `since_sn = curr_sn + 1`, which **necessarily** triggers `since_sn > curr_sn` unless a new event has incremented `curr_sn` in the meantime. So the fast path is the dominant idle-loop path, not a corner case.

## Behaviour change

| Path | Before | After |
| --- | --- | --- |
| `since_sn > curr_sn` | `{"pos":"200"}` (no `lists`) | `{"pos":"200","lists":{"all_rooms":{"count":N}}}` |
| Long-poll guard | already long-polled | unchanged (still long-polls, since `count` is unchanged) |
| Count change after a join | not surfaced (lists missing) | surfaced (`has_list_count_changes` returns `true`) |

`update_sync_list_counts` continues to be the source of truth for the cached count — the fast path now feeds it real data instead of an empty map.

## Implementation

- Extracted `compute_active_rooms` from `process_lists`. It runs the filter pipeline (`is_invite` / `room_types` / `not_room_types` / `is_dm` / `is_encrypted`) and returns the surviving rooms in input order. `process_lists` keeps owning sort + ops/range slicing.
- Moved room-set loading and `dm_rooms` computation above the `since_sn > curr_sn` branch so the fast path can compute counts without re-querying.
- The fast path inserts `SyncList { count, ops: vec![] }` per requested list. `ops` keeps `skip_serializing_if=Vec::is_empty`, so the wire shape is exactly `{ "count": N }`.

## Tests

Added in `cargo test`:

- **palpo-core**: `count_only_list_serializes_count_field` (wire-shape guard), `count_only_response_is_long_poll_empty` (palpo#72 regression guard).
- **palpo (sync_msc4186)**: `idle_repoll_preserves_count_and_long_poll_semantics` walks the full handler decision sequence across two consecutive responses; `count_change_after_room_join_breaks_out_of_long_poll` and `newly_introduced_list_is_treated_as_count_change` cover the counter-cases.
- **palpo (sync_v5)**: five `compute_active_rooms` unit tests for the no-DB filter branches (`no_filters_returns_all_rooms`, `is_invite_true/false_*`, `is_dm_true/false_*`).

End-to-end coverage with HTTP + DB is provided by complement / sytest, which run outside this workspace. A follow-up that drives `sync_events_v5` with five consecutive incremental syncs and asserts `count` is present in each response would round out coverage; happy to write that in a separate PR if reviewers prefer.

### Manual verification

The original repro from the bug report (against a patched palpo) now produces:

```bash
# Step 1 (no pos)  →  "pos": "200", "lists": {"all_rooms": {"count": 2, "ops": [...]}}
# Step 2 (pos=200) →  "pos": "200", "lists": {"all_rooms": {"count": 2}}    # was: {}
```

## Test plan

- [x] `cargo test --workspace --no-fail-fast` (10 binaries, 0 failures)
- [x] `cargo fmt --all -- --check`
- [x] `typos` clean on touched files
- [x] Run unmodified Element X / matrix-rust-sdk client against the patched server for ≥5 minutes idle; observe access log shows long-poll cadence (~30s), no `pos=N&timeout=0` flood.

## Cross-references

- Client-side robustness PR (caps worst-case traffic, does not address the server bug): matrix-org/matrix-rust-sdk#6361
- Earlier server-side empty-response fix (different but related): palpo#72
- Original Robrix2 investigation that surfaced this behaviour: Project-Robius-China/robrix2#30