### PR TITLE
fix(admin): constant-time comparison of MAS shared secret

### DIFF
--- a/crates/server/src/routing/admin.rs
+++ b/crates/server/src/routing/admin.rs
@@ -15,6 +15,7 @@ mod user_admin;
 mod user_lookup;
 
 use salvo::prelude::*;
+use subtle::ConstantTimeEq;
 
 use crate::routing::prelude::*;
 
@@ -40,7 +41,13 @@ pub async fn auth_by_mas_secret(aa: crate::AuthArgs) -> AppResult<()> {
         )
         .into());
     };
-    if token != mas_secret.as_str() {
+    // Use a constant-time comparison so the response time does not leak
+    // information about how many leading bytes of the secret matched.
+    let token_bytes = token.as_bytes();
+    let secret_bytes = mas_secret.as_bytes();
+    let matches: bool = token_bytes.len() == secret_bytes.len()
+        && token_bytes.ct_eq(secret_bytes).into();
+    if !matches {
         return Err(MatrixError::forbidden("Invalid MAS secret", None).into());
     }
     Ok(())


### PR DESCRIPTION
## Summary
- `routing/admin::auth_by_mas_secret` compared the caller's token to `admin.mas_secret` with `!=`, leaking matched-prefix length via timing.
- Mirrors the `subtle::ConstantTimeEq` pattern already used in `routing/appservice` (hs_token) and `uiaa` (registration token).

## Test plan
- [ ] `cargo check --workspace` (passes locally)
- [ ] Hit a `_palpo/mas/...` endpoint with a wrong secret and confirm response time is no longer prefix-dependent.

Refs `_report.md` finding **M33** (Medium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)