### PR TITLE
feat(media): harden response headers (nosniff + CSP) on media endpoints

### DIFF
--- a/crates/server/src/hoops.rs
+++ b/crates/server/src/hoops.rs
@@ -105,6 +105,41 @@ async fn access_control(
     // headers.insert("Cross-Origin-Opener-Policy", "same-origin".parse().unwrap());
 }
 
+/// Hardening hoop for media endpoints. Sets headers that prevent a browser
+/// from interpreting an uploaded blob as something more dangerous than its
+/// declared `Content-Type`:
+///
+/// * `X-Content-Type-Options: nosniff` — disable MIME sniffing, so e.g. an
+///   HTML payload uploaded with `image/jpeg` is not executed as HTML.
+/// * A tight `Content-Security-Policy` that forbids scripts, inline content,
+///   plugins and framing of the response. This matches Synapse's media CSP
+///   and protects against XSS via uploaded SVG/HTML when a third-party page
+///   embeds a media URL.
+/// * `X-Frame-Options: DENY` for legacy browsers that ignore CSP.
+///
+/// The middleware runs after the inner handler so it overrides any earlier
+/// (less strict) values that might have been set.
+#[handler]
+pub async fn media_security_headers(
+    req: &mut Request,
+    depot: &mut Depot,
+    res: &mut Response,
+    ctrl: &mut FlowCtrl,
+) {
+    ctrl.call_next(req, depot, res).await;
+    let headers = res.headers_mut();
+    headers.insert("X-Content-Type-Options", "nosniff".parse().unwrap());
+    headers.insert(
+        "Content-Security-Policy",
+        "sandbox; default-src 'none'; script-src 'none'; plugin-types application/pdf; \
+         style-src 'unsafe-inline'; object-src 'self';"
+            .parse()
+            .unwrap(),
+    );
+    headers.insert("X-Frame-Options", "DENY".parse().unwrap());
+    headers.insert("Referrer-Policy", "no-referrer".parse().unwrap());
+}
+
 /// Token-bucket rate limiter: maps IP → (available_tokens, last_check_time)
 struct RateLimiter {
     buckets: Mutex<HashMap<String, (f64, Instant)>>,

--- a/crates/server/src/routing/client/media.rs
+++ b/crates/server/src/routing/client/media.rs
@@ -26,6 +26,7 @@ use crate::{
 pub fn self_auth_router() -> Router {
     Router::with_path("media")
         .oapi_tag("client")
+        .hoop(hoops::media_security_headers)
         .push(
             Router::with_path("download/{server_name}/{media_id}")
                 .hoop(hoops::auth_by_access_token_or_signatures)

--- a/crates/server/src/routing/federation/media.rs
+++ b/crates/server/src/routing/federation/media.rs
@@ -19,6 +19,7 @@ use crate::{AppResult, AuthArgs, MatrixError, config, hoops, storage};
 pub fn router() -> Router {
     Router::with_path("media")
         .hoop(hoops::limit_rate)
+        .hoop(hoops::media_security_headers)
         .push(Router::with_path("download/{media_id}").get(get_content))
         .push(Router::with_path("thumbnail/{media_id}").get(get_thumbnail))
 }

--- a/crates/server/src/routing/media.rs
+++ b/crates/server/src/routing/media.rs
@@ -4,7 +4,9 @@ use super::client::media::*;
 use crate::hoops;
 
 pub fn router() -> Router {
-    let mut media = Router::with_path("media").oapi_tag("media");
+    let mut media = Router::with_path("media")
+        .oapi_tag("media")
+        .hoop(hoops::media_security_headers);
     for v in ["v3", "v1", "r0"] {
         media = media
             .push(


### PR DESCRIPTION
## Summary
The codebase had an `access_control` middleware in `hoops.rs` that *would* set `X-Content-Type-Options: nosniff` and a CSP — but it is **never wired into the service**, so no media response was actually sending those headers. That leaves a stored-XSS path: upload HTML with a lying \`Content-Type\` (or upload SVG), trick a browser into sniffing it, get script execution under the homeserver's origin.

This PR adds a dedicated `media_security_headers` middleware and attaches it to **all three** media routers:
- `/_matrix/client/v1/media/...`   (`routing/client/media.rs`)
- `/_matrix/media/v3|v1|r0/...`   (`routing/media.rs`)
- `/_matrix/federation/v1/media/...` (`routing/federation/media.rs`)

The header set follows Synapse's recipe:
- `X-Content-Type-Options: nosniff`
- `Content-Security-Policy: sandbox; default-src 'none'; script-src 'none'; plugin-types application/pdf; style-src 'unsafe-inline'; object-src 'self';`
- `X-Frame-Options: DENY`
- `Referrer-Policy: no-referrer`

## Test plan
- [ ] `cargo check --workspace` (passes locally)
- [ ] `curl -i https://palpo.example/_matrix/media/v3/download/...` → headers include `nosniff` + CSP
- [ ] Same for `/_matrix/federation/v1/media/...` and `/_matrix/client/v1/media/...`

Refs `_report.md` finding **M21** (Medium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)