### PR TITLE
fix(federation): avoid panic on missing PDU in /v1/state

### DIFF
--- a/crates/server/src/routing/federation/room.rs
+++ b/crates/server/src/routing/federation/room.rs
@@ -49,10 +49,16 @@ async fn get_state(
 
     let pdus = state::get_full_state_ids(state_hash)?
         .into_values()
-        .map(|id| {
-            sending::convert_to_outgoing_federation_event(
-                timeline::get_pdu_json(&id).unwrap().unwrap(),
-            )
+        .filter_map(|id| match timeline::get_pdu_json(&id) {
+            Ok(Some(json)) => Some(sending::convert_to_outgoing_federation_event(json)),
+            Ok(None) => {
+                error!("Could not find event json for state event {id} in db");
+                None
+            }
+            Err(e) => {
+                error!("Failed to load state event {id} from db: {e}");
+                None
+            }
         })
         .collect();
 


### PR DESCRIPTION
## Summary
- `/_matrix/federation/v1/state` previously called `timeline::get_pdu_json(&id).unwrap().unwrap()` for every state event id. A missing or unreadable PDU would panic the Tokio task and give a federated peer a trivial remote DoS against the endpoint.
- Switched to the same `filter_map` shape already used immediately below for the auth chain branch: log and skip events we cannot materialise.

## Test plan
- [ ] `cargo check --workspace` (passes locally)
- [ ] Manual: simulate a missing PDU and confirm the endpoint returns partial state rather than 500/panic
- [ ] Complement federation tests still green

Refs `_report.md` finding **C1** (Critical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)