### PR TITLE
fix(security): close SSRF on push, URL preview, and key notary

### DIFF
--- a/crates/server/src/media/preview.rs
+++ b/crates/server/src/media/preview.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, LazyLock, OnceLock};
+use std::sync::{Arc, LazyLock, OnceLock, RwLock};
 use std::time::Duration;
 
 use ipaddress::IPAddress;
@@ -10,7 +10,9 @@ use url::Url;
 use crate::core::identifiers::*;
 use crate::core::{MatrixError, UnixMillis};
 use crate::data::media::{DbUrlPreview, NewDbMetadata, NewDbUrlPreview};
-use crate::{AppResult, config, data, storage, utils};
+use crate::sending::resolver;
+use crate::utils::url_guard;
+use crate::{AppResult, TlsNameMap, config, data, storage, utils};
 
 static URL_PREVIEW_MUTEX: LazyLock<Mutex<HashMap<String, Arc<Mutex<()>>>>> =
     LazyLock::new(Default::default);
@@ -25,9 +27,19 @@ async fn get_url_preview_mutex(url: &str) -> Arc<Mutex<()>> {
 fn client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
     CLIENT.get_or_init(|| {
+        // Reject redirects so that a public origin cannot 30x to an internal
+        // address; install a CIDR-filtering DNS resolver so that hostnames
+        // resolving to denylisted IPs (including DNS-rebinding attempts) are
+        // refused at connect time. IP-literal hosts skip DNS resolution
+        // and are rejected by `url_guard::ensure_safe_outbound_url`.
+        let tls_name_override = Arc::new(RwLock::new(TlsNameMap::new()));
         reqwest::ClientBuilder::new()
             .timeout(Duration::from_secs(20))
             .user_agent("Palpo")
+            .redirect(reqwest::redirect::Policy::none())
+            .dns_resolver(Arc::new(resolver::Resolver::new_with_cidr_denylist(
+                tls_name_override,
+            )))
             .build()
             .expect("Failed to create reqwest client")
     })
@@ -259,17 +271,10 @@ pub async fn get_url_preview(url: &Url) -> AppResult<UrlPreviewData> {
 
 async fn request_url_preview(url: &Url) -> AppResult<UrlPreviewData> {
     let client = client();
-    // Only check IP denylist if one is actually configured. If the user has
-    // explicitly set an empty denylist (or omitted it intentionally), respect that.
+    // Reject IP-literal hosts that fall inside the denylist — those bypass
+    // DNS resolution and so are not caught by the resolver below.
+    url_guard::ensure_safe_outbound_url(url)?;
     let denylist_configured = !config::get().ip_range_denylist.is_empty();
-    if denylist_configured
-        && let Ok(ip) = IPAddress::parse(url.host_str().expect("URL previously validated"))
-        && !config::valid_cidr_range(&ip)
-    {
-        return Err(
-            MatrixError::forbidden("Requesting from this address is forbidden.", None).into(),
-        );
-    }
 
     let response = client.get(url.clone()).send().await?;
     debug!(
@@ -312,6 +317,10 @@ async fn request_url_preview(url: &Url) -> AppResult<UrlPreviewData> {
 }
 async fn download_image(url: &Url) -> AppResult<UrlPreviewData> {
     use image::ImageReader;
+
+    // The URL here can come from an attacker-controlled OpenGraph `og:image`
+    // tag, so re-apply the boundary check rather than trusting the caller.
+    url_guard::ensure_safe_outbound_url(url)?;
 
     let conf = crate::config::get();
     let image = client().get(url.to_owned()).send().await?;
@@ -364,6 +373,8 @@ async fn download_image(url: &Url) -> AppResult<UrlPreviewData> {
 
 async fn download_html(url: &Url) -> AppResult<UrlPreviewData> {
     use webpage::HTML;
+
+    url_guard::ensure_safe_outbound_url(url)?;
 
     let conf = crate::config::get();
     let client = client();

--- a/crates/server/src/routing/client/pusher.rs
+++ b/crates/server/src/routing/client/pusher.rs
@@ -1,9 +1,11 @@
 use salvo::oapi::extract::JsonBody;
 use salvo::prelude::*;
+use url::Url;
 
-use crate::core::client::push::{PushersResBody, SetPusherReqBody};
-use crate::core::push::Pusher;
+use crate::core::client::push::{PusherAction, PushersResBody, SetPusherReqBody};
+use crate::core::push::{Pusher, PusherKind};
 use crate::data::DataError;
+use crate::utils::url_guard;
 use crate::{DepotExt, EmptyResult, JsonResult, data, empty_ok, hoops, json_ok};
 
 pub fn authed_router() -> Router {
@@ -33,6 +35,18 @@ async fn pushers(depot: &mut Depot) -> JsonResult<PushersResBody> {
 #[endpoint]
 async fn set_pusher(body: JsonBody<SetPusherReqBody>, depot: &mut Depot) -> EmptyResult {
     let authed = depot.authed_info()?;
-    crate::user::pusher::set_pusher(authed, body.into_inner().0)?;
+    let action = body.into_inner().0;
+    if let PusherAction::Post(ref data) = action
+        && let PusherKind::Http(ref http) = data.pusher.kind
+    {
+        // Validate the push-gateway URL up front so the user gets an
+        // immediate, actionable error. The actual outbound request is also
+        // gated by a CIDR-filtering DNS resolver in `push_gateway_client`.
+        let url = Url::parse(&http.url).map_err(|e| {
+            crate::core::MatrixError::invalid_param(format!("invalid pusher URL: {e}"))
+        })?;
+        url_guard::ensure_safe_outbound_url(&url)?;
+    }
+    crate::user::pusher::set_pusher(authed, action)?;
     empty_ok()
 }

--- a/crates/server/src/sending.rs
+++ b/crates/server/src/sending.rs
@@ -133,12 +133,7 @@ pub fn federation_client() -> ClientWithMiddleware {
         .get_or_init(|| {
             let conf = crate::config::get();
             // Client is cheap to clone (Arc wrapper) and avoids lifetime issues
-            let _tls_name_override = Arc::new(RwLock::new(TlsNameMap::new()));
-
-            // let jwt_decoding_key = conf
-            //     .jwt_secret
-            //     .as_ref()
-            //     .map(|secret| jsonwebtoken::DecodingKey::from_secret(secret.as_bytes()));
+            let tls_name_override = Arc::new(RwLock::new(TlsNameMap::new()));
 
             let retry_policy = ExponentialBackoff::builder()
                 .retry_bounds(
@@ -149,13 +144,41 @@ pub fn federation_client() -> ClientWithMiddleware {
 
             let client = reqwest_client_builder(conf)
                 .expect("build reqwest client failed")
-                // .dns_resolver(Arc::new(Resolver::new(tls_name_override.clone())))
+                .dns_resolver(Arc::new(resolver::Resolver::new_with_cidr_denylist(
+                    tls_name_override,
+                )))
                 .timeout(Duration::from_secs(2 * 60))
                 .build()
                 .expect("build reqwest client failed");
             ClientBuilder::new(client)
                 .with(RetryTransientMiddleware::new_with_policy(retry_policy))
                 .build()
+        })
+        .clone()
+}
+
+/// Returns a client for outbound HTTP requests targeted by user-supplied
+/// URLs (push gateways). The client refuses to connect to addresses inside
+/// `config::cidr_range_denylist`, defending against SSRF where an
+/// authenticated user configures an internal URL as a push target.
+///
+/// Redirects are limited to two hops; redirect targets are also subject to
+/// the same DNS-level CIDR filtering.
+pub fn push_gateway_client() -> reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            let conf = crate::config::get();
+            let tls_name_override = Arc::new(RwLock::new(TlsNameMap::new()));
+            reqwest_client_builder(conf)
+                .expect("failed to build push gateway client")
+                .timeout(Duration::from_secs(60))
+                .redirect(reqwest::redirect::Policy::limited(2))
+                .dns_resolver(Arc::new(resolver::Resolver::new_with_cidr_denylist(
+                    tls_name_override,
+                )))
+                .build()
+                .expect("failed to build push gateway client")
         })
         .clone()
 }

--- a/crates/server/src/sending/resolver.rs
+++ b/crates/server/src/sending/resolver.rs
@@ -6,6 +6,7 @@ use std::{future, iter};
 
 use futures_util::FutureExt;
 use hyper_util::client::legacy::connect::dns::{GaiResolver, Name as HyperName};
+use ipaddress::IPAddress;
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use tower_service::Service as TowerService;
 
@@ -21,6 +22,7 @@ pub const RANDOM_USER_ID_LENGTH: usize = 10;
 pub struct Resolver {
     inner: GaiResolver,
     overrides: Arc<RwLock<TlsNameMap>>,
+    enforce_cidr_denylist: bool,
 }
 
 impl Resolver {
@@ -28,13 +30,45 @@ impl Resolver {
         Resolver {
             inner: GaiResolver::new(),
             overrides,
+            enforce_cidr_denylist: false,
+        }
+    }
+
+    /// Build a resolver that filters out any addresses that fall inside the
+    /// configured `ip_range_denylist`. This protects outbound HTTP from SSRF
+    /// to internal/loopback/link-local addresses, including DNS-rebinding
+    /// attempts where a public hostname resolves to a private IP.
+    ///
+    /// Note: IP-literal hosts skip DNS resolution entirely, so callers must
+    /// pre-validate IP-literal URLs (see `crate::utils::url_guard`).
+    pub fn new_with_cidr_denylist(overrides: Arc<RwLock<TlsNameMap>>) -> Self {
+        Resolver {
+            inner: GaiResolver::new(),
+            overrides,
+            enforce_cidr_denylist: true,
         }
     }
 }
 
+fn filter_denied_addrs(addrs: Addrs) -> Addrs {
+    if crate::config::get().ip_range_denylist.is_empty() {
+        return addrs;
+    }
+    let allowed: Vec<SocketAddr> = addrs
+        .filter(|addr| {
+            IPAddress::parse(addr.ip().to_string())
+                .map(|ip| crate::config::valid_cidr_range(&ip))
+                .unwrap_or(true)
+        })
+        .collect();
+    Box::new(allowed.into_iter())
+}
+
 impl Resolve for Resolver {
     fn resolve(&self, name: Name) -> Resolving {
-        self.overrides
+        let enforce = self.enforce_cidr_denylist;
+        let resolving: Resolving = self
+            .overrides
             .read()
             .unwrap()
             .get(name.as_str())
@@ -61,6 +95,15 @@ impl Resolve for Resolver {
                             .map_err(|err| -> Box<dyn StdError + Send + Sync> { Box::new(err) })
                     }),
                 )
-            })
+            });
+
+        if !enforce {
+            return resolving;
+        }
+
+        Box::pin(async move {
+            let addrs = resolving.await?;
+            Ok(filter_denied_addrs(addrs))
+        })
     }
 }

--- a/crates/server/src/server_key/request.rs
+++ b/crates/server/src/server_key/request.rs
@@ -98,6 +98,19 @@ pub async fn notary_request(
 }
 
 pub async fn server_request(target: &ServerName) -> AppResult<ServerSigningKeys> {
+    // Refuse to act as a notary for IP-literal server names. The Matrix
+    // `server_name` grammar permits IP literals, but allowing them lets an
+    // unauthenticated caller use the notary endpoints to probe arbitrary
+    // hosts (including the homeserver's internal network) by IP and port.
+    // DNS-name targets that resolve to denylisted IPs are blocked at
+    // connect time by the federation client's safe DNS resolver.
+    if target.is_ip_literal() {
+        return Err(
+            MatrixError::forbidden("federation requests to IP-literal server names are not allowed", None)
+                .into(),
+        );
+    }
+
     let request = server_keys_request(&target.origin().await)?.into_inner();
     let server_signing_key = crate::sending::send_federation_request(target, request, None)
         .await?

--- a/crates/server/src/user/pusher.rs
+++ b/crates/server/src/user/pusher.rs
@@ -16,7 +16,8 @@ use crate::data::connect;
 use crate::data::schema::*;
 use crate::data::user::pusher::NewDbPusher;
 use crate::event::PduEvent;
-use crate::{AppError, AppResult, AuthedInfo, data, room};
+use crate::utils::url_guard;
+use crate::{AppError, AppResult, AuthedInfo, data, room, sending};
 
 pub fn set_pusher(authed: &AuthedInfo, pusher: PusherAction) -> AppResult<()> {
     match pusher {
@@ -226,10 +227,18 @@ async fn send_notice(
                 notification.prio = NotificationPriority::High
             }
 
+            // Refuse user-supplied URLs that point at internal addresses or
+            // use schemes other than http(s). This is the boundary check;
+            // DNS-name hosts that resolve to denylisted IPs are also caught
+            // at connect time by `push_gateway_client`'s safe DNS resolver.
+            let url = Url::parse(&http.url)?;
+            url_guard::ensure_safe_outbound_url(&url)?;
+            let push_client = sending::push_gateway_client();
+
             if event_id_only {
-                crate::sending::post(Url::parse(&http.url)?)
+                crate::sending::post(url)
                     .stuff(SendEventNotificationReqBody::new(notification))?
-                    .send::<()>()
+                    .send_by_client::<()>(push_client)
                     .await?;
             } else {
                 notification.sender = Some(event.sender.clone());
@@ -243,9 +252,9 @@ async fn send_notice(
                     data::user::display_name(&event.sender).ok().flatten();
                 notification.room_name = room::get_name(&event.room_id).ok();
 
-                crate::sending::post(Url::parse(&http.url)?)
+                crate::sending::post(url)
                     .stuff(SendEventNotificationReqBody::new(notification))?
-                    .send::<()>()
+                    .send_by_client::<()>(push_client)
                     .await?;
             }
 

--- a/crates/server/src/utils.rs
+++ b/crates/server/src/utils.rs
@@ -17,6 +17,7 @@ pub mod stream;
 pub mod string;
 pub use stream::*;
 pub mod content_disposition;
+pub mod url_guard;
 mod mutex_map;
 pub use mutex_map::{MutexMap, MutexMapGuard};
 mod sequm_queue;

--- a/crates/server/src/utils/url_guard.rs
+++ b/crates/server/src/utils/url_guard.rs
@@ -1,0 +1,70 @@
+//! Boundary checks for outbound HTTP destinations supplied by clients.
+//!
+//! Two layers protect against SSRF:
+//!
+//! 1. The reqwest clients used for user-influenced outbound traffic (push
+//!    gateways, URL preview, federation) install a CIDR-filtering DNS
+//!    resolver (see [`crate::sending::resolver::Resolver::new_with_cidr_denylist`]).
+//!    That resolver filters DNS results against `config::cidr_range_denylist`
+//!    at connect time, which prevents both ordinary hostnames that resolve
+//!    to internal addresses and DNS-rebinding attempts.
+//!
+//! 2. This module supplies fast pre-flight checks: scheme allowlist and
+//!    rejection of IP-literal hosts that fall inside the denylist (those
+//!    bypass DNS resolution entirely, so the resolver never sees them).
+//!
+//! Both layers are needed: the resolver alone misses IP-literal hosts,
+//! and the pre-flight check alone is racy with the actual connect.
+
+use ipaddress::IPAddress;
+use url::Url;
+
+use crate::AppResult;
+use crate::core::MatrixError;
+
+/// Reject schemes outside `http`/`https`. This refuses gopher://, file://,
+/// ftp://, ssh://, etc., which can otherwise smuggle requests via reqwest's
+/// underlying http client behavior or proxy stack.
+pub fn ensure_http_scheme(url: &Url) -> AppResult<()> {
+    match url.scheme() {
+        "http" | "https" => Ok(()),
+        other => Err(MatrixError::forbidden(
+            format!("URL scheme '{other}' is not allowed for outbound requests"),
+            None,
+        )
+        .into()),
+    }
+}
+
+/// Reject URLs whose host is an IP literal that falls inside the configured
+/// `ip_range_denylist`. IP-literal hosts skip DNS resolution and therefore
+/// bypass the CIDR filter installed on the reqwest resolver, so they must be
+/// caught here.
+pub fn ensure_ip_literal_host_allowed(url: &Url) -> AppResult<()> {
+    let conf = crate::config::get();
+    if conf.ip_range_denylist.is_empty() {
+        return Ok(());
+    }
+    let Some(host) = url.host_str() else {
+        return Err(MatrixError::forbidden("URL has no host", None).into());
+    };
+    if let Ok(ip) = IPAddress::parse(host)
+        && !crate::config::valid_cidr_range(&ip)
+    {
+        return Err(MatrixError::forbidden(
+            "Requesting from this address is forbidden.",
+            None,
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// Pre-flight boundary check for an outbound URL supplied by a client:
+/// scheme allowlist + IP-literal denylist. Hostnames that need DNS
+/// resolution are validated at connect time by the safe resolver.
+pub fn ensure_safe_outbound_url(url: &Url) -> AppResult<()> {
+    ensure_http_scheme(url)?;
+    ensure_ip_literal_host_allowed(url)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes four SSRF surfaces that allow callers to direct the server to make HTTP requests against internal addresses.

| # | Surface | Severity | Auth required |
|---|---------|----------|---------------|
| 1 | Push gateway URL (`POST /_matrix/client/v3/pushers/set` → outbound POST) | High | Local user |
| 2 | URL preview `og:image` follow-on fetch (response exfiltrated via `mxc://`) | High | Local user |
| 3 | URL preview DNS-name → internal IP / DNS-rebinding / 30x to internal | High | Local user |
| 4 | Federation key notary (`/_matrix/key/v2/query[/{server_name}]`) | High | None (notary is public per Matrix spec) |

### Root causes

- `config::valid_cidr_range` was only consulted in URL preview, and even there only for IP-literal hosts. Push gateway, og:image follow-on fetches, and federation HTTP client did not consult it at all.
- Default reqwest redirects (10 hops) let a public origin 30x to internal addresses.
- `ServerName` grammar permits IP literals (`127.0.0.1:6379`, `[::1]:8448`), so the public notary endpoint could be used as an internal port scanner.

## Mitigations (defense in depth)

1. **Boundary check** — `crates/server/src/utils/url_guard.rs`: scheme allowlist + IP-literal denylist for outbound URLs supplied by clients. IP-literal hosts skip DNS resolution entirely, so they must be caught here.
2. **Connect-time DNS filter** — `crates/server/src/sending/resolver.rs::Resolver::new_with_cidr_denylist`: filters DNS results against `cidr_range_denylist`. Catches DNS-name → internal-IP, DNS rebinding, and any HTTP redirect that the client still follows.
3. **No-redirect / bounded-redirect policy** on URL preview and push clients.

## Per-finding fixes

- **Push gateway** — `set_pusher` validates the URL up front via `url_guard`; `send_notice` re-validates at send time and uses the new `sending::push_gateway_client()` (safe resolver + 2-hop redirect cap).
- **URL preview** — preview's reqwest client now uses the safe resolver and `redirect::Policy::none()`. `request_url_preview`, `download_image`, and `download_html` each call `ensure_safe_outbound_url` so an attacker-controlled `og:image` cannot reach internal addresses.
- **Federation key notary** — `server_key::request::server_request` rejects IP-literal target server names; `sending::federation_client()` now installs the safe resolver (replacing a previously commented-out resolver line).

## Test plan
- [ ] `cargo check -p palpo` (passes locally)
- [ ] `cargo test -p palpo` 
- [ ] Manual: configure a pusher pointing at `http://127.0.0.1:8008/...` and verify the request is rejected at `set_pusher` (with denylist set)
- [ ] Manual: `GET /_matrix/client/v1/media/preview_url?url=https://example.com/p` where `og:image=http://169.254.169.254/...` — confirm the og:image fetch is refused and no internal data is stored
- [ ] Manual: `GET /_matrix/key/v2/query/127.0.0.1%3A6379` — confirm 403, no internal connection
- [ ] Manual: configure a public DNS name with an A-record pointing to `127.0.0.1`, request a URL preview against it — confirm the resolver rejects it at connect time

## Notes
- Operators who set `ip_range_denylist = []` explicitly disable IP-level filtering by design. Behavior matches the pre-existing URL preview logic in that case.
- The default `ip_range_denylist` already covers loopback, RFC1918, link-local, 169.254/16, IPv6 ULA/link-local, etc., so default deployments are protected without further configuration.