### PR TITLE
fix(media): bound thumbnail width/height at request entry

### DIFF
--- a/crates/server/src/media.rs
+++ b/crates/server/src/media.rs
@@ -143,6 +143,29 @@ pub fn thumbnail_properties(width: u32, height: u32) -> Option<(u32, u32, bool)>
     }
 }
 
+/// Upper bound on `width` / `height` accepted from a thumbnail request.
+///
+/// `ThumbnailReqArgs::{width,height}` are `u32`, which means a remote can
+/// ask for `4_294_967_295 x 4_294_967_295` and the server will at least
+/// do a database lookup with those values before falling back. Clamp the
+/// request at the boundary so neither the DB nor the image decoder has
+/// to defend against absurd inputs.
+pub const MAX_THUMBNAIL_DIMENSION: u32 = 2048;
+
+/// Reject thumbnail requests whose declared width or height is implausibly
+/// large. Returns `Err(M_INVALID_PARAM)` if either dimension exceeds
+/// [`MAX_THUMBNAIL_DIMENSION`].
+pub fn validate_thumbnail_dimensions(width: u32, height: u32) -> AppResult<()> {
+    if width > MAX_THUMBNAIL_DIMENSION || height > MAX_THUMBNAIL_DIMENSION {
+        return Err(crate::MatrixError::invalid_param(format!(
+            "thumbnail dimensions must be <= {MAX_THUMBNAIL_DIMENSION} \
+             (requested {width}x{height})"
+        ))
+        .into());
+    }
+    Ok(())
+}
+
 pub fn get_all_mxcs() -> AppResult<Vec<OwnedMxcUri>> {
     let mxcs = media_metadatas::table
         .select((media_metadatas::origin_server, media_metadatas::media_id))

--- a/crates/server/src/routing/client/media.rs
+++ b/crates/server/src/routing/client/media.rs
@@ -312,6 +312,7 @@ pub async fn get_thumbnail(
     _req: &mut Request,
     res: &mut Response,
 ) -> AppResult<()> {
+    crate::media::validate_thumbnail_dimensions(args.width, args.height)?;
     if args.server_name.is_remote() && args.allow_remote {
         let origin = args.server_name.origin().await;
         let mut url = Url::parse(&format!(

--- a/crates/server/src/routing/federation/media.rs
+++ b/crates/server/src/routing/federation/media.rs
@@ -74,6 +74,7 @@ pub async fn get_thumbnail(
     _req: &mut Request,
     res: &mut Response,
 ) -> AppResult<()> {
+    crate::media::validate_thumbnail_dimensions(args.width, args.height)?;
     let server_name = &config::get().server_name;
     if let Some(DbThumbnail {
         id, content_type, ..


### PR DESCRIPTION
## Summary
- `ThumbnailReqArgs::{width,height}` are `u32` with no validation. A remote can ask for `4_294_967_295 × 4_294_967_295` and the handler will still issue a DB lookup, decode the original image into memory and run resize on those values before falling back.
- Introduce `MAX_THUMBNAIL_DIMENSION = 2048` and a tiny `validate_thumbnail_dimensions()` helper. Both the client (`/_matrix/client/v1/media/thumbnail/...`, `/_matrix/media/v3/thumbnail/...`) and federation (`/_matrix/federation/v1/media/thumbnail/...`) handlers reject out-of-range requests with `M_INVALID_PARAM` before any IO.

## Test plan
- [ ] `cargo check --workspace` (passes locally)
- [ ] `curl '...thumbnail/.../...?width=99999&height=99999'` → returns `M_INVALID_PARAM`
- [ ] `curl '...thumbnail/.../...?width=64&height=64'` → still serves a normal thumbnail

Refs `_report.md` finding **M22** (Medium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)