### PR TITLE
fix(security): use constant-time comparison for appservice tokens

### DIFF
--- a/crates/server/src/appservice.rs
+++ b/crates/server/src/appservice.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use diesel::prelude::*;
 use regex::RegexSet;
 use serde::{Deserialize, Serialize};
+use subtle::ConstantTimeEq;
 
 use crate::core::appservice::{Namespace, Registration};
 use crate::core::identifiers::*;
@@ -320,9 +321,17 @@ pub fn get_registration(id: &str) -> AppResult<Option<Registration>> {
     }
 }
 pub async fn find_from_token(token: &str) -> AppResult<Option<RegistrationInfo>> {
+    // Constant-time comparison so we don't leak `as_token` bytes via
+    // response timing. The same pattern is used in `hoops/auth.rs`.
     Ok(all()?
         .values()
-        .find(|info| info.registration.as_token == token)
+        .find(|info| {
+            info.registration
+                .as_token
+                .as_bytes()
+                .ct_eq(token.as_bytes())
+                .into()
+        })
         .cloned())
 }
 

--- a/crates/server/src/routing/appservice/third_party.rs
+++ b/crates/server/src/routing/appservice/third_party.rs
@@ -1,5 +1,6 @@
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
+use subtle::ConstantTimeEq;
 
 use crate::core::appservice::third_party::*;
 use crate::core::third_party::Protocol;
@@ -23,7 +24,11 @@ pub fn router() -> Router {
 fn verify_hs_token(aa: &AuthArgs) -> Result<(), crate::AppError> {
     let token = aa.require_access_token()?;
     let appservices = crate::appservices();
-    if appservices.iter().any(|a| a.hs_token == token) {
+    // Constant-time comparison; mirrors `routing/appservice.rs::verify_hs_token`.
+    if appservices
+        .iter()
+        .any(|a| a.hs_token.as_bytes().ct_eq(token.as_bytes()).into())
+    {
         Ok(())
     } else {
         Err(MatrixError::forbidden("Invalid hs_token", None).into())

--- a/crates/server/src/routing/appservice/transaction.rs
+++ b/crates/server/src/routing/appservice/transaction.rs
@@ -1,5 +1,6 @@
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
+use subtle::ConstantTimeEq;
 
 use crate::core::appservice::event::PushEventsReqBody;
 use crate::{AuthArgs, EmptyResult, MatrixError, empty_ok};
@@ -24,11 +25,14 @@ async fn send_event(
     let token = aa.require_access_token()?;
 
     // Validate the hs_token: the calling homeserver must authenticate with the
-    // hs_token that matches one of our registered appservices.
+    // hs_token that matches one of our registered appservices. Use a
+    // constant-time comparison to avoid leaking the token byte-by-byte
+    // through response timing (mirrors the pattern in
+    // `routing/appservice.rs::verify_hs_token`).
     let appservices = crate::appservices();
     let appservice = appservices
         .iter()
-        .find(|a| a.hs_token == token)
+        .find(|a| a.hs_token.as_bytes().ct_eq(token.as_bytes()).into())
         .ok_or_else(|| MatrixError::forbidden("Invalid hs_token", None))?;
 
     let txn_id = txn_id.into_inner();

--- a/crates/server/src/routing/client/register.rs
+++ b/crates/server/src/routing/client/register.rs
@@ -2,6 +2,7 @@ use diesel::prelude::*;
 use palpo_core::presence::PresenceState;
 use salvo::oapi::extract::{JsonBody, QueryParam};
 use salvo::prelude::*;
+use subtle::ConstantTimeEq;
 
 use crate::core::UnixMillis;
 use crate::core::client::account::{LoginType, RegistrationKind};
@@ -96,9 +97,17 @@ async fn register(
     let mut appservice = None;
     if body.login_type == Some(LoginType::ApplicationService) {
         let token = aa.require_access_token()?;
+        // Constant-time comparison so we don't leak `as_token` bytes via
+        // response timing. The same pattern is used in `hoops/auth.rs`.
         let matched = crate::appservices()
             .iter()
-            .find(|appservice| appservice.as_token == token)
+            .find(|appservice| {
+                appservice
+                    .as_token
+                    .as_bytes()
+                    .ct_eq(token.as_bytes())
+                    .into()
+            })
             .cloned();
         let Some(matched) = matched else {
             return Err(MatrixError::missing_token("missing appservice token").into());


### PR DESCRIPTION
## Summary

Four appservice-token validation sites compare \`as_token\`/\`hs_token\` with \`String\`/\`&str\` \`PartialEq\`, which short-circuits on the first mismatching byte and leaks per-byte timing information. Other sites in this codebase already use \`subtle::ConstantTimeEq\` ([\`routing/appservice.rs::verify_hs_token\`](crates/server/src/routing/appservice.rs#L31), [\`hoops/auth.rs\`](crates/server/src/hoops/auth.rs#L96)) — this PR makes the four outliers consistent.

## Vulnerable sites fixed

| File | Token | Surface |
|------|-------|---------|
| \`routing/appservice/transaction.rs\` | \`hs_token\` | \`PUT /_matrix/app/v1/transactions/{txnId}\` |
| \`routing/appservice/third_party.rs\` | \`hs_token\` | \`/_matrix/app/v1/thirdparty/*\` |
| \`routing/client/register.rs\` | \`as_token\` | \`POST /_matrix/client/v3/register\` (login_type \`m.login.application_service\`) |
| \`appservice.rs::find_from_token\` | \`as_token\` | Helper used across CS API auth paths |

## Impact if exploited

- **\`as_token\` recovery** lets a network attacker register users in the appservice namespace and authenticate as the appservice on the C-S API, including masquerading as any user inside that namespace.
- **\`hs_token\` recovery** lets an attacker submit appservice transactions impersonating the homeserver to the appservice.

## Fix

All four sites now use the existing pattern:

\`\`\`rust
appservice.hs_token.as_bytes().ct_eq(token.as_bytes()).into()
\`\`\`

\`subtle\` is already a workspace dependency of \`palpo\` ([\`crates/server/Cargo.toml:200\`](crates/server/Cargo.toml#L200)) and is used elsewhere in the same crate, so no new dependency is introduced.

## Test plan
- [x] \`cargo check -p palpo\` passes
- [ ] \`cargo test -p palpo\`
- [ ] Manual: appservice with valid \`hs_token\` still authenticates on \`/transactions\`, \`/thirdparty/*\`, \`/ping\`
- [ ] Manual: registration with valid appservice \`as_token\` still succeeds; invalid token still returns 403

## Related
This is a follow-up to #190 (SSRF mitigations). The two are independent and can be reviewed/merged in any order.