### PR TITLE
chore(ci): auto-publish GitHub release on tag push

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -39,7 +39,7 @@ jobs:
           # changelog: "CHANGELOG.md"
           title: "$version"
           branch: main
-          draft: true
+          draft: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Switches the `Create GitHub release` step in `release-binaries.yml` from `draft: true` to `draft: false` so the release is published immediately when a `vX.Y.Z` tag is pushed.
- The `upload-binaries` matrix (linux-gnu, macos-aarch64, windows-msvc) continues to attach the per-platform archives to the published release as each job completes.

## Why
- The v0.3.0 release ended up empty because the workflow's tag-push trigger didn't fire and, even when it does, `draft: true` left the release unpublished. Auto-publishing matches the v0.2.x flow users expect: push the tag, get a published release with binaries.

## Notes
- There is a brief window after `create-release` finishes where the release is published but binaries are still building. That mirrors the upstream `taiki-e/create-gh-release-action` recommendation for tag-push releases.
- For tags created via `gh release create` or the web UI (which can bypass workflow triggers), continue to use `git push origin <tag>` so this workflow runs.

## Test plan
- [ ] Next `vX.Y.Z` tag push produces a published release with the three platform archives attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)