### PR TITLE
chore(config): refuse insecure TLS / JWT toggles in release builds

### DIFF
--- a/crates/server/src/config/server.rs
+++ b/crates/server/src/config/server.rs
@@ -872,13 +872,40 @@ impl ServerConfig {
             tracing::warn!("Note: palpo was built without optimisations (i.e. debug build)");
         }
 
-        // if self
-        //     .allow_invalid_tls_certificates_yes_i_know_what_the_fuck_i_am_doing_with_this_and_i_know_this_is_insecure
-        // {
-        //     tracing::warn!(
-        //         "\n\nWARNING: \n\nTLS CERTIFICATE VALIDATION IS DISABLED, THIS IS HIGHLY INSECURE
-        // AND SHOULD NOT BE USED IN PRODUCTION.\n\n"     );
-        // }
+        if self.allow_invalid_tls_certificates {
+            tracing::error!(
+                "\n\n!!! TLS CERTIFICATE VALIDATION IS DISABLED !!!\n\
+                 allow_invalid_tls_certificates=true exposes every outbound HTTPS request \
+                 (federation, key fetches, URL previews) to silent MITM. \
+                 This must not be used in production.\n"
+            );
+            if cfg!(not(debug_assertions))
+                && std::env::var("PALPO_ALLOW_INSECURE_TLS").as_deref() != Ok("1")
+            {
+                return Err(AppError::internal(
+                    "allow_invalid_tls_certificates=true is refused in release builds. \
+                     Set PALPO_ALLOW_INSECURE_TLS=1 to override (debug/testing only).",
+                ));
+            }
+        }
+
+        if let Some(jwt) = self.enabled_jwt()
+            && !jwt.validate_signature
+        {
+            tracing::error!(
+                "\n\n!!! JWT SIGNATURE VALIDATION IS DISABLED !!!\n\
+                 jwt.validate_signature=false accepts any token as a valid login. \
+                 This must not be used in production.\n"
+            );
+            if cfg!(not(debug_assertions))
+                && std::env::var("PALPO_ALLOW_UNSIGNED_JWT").as_deref() != Ok("1")
+            {
+                return Err(AppError::internal(
+                    "jwt.validate_signature=false is refused in release builds. \
+                     Set PALPO_ALLOW_UNSIGNED_JWT=1 to override (debug/testing only).",
+                ));
+            }
+        }
 
         self.warn_deprecated();
         self.warn_unknown_key();

--- a/crates/server/src/config/server.rs
+++ b/crates/server/src/config/server.rs
@@ -872,9 +872,14 @@ impl ServerConfig {
             tracing::warn!("Note: palpo was built without optimisations (i.e. debug build)");
         }
 
+        // NOTE: `check()` runs *before* `logging::init()` in main, so a
+        // `tracing::error!` here would be dropped on the floor. Use
+        // `eprintln!` so the banners are always written to stderr regardless
+        // of whether a tracing subscriber has been installed yet.
+
         if self.allow_invalid_tls_certificates {
-            tracing::error!(
-                "\n\n!!! TLS CERTIFICATE VALIDATION IS DISABLED !!!\n\
+            eprintln!(
+                "\n!!! TLS CERTIFICATE VALIDATION IS DISABLED !!!\n\
                  allow_invalid_tls_certificates=true exposes every outbound HTTPS request \
                  (federation, key fetches, URL previews) to silent MITM. \
                  This must not be used in production.\n"
@@ -892,8 +897,8 @@ impl ServerConfig {
         if let Some(jwt) = self.enabled_jwt()
             && !jwt.validate_signature
         {
-            tracing::error!(
-                "\n\n!!! JWT SIGNATURE VALIDATION IS DISABLED !!!\n\
+            eprintln!(
+                "\n!!! JWT SIGNATURE VALIDATION IS DISABLED !!!\n\
                  jwt.validate_signature=false accepts any token as a valid login. \
                  This must not be used in production.\n"
             );

--- a/crates/server/src/sending.rs
+++ b/crates/server/src/sending.rs
@@ -943,6 +943,10 @@ fn reqwest_client_builder(config: &ServerConfig) -> AppResult<reqwest::ClientBui
         .timeout(Duration::from_secs(60 * 3));
 
     if config.allow_invalid_tls_certificates {
+        tracing::warn!(
+            "building HTTP client with TLS validation disabled \
+             (allow_invalid_tls_certificates=true); outbound requests are MITM-able"
+        );
         reqwest_client_builder = reqwest_client_builder.danger_accept_invalid_certs(true);
     }
 

--- a/crates/server/src/user/session.rs
+++ b/crates/server/src/user/session.rs
@@ -12,11 +12,8 @@ pub struct JwtClaims {
 }
 
 pub fn validate_jwt_token(config: &JwtConfig, token: &str) -> AppResult<JwtClaims> {
-    if !config.validate_signature {
-        warn!(
-            "JWT signature validation is disabled! This is insecure and should not be used in production."
-        );
-    }
+    // The "JWT signature validation disabled" banner is emitted once on startup
+    // by ServerConfig::check(); we don't re-warn per request here.
 
     let verifier = init_jwt_verifier(config)?;
     let validator = init_jwt_validator(config)?;


### PR DESCRIPTION
## Summary
- `allow_invalid_tls_certificates = true` silently MITMs every federation / key-fetch / URL-preview request.
- `jwt.validate_signature = false` accepts any token as a valid login.
- Both used to emit only a buried `warn!` (one per JWT call, none at all for TLS).

This PR:
1. Emits a loud, single-shot `error!` banner at startup in `ServerConfig::check()` for either flag.
2. In **release builds**, refuses to start unless the operator explicitly sets `PALPO_ALLOW_INSECURE_TLS=1` / `PALPO_ALLOW_UNSIGNED_JWT=1`. Debug builds continue to start with just the banner so the existing dev/test workflows keep working.
3. Keeps a single `warn!` at the spot the insecure reqwest client is actually built; removes the redundant per-request JWT warn now that the banner covers it.

## Test plan
- [ ] `cargo check --workspace` (passes locally)
- [ ] `cargo build --release` with `allow_invalid_tls_certificates=true` → server refuses to start with a clear message
- [ ] Same, with the env var set → server starts and prints the banner once
- [ ] Debug build with `allow_invalid_tls_certificates=true` → server starts, banner is visible

Refs `_report.md` findings **C2** (Critical) and **H1** (High).

🤖 Generated with [Claude Code](https://claude.com/claude-code)