### PR TITLE
refactor(db): migrate from synchronous diesel+r2d2 to diesel-async+deadpool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,6 +1365,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c03c416ed1a30fbb027ef484ba6ab6f80e1eada675e1a2b92fd673c045a1f1d"
 
 [[package]]
+name = "deadpool"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883466cb8db62725aee5f4a6011e8a5d42912b42632df32aad57fc91127c6e04"
+dependencies = [
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2657f61fb1dd8bf37a8d51093cc7cee4e77125b22f7753f49b289f831bec2bae"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,6 +1455,21 @@ dependencies = [
  "pq-sys",
  "r2d2",
  "serde_json",
+]
+
+[[package]]
+name = "diesel-async"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c20ddcc6737cecdaef3dfecb2796bdfe3002456521189d30be8e4c5a1bc821d"
+dependencies = [
+ "deadpool",
+ "diesel",
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-postgres",
 ]
 
 [[package]]
@@ -1707,6 +1742,12 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fast32"
@@ -2941,6 +2982,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "link-section"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3091,6 +3141,16 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3390,6 +3450,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3431,7 +3509,7 @@ dependencies = [
  "http-body",
  "jiff",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "mea",
  "percent-encoding",
  "quick-xml 0.38.4",
@@ -3480,7 +3558,7 @@ dependencies = [
  "crc32c",
  "http",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "opendal-core",
  "quick-xml 0.38.4",
  "reqsign-aws-v4",
@@ -3528,6 +3606,7 @@ dependencies = [
  "cyborgtime",
  "data-encoding",
  "diesel",
+ "diesel-async",
  "diesel_migrations",
  "dotenvy",
  "dtor",
@@ -3695,7 +3774,9 @@ dependencies = [
  "cookie",
  "cyborgtime",
  "data-encoding",
+ "deadpool",
  "diesel",
+ "diesel-async",
  "diesel_migrations",
  "dotenvy",
  "fast32",
@@ -3721,7 +3802,6 @@ dependencies = [
  "rust-argon2",
  "salvo",
  "sanitize-filename",
- "scheduled-thread-pool",
  "secrecy",
  "serde",
  "serde-saphyr",
@@ -4081,6 +4161,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac 0.13.0",
+ "md-5 0.11.0",
+ "memchr",
+ "rand 0.10.1",
+ "sha2 0.11.0",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
 ]
 
 [[package]]
@@ -5779,6 +5888,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6116,6 +6236,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf 0.13.1",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.10.1",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -6499,10 +6645,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6660,6 +6827,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6675,6 +6851,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -6861,6 +7046,19 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
+]
 
 [[package]]
 name = "widestring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ tempfile = "3.27.0"
 termimad = { version = "0.34.1", default-features = false }
 textnonce = "1.0.0"
 thiserror = "2.0.18"
-tokio = { version = "1.52.3", features = ["macros", "parking_lot", "process"] }
+tokio = { version = "1.52.3", features = ["macros", "parking_lot", "process", "rt-multi-thread"] }
 tokio-stream = { version = "0.1.18", features = ["sync"] }
 tokio-util = { version = "0.7.18", features = ["io"] }
 toml = { version = "1.1.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,9 @@ core_affinity = "0.8.3"
 cyborgtime = "2.1.1"
 data-encoding = "2.11.0"
 date_header = "1.0.5"
+deadpool = { version = "0.13" }
 diesel = { version = "2.3.9" }
-# diesel-async = { version = "0.6.1" }
+diesel-async = { version = "0.9.0" }
 # diesel_full_text_search = { version = "2.2.0" }
 diesel_migrations = "2.3.2"
 dotenvy = "0.15.7"

--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -80,17 +80,19 @@ pub type EventIdSet = HashSet<OwnedEventId>;
 ///
 /// [state resolution]: https://spec.matrix.org/latest/rooms/v2/#state-resolution
 #[instrument(skip_all)]
-pub async fn resolve<'a, MapsIter, Pdu, Fetch, Fut>(
+pub async fn resolve<'a, MapsIter, Pdu, Fetch, Fut, FetchSub, FutSub>(
     auth_rules: &AuthorizationRules,
     state_res_rules: StateResolutionV2Rules,
     state_maps: impl IntoIterator<IntoIter = MapsIter>,
     auth_chains: Vec<EventIdSet>,
     fetch_event: &Fetch,
-    fetch_conflicted_state_subgraph: impl Fn(&StateMap<Vec<OwnedEventId>>) -> Option<EventIdSet>,
+    fetch_conflicted_state_subgraph: FetchSub,
 ) -> Result<StateMap<OwnedEventId>, StateError>
 where
     Fetch: Fn(OwnedEventId) -> Fut + Sync,
     Fut: Future<Output = StateResult<Pdu>> + Send,
+    FetchSub: FnOnce(&StateMap<Vec<OwnedEventId>>) -> FutSub,
+    FutSub: Future<Output = Option<EventIdSet>> + Send,
     Pdu: Event + Clone + Sync + Send,
     Pdu::Id: Clone,
     MapsIter: Iterator<Item = &'a StateMap<OwnedEventId>> + Clone,
@@ -115,6 +117,7 @@ where
     // Since v12, fetch the conflicted state subgraph.
     let conflicted_state_subgraph = if state_res_rules.consider_conflicted_state_subgraph {
         let conflicted_state_subgraph = fetch_conflicted_state_subgraph(&conflicted_state_set)
+            .await
             .ok_or(StateError::FetchConflictedStateSubgraphFailed)?;
 
         info!(

--- a/crates/data/Cargo.toml
+++ b/crates/data/Cargo.toml
@@ -36,13 +36,14 @@ config = { workspace = true }
 cookie = { workspace = true }
 cyborgtime = { workspace = true }
 data-encoding = { workspace = true }
+deadpool = { workspace = true, features = ["managed", "rt_tokio_1"] }
 diesel = { workspace = true, features = [
     "postgres",
     "serde_json",
     "chrono",
     "numeric",
-    "r2d2",
 ] }
+diesel-async = { workspace = true, features = ["postgres", "deadpool"] }
 diesel_migrations = { workspace = true }
 dotenvy = { workspace = true }
 fast32 = { workspace = true }
@@ -80,7 +81,6 @@ salvo = { workspace = true, features = [
     "size-limiter",
 ] }
 sanitize-filename = { workspace = true }
-scheduled-thread-pool = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }

--- a/crates/data/src/config.rs
+++ b/crates/data/src/config.rs
@@ -13,8 +13,6 @@
 
 use std::fmt;
 
-use diesel::prelude::*;
-use diesel::r2d2::{self, CustomizeConnection};
 use serde::{Deserialize, Serialize};
 
 use crate::core::serde::default_false;
@@ -98,33 +96,3 @@ impl fmt::Display for DbConfig {
 //         self.primary.read_only_mode
 //     }
 // }
-
-#[derive(Debug, Clone, Copy)]
-pub struct ConnectionConfig {
-    pub statement_timeout: u64,
-    // pub read_only: bool,
-}
-
-impl CustomizeConnection<PgConnection, r2d2::Error> for ConnectionConfig {
-    fn on_acquire(&self, conn: &mut PgConnection) -> Result<(), r2d2::Error> {
-        use diesel::sql_query;
-
-        // SAFETY: statement_timeout is a u64, which guarantees it's a valid integer.
-        // PostgreSQL SET statements don't support parameterized queries, so we must
-        // use string formatting. The u64 type ensures no SQL injection is possible
-        // since it can only contain numeric digits.
-        //
-        // Validate the timeout is within a reasonable range (0 to 1 hour in ms)
-        // to prevent potential DoS through extremely long timeouts.
-        let timeout = self.statement_timeout.min(3_600_000);
-        sql_query(format!("SET statement_timeout = {}", timeout))
-            .execute(conn)
-            .map_err(r2d2::Error::QueryError)?;
-        // if self.read_only {
-        //     sql_query("SET default_transaction_read_only = 't'")
-        //         .execute(conn)
-        //         .map_err(r2d2::Error::QueryError)?;
-        // }
-        Ok(())
-    }
-}

--- a/crates/data/src/lib.rs
+++ b/crates/data/src/lib.rs
@@ -1,10 +1,8 @@
-use std::sync::{Arc, OnceLock};
-use std::time::Duration;
+use std::sync::OnceLock;
 
-use diesel::prelude::*;
-use diesel::r2d2::{self, State};
+use diesel::{Connection, PgConnection};
+use diesel_async::RunQueryDsl;
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
-use scheduled_thread_pool::ScheduledThreadPool;
 use url::Url;
 
 extern crate tracing;
@@ -40,28 +38,25 @@ pub static REPLICA_POOL: OnceLock<Option<DieselPool>> = OnceLock::new();
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
 pub fn init(config: &DbConfig) {
-    let builder = r2d2::Pool::builder()
-        .max_size(config.pool_size)
-        .min_idle(config.min_idle)
-        .connection_timeout(Duration::from_millis(config.connection_timeout))
-        .connection_customizer(Box::new(config::ConnectionConfig {
-            statement_timeout: config.statement_timeout,
-        }))
-        .thread_pool(Arc::new(ScheduledThreadPool::new(config.helper_threads)));
-
-    let pool =
-        DieselPool::new(&config.url, config, builder).expect("diesel pool should be created");
+    let pool = DieselPool::new(&config.url, config).expect("diesel pool should be created");
     DIESEL_POOL.set(pool).expect("diesel pool should be set");
-    migrate();
+    migrate(config);
 }
-pub fn migrate() {
-    let conn = &mut connect().expect("db connect should worked");
+
+/// Run pending migrations using a one-off synchronous connection.
+///
+/// `diesel_migrations` only operates on synchronous connections, so this
+/// establishes a dedicated `PgConnection` separate from the async pool. It also
+/// doubles as a fail-fast connectivity check at startup.
+pub fn migrate(config: &DbConfig) {
+    let url = connection_url(config, &config.url);
+    let mut conn = PgConnection::establish(&url).expect("db connect should worked");
     conn.run_pending_migrations(MIGRATIONS)
         .expect("migrate db should worked");
 }
 
-pub fn connect() -> Result<PgPooledConnection, PoolError> {
-    match DIESEL_POOL.get().expect("diesel pool should set").get() {
+pub async fn connect() -> Result<PgPooledConnection, PoolError> {
+    match DIESEL_POOL.get().expect("diesel pool should set").get().await {
         Ok(conn) => Ok(conn),
         Err(e) => {
             tracing::error!("db connect error: {e}");
@@ -69,8 +64,8 @@ pub fn connect() -> Result<PgPooledConnection, PoolError> {
         }
     }
 }
-pub fn state() -> State {
-    DIESEL_POOL.get().expect("diesel pool should set").state()
+pub fn status() -> deadpool::managed::Status {
+    DIESEL_POOL.get().expect("diesel pool should set").status()
 }
 
 pub fn connection_url(config: &DbConfig, url: &str) -> String {
@@ -97,13 +92,15 @@ fn maybe_append_url_param(url: &mut Url, key: &str, value: &str) {
     }
 }
 
-pub fn next_sn() -> DataResult<Seqnum> {
+pub async fn next_sn() -> DataResult<Seqnum> {
     diesel::dsl::sql::<diesel::sql_types::BigInt>("SELECT nextval('occur_sn_seq')")
-        .get_result::<Seqnum>(&mut connect()?)
+        .get_result::<Seqnum>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
-pub fn curr_sn() -> DataResult<Seqnum> {
+pub async fn curr_sn() -> DataResult<Seqnum> {
     diesel::dsl::sql::<diesel::sql_types::BigInt>("SELECT last_value from occur_sn_seq")
-        .get_result::<Seqnum>(&mut connect()?)
+        .get_result::<Seqnum>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }

--- a/crates/data/src/macros.rs
+++ b/crates/data/src/macros.rs
@@ -2,12 +2,15 @@
 macro_rules! diesel_exists {
     ($query:expr, $conn:expr) => {{
         // tracing::info!( sql = %debug_query!(&$query), "diesel_exists");
-        diesel::select(diesel::dsl::exists($query)).get_result::<bool>($conn)
+        diesel::select(diesel::dsl::exists($query))
+            .get_result::<bool>($conn)
+            .await
     }};
     ($query:expr, $default:expr, $conn:expr) => {{
         // tracing::info!( sql = debug_query!(&$query), "diesel_exists");
         diesel::select(diesel::dsl::exists($query))
             .get_result::<bool>($conn)
+            .await
             .unwrap_or($default)
     }};
 }

--- a/crates/data/src/media.rs
+++ b/crates/data/src/media.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::core::UnixMillis;
 use crate::core::identifiers::*;
@@ -35,22 +36,27 @@ pub struct NewDbMetadata {
     pub created_at: UnixMillis,
 }
 
-pub fn get_metadata(server_name: &ServerName, media_id: &str) -> DataResult<Option<DbMetadata>> {
+pub async fn get_metadata(
+    server_name: &ServerName,
+    media_id: &str,
+) -> DataResult<Option<DbMetadata>> {
     media_metadatas::table
         .filter(media_metadatas::media_id.eq(media_id))
         .filter(media_metadatas::origin_server.eq(server_name))
-        .first::<DbMetadata>(&mut connect()?)
+        .first::<DbMetadata>(&mut connect().await?)
+        .await
         .optional()
         .map_err(Into::into)
 }
 
-pub fn delete_media(server_name: &ServerName, media_id: &str) -> DataResult<()> {
+pub async fn delete_media(server_name: &ServerName, media_id: &str) -> DataResult<()> {
     diesel::delete(
         media_metadatas::table
             .filter(media_metadatas::media_id.eq(media_id))
             .filter(media_metadatas::origin_server.eq(server_name)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }
 
@@ -82,7 +88,7 @@ pub struct NewDbThumbnail {
     pub created_at: UnixMillis,
 }
 
-pub fn get_thumbnail_by_dimension(
+pub async fn get_thumbnail_by_dimension(
     origin_server: &ServerName,
     media_id: &str,
     width: u32,
@@ -93,7 +99,8 @@ pub fn get_thumbnail_by_dimension(
         .filter(media_thumbnails::media_id.eq(media_id))
         .filter(media_thumbnails::width.eq(width as i32))
         .filter(media_thumbnails::height.eq(height as i32))
-        .first::<DbThumbnail>(&mut connect()?)
+        .first::<DbThumbnail>(&mut connect().await?)
+        .await
         .optional()
         .map_err(Into::into)
 }
@@ -129,32 +136,35 @@ pub struct NewDbUrlPreview {
     pub created_at: UnixMillis,
 }
 
-pub fn get_url_preview(url: &str) -> DataResult<DbUrlPreview> {
+pub async fn get_url_preview(url: &str) -> DataResult<DbUrlPreview> {
     media_url_previews::table
         .filter(media_url_previews::url.eq(url))
-        .first::<DbUrlPreview>(&mut connect()?)
+        .first::<DbUrlPreview>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
-pub fn set_url_preview(preview: &NewDbUrlPreview) -> DataResult<()> {
+pub async fn set_url_preview(preview: &NewDbUrlPreview) -> DataResult<()> {
     diesel::insert_into(media_url_previews::table)
         .values(preview)
         .on_conflict(media_url_previews::url)
         .do_update()
         .set(preview)
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
-pub fn insert_metadata(metadata: &NewDbMetadata) -> DataResult<()> {
+pub async fn insert_metadata(metadata: &NewDbMetadata) -> DataResult<()> {
     diesel::insert_into(media_metadatas::table)
         .values(metadata)
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
 /// List media uploaded by a user with pagination
-pub fn list_media_by_user(
+pub async fn list_media_by_user(
     user_id: &UserId,
     from: i64,
     limit: i64,
@@ -165,7 +175,8 @@ pub fn list_media_by_user(
     let total = media_metadatas::table
         .filter(media_metadatas::created_by.eq(user_id.as_str()))
         .count()
-        .get_result::<i64>(&mut connect()?)?;
+        .get_result::<i64>(&mut connect().await?)
+        .await?;
 
     // Build query with ordering
     let direction_desc = direction.map(|d| d == "b").unwrap_or(true);
@@ -215,14 +226,15 @@ pub fn list_media_by_user(
     let media = query
         .offset(from)
         .limit(limit)
-        .load::<DbMetadata>(&mut connect()?)?;
+        .load::<DbMetadata>(&mut connect().await?)
+        .await?;
 
     Ok((media, total))
 }
 
 /// Delete multiple media items by their IDs
 /// Returns the list of deleted media IDs and total count
-pub fn delete_media_by_ids(
+pub async fn delete_media_by_ids(
     server_name: &ServerName,
     media_ids: &[String],
 ) -> DataResult<(Vec<String>, i64)> {
@@ -234,7 +246,8 @@ pub fn delete_media_by_ids(
                 .filter(media_metadatas::media_id.eq(media_id))
                 .filter(media_metadatas::origin_server.eq(server_name)),
         )
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
 
         if rows > 0 {
             // Also delete thumbnails
@@ -243,7 +256,8 @@ pub fn delete_media_by_ids(
                     .filter(media_thumbnails::media_id.eq(media_id))
                     .filter(media_thumbnails::origin_server.eq(server_name)),
             )
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
             deleted.push(media_id.clone());
         }
     }
@@ -254,7 +268,10 @@ pub fn delete_media_by_ids(
 
 /// Purge old remote media cache (media from other servers)
 /// Returns the count of deleted items
-pub fn purge_remote_media_cache(local_server: &ServerName, before_ts: i64) -> DataResult<i64> {
+pub async fn purge_remote_media_cache(
+    local_server: &ServerName,
+    before_ts: i64,
+) -> DataResult<i64> {
     let before_ts = UnixMillis(before_ts as u64);
 
     // Delete thumbnails first
@@ -263,7 +280,8 @@ pub fn purge_remote_media_cache(local_server: &ServerName, before_ts: i64) -> Da
             .filter(media_thumbnails::origin_server.ne(local_server))
             .filter(media_thumbnails::created_at.lt(before_ts)),
     )
-    .execute(&mut connect()?)? as i64;
+    .execute(&mut connect().await?)
+    .await? as i64;
 
     // Delete metadata
     let deleted_metadata = diesel::delete(
@@ -271,13 +289,14 @@ pub fn purge_remote_media_cache(local_server: &ServerName, before_ts: i64) -> Da
             .filter(media_metadatas::origin_server.ne(local_server))
             .filter(media_metadatas::created_at.lt(before_ts)),
     )
-    .execute(&mut connect()?)? as i64;
+    .execute(&mut connect().await?)
+    .await? as i64;
 
     Ok(deleted_metadata + deleted_thumbnails)
 }
 
 /// Delete old local media before a timestamp and larger than size_gt
-pub fn delete_old_local_media(
+pub async fn delete_old_local_media(
     local_server: &ServerName,
     before_ts: i64,
     size_gt: i64,
@@ -290,7 +309,8 @@ pub fn delete_old_local_media(
         .filter(media_metadatas::created_at.lt(before_ts))
         .filter(media_metadatas::file_size.gt(size_gt))
         .select(media_metadatas::media_id)
-        .load::<String>(&mut connect()?)?;
+        .load::<String>(&mut connect().await?)
+        .await?;
 
     if media_ids.is_empty() {
         return Ok((vec![], 0));
@@ -302,7 +322,8 @@ pub fn delete_old_local_media(
             .filter(media_thumbnails::origin_server.eq(local_server))
             .filter(media_thumbnails::media_id.eq_any(&media_ids)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
 
     // Delete metadata
     diesel::delete(
@@ -310,7 +331,8 @@ pub fn delete_old_local_media(
             .filter(media_metadatas::origin_server.eq(local_server))
             .filter(media_metadatas::media_id.eq_any(&media_ids)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
 
     let total = media_ids.len() as i64;
     Ok((media_ids, total))
@@ -326,14 +348,14 @@ pub struct UserMediaStatsRow {
     pub media_length: i64,
 }
 
-pub fn get_user_media_statistics(
+pub async fn get_user_media_statistics(
     offset: i64,
     limit: i64,
     search_term: Option<&str>,
     order_by: Option<&str>,
     dir: Option<&str>,
 ) -> DataResult<(Vec<UserMediaStatsRow>, i64)> {
-    let mut conn = connect()?;
+    let mut conn = connect().await?;
     let order_col = match order_by {
         Some("media_count") => "media_count",
         _ => "media_length",
@@ -354,7 +376,8 @@ pub fn get_user_media_statistics(
             .to_string();
         let total: i64 = diesel::sql_query(&count_sql)
             .bind::<diesel::sql_types::Text, _>(&like_pattern)
-            .get_result::<CountResult>(&mut conn)?
+            .get_result::<CountResult>(&mut conn)
+            .await?
             .count;
 
         let data_sql = format!(
@@ -370,7 +393,8 @@ pub fn get_user_media_statistics(
         );
         let rows = diesel::sql_query(&data_sql)
             .bind::<diesel::sql_types::Text, _>(&like_pattern)
-            .load::<UserMediaStatsRow>(&mut conn)?;
+            .load::<UserMediaStatsRow>(&mut conn)
+            .await?;
         (rows, total)
     } else {
         let count_sql = "SELECT COUNT(*) AS count FROM (\
@@ -379,7 +403,8 @@ pub fn get_user_media_statistics(
                 GROUP BY created_by\
             ) sub";
         let total: i64 = diesel::sql_query(count_sql)
-            .get_result::<CountResult>(&mut conn)?
+            .get_result::<CountResult>(&mut conn)
+            .await?
             .count;
 
         let data_sql = format!(
@@ -393,7 +418,9 @@ pub fn get_user_media_statistics(
             LIMIT {} OFFSET {}",
             order_col, order_dir, limit, offset
         );
-        let rows = diesel::sql_query(&data_sql).load::<UserMediaStatsRow>(&mut conn)?;
+        let rows = diesel::sql_query(&data_sql)
+            .load::<UserMediaStatsRow>(&mut conn)
+            .await?;
         (rows, total)
     };
 

--- a/crates/data/src/pool.rs
+++ b/crates/data/src/pool.rs
@@ -1,88 +1,88 @@
-use std::ops::Deref;
 use std::time::Duration;
 
-use diesel::prelude::*;
-use diesel::r2d2::{self, ConnectionManager, State};
+use deadpool::Runtime;
+use deadpool::managed::{Status, Timeouts};
+use diesel::ConnectionError;
+use diesel_async::pooled_connection::deadpool::{
+    BuildError, Object, Pool, PoolError as DeadpoolError,
+};
+use diesel_async::pooled_connection::{AsyncDieselConnectionManager, ManagerConfig};
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use futures_util::FutureExt;
 use thiserror::Error;
 
 use super::{DbConfig, connection_url};
 
-pub type PgPool = r2d2::Pool<ConnectionManager<PgConnection>>;
-pub type PgPooledConnection = r2d2::PooledConnection<ConnectionManager<PgConnection>>;
+pub type PgPool = Pool<AsyncPgConnection>;
+pub type PgPooledConnection = Object<AsyncPgConnection>;
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct DieselPool {
     inner: PgPool,
 }
 
-impl DieselPool {
-    pub(crate) fn new(
-        url: &str,
-        config: &DbConfig,
-        r2d2_config: r2d2::Builder<ConnectionManager<PgConnection>>,
-    ) -> Result<DieselPool, PoolError> {
-        let manager = ConnectionManager::new(connection_url(config, url));
-
-        let pool = DieselPool {
-            inner: r2d2_config.build_unchecked(manager),
-        };
-        match pool.wait_until_healthy(Duration::from_secs(10)) {
-            Ok(()) => {
-                tracing::info!("Database pool is healthy");
-            }
-            Err(PoolError::UnhealthyPool) => {
-                tracing::error!("Database pool is unhealthy");
-            }
-            Err(e) => {
-                tracing::error!("Database pool is unhealthy: {e}");
-                return Err(e);
-            }
-        }
-        tracing::info!("Database pool is created");
-
-        Ok(pool)
-    }
-
-    pub fn new_background_worker(inner: r2d2::Pool<ConnectionManager<PgConnection>>) -> Self {
-        Self { inner }
-    }
-
-    pub fn get(&self) -> Result<PgPooledConnection, PoolError> {
-        Ok(self.inner.get()?)
-    }
-
-    pub fn state(&self) -> State {
-        self.inner.state()
-    }
-
-    pub fn wait_until_healthy(&self, timeout: Duration) -> Result<(), PoolError> {
-        match self.inner.get_timeout(timeout) {
-            Ok(_) => Ok(()),
-            Err(_) if !self.is_healthy() => Err(PoolError::UnhealthyPool),
-            Err(err) => Err(PoolError::R2D2(err)),
-        }
-    }
-
-    fn is_healthy(&self) -> bool {
-        let state = self.state();
-        state.connections > 0 && state.idle_connections > 0
+impl std::fmt::Debug for DieselPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DieselPool").finish_non_exhaustive()
     }
 }
 
-impl Deref for DieselPool {
-    type Target = PgPool;
+impl DieselPool {
+    pub(crate) fn new(url: &str, config: &DbConfig) -> Result<DieselPool, PoolError> {
+        let conn_url = connection_url(config, url);
 
-    fn deref(&self) -> &Self::Target {
-        &self.inner
+        // PostgreSQL `SET` does not support bind parameters, so the value is
+        // formatted into the statement. `statement_timeout` is a `u64` clamped to
+        // one hour, so no injection is possible.
+        let statement_timeout = config.statement_timeout.min(3_600_000);
+
+        let mut manager_config = ManagerConfig::default();
+        manager_config.custom_setup = Box::new(move |url: &str| {
+            let url = url.to_owned();
+            async move {
+                let mut conn = AsyncPgConnection::establish(&url).await?;
+                diesel::sql_query(format!("SET statement_timeout = {statement_timeout}"))
+                    .execute(&mut conn)
+                    .await
+                    .map_err(ConnectionError::CouldntSetupConfiguration)?;
+                Ok(conn)
+            }
+            .boxed()
+        });
+
+        let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new_with_config(
+            conn_url,
+            manager_config,
+        );
+
+        let timeout = Duration::from_millis(config.connection_timeout);
+        let inner = Pool::builder(manager)
+            .max_size(config.pool_size as usize)
+            .runtime(Runtime::Tokio1)
+            .timeouts(Timeouts {
+                wait: Some(timeout),
+                create: Some(timeout),
+                recycle: Some(timeout),
+            })
+            .build()?;
+
+        tracing::info!("Database pool is created");
+        Ok(DieselPool { inner })
+    }
+
+    pub async fn get(&self) -> Result<PgPooledConnection, PoolError> {
+        Ok(self.inner.get().await?)
+    }
+
+    pub fn status(&self) -> Status {
+        self.inner.status()
     }
 }
 
 #[derive(Debug, Error)]
 pub enum PoolError {
     #[error(transparent)]
-    R2D2(#[from] r2d2::PoolError),
-    #[error("unhealthy database pool")]
-    UnhealthyPool,
-    #[error("Failed to lock test database connection")]
-    TestConnectionUnavailable,
+    Build(#[from] BuildError),
+    #[error(transparent)]
+    Get(#[from] DeadpoolError),
 }

--- a/crates/data/src/room.rs
+++ b/crates/data/src/room.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use serde::Deserialize;
 
 use crate::core::events::StateEventType;
@@ -209,13 +210,14 @@ pub struct DbEventData {
 }
 
 impl DbEventData {
-    pub fn save(&self) -> DataResult<()> {
+    pub async fn save(&self) -> DataResult<()> {
         diesel::insert_into(event_datas::table)
             .values(self)
             .on_conflict(event_datas::event_id)
             .do_update()
             .set(self)
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         Ok(())
     }
 }
@@ -244,10 +246,11 @@ pub struct DbEvent {
     pub rejection_reason: Option<String>,
 }
 impl DbEvent {
-    pub fn get_by_id(id: &EventId) -> DataResult<Self> {
+    pub async fn get_by_id(id: &EventId) -> DataResult<Self> {
         events::table
             .find(id)
-            .first(&mut connect()?)
+            .first(&mut connect().await?)
+            .await
             .map_err(Into::into)
     }
 }
@@ -338,13 +341,14 @@ impl NewDbEvent {
             .map_err(|_e| MatrixError::bad_json("invalid json for event"))?)
     }
 
-    pub fn save(&self) -> DataResult<()> {
+    pub async fn save(&self) -> DataResult<()> {
         diesel::insert_into(events::table)
             .values(self)
             .on_conflict(events::id)
             .do_update()
             .set(self)
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         Ok(())
     }
 }
@@ -377,15 +381,15 @@ pub struct NewDbEventPushAction {
     pub thread_id: Option<OwnedEventId>,
 }
 
-pub fn is_disabled(room_id: &RoomId) -> DataResult<bool> {
+pub async fn is_disabled(room_id: &RoomId) -> DataResult<bool> {
     let query = rooms::table
         .filter(rooms::id.eq(room_id))
         .filter(rooms::disabled.eq(true));
-    Ok(diesel_exists!(query, &mut connect()?)?)
+    Ok(diesel_exists!(query, &mut connect().await?)?)
 }
 
-pub fn add_joined_server(room_id: &RoomId, server_name: &ServerName) -> DataResult<()> {
-    let next_sn = crate::next_sn()?;
+pub async fn add_joined_server(room_id: &RoomId, server_name: &ServerName) -> DataResult<()> {
+    let next_sn = crate::next_sn().await?;
     diesel::insert_into(room_joined_servers::table)
         .values((
             room_joined_servers::room_id.eq(room_id),
@@ -393,7 +397,8 @@ pub fn add_joined_server(room_id: &RoomId, server_name: &ServerName) -> DataResu
             room_joined_servers::occur_sn.eq(next_sn),
         ))
         .on_conflict_do_nothing()
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
@@ -405,16 +410,17 @@ pub struct NewDbBannedRoom {
     pub created_at: UnixMillis,
 }
 
-pub fn is_banned(room_id: &RoomId) -> DataResult<bool> {
+pub async fn is_banned(room_id: &RoomId) -> DataResult<bool> {
     let query = banned_rooms::table.filter(banned_rooms::room_id.eq(room_id));
-    Ok(diesel_exists!(query, &mut connect()?)?)
+    Ok(diesel_exists!(query, &mut connect().await?)?)
 }
 
-pub fn is_public(room_id: &RoomId) -> DataResult<bool> {
+pub async fn is_public(room_id: &RoomId) -> DataResult<bool> {
     rooms::table
         .filter(rooms::id.eq(room_id))
         .select(rooms::is_public)
-        .first(&mut connect()?)
+        .first(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
@@ -446,17 +452,18 @@ pub struct NewDbEventEdge {
 }
 
 impl NewDbEventEdge {
-    pub fn save(&self) -> DataResult<()> {
+    pub async fn save(&self) -> DataResult<()> {
         diesel::insert_into(event_edges::table)
             .values(self)
             .on_conflict_do_nothing()
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         Ok(())
     }
 }
 
 // >= min_sn and <= max_sn
-pub fn get_timeline_gaps(
+pub async fn get_timeline_gaps(
     room_id: &RoomId,
     min_sn: Seqnum,
     max_sn: Seqnum,
@@ -467,7 +474,8 @@ pub fn get_timeline_gaps(
         .filter(timeline_gaps::event_sn.le(max_sn))
         .order(timeline_gaps::event_sn.asc())
         .select(timeline_gaps::event_sn)
-        .load::<Seqnum>(&mut connect()?)?;
+        .load::<Seqnum>(&mut connect().await?)
+        .await?;
     Ok(gaps)
 }
 

--- a/crates/data/src/room/event.rs
+++ b/crates/data/src/room/event.rs
@@ -1,14 +1,15 @@
-use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::room::NewDbEventPushAction;
 use crate::schema::*;
 use crate::{DataResult, connect};
 
 #[tracing::instrument]
-pub fn upsert_push_action(action: &NewDbEventPushAction) -> DataResult<()> {
+pub async fn upsert_push_action(action: &NewDbEventPushAction) -> DataResult<()> {
     diesel::insert_into(event_push_actions::table)
         .values(action)
         .on_conflict_do_nothing()
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }

--- a/crates/data/src/room/event_report.rs
+++ b/crates/data/src/room/event_report.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::core::UnixMillis;
 use crate::core::identifiers::*;
@@ -95,16 +96,19 @@ pub struct EventReportFilter {
 }
 
 /// Create a new event report
-pub fn create_event_report(report: NewDbEventReport) -> DataResult<i64> {
+pub async fn create_event_report(report: NewDbEventReport) -> DataResult<i64> {
     let result = diesel::insert_into(event_reports::table)
         .values(&report)
         .returning(event_reports::id)
-        .get_result::<i64>(&mut connect()?)?;
+        .get_result::<i64>(&mut connect().await?)
+        .await?;
     Ok(result)
 }
 
 /// List event reports with pagination and filtering
-pub fn list_event_reports(filter: &EventReportFilter) -> DataResult<(Vec<EventReportInfo>, i64)> {
+pub async fn list_event_reports(
+    filter: &EventReportFilter,
+) -> DataResult<(Vec<EventReportInfo>, i64)> {
     let mut count_query = event_reports::table.into_boxed();
     let mut query = event_reports::table.into_boxed();
 
@@ -121,7 +125,10 @@ pub fn list_event_reports(filter: &EventReportFilter) -> DataResult<(Vec<EventRe
     }
 
     // Get total count
-    let total = count_query.count().get_result::<i64>(&mut connect()?)?;
+    let total = count_query
+        .count()
+        .get_result::<i64>(&mut connect().await?)
+        .await?;
 
     // Apply ordering - default is backwards (newest first)
     let direction_forward = filter.direction.as_ref().map(|d| d == "f").unwrap_or(false);
@@ -140,43 +147,48 @@ pub fn list_event_reports(filter: &EventReportFilter) -> DataResult<(Vec<EventRe
     let limit = filter.limit.unwrap_or(100).min(1000);
     query = query.limit(limit);
 
-    let reports = query.load::<DbEventReport>(&mut connect()?)?;
+    let reports = query.load::<DbEventReport>(&mut connect().await?).await?;
 
     Ok((reports.into_iter().map(Into::into).collect(), total))
 }
 
 /// Get a single event report by ID
-pub fn get_event_report(report_id: i64) -> DataResult<Option<DbEventReport>> {
+pub async fn get_event_report(report_id: i64) -> DataResult<Option<DbEventReport>> {
     event_reports::table
         .find(report_id)
-        .first::<DbEventReport>(&mut connect()?)
+        .first::<DbEventReport>(&mut connect().await?)
+        .await
         .optional()
         .map_err(Into::into)
 }
 
 /// Update an event report status by ID
-pub fn update_event_report_status(
+pub async fn update_event_report_status(
     report_id: i64,
     status: &str,
 ) -> DataResult<Option<DbEventReport>> {
     diesel::update(event_reports::table.find(report_id))
         .set(event_reports::status.eq(status))
-        .get_result::<DbEventReport>(&mut connect()?)
+        .get_result::<DbEventReport>(&mut connect().await?)
+        .await
         .optional()
         .map_err(Into::into)
 }
 
 /// Delete an event report by ID
 /// Returns true if deleted, false if not found
-pub fn delete_event_report(report_id: i64) -> DataResult<bool> {
-    let result = diesel::delete(event_reports::table.find(report_id)).execute(&mut connect()?)?;
+pub async fn delete_event_report(report_id: i64) -> DataResult<bool> {
+    let result = diesel::delete(event_reports::table.find(report_id))
+        .execute(&mut connect().await?)
+        .await?;
     Ok(result > 0)
 }
 
 /// Get event reports count for statistics
-pub fn count_event_reports() -> DataResult<i64> {
+pub async fn count_event_reports() -> DataResult<i64> {
     event_reports::table
         .count()
-        .get_result::<i64>(&mut connect()?)
+        .get_result::<i64>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }

--- a/crates/data/src/room/receipt.rs
+++ b/crates/data/src/room/receipt.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::core::events::AnySyncEphemeralRoomEvent;
 use crate::core::events::receipt::{Receipt, ReceiptEventContent, ReceiptType};
@@ -13,7 +14,7 @@ use crate::{DataResult, connect, next_sn};
 
 /// Returns an iterator over the most recent read_receipts in a room that happened after the event
 /// with id `since`.
-pub fn read_receipts(
+pub async fn read_receipts(
     room_id: &RoomId,
     since_sn: Seqnum,
 ) -> DataResult<BTreeMap<OwnedUserId, ReceiptEventContent>> {
@@ -22,7 +23,8 @@ pub fn read_receipts(
         .filter(event_receipts::sn.ge(since_sn))
         .filter(event_receipts::room_id.eq(room_id))
         .order_by(event_receipts::sn.desc())
-        .load::<DbReceipt>(&mut connect()?)?;
+        .load::<DbReceipt>(&mut connect().await?)
+        .await?;
     let unthread_receipts = receipts
         .iter()
         .filter(|r| r.thread_id.is_none())
@@ -69,7 +71,7 @@ pub fn read_receipts(
 
 /// Sets a private read marker at `count`.
 #[tracing::instrument]
-pub fn set_private_read(
+pub async fn set_private_read(
     room_id: &RoomId,
     user_id: &UserId,
     event_id: &EventId,
@@ -77,7 +79,7 @@ pub fn set_private_read(
 ) -> DataResult<()> {
     diesel::insert_into(event_receipts::table)
         .values(&DbReceipt {
-            sn: next_sn()?,
+            sn: next_sn().await?,
             ty: ReceiptType::ReadPrivate.to_string(),
             room_id: room_id.to_owned(),
             user_id: user_id.to_owned(),
@@ -87,18 +89,20 @@ pub fn set_private_read(
             json_data: JsonValue::default(),
             receipt_at: UnixMillis::now(),
         })
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
-pub fn last_private_read_update_sn(user_id: &UserId, room_id: &RoomId) -> DataResult<Seqnum> {
+pub async fn last_private_read_update_sn(user_id: &UserId, room_id: &RoomId) -> DataResult<Seqnum> {
     let event_sn = event_receipts::table
         .filter(event_receipts::room_id.eq(room_id))
         .filter(event_receipts::user_id.eq(user_id))
         .filter(event_receipts::ty.eq(ReceiptType::ReadPrivate.to_string()))
         .order_by(event_receipts::event_sn.desc())
         .select(event_receipts::event_sn)
-        .first::<Seqnum>(&mut connect()?)?;
+        .first::<Seqnum>(&mut connect().await?)
+        .await?;
 
     Ok(event_sn)
 }

--- a/crates/data/src/room/timeline.rs
+++ b/crates/data/src/room/timeline.rs
@@ -1,5 +1,6 @@
 use diesel::prelude::*;
 use diesel::result::Error as DieselError;
+use diesel_async::{AsyncConnection, RunQueryDsl};
 
 use crate::core::UnixMillis;
 use crate::core::identifiers::*;
@@ -8,7 +9,7 @@ use crate::schema::*;
 use crate::{DataResult, connect};
 
 /// Get PDUs by room with pagination
-pub fn get_pdus_by_room(
+pub async fn get_pdus_by_room(
     room_id: &RoomId,
     from_sn: Option<i64>,
     limit: i64,
@@ -33,19 +34,23 @@ pub fn get_pdus_by_room(
         query = query.order(events::sn.asc());
     }
 
-    query.limit(limit).load(&mut connect()?).map_err(Into::into)
+    query
+        .limit(limit)
+        .load(&mut connect().await?)
+        .await
+        .map_err(Into::into)
 }
 
 /// Purge room history before a given timestamp.
 /// State events (those with state_key set) are preserved.
 /// Returns the number of events deleted.
-pub fn purge_room_history(room_id: &RoomId, before_ts: i64) -> DataResult<i64> {
+pub async fn purge_room_history(room_id: &RoomId, before_ts: i64) -> DataResult<i64> {
     let before_ts_millis = UnixMillis::from_system_time(
         std::time::UNIX_EPOCH + std::time::Duration::from_millis(before_ts as u64),
     )
     .unwrap_or(UnixMillis::now());
 
-    let mut conn = connect()?;
+    let mut conn = connect().await?;
 
     // Collect event IDs and SNs to purge (skip state events)
     let to_purge: Vec<(String, i64)> = events::table
@@ -53,7 +58,8 @@ pub fn purge_room_history(room_id: &RoomId, before_ts: i64) -> DataResult<i64> {
         .filter(events::origin_server_ts.lt(before_ts_millis))
         .filter(events::state_key.is_null())
         .select((events::id, events::sn))
-        .load::<(String, i64)>(&mut conn)?;
+        .load::<(String, i64)>(&mut conn)
+        .await?;
 
     if to_purge.is_empty() {
         return Ok(0);
@@ -67,52 +73,73 @@ pub fn purge_room_history(room_id: &RoomId, before_ts: i64) -> DataResult<i64> {
     // the transaction, a half-finished purge would leak event-relations
     // pointing at events that no longer exist, which then resurface as
     // hard-to-debug consistency errors on subsequent timeline reads.
-    conn.transaction::<_, DieselError, _>(|conn| {
+    conn.transaction::<_, DieselError, _>(async |conn| {
         // Delete from related tables (no foreign key constraints, order doesn't matter)
         for chunk in event_ids.chunks(500) {
-            diesel::delete(event_datas::table.filter(event_datas::event_id.eq_any(chunk)))
-                .execute(conn)?;
-            diesel::delete(event_edges::table.filter(event_edges::event_id.eq_any(chunk)))
-                .execute(conn)?;
-            diesel::delete(
-                event_forward_extremities::table
-                    .filter(event_forward_extremities::event_id.eq_any(chunk)),
-            )
-            .execute(conn)?;
-            diesel::delete(
-                event_backward_extremities::table
-                    .filter(event_backward_extremities::event_id.eq_any(chunk)),
-            )
-            .execute(conn)?;
-            diesel::delete(event_relations::table.filter(event_relations::event_id.eq_any(chunk)))
-                .execute(conn)?;
-            diesel::delete(event_receipts::table.filter(event_receipts::event_id.eq_any(chunk)))
-                .execute(conn)?;
-            diesel::delete(event_searches::table.filter(event_searches::event_id.eq_any(chunk)))
-                .execute(conn)?;
-            diesel::delete(
-                event_push_actions::table.filter(event_push_actions::event_id.eq_any(chunk)),
-            )
-            .execute(conn)?;
-            diesel::delete(event_points::table.filter(event_points::event_id.eq_any(chunk)))
-                .execute(conn)?;
-            diesel::delete(event_missings::table.filter(event_missings::event_id.eq_any(chunk)))
-                .execute(conn)?;
-            diesel::delete(threads::table.filter(threads::event_id.eq_any(chunk)))
-                .execute(conn)?;
-            diesel::delete(timeline_gaps::table.filter(timeline_gaps::event_id.eq_any(chunk)))
-                .execute(conn)?;
-            // Delete the events themselves
-            diesel::delete(events::table.filter(events::id.eq_any(chunk))).execute(conn)?;
-        }
+                diesel::delete(event_datas::table.filter(event_datas::event_id.eq_any(chunk)))
+                    .execute(conn)
+                    .await?;
+                diesel::delete(event_edges::table.filter(event_edges::event_id.eq_any(chunk)))
+                    .execute(conn)
+                    .await?;
+                diesel::delete(
+                    event_forward_extremities::table
+                        .filter(event_forward_extremities::event_id.eq_any(chunk)),
+                )
+                .execute(conn)
+                .await?;
+                diesel::delete(
+                    event_backward_extremities::table
+                        .filter(event_backward_extremities::event_id.eq_any(chunk)),
+                )
+                .execute(conn)
+                .await?;
+                diesel::delete(
+                    event_relations::table.filter(event_relations::event_id.eq_any(chunk)),
+                )
+                .execute(conn)
+                .await?;
+                diesel::delete(
+                    event_receipts::table.filter(event_receipts::event_id.eq_any(chunk)),
+                )
+                .execute(conn)
+                .await?;
+                diesel::delete(
+                    event_searches::table.filter(event_searches::event_id.eq_any(chunk)),
+                )
+                .execute(conn)
+                .await?;
+                diesel::delete(
+                    event_push_actions::table.filter(event_push_actions::event_id.eq_any(chunk)),
+                )
+                .execute(conn)
+                .await?;
+                diesel::delete(event_points::table.filter(event_points::event_id.eq_any(chunk)))
+                    .execute(conn)
+                    .await?;
+                diesel::delete(event_missings::table.filter(event_missings::event_id.eq_any(chunk)))
+                    .execute(conn)
+                    .await?;
+                diesel::delete(threads::table.filter(threads::event_id.eq_any(chunk)))
+                    .execute(conn)
+                    .await?;
+                diesel::delete(timeline_gaps::table.filter(timeline_gaps::event_id.eq_any(chunk)))
+                    .execute(conn)
+                    .await?;
+                // Delete the events themselves
+                diesel::delete(events::table.filter(events::id.eq_any(chunk)))
+                    .execute(conn)
+                    .await?;
+            }
         Ok(())
-    })?;
+    })
+    .await?;
 
     Ok(to_purge.len() as i64)
 }
 
 /// Get PDU by timestamp
-pub fn get_pdu_by_timestamp(
+pub async fn get_pdu_by_timestamp(
     room_id: &RoomId,
     ts: i64,
     backward: bool,
@@ -137,5 +164,9 @@ pub fn get_pdu_by_timestamp(
             .order(events::origin_server_ts.asc());
     }
 
-    query.first(&mut connect()?).optional().map_err(Into::into)
+    query
+        .first(&mut connect().await?)
+        .await
+        .optional()
+        .map_err(Into::into)
 }

--- a/crates/data/src/sending.rs
+++ b/crates/data/src/sending.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::core::identifiers::*;
 pub use crate::core::sending::*;
@@ -36,12 +37,13 @@ pub struct NewDbOutgoingRequest {
 }
 
 /// Get all known federation destinations
-pub fn get_all_destinations() -> DataResult<Vec<OwnedServerName>> {
+pub async fn get_all_destinations() -> DataResult<Vec<OwnedServerName>> {
     let servers: Vec<OwnedServerName> = outgoing_requests::table
         .filter(outgoing_requests::server_id.is_not_null())
         .select(outgoing_requests::server_id)
         .distinct()
-        .load::<Option<OwnedServerName>>(&mut connect()?)?
+        .load::<Option<OwnedServerName>>(&mut connect().await?)
+        .await?
         .into_iter()
         .flatten()
         .collect();
@@ -49,23 +51,24 @@ pub fn get_all_destinations() -> DataResult<Vec<OwnedServerName>> {
 }
 
 /// Check if a destination is known
-pub fn is_destination_known(server: &ServerName) -> DataResult<bool> {
+pub async fn is_destination_known(server: &ServerName) -> DataResult<bool> {
     let query = outgoing_requests::table.filter(outgoing_requests::server_id.eq(server));
-    Ok(diesel_exists!(query, &mut connect()?)?)
+    Ok(diesel_exists!(query, &mut connect().await?)?)
 }
 
 /// Get rooms shared with a destination
-pub fn get_destination_rooms(server: &ServerName) -> DataResult<Vec<OwnedRoomId>> {
+pub async fn get_destination_rooms(server: &ServerName) -> DataResult<Vec<OwnedRoomId>> {
     use crate::schema::room_joined_servers;
     let rooms: Vec<OwnedRoomId> = room_joined_servers::table
         .filter(room_joined_servers::server_id.eq(server))
         .select(room_joined_servers::room_id)
-        .load(&mut connect()?)?;
+        .load(&mut connect().await?)
+        .await?;
     Ok(rooms)
 }
 
 /// Reset retry timings for a destination
-pub fn reset_destination_retry(server: &ServerName) -> DataResult<()> {
+pub async fn reset_destination_retry(server: &ServerName) -> DataResult<()> {
     diesel::update(
         outgoing_requests::table
             .filter(outgoing_requests::kind.eq("normal"))
@@ -75,6 +78,7 @@ pub fn reset_destination_retry(server: &ServerName) -> DataResult<()> {
         outgoing_requests::retry_count.eq(0),
         outgoing_requests::last_failed_at.eq(None::<i64>),
     ))
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }

--- a/crates/data/src/user.rs
+++ b/crates/data/src/user.rs
@@ -28,6 +28,7 @@ use std::mem;
 
 use diesel::dsl;
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 pub use external_id::*;
 pub use presence::*;
 pub use registration_token::*;
@@ -110,22 +111,24 @@ pub struct NewDbUserThreepid {
     pub added_at: UnixMillis,
 }
 
-pub fn is_admin(user_id: &UserId) -> DataResult<bool> {
+pub async fn is_admin(user_id: &UserId) -> DataResult<bool> {
     users::table
         .filter(users::id.eq(user_id))
         .select(users::is_admin)
-        .first::<bool>(&mut connect()?)
+        .first::<bool>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
 /// Returns an iterator over all rooms this user joined.
-pub fn joined_rooms(user_id: &UserId) -> DataResult<Vec<OwnedRoomId>> {
+pub async fn joined_rooms(user_id: &UserId) -> DataResult<Vec<OwnedRoomId>> {
     let room_memeberships = room_users::table
         .filter(room_users::user_id.eq(user_id))
         .distinct_on(room_users::room_id)
         .select((room_users::room_id, room_users::membership))
         .order_by((room_users::room_id.desc(), room_users::id.desc()))
-        .load::<(OwnedRoomId, String)>(&mut connect()?)?;
+        .load::<(OwnedRoomId, String)>(&mut connect().await?)
+        .await?;
     Ok(room_memeberships
         .into_iter()
         .filter_map(|(room_id, membership)| {
@@ -138,30 +141,33 @@ pub fn joined_rooms(user_id: &UserId) -> DataResult<Vec<OwnedRoomId>> {
         .collect::<Vec<_>>())
 }
 
-pub fn ignored_users(user_id: &UserId) -> DataResult<Vec<OwnedUserId>> {
+pub async fn ignored_users(user_id: &UserId) -> DataResult<Vec<OwnedUserId>> {
     user_ignores::table
         .filter(user_ignores::user_id.eq(user_id))
         .select(user_ignores::ignored_id)
-        .load::<OwnedUserId>(&mut connect()?)
+        .load::<OwnedUserId>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
 /// Returns an iterator over all rooms a user was invited to.
-pub fn invited_rooms(
+pub async fn invited_rooms(
     user_id: &UserId,
     since_sn: i64,
 ) -> DataResult<Vec<(OwnedRoomId, Vec<RawJson<AnyStrippedStateEvent>>)>> {
     let ingored_ids = user_ignores::table
         .filter(user_ignores::user_id.eq(user_id))
         .select(user_ignores::ignored_id)
-        .load::<OwnedUserId>(&mut connect()?)?;
+        .load::<OwnedUserId>(&mut connect().await?)
+        .await?;
     let list = room_users::table
         .filter(room_users::user_id.eq(user_id))
         .filter(room_users::membership.eq("invite"))
         .filter(room_users::event_sn.ge(since_sn))
         .filter(room_users::sender_id.ne_all(&ingored_ids))
         .select((room_users::room_id, room_users::state_data))
-        .load::<(OwnedRoomId, Option<JsonValue>)>(&mut connect()?)?
+        .load::<(OwnedRoomId, Option<JsonValue>)>(&mut connect().await?)
+        .await?
         .into_iter()
         .filter_map(|(room_id, state_data)| {
             state_data
@@ -172,7 +178,7 @@ pub fn invited_rooms(
     Ok(list)
 }
 
-pub fn knocked_rooms(
+pub async fn knocked_rooms(
     user_id: &UserId,
     since_sn: i64,
 ) -> DataResult<Vec<(OwnedRoomId, Vec<RawJson<AnyStrippedStateEvent>>)>> {
@@ -181,7 +187,8 @@ pub fn knocked_rooms(
         .filter(room_users::membership.eq("knock"))
         .filter(room_users::event_sn.ge(since_sn))
         .select((room_users::room_id, room_users::state_data))
-        .load::<(OwnedRoomId, Option<JsonValue>)>(&mut connect()?)?
+        .load::<(OwnedRoomId, Option<JsonValue>)>(&mut connect().await?)
+        .await?
         .into_iter()
         .filter_map(|(room_id, state_data)| {
             state_data
@@ -193,200 +200,220 @@ pub fn knocked_rooms(
 }
 
 /// Check if a user has an account on this homeserver.
-pub fn user_exists(user_id: &UserId) -> DataResult<bool> {
+pub async fn user_exists(user_id: &UserId) -> DataResult<bool> {
     let query = users::table.find(user_id);
-    diesel_exists!(query, &mut connect()?).map_err(Into::into)
+    diesel_exists!(query, &mut connect().await?).map_err(Into::into)
 }
 
-pub fn get_user(user_id: &UserId) -> DataResult<DbUser> {
+pub async fn get_user(user_id: &UserId) -> DataResult<DbUser> {
     users::table
         .find(user_id)
-        .first::<DbUser>(&mut connect()?)
+        .first::<DbUser>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
 /// Returns the number of users registered on this server.
-pub fn count() -> DataResult<u64> {
+pub async fn count() -> DataResult<u64> {
     let count = user_passwords::table
         .select(dsl::count(user_passwords::user_id).aggregate_distinct())
-        .first::<i64>(&mut connect()?)?;
+        .first::<i64>(&mut connect().await?)
+        .await?;
     Ok(count as u64)
 }
 
 /// Returns a list of local users as list of usernames.
 ///
 /// A user account is considered `local` if the length of it's password is greater then zero.
-pub fn list_local_users() -> DataResult<Vec<OwnedUserId>> {
+pub async fn list_local_users() -> DataResult<Vec<OwnedUserId>> {
     user_passwords::table
         .select(user_passwords::user_id)
-        .load::<OwnedUserId>(&mut connect()?)
+        .load::<OwnedUserId>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
 /// Returns the display_name of a user on this homeserver.
-pub fn display_name(user_id: &UserId) -> DataResult<Option<String>> {
+pub async fn display_name(user_id: &UserId) -> DataResult<Option<String>> {
     user_profiles::table
         .filter(user_profiles::user_id.eq(user_id.as_str()))
         .filter(user_profiles::room_id.is_null())
         .select(user_profiles::display_name)
-        .first::<Option<String>>(&mut connect()?)
+        .first::<Option<String>>(&mut connect().await?)
+        .await
         .optional()
         .map(Option::flatten)
         .map_err(Into::into)
 }
-pub fn set_display_name(user_id: &UserId, display_name: &str) -> DataResult<()> {
+pub async fn set_display_name(user_id: &UserId, display_name: &str) -> DataResult<()> {
     diesel::update(
         user_profiles::table
             .filter(user_profiles::user_id.eq(user_id.as_str()))
             .filter(user_profiles::room_id.is_null()),
     )
     .set(user_profiles::display_name.eq(display_name))
-    .execute(&mut connect()?)
+    .execute(&mut connect().await?)
+    .await
     .map(|_| ())
     .map_err(Into::into)
 }
-pub fn remove_display_name(user_id: &UserId) -> DataResult<()> {
+pub async fn remove_display_name(user_id: &UserId) -> DataResult<()> {
     diesel::update(
         user_profiles::table
             .filter(user_profiles::user_id.eq(user_id.as_str()))
             .filter(user_profiles::room_id.is_null()),
     )
     .set(user_profiles::display_name.eq::<Option<String>>(None))
-    .execute(&mut connect()?)
+    .execute(&mut connect().await?)
+    .await
     .map(|_| ())
     .map_err(Into::into)
 }
 
 /// Get the avatar_url of a user.
-pub fn avatar_url(user_id: &UserId) -> DataResult<Option<OwnedMxcUri>> {
+pub async fn avatar_url(user_id: &UserId) -> DataResult<Option<OwnedMxcUri>> {
     user_profiles::table
         .filter(user_profiles::user_id.eq(user_id.as_str()))
         .filter(user_profiles::room_id.is_null())
         .select(user_profiles::avatar_url)
-        .first::<Option<OwnedMxcUri>>(&mut connect()?)
+        .first::<Option<OwnedMxcUri>>(&mut connect().await?)
+        .await
         .optional()
         .map(Option::flatten)
         .map_err(Into::into)
 }
-pub fn set_avatar_url(user_id: &UserId, avatar_url: &MxcUri) -> DataResult<()> {
+pub async fn set_avatar_url(user_id: &UserId, avatar_url: &MxcUri) -> DataResult<()> {
     diesel::update(
         user_profiles::table
             .filter(user_profiles::user_id.eq(user_id.as_str()))
             .filter(user_profiles::room_id.is_null()),
     )
     .set(user_profiles::avatar_url.eq(avatar_url.as_str()))
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }
-pub fn remove_avatar_url(user_id: &UserId) -> DataResult<()> {
+pub async fn remove_avatar_url(user_id: &UserId) -> DataResult<()> {
     diesel::update(
         user_profiles::table
             .filter(user_profiles::user_id.eq(user_id.as_str()))
             .filter(user_profiles::room_id.is_null()),
     )
     .set(user_profiles::avatar_url.eq::<Option<String>>(None))
-    .execute(&mut connect()?)
+    .execute(&mut connect().await?)
+    .await
     .map(|_| ())
     .map_err(Into::into)
 }
 
-pub fn delete_profile(user_id: &UserId) -> DataResult<()> {
+pub async fn delete_profile(user_id: &UserId) -> DataResult<()> {
     diesel::delete(
         user_profiles::table
             .filter(user_profiles::user_id.eq(user_id.as_str()))
             .filter(user_profiles::room_id.is_null()),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }
 
 /// Get the blurhash of a user.
-pub fn blurhash(user_id: &UserId) -> DataResult<Option<String>> {
+pub async fn blurhash(user_id: &UserId) -> DataResult<Option<String>> {
     user_profiles::table
         .filter(user_profiles::user_id.eq(user_id.as_str()))
         .filter(user_profiles::room_id.is_null())
         .select(user_profiles::blurhash)
-        .first::<Option<String>>(&mut connect()?)
+        .first::<Option<String>>(&mut connect().await?)
+        .await
         .optional()
         .map(Option::flatten)
         .map_err(Into::into)
 }
 
-pub fn is_deactivated(user_id: &UserId) -> DataResult<bool> {
+pub async fn is_deactivated(user_id: &UserId) -> DataResult<bool> {
     let deactivated_at = users::table
         .filter(users::id.eq(user_id))
         .select(users::deactivated_at)
-        .first::<Option<UnixMillis>>(&mut connect()?)
+        .first::<Option<UnixMillis>>(&mut connect().await?)
+        .await
         .optional()?
         .flatten();
     Ok(deactivated_at.is_some())
 }
 
-pub fn is_locked(user_id: &UserId) -> DataResult<bool> {
+pub async fn is_locked(user_id: &UserId) -> DataResult<bool> {
     let locked_at = users::table
         .filter(users::id.eq(user_id))
         .select(users::locked_at)
-        .first::<Option<UnixMillis>>(&mut connect()?)
+        .first::<Option<UnixMillis>>(&mut connect().await?)
+        .await
         .optional()?
         .flatten();
     Ok(locked_at.is_some())
 }
 
-pub fn is_suspended(user_id: &UserId) -> DataResult<bool> {
+pub async fn is_suspended(user_id: &UserId) -> DataResult<bool> {
     let suspended_at = users::table
         .filter(users::id.eq(user_id))
         .select(users::suspended_at)
-        .first::<Option<UnixMillis>>(&mut connect()?)
+        .first::<Option<UnixMillis>>(&mut connect().await?)
+        .await
         .optional()?
         .flatten();
     Ok(suspended_at.is_some())
 }
 
-pub fn is_guest(user_id: &UserId) -> DataResult<bool> {
+pub async fn is_guest(user_id: &UserId) -> DataResult<bool> {
     users::table
         .filter(users::id.eq(user_id))
         .select(users::is_guest)
-        .first::<bool>(&mut connect()?)
+        .first::<bool>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
-pub fn set_guest(user_id: &UserId, is_guest: bool) -> DataResult<()> {
+pub async fn set_guest(user_id: &UserId, is_guest: bool) -> DataResult<()> {
     diesel::update(users::table.find(user_id))
         .set(users::is_guest.eq(is_guest))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
-pub fn all_device_ids(user_id: &UserId) -> DataResult<Vec<OwnedDeviceId>> {
+pub async fn all_device_ids(user_id: &UserId) -> DataResult<Vec<OwnedDeviceId>> {
     user_devices::table
         .filter(user_devices::user_id.eq(user_id))
         .select(user_devices::device_id)
-        .load::<OwnedDeviceId>(&mut connect()?)
+        .load::<OwnedDeviceId>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
-pub fn delete_access_tokens(user_id: &UserId) -> DataResult<()> {
+pub async fn delete_access_tokens(user_id: &UserId) -> DataResult<()> {
     diesel::delete(user_access_tokens::table.filter(user_access_tokens::user_id.eq(user_id)))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
-pub fn delete_refresh_tokens(user_id: &UserId) -> DataResult<()> {
+pub async fn delete_refresh_tokens(user_id: &UserId) -> DataResult<()> {
     diesel::delete(user_refresh_tokens::table.filter(user_refresh_tokens::user_id.eq(user_id)))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
-pub fn remove_all_devices(user_id: &UserId) -> DataResult<()> {
-    delete_access_tokens(user_id)?;
-    delete_refresh_tokens(user_id)?;
-    pusher::delete_user_pushers(user_id)
+pub async fn remove_all_devices(user_id: &UserId) -> DataResult<()> {
+    delete_access_tokens(user_id).await?;
+    delete_refresh_tokens(user_id).await?;
+    pusher::delete_user_pushers(user_id).await
 }
-pub fn delete_dehydrated_devices(user_id: &UserId) -> DataResult<()> {
+pub async fn delete_dehydrated_devices(user_id: &UserId) -> DataResult<()> {
     diesel::delete(
         user_dehydrated_devices::table.filter(user_dehydrated_devices::user_id.eq(user_id)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }
 
@@ -418,29 +445,34 @@ pub fn clean_signatures<F: Fn(&UserId) -> bool>(
     Ok(())
 }
 
-pub fn deactivate(user_id: &UserId) -> DataResult<()> {
+pub async fn deactivate(user_id: &UserId) -> DataResult<()> {
     diesel::update(users::table.find(user_id))
         .set((users::deactivated_at.eq(UnixMillis::now()),))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
 
     diesel::delete(user_threepids::table.filter(user_threepids::user_id.eq(user_id)))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     diesel::delete(user_access_tokens::table.filter(user_access_tokens::user_id.eq(user_id)))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
 
     Ok(())
 }
 
-pub fn reactivate(user_id: &UserId) -> DataResult<()> {
+pub async fn reactivate(user_id: &UserId) -> DataResult<()> {
     diesel::update(users::table.find(user_id))
         .set(users::deactivated_at.eq::<Option<UnixMillis>>(None))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
-pub fn set_ignored_users(user_id: &UserId, ignored_ids: &[OwnedUserId]) -> DataResult<()> {
+pub async fn set_ignored_users(user_id: &UserId, ignored_ids: &[OwnedUserId]) -> DataResult<()> {
     diesel::delete(user_ignores::table.filter(user_ignores::user_id.eq(user_id)))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     for ignored_id in ignored_ids {
         diesel::insert_into(user_ignores::table)
             .values(NewDbUserIgnore {
@@ -449,18 +481,20 @@ pub fn set_ignored_users(user_id: &UserId, ignored_ids: &[OwnedUserId]) -> DataR
                 created_at: UnixMillis::now(),
             })
             .on_conflict_do_nothing()
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     }
     Ok(())
 }
 
 /// Get user_id by third party ID (email, phone, etc.)
-pub fn get_user_by_threepid(medium: &str, address: &str) -> DataResult<Option<OwnedUserId>> {
+pub async fn get_user_by_threepid(medium: &str, address: &str) -> DataResult<Option<OwnedUserId>> {
     user_threepids::table
         .filter(user_threepids::medium.eq(medium))
         .filter(user_threepids::address.eq(address))
         .select(user_threepids::user_id)
-        .first::<OwnedUserId>(&mut connect()?)
+        .first::<OwnedUserId>(&mut connect().await?)
+        .await
         .optional()
         .map_err(Into::into)
 }
@@ -475,7 +509,7 @@ pub struct ThreepidInfo {
 }
 
 /// Get all threepids for a user
-pub fn get_threepids(user_id: &UserId) -> DataResult<Vec<ThreepidInfo>> {
+pub async fn get_threepids(user_id: &UserId) -> DataResult<Vec<ThreepidInfo>> {
     user_threepids::table
         .filter(user_threepids::user_id.eq(user_id))
         .select((
@@ -484,7 +518,8 @@ pub fn get_threepids(user_id: &UserId) -> DataResult<Vec<ThreepidInfo>> {
             user_threepids::added_at,
             user_threepids::validated_at,
         ))
-        .load::<(String, String, UnixMillis, UnixMillis)>(&mut connect()?)
+        .load::<(String, String, UnixMillis, UnixMillis)>(&mut connect().await?)
+        .await
         .map(|rows| {
             rows.into_iter()
                 .map(|(medium, address, added_at, validated_at)| ThreepidInfo {
@@ -499,13 +534,14 @@ pub fn get_threepids(user_id: &UserId) -> DataResult<Vec<ThreepidInfo>> {
 }
 
 /// Replace all threepids for a user
-pub fn replace_threepids(
+pub async fn replace_threepids(
     user_id: &UserId,
     threepids: &[(String, String, Option<i64>, Option<i64>)],
 ) -> DataResult<()> {
-    let mut conn = connect()?;
+    let mut conn = connect().await?;
     diesel::delete(user_threepids::table.filter(user_threepids::user_id.eq(user_id)))
-        .execute(&mut conn)?;
+        .execute(&mut conn)
+        .await?;
 
     let now = UnixMillis::now();
     for (medium, address, added_at, validated_at) in threepids {
@@ -517,65 +553,73 @@ pub fn replace_threepids(
                 validated_at: validated_at.map(|ts| UnixMillis(ts as u64)).unwrap_or(now),
                 added_at: added_at.map(|ts| UnixMillis(ts as u64)).unwrap_or(now),
             })
-            .execute(&mut conn)?;
+            .execute(&mut conn)
+            .await?;
     }
     Ok(())
 }
 
 /// Set admin status for a user
-pub fn set_admin(user_id: &UserId, is_admin: bool) -> DataResult<()> {
+pub async fn set_admin(user_id: &UserId, is_admin: bool) -> DataResult<()> {
     diesel::update(users::table.find(user_id))
         .set(users::is_admin.eq(is_admin))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
 /// Set shadow ban status for a user
-pub fn set_shadow_banned(user_id: &UserId, shadow_banned: bool) -> DataResult<()> {
+pub async fn set_shadow_banned(user_id: &UserId, shadow_banned: bool) -> DataResult<()> {
     diesel::update(users::table.find(user_id))
         .set(users::shadow_banned.eq(shadow_banned))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
 /// Set user type (e.g. guest/user/admin specific types)
-pub fn set_user_type(user_id: &UserId, user_type: Option<&str>) -> DataResult<()> {
+pub async fn set_user_type(user_id: &UserId, user_type: Option<&str>) -> DataResult<()> {
     diesel::update(users::table.find(user_id))
         .set(users::ty.eq(user_type))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
 /// Set locked status for a user
-pub fn set_locked(user_id: &UserId, locked: bool, locker_id: Option<&UserId>) -> DataResult<()> {
+pub async fn set_locked(user_id: &UserId, locked: bool, locker_id: Option<&UserId>) -> DataResult<()> {
     if locked {
         diesel::update(users::table.find(user_id))
             .set((
                 users::locked_at.eq(Some(UnixMillis::now())),
                 users::locked_by.eq(locker_id.map(|u| u.to_owned())),
             ))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     } else {
         diesel::update(users::table.find(user_id))
             .set((
                 users::locked_at.eq::<Option<UnixMillis>>(None),
                 users::locked_by.eq::<Option<OwnedUserId>>(None),
             ))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     }
     Ok(())
 }
 
 /// Set suspended status for a user
-pub fn set_suspended(user_id: &UserId, suspended: bool) -> DataResult<()> {
+pub async fn set_suspended(user_id: &UserId, suspended: bool) -> DataResult<()> {
     if suspended {
         diesel::update(users::table.find(user_id))
             .set(users::suspended_at.eq(Some(UnixMillis::now())))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     } else {
         diesel::update(users::table.find(user_id))
             .set(users::suspended_at.eq::<Option<UnixMillis>>(None))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     }
     Ok(())
 }
@@ -611,7 +655,7 @@ fn escape_like_pattern(value: &str) -> String {
     escaped
 }
 
-pub fn list_users(filter: &ListUsersFilter) -> DataResult<(Vec<DbUser>, i64)> {
+pub async fn list_users(filter: &ListUsersFilter) -> DataResult<(Vec<DbUser>, i64)> {
     let mut query = users::table.into_boxed();
     let mut count_query = users::table.into_boxed();
 
@@ -648,7 +692,7 @@ pub fn list_users(filter: &ListUsersFilter) -> DataResult<(Vec<DbUser>, i64)> {
     }
 
     // Get total count with filters applied
-    let total: i64 = count_query.count().get_result(&mut connect()?)?;
+    let total: i64 = count_query.count().get_result(&mut connect().await?).await?;
 
     // Apply ordering
     let dir_asc = filter.dir.as_ref().map(|d| d == "f").unwrap_or(true);
@@ -705,7 +749,7 @@ pub fn list_users(filter: &ListUsersFilter) -> DataResult<(Vec<DbUser>, i64)> {
     let limit = filter.limit.unwrap_or(100).min(1000);
     query = query.limit(limit);
 
-    let users = query.load::<DbUser>(&mut connect()?)?;
+    let users = query.load::<DbUser>(&mut connect().await?).await?;
 
     Ok((users, total))
 }
@@ -717,14 +761,15 @@ pub struct RateLimitOverride {
     pub burst_count: Option<i32>,
 }
 
-pub fn get_ratelimit(user_id: &UserId) -> DataResult<Option<RateLimitOverride>> {
+pub async fn get_ratelimit(user_id: &UserId) -> DataResult<Option<RateLimitOverride>> {
     user_ratelimit_override::table
         .find(user_id)
         .select((
             user_ratelimit_override::messages_per_second,
             user_ratelimit_override::burst_count,
         ))
-        .first::<(Option<i32>, Option<i32>)>(&mut connect()?)
+        .first::<(Option<i32>, Option<i32>)>(&mut connect().await?)
+        .await
         .optional()
         .map(|opt| {
             opt.map(|(mps, bc)| RateLimitOverride {
@@ -735,7 +780,7 @@ pub fn get_ratelimit(user_id: &UserId) -> DataResult<Option<RateLimitOverride>> 
         .map_err(Into::into)
 }
 
-pub fn set_ratelimit(
+pub async fn set_ratelimit(
     user_id: &UserId,
     messages_per_second: Option<i32>,
     burst_count: Option<i32>,
@@ -752,11 +797,14 @@ pub fn set_ratelimit(
             user_ratelimit_override::messages_per_second.eq(messages_per_second),
             user_ratelimit_override::burst_count.eq(burst_count),
         ))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
-pub fn delete_ratelimit(user_id: &UserId) -> DataResult<()> {
-    diesel::delete(user_ratelimit_override::table.find(user_id)).execute(&mut connect()?)?;
+pub async fn delete_ratelimit(user_id: &UserId) -> DataResult<()> {
+    diesel::delete(user_ratelimit_override::table.find(user_id))
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }

--- a/crates/data/src/user/data.rs
+++ b/crates/data/src/user/data.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use serde::de::DeserializeOwned;
 
 use crate::core::events::{AnyRawAccountDataEvent, RoomAccountDataEventType};
@@ -34,7 +35,7 @@ pub struct NewDbUserData {
 
 /// Places one event in the account data of the user and removes the previous entry.
 #[tracing::instrument(skip(room_id, user_id, event_type, json_data))]
-pub fn set_data(
+pub async fn set_data(
     user_id: &UserId,
     room_id: Option<OwnedRoomId>,
     event_type: &str,
@@ -45,7 +46,8 @@ pub fn set_data(
             .filter(user_datas::user_id.eq(user_id))
             .filter(user_datas::room_id.eq(room_id))
             .filter(user_datas::data_type.eq(event_type))
-            .first::<DbUserData>(&mut connect()?)
+            .first::<DbUserData>(&mut connect().await?)
+            .await
             .optional()?;
         if let Some(user_data) = user_data
             && user_data.json_data == json_data
@@ -57,7 +59,8 @@ pub fn set_data(
             .filter(user_datas::user_id.eq(user_id))
             .filter(user_datas::room_id.is_null())
             .filter(user_datas::data_type.eq(event_type))
-            .first::<DbUserData>(&mut connect()?)
+            .first::<DbUserData>(&mut connect().await?)
+            .await
             .optional()?;
         if let Some(user_data) = user_data
             && user_data.json_data == json_data
@@ -71,7 +74,7 @@ pub fn set_data(
         room_id: room_id.clone(),
         data_type: event_type.to_owned(),
         json_data,
-        occur_sn: Some(crate::next_sn()?),
+        occur_sn: Some(crate::next_sn().await?),
         created_at: UnixMillis::now(),
     };
     diesel::insert_into(user_datas::table)
@@ -83,12 +86,13 @@ pub fn set_data(
         ))
         .do_update()
         .set(&new_data)
-        .get_result::<DbUserData>(&mut connect()?)
+        .get_result::<DbUserData>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
 #[tracing::instrument]
-pub fn get_data<E: DeserializeOwned>(
+pub async fn get_data<E: DeserializeOwned>(
     user_id: &UserId,
     room_id: Option<&RoomId>,
     kind: &str,
@@ -102,13 +106,14 @@ pub fn get_data<E: DeserializeOwned>(
         )
         .filter(user_datas::data_type.eq(kind))
         .order_by(user_datas::id.desc())
-        .first::<DbUserData>(&mut connect()?)?;
+        .first::<DbUserData>(&mut connect().await?)
+        .await?;
     Ok(serde_json::from_value(row.json_data)?)
 }
 
 /// Searches the account data for a specific kind.
 #[tracing::instrument]
-pub fn get_room_data<E: DeserializeOwned>(
+pub async fn get_room_data<E: DeserializeOwned>(
     user_id: &UserId,
     room_id: &RoomId,
     kind: &str,
@@ -118,7 +123,8 @@ pub fn get_room_data<E: DeserializeOwned>(
         .filter(user_datas::room_id.eq(room_id))
         .filter(user_datas::data_type.eq(kind))
         .order_by(user_datas::id.desc())
-        .first::<DbUserData>(&mut connect()?)
+        .first::<DbUserData>(&mut connect().await?)
+        .await
         .optional()?;
     if let Some(row) = row {
         Ok(Some(serde_json::from_value(row.json_data)?))
@@ -128,13 +134,17 @@ pub fn get_room_data<E: DeserializeOwned>(
 }
 
 #[tracing::instrument]
-pub fn get_global_data<E: DeserializeOwned>(user_id: &UserId, kind: &str) -> DataResult<Option<E>> {
+pub async fn get_global_data<E: DeserializeOwned>(
+    user_id: &UserId,
+    kind: &str,
+) -> DataResult<Option<E>> {
     let row = user_datas::table
         .filter(user_datas::user_id.eq(user_id))
         .filter(user_datas::room_id.is_null())
         .filter(user_datas::data_type.eq(kind))
         .order_by(user_datas::id.desc())
-        .first::<DbUserData>(&mut connect()?)
+        .first::<DbUserData>(&mut connect().await?)
+        .await
         .optional()?;
     if let Some(row) = row {
         Ok(Some(serde_json::from_value(row.json_data)?))
@@ -144,18 +154,19 @@ pub fn get_global_data<E: DeserializeOwned>(user_id: &UserId, kind: &str) -> Dat
 }
 
 /// Get all global account data for a user
-pub fn get_global_account_data(user_id: &UserId) -> DataResult<HashMap<String, JsonValue>> {
+pub async fn get_global_account_data(user_id: &UserId) -> DataResult<HashMap<String, JsonValue>> {
     user_datas::table
         .filter(user_datas::user_id.eq(user_id))
         .filter(user_datas::room_id.is_null())
         .select((user_datas::data_type, user_datas::json_data))
-        .load::<(String, JsonValue)>(&mut connect()?)
+        .load::<(String, JsonValue)>(&mut connect().await?)
+        .await
         .map(|rows| rows.into_iter().collect())
         .map_err(Into::into)
 }
 
 /// Get all room-specific account data for a user
-pub fn get_room_account_data(
+pub async fn get_room_account_data(
     user_id: &UserId,
 ) -> DataResult<HashMap<String, HashMap<String, JsonValue>>> {
     let rows = user_datas::table
@@ -166,7 +177,8 @@ pub fn get_room_account_data(
             user_datas::data_type,
             user_datas::json_data,
         ))
-        .load::<(Option<OwnedRoomId>, String, JsonValue)>(&mut connect()?)?;
+        .load::<(Option<OwnedRoomId>, String, JsonValue)>(&mut connect().await?)
+        .await?;
 
     let mut result = HashMap::new();
     for (room_id, data_type, json_data) in rows {
@@ -182,7 +194,7 @@ pub fn get_room_account_data(
 
 /// Returns all changes to the account data that happened after `since`.
 #[tracing::instrument(skip(room_id, user_id, since_sn))]
-pub fn data_changes(
+pub async fn data_changes(
     room_id: Option<&RoomId>,
     user_id: &UserId,
     since_sn: Seqnum,
@@ -203,11 +215,13 @@ pub fn data_changes(
         query
             .filter(user_datas::occur_sn.le(until_sn))
             .order_by(user_datas::occur_sn.asc())
-            .load::<DbUserData>(&mut connect()?)?
+            .load::<DbUserData>(&mut connect().await?)
+            .await?
     } else {
         query
             .order_by(user_datas::occur_sn.asc())
-            .load::<DbUserData>(&mut connect()?)?
+            .load::<DbUserData>(&mut connect().await?)
+            .await?
     };
 
     for db_data in db_datas {

--- a/crates/data/src/user/data.rs
+++ b/crates/data/src/user/data.rs
@@ -41,54 +41,63 @@ pub async fn set_data(
     event_type: &str,
     json_data: JsonValue,
 ) -> DataResult<DbUserData> {
-    if let Some(room_id) = &room_id {
-        let user_data = user_datas::table
+    // Locate the current row explicitly. Global account data is stored with
+    // `room_id = NULL`, and the `user_datas_udx` unique index treats NULLs as
+    // distinct (Postgres default), so `ON CONFLICT (user_id, room_id,
+    // data_type)` never matches a NULL `room_id` and would insert a duplicate
+    // row on every update. We therefore find the latest existing row and
+    // update it in place (or insert when none exists).
+    let existing = if let Some(room_id) = &room_id {
+        user_datas::table
             .filter(user_datas::user_id.eq(user_id))
             .filter(user_datas::room_id.eq(room_id))
             .filter(user_datas::data_type.eq(event_type))
+            .order_by(user_datas::id.desc())
             .first::<DbUserData>(&mut connect().await?)
             .await
-            .optional()?;
-        if let Some(user_data) = user_data
-            && user_data.json_data == json_data
-        {
-            return Ok(user_data);
-        }
+            .optional()?
     } else {
-        let user_data = user_datas::table
+        user_datas::table
             .filter(user_datas::user_id.eq(user_id))
             .filter(user_datas::room_id.is_null())
             .filter(user_datas::data_type.eq(event_type))
+            .order_by(user_datas::id.desc())
             .first::<DbUserData>(&mut connect().await?)
             .await
-            .optional()?;
-        if let Some(user_data) = user_data
-            && user_data.json_data == json_data
-        {
-            return Ok(user_data);
-        }
+            .optional()?
+    };
+
+    if let Some(existing) = &existing
+        && existing.json_data == json_data
+    {
+        return Ok(existing.clone());
     }
 
-    let new_data = NewDbUserData {
-        user_id: user_id.to_owned(),
-        room_id: room_id.clone(),
-        data_type: event_type.to_owned(),
-        json_data,
-        occur_sn: Some(crate::next_sn().await?),
-        created_at: UnixMillis::now(),
-    };
-    diesel::insert_into(user_datas::table)
-        .values(&new_data)
-        .on_conflict((
-            user_datas::user_id,
-            user_datas::room_id,
-            user_datas::data_type,
-        ))
-        .do_update()
-        .set(&new_data)
-        .get_result::<DbUserData>(&mut connect().await?)
-        .await
-        .map_err(Into::into)
+    if let Some(existing) = existing {
+        diesel::update(user_datas::table.find(existing.id))
+            .set((
+                user_datas::json_data.eq(&json_data),
+                user_datas::occur_sn.eq(crate::next_sn().await?),
+                user_datas::created_at.eq(UnixMillis::now()),
+            ))
+            .get_result::<DbUserData>(&mut connect().await?)
+            .await
+            .map_err(Into::into)
+    } else {
+        let new_data = NewDbUserData {
+            user_id: user_id.to_owned(),
+            room_id: room_id.clone(),
+            data_type: event_type.to_owned(),
+            json_data,
+            occur_sn: Some(crate::next_sn().await?),
+            created_at: UnixMillis::now(),
+        };
+        diesel::insert_into(user_datas::table)
+            .values(&new_data)
+            .get_result::<DbUserData>(&mut connect().await?)
+            .await
+            .map_err(Into::into)
+    }
 }
 
 #[tracing::instrument]

--- a/crates/data/src/user/device.rs
+++ b/crates/data/src/user/device.rs
@@ -1,5 +1,6 @@
 use diesel::prelude::*;
 use diesel::result::Error as DieselError;
+use diesel_async::{AsyncConnection, RunQueryDsl};
 
 use crate::core::client::device::Device;
 use crate::core::events::AnyToDeviceEvent;
@@ -91,7 +92,7 @@ pub struct NewDbDeviceInbox {
     pub created_at: i64,
 }
 
-pub fn create_device(
+pub async fn create_device(
     user_id: &UserId,
     device_id: &DeviceId,
     token: &str,
@@ -109,7 +110,8 @@ pub fn create_device(
             last_seen_at: Some(UnixMillis::now()),
             created_at: UnixMillis::now(),
         })
-        .get_result(&mut connect()?)?;
+        .get_result(&mut connect().await?)
+        .await?;
 
     diesel::insert_into(user_access_tokens::table)
         .values(NewDbAccessToken::new(
@@ -118,15 +120,17 @@ pub fn create_device(
             token.to_owned(),
             None,
         ))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(device)
 }
 
-pub fn get_device(user_id: &UserId, device_id: &DeviceId) -> DataResult<DbUserDevice> {
+pub async fn get_device(user_id: &UserId, device_id: &DeviceId) -> DataResult<DbUserDevice> {
     user_devices::table
         .filter(user_devices::user_id.eq(user_id))
         .filter(user_devices::device_id.eq(device_id))
-        .first::<DbUserDevice>(&mut connect()?)
+        .first::<DbUserDevice>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
@@ -157,7 +161,7 @@ impl From<DeviceUpdate> for DbUserDeviceChanges {
     }
 }
 
-pub fn update_device(
+pub async fn update_device(
     user_id: &UserId,
     device_id: &DeviceId,
     update: DeviceUpdate,
@@ -169,35 +173,38 @@ pub fn update_device(
             .filter(user_devices::device_id.eq(device_id)),
     )
     .set(changes)
-    .get_result::<DbUserDevice>(&mut connect()?)
+    .get_result::<DbUserDevice>(&mut connect().await?)
+    .await
     .map_err(Into::into)
 }
 
-pub fn get_devices(user_id: &UserId) -> DataResult<Vec<DbUserDevice>> {
+pub async fn get_devices(user_id: &UserId) -> DataResult<Vec<DbUserDevice>> {
     user_devices::table
         .filter(user_devices::user_id.eq(user_id))
-        .load::<DbUserDevice>(&mut connect()?)
+        .load::<DbUserDevice>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
-pub fn is_device_exists(user_id: &UserId, device_id: &DeviceId) -> DataResult<bool> {
+pub async fn is_device_exists(user_id: &UserId, device_id: &DeviceId) -> DataResult<bool> {
     let query = user_devices::table
         .filter(user_devices::user_id.eq(user_id))
         .filter(user_devices::device_id.eq(device_id));
-    diesel_exists!(query, &mut connect()?).map_err(Into::into)
+    diesel_exists!(query, &mut connect().await?).map_err(Into::into)
 }
 
-pub fn remove_device(user_id: &UserId, device_id: &DeviceId) -> DataResult<()> {
+pub async fn remove_device(user_id: &UserId, device_id: &DeviceId) -> DataResult<()> {
     let count = diesel::delete(
         user_devices::table
             .filter(user_devices::user_id.eq(user_id))
             .filter(user_devices::device_id.eq(device_id)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     if count == 0 {
         if diesel_exists!(
             user_devices::table.filter(user_devices::device_id.eq(device_id)),
-            &mut connect()?
+            &mut connect().await?
         )? {
             return Err(MatrixError::forbidden("Device not owned by user.", None).into());
         } else {
@@ -205,42 +212,47 @@ pub fn remove_device(user_id: &UserId, device_id: &DeviceId) -> DataResult<()> {
         }
     }
 
-    delete_access_tokens(user_id, device_id)?;
-    delete_refresh_tokens(user_id, device_id)?;
-    super::pusher::delete_device_pushers(user_id, device_id)?;
+    delete_access_tokens(user_id, device_id).await?;
+    delete_refresh_tokens(user_id, device_id).await?;
+    super::pusher::delete_device_pushers(user_id, device_id).await?;
     Ok(())
 }
 
-pub fn set_refresh_token(
+pub async fn set_refresh_token(
     user_id: &UserId,
     device_id: &DeviceId,
     token: &str,
     expires_at: u64,
     ultimate_session_expires_at: u64,
 ) -> DataResult<i64> {
-    let id = connect()?.transaction::<_, DieselError, _>(|conn| {
-        diesel::delete(
-            user_refresh_tokens::table
-                .filter(user_refresh_tokens::user_id.eq(user_id))
-                .filter(user_refresh_tokens::device_id.eq(device_id)),
-        )
-        .execute(conn)?;
-        diesel::insert_into(user_refresh_tokens::table)
-            .values(NewDbRefreshToken::new(
-                user_id.to_owned(),
-                device_id.to_owned(),
-                token.to_owned(),
-                expires_at as i64,
-                ultimate_session_expires_at as i64,
-            ))
-            .returning(user_refresh_tokens::id)
-            .get_result::<i64>(conn)
-    })?;
+    let id = connect()
+        .await?
+        .transaction::<_, DieselError, _>(async |conn| {
+            diesel::delete(
+                user_refresh_tokens::table
+                    .filter(user_refresh_tokens::user_id.eq(user_id))
+                    .filter(user_refresh_tokens::device_id.eq(device_id)),
+            )
+            .execute(conn)
+            .await?;
+            diesel::insert_into(user_refresh_tokens::table)
+                .values(NewDbRefreshToken::new(
+                    user_id.to_owned(),
+                    device_id.to_owned(),
+                    token.to_owned(),
+                    expires_at as i64,
+                    ultimate_session_expires_at as i64,
+                ))
+                .returning(user_refresh_tokens::id)
+                .get_result::<i64>(conn)
+                .await
+        })
+        .await?;
 
     Ok(id)
 }
 
-pub fn set_access_token(
+pub async fn set_access_token(
     user_id: &UserId,
     device_id: &DeviceId,
     token: &str,
@@ -256,31 +268,34 @@ pub fn set_access_token(
         .on_conflict((user_access_tokens::user_id, user_access_tokens::device_id))
         .do_update()
         .set(user_access_tokens::token.eq(token))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
-pub fn delete_access_tokens(user_id: &UserId, device_id: &DeviceId) -> DataResult<()> {
+pub async fn delete_access_tokens(user_id: &UserId, device_id: &DeviceId) -> DataResult<()> {
     diesel::delete(
         user_access_tokens::table
             .filter(user_access_tokens::user_id.eq(user_id))
             .filter(user_access_tokens::device_id.eq(device_id)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }
 
-pub fn delete_refresh_tokens(user_id: &UserId, device_id: &DeviceId) -> DataResult<()> {
+pub async fn delete_refresh_tokens(user_id: &UserId, device_id: &DeviceId) -> DataResult<()> {
     diesel::delete(
         user_refresh_tokens::table
             .filter(user_refresh_tokens::user_id.eq(user_id))
             .filter(user_refresh_tokens::device_id.eq(device_id)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }
 
-pub fn get_to_device_events(
+pub async fn get_to_device_events(
     user_id: &UserId,
     device_id: &DeviceId,
     _since_sn: Option<Seqnum>,
@@ -289,7 +304,8 @@ pub fn get_to_device_events(
     device_inboxes::table
         .filter(device_inboxes::user_id.eq(user_id))
         .filter(device_inboxes::device_id.eq(device_id))
-        .load::<DbDeviceInbox>(&mut connect()?)?
+        .load::<DbDeviceInbox>(&mut connect().await?)
+        .await?
         .into_iter()
         .map(|event| {
             serde_json::from_value(event.json_data.clone())
@@ -298,7 +314,7 @@ pub fn get_to_device_events(
         .collect::<DataResult<Vec<_>>>()
 }
 
-pub fn add_to_device_event(
+pub async fn add_to_device_event(
     sender: &UserId,
     target_user_id: &UserId,
     target_device_id: &DeviceId,
@@ -319,12 +335,13 @@ pub fn add_to_device_event(
             json_data,
             created_at: UnixMillis::now().get() as i64,
         })
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
 
     Ok(())
 }
 
-pub fn remove_to_device_events(
+pub async fn remove_to_device_events(
     user_id: &UserId,
     device_id: &DeviceId,
     until_sn: Seqnum,
@@ -335,6 +352,7 @@ pub fn remove_to_device_events(
             .filter(device_inboxes::device_id.eq(device_id))
             .filter(device_inboxes::occur_sn.le(until_sn)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }

--- a/crates/data/src/user/external_id.rs
+++ b/crates/data/src/user/external_id.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::core::UnixMillis;
 use crate::core::identifiers::*;
@@ -25,7 +26,7 @@ pub struct NewDbUserExternalId {
 }
 
 /// Get user_id by external auth provider and external_id
-pub fn get_user_by_external_id(
+pub async fn get_user_by_external_id(
     auth_provider: &str,
     external_id: &str,
 ) -> DataResult<Option<OwnedUserId>> {
@@ -33,21 +34,23 @@ pub fn get_user_by_external_id(
         .filter(user_external_ids::auth_provider.eq(auth_provider))
         .filter(user_external_ids::external_id.eq(external_id))
         .select(user_external_ids::user_id)
-        .first::<OwnedUserId>(&mut connect()?)
+        .first::<OwnedUserId>(&mut connect().await?)
+        .await
         .optional()
         .map_err(Into::into)
 }
 
 /// Get all external IDs for a user
-pub fn get_external_ids_by_user(user_id: &UserId) -> DataResult<Vec<DbUserExternalId>> {
+pub async fn get_external_ids_by_user(user_id: &UserId) -> DataResult<Vec<DbUserExternalId>> {
     user_external_ids::table
         .filter(user_external_ids::user_id.eq(user_id))
-        .load::<DbUserExternalId>(&mut connect()?)
+        .load::<DbUserExternalId>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
 /// Record a new external ID for a user
-pub fn record_external_id(
+pub async fn record_external_id(
     auth_provider: &str,
     external_id: &str,
     user_id: &UserId,
@@ -59,20 +62,20 @@ pub fn record_external_id(
             user_id: user_id.to_owned(),
             created_at: UnixMillis::now(),
         })
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?).await?;
     Ok(())
 }
 
 /// Replace all external IDs for a user
-pub fn replace_external_ids(
+pub async fn replace_external_ids(
     user_id: &UserId,
     new_external_ids: &[(String, String)], // (auth_provider, external_id)
 ) -> DataResult<()> {
-    let mut conn = connect()?;
+    let mut conn = connect().await?;
 
     // Delete existing external IDs for this user
     diesel::delete(user_external_ids::table.filter(user_external_ids::user_id.eq(user_id)))
-        .execute(&mut conn)?;
+        .execute(&mut conn).await?;
 
     // Insert new external IDs
     let now = UnixMillis::now();
@@ -84,19 +87,19 @@ pub fn replace_external_ids(
                 user_id: user_id.to_owned(),
                 created_at: now,
             })
-            .execute(&mut conn)?;
+            .execute(&mut conn).await?;
     }
 
     Ok(())
 }
 
 /// Delete a specific external ID
-pub fn delete_external_id(auth_provider: &str, external_id: &str) -> DataResult<()> {
+pub async fn delete_external_id(auth_provider: &str, external_id: &str) -> DataResult<()> {
     diesel::delete(
         user_external_ids::table
             .filter(user_external_ids::auth_provider.eq(auth_provider))
             .filter(user_external_ids::external_id.eq(external_id)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?).await?;
     Ok(())
 }

--- a/crates/data/src/user/filter.rs
+++ b/crates/data/src/user/filter.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::core::UnixMillis;
 use crate::core::client::filter::FilterDefinition;
@@ -24,22 +25,24 @@ pub struct NewDbUserFilter {
     pub created_at: UnixMillis,
 }
 
-pub fn get_filter(user_id: &UserId, filter_id: i64) -> DataResult<FilterDefinition> {
+pub async fn get_filter(user_id: &UserId, filter_id: i64) -> DataResult<FilterDefinition> {
     let filter = user_filters::table
         .filter(user_filters::id.eq(filter_id))
         .filter(user_filters::user_id.eq(user_id))
         .select(user_filters::filter)
-        .first(&mut connect()?)?;
+        .first(&mut connect().await?)
+        .await?;
     Ok(serde_json::from_value(filter)?)
 }
 
-pub fn create_filter(user_id: &UserId, filter: &FilterDefinition) -> DataResult<i64> {
+pub async fn create_filter(user_id: &UserId, filter: &FilterDefinition) -> DataResult<i64> {
     let filter = diesel::insert_into(user_filters::table)
         .values(NewDbUserFilter {
             user_id: user_id.to_owned(),
             filter: serde_json::to_value(filter)?,
             created_at: UnixMillis::now(),
         })
-        .get_result::<DbUserFilter>(&mut connect()?)?;
+        .get_result::<DbUserFilter>(&mut connect().await?)
+        .await?;
     Ok(filter.id)
 }

--- a/crates/data/src/user/key.rs
+++ b/crates/data/src/user/key.rs
@@ -229,7 +229,7 @@ pub async fn keys_changed_users(
                     .eq_any(&room_ids)
                     .or(e2e_key_changes::user_id.eq(user_id)),
             )
-            .filter(e2e_key_changes::occur_sn.ge(since_sn))
+            .filter(e2e_key_changes::occur_sn.gt(since_sn))
             .filter(e2e_key_changes::occur_sn.le(until_sn))
             .select(e2e_key_changes::user_id)
             .load::<OwnedUserId>(&mut connect().await?)
@@ -242,7 +242,7 @@ pub async fn keys_changed_users(
                     .eq_any(&room_ids)
                     .or(e2e_key_changes::user_id.eq(user_id)),
             )
-            .filter(e2e_key_changes::occur_sn.ge(since_sn))
+            .filter(e2e_key_changes::occur_sn.gt(since_sn))
             .select(e2e_key_changes::user_id)
             .load::<OwnedUserId>(&mut connect().await?)
             .await

--- a/crates/data/src/user/key.rs
+++ b/crates/data/src/user/key.rs
@@ -229,7 +229,7 @@ pub async fn keys_changed_users(
                     .eq_any(&room_ids)
                     .or(e2e_key_changes::user_id.eq(user_id)),
             )
-            .filter(e2e_key_changes::occur_sn.gt(since_sn))
+            .filter(e2e_key_changes::occur_sn.ge(since_sn))
             .filter(e2e_key_changes::occur_sn.le(until_sn))
             .select(e2e_key_changes::user_id)
             .load::<OwnedUserId>(&mut connect().await?)
@@ -242,7 +242,7 @@ pub async fn keys_changed_users(
                     .eq_any(&room_ids)
                     .or(e2e_key_changes::user_id.eq(user_id)),
             )
-            .filter(e2e_key_changes::occur_sn.gt(since_sn))
+            .filter(e2e_key_changes::occur_sn.ge(since_sn))
             .select(e2e_key_changes::user_id)
             .load::<OwnedUserId>(&mut connect().await?)
             .await

--- a/crates/data/src/user/key.rs
+++ b/crates/data/src/user/key.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::core::encryption::DeviceKeys;
 use crate::core::identifiers::*;
@@ -138,7 +139,7 @@ pub struct NewDbKeyChange {
     pub changed_at: UnixMillis,
 }
 
-pub fn count_one_time_keys(
+pub async fn count_one_time_keys(
     user_id: &UserId,
     device_id: &DeviceId,
 ) -> DataResult<BTreeMap<DeviceKeyAlgorithm, u64>> {
@@ -147,14 +148,14 @@ pub fn count_one_time_keys(
         .filter(e2e_one_time_keys::device_id.eq(device_id))
         .group_by(e2e_one_time_keys::algorithm)
         .select((e2e_one_time_keys::algorithm, diesel::dsl::count_star()))
-        .load::<(String, i64)>(&mut connect()?)?;
+        .load::<(String, i64)>(&mut connect().await?).await?;
     Ok(BTreeMap::from_iter(
         list.into_iter()
             .map(|(k, v)| (DeviceKeyAlgorithm::from(k), v as u64)),
     ))
 }
 
-pub fn add_device_keys(
+pub async fn add_device_keys(
     user_id: &UserId,
     device_id: &DeviceId,
     device_keys: &DeviceKeys,
@@ -172,33 +173,34 @@ pub fn add_device_keys(
         .on_conflict((e2e_device_keys::user_id, e2e_device_keys::device_id))
         .do_update()
         .set(&new_device_key)
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?).await?;
     Ok(())
 }
 
-pub fn get_device_keys(user_id: &UserId, device_id: &DeviceId) -> DataResult<Option<DeviceKeys>> {
+pub async fn get_device_keys(user_id: &UserId, device_id: &DeviceId) -> DataResult<Option<DeviceKeys>> {
     e2e_device_keys::table
         .filter(e2e_device_keys::user_id.eq(user_id))
         .filter(e2e_device_keys::device_id.eq(device_id))
         .select(e2e_device_keys::key_data)
-        .first::<JsonValue>(&mut connect()?)
+        .first::<JsonValue>(&mut connect().await?)
+        .await
         .optional()?
         .map(|v| serde_json::from_value(v).map_err(Into::into))
         .transpose()
 }
 
-pub fn get_device_keys_and_sigs(
+pub async fn get_device_keys_and_sigs(
     user_id: &UserId,
     device_id: &DeviceId,
 ) -> DataResult<Option<DeviceKeys>> {
-    let Some(mut device_keys) = get_device_keys(user_id, device_id)? else {
+    let Some(mut device_keys) = get_device_keys(user_id, device_id).await? else {
         return Ok(None);
     };
     let signatures = e2e_cross_signing_sigs::table
         .filter(e2e_cross_signing_sigs::origin_user_id.eq(user_id))
         .filter(e2e_cross_signing_sigs::target_user_id.eq(user_id))
         .filter(e2e_cross_signing_sigs::target_device_id.eq(device_id))
-        .load::<DbCrossSignature>(&mut connect()?)?;
+        .load::<DbCrossSignature>(&mut connect().await?).await?;
     for DbCrossSignature {
         origin_key_id,
         signature,
@@ -214,12 +216,12 @@ pub fn get_device_keys_and_sigs(
     Ok(Some(device_keys))
 }
 
-pub fn keys_changed_users(
+pub async fn keys_changed_users(
     user_id: &UserId,
     since_sn: Seqnum,
     until_sn: Option<Seqnum>,
 ) -> DataResult<Vec<OwnedUserId>> {
-    let room_ids = crate::user::joined_rooms(user_id)?;
+    let room_ids = crate::user::joined_rooms(user_id).await?;
     if let Some(until_sn) = until_sn {
         e2e_key_changes::table
             .filter(
@@ -230,7 +232,8 @@ pub fn keys_changed_users(
             .filter(e2e_key_changes::occur_sn.ge(since_sn))
             .filter(e2e_key_changes::occur_sn.le(until_sn))
             .select(e2e_key_changes::user_id)
-            .load::<OwnedUserId>(&mut connect()?)
+            .load::<OwnedUserId>(&mut connect().await?)
+            .await
             .map_err(Into::into)
     } else {
         e2e_key_changes::table
@@ -241,23 +244,24 @@ pub fn keys_changed_users(
             )
             .filter(e2e_key_changes::occur_sn.ge(since_sn))
             .select(e2e_key_changes::user_id)
-            .load::<OwnedUserId>(&mut connect()?)
+            .load::<OwnedUserId>(&mut connect().await?)
+            .await
             .map_err(Into::into)
     }
 }
 
 /// Check if user has a master cross-signing key
-pub fn has_master_cross_signing_key(user_id: &UserId) -> DataResult<bool> {
+pub async fn has_master_cross_signing_key(user_id: &UserId) -> DataResult<bool> {
     let count = e2e_cross_signing_keys::table
         .filter(e2e_cross_signing_keys::user_id.eq(user_id))
         .filter(e2e_cross_signing_keys::key_type.eq("master"))
         .count()
-        .get_result::<i64>(&mut connect()?)?;
+        .get_result::<i64>(&mut connect().await?).await?;
     Ok(count > 0)
 }
 
 /// Set the timestamp until which cross-signing key replacement is allowed without UIA
-pub fn set_cross_signing_replacement_allowed(user_id: &UserId, expires_ts: i64) -> DataResult<()> {
+pub async fn set_cross_signing_replacement_allowed(user_id: &UserId, expires_ts: i64) -> DataResult<()> {
     diesel::insert_into(e2e_cross_signing_uia_bypass::table)
         .values((
             e2e_cross_signing_uia_bypass::user_id.eq(user_id),
@@ -266,16 +270,17 @@ pub fn set_cross_signing_replacement_allowed(user_id: &UserId, expires_ts: i64) 
         .on_conflict(e2e_cross_signing_uia_bypass::user_id)
         .do_update()
         .set(e2e_cross_signing_uia_bypass::updatable_before_ts.eq(expires_ts))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?).await?;
     Ok(())
 }
 
 /// Get the timestamp until which cross-signing key replacement is allowed without UIA
-pub fn get_cross_signing_replacement_allowed(user_id: &UserId) -> DataResult<Option<i64>> {
+pub async fn get_cross_signing_replacement_allowed(user_id: &UserId) -> DataResult<Option<i64>> {
     e2e_cross_signing_uia_bypass::table
         .filter(e2e_cross_signing_uia_bypass::user_id.eq(user_id))
         .select(e2e_cross_signing_uia_bypass::updatable_before_ts)
-        .first::<i64>(&mut connect()?)
+        .first::<i64>(&mut connect().await?)
+        .await
         .optional()
         .map_err(Into::into)
 }

--- a/crates/data/src/user/key_backup.rs
+++ b/crates/data/src/user/key_backup.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::core::UnixMillis;
 use crate::core::client::backup::{BackupAlgorithm, KeyBackupData};
@@ -75,7 +76,7 @@ pub struct NewDbRoomKeysVersion {
     pub created_at: UnixMillis,
 }
 
-pub fn create_backup(
+pub async fn create_backup(
     user_id: &UserId,
     algorithm: &RawJson<BackupAlgorithm>,
 ) -> DataResult<DbRoomKeysVersion> {
@@ -89,11 +90,12 @@ pub fn create_backup(
     };
     diesel::insert_into(e2e_room_keys_versions::table)
         .values(&new_keys_version)
-        .get_result(&mut connect()?)
+        .get_result(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
-pub fn update_backup(
+pub async fn update_backup(
     user_id: &UserId,
     version: i64,
     algorithm: &BackupAlgorithm,
@@ -107,20 +109,21 @@ pub fn update_backup(
         e2e_room_keys_versions::algorithm.eq(serde_json::to_value(algorithm)?),
         e2e_room_keys_versions::etag.eq(UnixMillis::now().get() as i64),
     ))
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?).await?;
     Ok(())
 }
 
-pub fn get_latest_room_key(user_id: &UserId) -> DataResult<Option<DbRoomKey>> {
+pub async fn get_latest_room_key(user_id: &UserId) -> DataResult<Option<DbRoomKey>> {
     e2e_room_keys::table
         .filter(e2e_room_keys::user_id.eq(user_id))
         .order(e2e_room_keys::version.desc())
-        .first::<DbRoomKey>(&mut connect()?)
+        .first::<DbRoomKey>(&mut connect().await?)
+        .await
         .optional()
         .map_err(Into::into)
 }
 
-pub fn get_room_key(
+pub async fn get_room_key(
     user_id: &UserId,
     room_id: &RoomId,
     version: i64,
@@ -129,21 +132,23 @@ pub fn get_room_key(
         .filter(e2e_room_keys::user_id.eq(user_id))
         .filter(e2e_room_keys::room_id.eq(room_id))
         .filter(e2e_room_keys::version.eq(version))
-        .first::<DbRoomKey>(&mut connect()?)
+        .first::<DbRoomKey>(&mut connect().await?)
+        .await
         .optional()
         .map_err(Into::into)
 }
 
-pub fn get_latest_room_keys_version(user_id: &UserId) -> DataResult<Option<DbRoomKeysVersion>> {
+pub async fn get_latest_room_keys_version(user_id: &UserId) -> DataResult<Option<DbRoomKeysVersion>> {
     e2e_room_keys_versions::table
         .filter(e2e_room_keys_versions::user_id.eq(user_id))
         .filter(e2e_room_keys_versions::is_trashed.eq(false))
         .order(e2e_room_keys_versions::version.desc())
-        .first::<DbRoomKeysVersion>(&mut connect()?)
+        .first::<DbRoomKeysVersion>(&mut connect().await?)
+        .await
         .optional()
         .map_err(Into::into)
 }
-pub fn get_room_keys_version(
+pub async fn get_room_keys_version(
     user_id: &UserId,
     version: i64,
 ) -> DataResult<Option<DbRoomKeysVersion>> {
@@ -151,12 +156,13 @@ pub fn get_room_keys_version(
         .filter(e2e_room_keys_versions::user_id.eq(user_id))
         .filter(e2e_room_keys_versions::version.eq(version))
         .filter(e2e_room_keys_versions::is_trashed.eq(false))
-        .first::<DbRoomKeysVersion>(&mut connect()?)
+        .first::<DbRoomKeysVersion>(&mut connect().await?)
+        .await
         .optional()
         .map_err(Into::into)
 }
 
-pub fn add_key(
+pub async fn add_key(
     user_id: &UserId,
     version: i64,
     room_id: &RoomId,
@@ -175,7 +181,7 @@ pub fn add_key(
         created_at: UnixMillis::now(),
     };
 
-    let exist_key = get_key_for_session(user_id, version, room_id, session_id)?;
+    let exist_key = get_key_for_session(user_id, version, room_id, session_id).await?;
     let replace = if let Some(exist_key) = exist_key {
         if (new_key.is_verified && !exist_key.is_verified)
             || new_key.first_message_index < exist_key.first_message_index
@@ -200,31 +206,33 @@ pub fn add_key(
             ))
             .do_update()
             .set(&new_key)
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?).await?;
     }
     Ok(())
 }
 
-pub fn count_keys(user_id: &UserId, version: i64) -> DataResult<i64> {
+pub async fn count_keys(user_id: &UserId, version: i64) -> DataResult<i64> {
     e2e_room_keys::table
         .filter(e2e_room_keys::user_id.eq(user_id))
         .filter(e2e_room_keys::version.eq(version))
         .count()
-        .get_result(&mut connect()?)
+        .get_result(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
-pub fn get_etag(user_id: &UserId, version: i64) -> DataResult<String> {
+pub async fn get_etag(user_id: &UserId, version: i64) -> DataResult<String> {
     e2e_room_keys_versions::table
         .filter(e2e_room_keys_versions::user_id.eq(user_id))
         .filter(e2e_room_keys_versions::version.eq(version))
         .select(e2e_room_keys_versions::etag)
-        .first(&mut connect()?)
+        .first(&mut connect().await?)
+        .await
         .map(|etag: i64| etag.to_string())
         .map_err(Into::into)
 }
 
-pub fn get_key_for_session(
+pub async fn get_key_for_session(
     user_id: &UserId,
     version: i64,
     room_id: &RoomId,
@@ -235,45 +243,46 @@ pub fn get_key_for_session(
         .filter(e2e_room_keys::version.eq(version))
         .filter(e2e_room_keys::room_id.eq(room_id))
         .filter(e2e_room_keys::session_id.eq(session_id))
-        .first::<DbRoomKey>(&mut connect()?)
+        .first::<DbRoomKey>(&mut connect().await?)
+        .await
         .optional()
         .map_err(Into::into)
 }
 
-pub fn delete_backup(user_id: &UserId, version: i64) -> DataResult<()> {
-    delete_all_keys(user_id, version)?;
+pub async fn delete_backup(user_id: &UserId, version: i64) -> DataResult<()> {
+    delete_all_keys(user_id, version).await?;
     diesel::update(
         e2e_room_keys_versions::table
             .filter(e2e_room_keys_versions::user_id.eq(user_id))
             .filter(e2e_room_keys_versions::version.eq(version)),
     )
     .set(e2e_room_keys_versions::is_trashed.eq(true))
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?).await?;
     Ok(())
 }
 
-pub fn delete_all_keys(user_id: &UserId, version: i64) -> DataResult<()> {
+pub async fn delete_all_keys(user_id: &UserId, version: i64) -> DataResult<()> {
     diesel::delete(
         e2e_room_keys::table
             .filter(e2e_room_keys::user_id.eq(user_id))
             .filter(e2e_room_keys::version.eq(version)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?).await?;
     Ok(())
 }
 
-pub fn delete_room_keys(user_id: &UserId, version: i64, room_id: &RoomId) -> DataResult<()> {
+pub async fn delete_room_keys(user_id: &UserId, version: i64, room_id: &RoomId) -> DataResult<()> {
     diesel::delete(
         e2e_room_keys::table
             .filter(e2e_room_keys::user_id.eq(user_id))
             .filter(e2e_room_keys::version.eq(version))
             .filter(e2e_room_keys::room_id.eq(room_id)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?).await?;
     Ok(())
 }
 
-pub fn delete_room_key(
+pub async fn delete_room_key(
     user_id: &UserId,
     version: i64,
     room_id: &RoomId,
@@ -286,6 +295,6 @@ pub fn delete_room_key(
             .filter(e2e_room_keys::room_id.eq(room_id))
             .filter(e2e_room_keys::session_id.eq(session_id)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?).await?;
     Ok(())
 }

--- a/crates/data/src/user/presence.rs
+++ b/crates/data/src/user/presence.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::core::events::presence::{PresenceEvent, PresenceEventContent};
 use crate::core::identifiers::*;
@@ -41,7 +42,7 @@ pub struct NewDbPresence {
 
 impl DbPresence {
     /// Creates a PresenceEvent from available data.
-    pub fn to_presence_event(&self, user_id: &UserId) -> DataResult<PresenceEvent> {
+    pub async fn to_presence_event(&self, user_id: &UserId) -> DataResult<PresenceEvent> {
         let now = UnixMillis::now();
         let state = self
             .state
@@ -55,7 +56,7 @@ impl DbPresence {
                 .map(|last_active_at| now.0.saturating_sub(last_active_at.0))
         };
 
-        let profile = crate::user::get_profile(user_id, None)?;
+        let profile = crate::user::get_profile(user_id, None).await?;
         Ok(PresenceEvent {
             sender: user_id.to_owned(),
             content: PresenceEventContent {
@@ -70,67 +71,73 @@ impl DbPresence {
     }
 }
 
-pub fn last_presence(user_id: &UserId) -> DataResult<PresenceEvent> {
+pub async fn last_presence(user_id: &UserId) -> DataResult<PresenceEvent> {
     let presence = user_presences::table
         .filter(user_presences::user_id.eq(user_id))
-        .first::<DbPresence>(&mut connect()?)
+        .first::<DbPresence>(&mut connect().await?)
+        .await
         .optional()?;
     if let Some(data) = presence {
-        Ok(data.to_presence_event(user_id)?)
+        Ok(data.to_presence_event(user_id).await?)
     } else {
         Err(MatrixError::not_found("No presence data found for user").into())
     }
 }
 
 /// Adds a presence event which will be saved until a new event replaces it.
-pub fn set_presence(db_presence: NewDbPresence, force: bool) -> DataResult<bool> {
+pub async fn set_presence(db_presence: NewDbPresence, force: bool) -> DataResult<bool> {
     let mut state_changed = false;
     let sender_id = &db_presence.user_id;
     let old_state = user_presences::table
         .filter(user_presences::user_id.eq(sender_id))
         .select(user_presences::state)
-        .first::<Option<String>>(&mut connect()?)
+        .first::<Option<String>>(&mut connect().await?)
+        .await
         .optional()?
         .flatten();
 
     if old_state.as_ref() != db_presence.state.as_ref() || force {
         diesel::delete(user_presences::table.filter(user_presences::user_id.eq(sender_id)))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         diesel::insert_into(user_presences::table)
             .values(&db_presence)
             .on_conflict(user_presences::user_id)
             .do_update()
             .set(&db_presence)
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         state_changed = true;
     }
     Ok(state_changed)
 }
 
 /// Removes the presence record for the given user from the database.
-pub fn remove_presence(user_id: &UserId) -> DataResult<()> {
+pub async fn remove_presence(user_id: &UserId) -> DataResult<()> {
     diesel::delete(user_presences::table.filter(user_presences::user_id.eq(user_id)))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
 /// Returns the most recent presence updates that happened after the event with id `since`.
-pub fn presences_since(since_sn: i64) -> DataResult<HashMap<OwnedUserId, PresenceEvent>> {
+pub async fn presences_since(since_sn: i64) -> DataResult<HashMap<OwnedUserId, PresenceEvent>> {
     let presences = user_presences::table
         .filter(user_presences::occur_sn.ge(since_sn))
-        .load::<DbPresence>(&mut connect()?)?;
-    presences
-        .into_iter()
-        .map(|presence| {
-            presence
-                .to_presence_event(&presence.user_id)
-                .map(|event| (presence.user_id, event))
-        })
-        .collect()
+        .load::<DbPresence>(&mut connect().await?)
+        .await?;
+    let mut result = HashMap::new();
+    for presence in presences {
+        let event = presence.to_presence_event(&presence.user_id).await?;
+        result.insert(presence.user_id, event);
+    }
+    Ok(result)
 }
 
 // Unset online/unavailable presence to offline on startup
-pub fn unset_all_presences() -> DataResult<()> {
-    diesel::delete(user_presences::table).execute(&mut connect()?)?;
+pub async fn unset_all_presences() -> DataResult<()> {
+    diesel::delete(user_presences::table)
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }

--- a/crates/data/src/user/profile.rs
+++ b/crates/data/src/user/profile.rs
@@ -1,5 +1,6 @@
 use diesel::prelude::*;
 use diesel::sql_types::{Jsonb, Text};
+use diesel_async::RunQueryDsl;
 
 use crate::core::identifiers::*;
 use crate::core::serde::{JsonObject, JsonValue};
@@ -31,29 +32,32 @@ pub struct NewDbProfile {
     pub blurhash: Option<String>,
 }
 
-pub fn get_profile(user_id: &UserId, room_id: Option<&RoomId>) -> DataResult<Option<DbProfile>> {
+pub async fn get_profile(user_id: &UserId, room_id: Option<&RoomId>) -> DataResult<Option<DbProfile>> {
     let profile = if let Some(room_id) = room_id {
         user_profiles::table
             .filter(user_profiles::user_id.eq(user_id.as_str()))
             .filter(user_profiles::room_id.eq(room_id))
-            .first::<DbProfile>(&mut connect()?)
+            .first::<DbProfile>(&mut connect().await?)
+            .await
             .optional()?
     } else {
         user_profiles::table
             .filter(user_profiles::user_id.eq(user_id.as_str()))
             .filter(user_profiles::room_id.is_null())
-            .first::<DbProfile>(&mut connect()?)
+            .first::<DbProfile>(&mut connect().await?)
+            .await
             .optional()?
     };
     Ok(profile)
 }
 
-pub fn profile_fields(user_id: &UserId) -> DataResult<JsonObject> {
+pub async fn profile_fields(user_id: &UserId) -> DataResult<JsonObject> {
     let fields = user_profiles::table
         .filter(user_profiles::user_id.eq(user_id))
         .filter(user_profiles::room_id.is_null())
         .select(user_profiles::fields)
-        .first::<JsonValue>(&mut connect()?)
+        .first::<JsonValue>(&mut connect().await?)
+        .await
         .optional()?;
 
     Ok(fields
@@ -63,8 +67,8 @@ pub fn profile_fields(user_id: &UserId) -> DataResult<JsonObject> {
         .unwrap_or_default())
 }
 
-pub fn profile_field(user_id: &UserId, field: &str) -> DataResult<Option<JsonValue>> {
-    Ok(profile_fields(user_id)?.remove(field))
+pub async fn profile_field(user_id: &UserId, field: &str) -> DataResult<Option<JsonValue>> {
+    Ok(profile_fields(user_id).await?.remove(field))
 }
 
 fn ensure_profile_updated(updated: usize) -> DataResult<()> {
@@ -75,7 +79,7 @@ fn ensure_profile_updated(updated: usize) -> DataResult<()> {
     Ok(())
 }
 
-pub fn set_profile_field(user_id: &UserId, field: &str, value: JsonValue) -> DataResult<()> {
+pub async fn set_profile_field(user_id: &UserId, field: &str, value: JsonValue) -> DataResult<()> {
     let updated = diesel::sql_query(
         "UPDATE user_profiles \
          SET fields = fields || jsonb_build_object($2, $3::jsonb) \
@@ -84,12 +88,13 @@ pub fn set_profile_field(user_id: &UserId, field: &str, value: JsonValue) -> Dat
     .bind::<Text, _>(user_id.as_str())
     .bind::<Text, _>(field)
     .bind::<Jsonb, _>(value)
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
 
     ensure_profile_updated(updated)
 }
 
-pub fn delete_profile_field(user_id: &UserId, field: &str) -> DataResult<()> {
+pub async fn delete_profile_field(user_id: &UserId, field: &str) -> DataResult<()> {
     let updated = diesel::sql_query(
         "UPDATE user_profiles \
          SET fields = fields - $2 \
@@ -97,7 +102,8 @@ pub fn delete_profile_field(user_id: &UserId, field: &str) -> DataResult<()> {
     )
     .bind::<Text, _>(user_id.as_str())
     .bind::<Text, _>(field)
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
 
     ensure_profile_updated(updated)
 }

--- a/crates/data/src/user/push_rule.rs
+++ b/crates/data/src/user/push_rule.rs
@@ -2,6 +2,7 @@ use std::{fmt::Debug, mem};
 
 use bytes::BytesMut;
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use palpo_core::push::PusherIds;
 use tracing::{info, warn};
 
@@ -68,10 +69,11 @@ pub struct NewDbPushRule {
 //     }
 // }
 
-pub fn get_push_rules(user_id: &UserId) -> DataResult<Vec<DbPushRule>> {
+pub async fn get_push_rules(user_id: &UserId) -> DataResult<Vec<DbPushRule>> {
     let push_rules = push_rules::table
         .filter(push_rules::user_id.eq(user_id))
         .order_by((push_rules::priority_class.asc(), push_rules::priority.asc()))
-        .load::<DbPushRule>(&mut db::connect()?)?;
+        .load::<DbPushRule>(&mut db::connect().await?)
+        .await?;
     Ok(push_rules)
 }

--- a/crates/data/src/user/pusher.rs
+++ b/crates/data/src/user/pusher.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use palpo_core::push::PusherIds;
 
 use crate::core::UnixMillis;
@@ -78,12 +79,13 @@ impl TryInto<Pusher> for DbPusher {
     }
 }
 
-pub fn get_pusher(user_id: &UserId, pushkey: &str) -> DataResult<Option<Pusher>> {
+pub async fn get_pusher(user_id: &UserId, pushkey: &str) -> DataResult<Option<Pusher>> {
     let pusher = user_pushers::table
         .filter(user_pushers::user_id.eq(user_id))
         .filter(user_pushers::pushkey.eq(pushkey))
         .order_by(user_pushers::id.desc())
-        .first::<DbPusher>(&mut connect()?)
+        .first::<DbPusher>(&mut connect().await?)
+        .await
         .optional()?;
     if let Some(pusher) = pusher {
         pusher.try_into().map(Option::Some)
@@ -92,11 +94,12 @@ pub fn get_pusher(user_id: &UserId, pushkey: &str) -> DataResult<Option<Pusher>>
     }
 }
 
-pub fn get_pushers(user_id: &UserId) -> DataResult<Vec<DbPusher>> {
+pub async fn get_pushers(user_id: &UserId) -> DataResult<Vec<DbPusher>> {
     user_pushers::table
         .filter(user_pushers::user_id.eq(user_id))
         .order_by(user_pushers::id.desc())
-        .load::<DbPusher>(&mut connect()?)
+        .load::<DbPusher>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
@@ -118,6 +121,7 @@ pub async fn get_actions<'a>(
         member_count: 10_u32.into(), // TODO: get member count efficiently
         user_id: user.to_owned(),
         user_display_name: crate::user::display_name(user)
+            .await
             .ok()
             .flatten()
             .unwrap_or_else(|| user.localpart().to_owned()),
@@ -131,26 +135,29 @@ pub async fn get_actions<'a>(
     Ok(ruleset.get_actions(pdu, &ctx).await)
 }
 
-pub fn get_push_keys(user_id: &UserId) -> DataResult<Vec<String>> {
+pub async fn get_push_keys(user_id: &UserId) -> DataResult<Vec<String>> {
     user_pushers::table
         .filter(user_pushers::user_id.eq(user_id))
         .select(user_pushers::pushkey)
-        .load::<String>(&mut connect()?)
+        .load::<String>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
-pub fn delete_user_pushers(user_id: &UserId) -> DataResult<()> {
+pub async fn delete_user_pushers(user_id: &UserId) -> DataResult<()> {
     diesel::delete(user_pushers::table.filter(user_pushers::user_id.eq(user_id)))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
-pub fn delete_device_pushers(user_id: &UserId, device_id: &DeviceId) -> DataResult<()> {
+pub async fn delete_device_pushers(user_id: &UserId, device_id: &DeviceId) -> DataResult<()> {
     diesel::delete(
         user_pushers::table
             .filter(user_pushers::user_id.eq(user_id))
             .filter(user_pushers::device_id.eq(device_id)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }

--- a/crates/data/src/user/registration_token.rs
+++ b/crates/data/src/user/registration_token.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::core::UnixMillis;
 use crate::schema::*;
@@ -69,7 +70,7 @@ impl From<DbRegistrationToken> for RegistrationTokenInfo {
 /// and have uses remaining) are returned.
 /// If `valid` is Some(false), only invalid tokens are returned.
 /// If `valid` is None, all tokens are returned.
-pub fn list_registration_tokens(valid: Option<bool>) -> DataResult<Vec<RegistrationTokenInfo>> {
+pub async fn list_registration_tokens(valid: Option<bool>) -> DataResult<Vec<RegistrationTokenInfo>> {
     let mut query = user_registration_tokens::table.into_boxed();
 
     if let Some(is_valid) = valid {
@@ -107,16 +108,17 @@ pub fn list_registration_tokens(valid: Option<bool>) -> DataResult<Vec<Registrat
 
     let tokens = query
         .order(user_registration_tokens::created_at.desc())
-        .load::<DbRegistrationToken>(&mut connect()?)?;
+        .load::<DbRegistrationToken>(&mut connect().await?).await?;
 
     Ok(tokens.into_iter().map(Into::into).collect())
 }
 
 /// Get a single registration token by its token string
-pub fn get_registration_token(token: &str) -> DataResult<Option<RegistrationTokenInfo>> {
+pub async fn get_registration_token(token: &str) -> DataResult<Option<RegistrationTokenInfo>> {
     let result = user_registration_tokens::table
         .filter(user_registration_tokens::token.eq(token))
-        .first::<DbRegistrationToken>(&mut connect()?)
+        .first::<DbRegistrationToken>(&mut connect().await?)
+        .await
         .optional()?;
 
     Ok(result.map(Into::into))
@@ -125,7 +127,7 @@ pub fn get_registration_token(token: &str) -> DataResult<Option<RegistrationToke
 /// Create a new registration token
 ///
 /// Returns true if created successfully, false if token already exists
-pub fn create_registration_token(
+pub async fn create_registration_token(
     token: &str,
     uses_allowed: Option<i64>,
     expires_at: Option<i64>,
@@ -136,7 +138,7 @@ pub fn create_registration_token(
         .values(&new_token)
         .on_conflict(user_registration_tokens::token)
         .do_nothing()
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?).await?;
 
     Ok(result > 0)
 }
@@ -144,7 +146,7 @@ pub fn create_registration_token(
 /// Update a registration token
 ///
 /// Returns the updated token info if found, None if token doesn't exist
-pub fn update_registration_token(
+pub async fn update_registration_token(
     token: &str,
     uses_allowed: Option<Option<i64>>,
     expires_at: Option<Option<i64>>,
@@ -152,7 +154,8 @@ pub fn update_registration_token(
     // First check if the token exists
     let existing = user_registration_tokens::table
         .filter(user_registration_tokens::token.eq(token))
-        .first::<DbRegistrationToken>(&mut connect()?)
+        .first::<DbRegistrationToken>(&mut connect().await?)
+        .await
         .optional()?;
 
     if existing.is_none() {
@@ -160,14 +163,14 @@ pub fn update_registration_token(
     }
 
     // Build update based on what was provided
-    let mut conn = connect()?;
+    let mut conn = connect().await?;
 
     if let Some(new_uses_allowed) = uses_allowed {
         diesel::update(
             user_registration_tokens::table.filter(user_registration_tokens::token.eq(token)),
         )
         .set(user_registration_tokens::uses_allowed.eq(new_uses_allowed))
-        .execute(&mut conn)?;
+        .execute(&mut conn).await?;
     }
 
     if let Some(new_expires_at) = expires_at {
@@ -175,21 +178,21 @@ pub fn update_registration_token(
             user_registration_tokens::table.filter(user_registration_tokens::token.eq(token)),
         )
         .set(user_registration_tokens::expires_at.eq(new_expires_at))
-        .execute(&mut conn)?;
+        .execute(&mut conn).await?;
     }
 
     // Return updated token
-    get_registration_token(token)
+    get_registration_token(token).await
 }
 
 /// Delete a registration token
 ///
 /// Returns true if deleted, false if token didn't exist
-pub fn delete_registration_token(token: &str) -> DataResult<bool> {
+pub async fn delete_registration_token(token: &str) -> DataResult<bool> {
     let result = diesel::delete(
         user_registration_tokens::table.filter(user_registration_tokens::token.eq(token)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?).await?;
 
     Ok(result > 0)
 }
@@ -224,10 +227,11 @@ pub fn is_valid_token_chars(token: &str) -> bool {
 /// - It exists
 /// - It has not expired (or has no expiry)
 /// - It has uses remaining (or has unlimited uses)
-pub fn is_token_valid(token: &str) -> DataResult<bool> {
+pub async fn is_token_valid(token: &str) -> DataResult<bool> {
     let db_token = user_registration_tokens::table
         .filter(user_registration_tokens::token.eq(token))
-        .first::<DbRegistrationToken>(&mut connect()?)
+        .first::<DbRegistrationToken>(&mut connect().await?)
+        .await
         .optional()?;
 
     let Some(db_token) = db_token else {
@@ -254,23 +258,24 @@ pub fn is_token_valid(token: &str) -> DataResult<bool> {
 }
 
 /// Increment the pending count for a token (when registration starts)
-pub fn increment_pending(token: &str) -> DataResult<bool> {
+pub async fn increment_pending(token: &str) -> DataResult<bool> {
     let result = diesel::update(
         user_registration_tokens::table.filter(user_registration_tokens::token.eq(token)),
     )
     .set(user_registration_tokens::pending.eq(user_registration_tokens::pending + 1))
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?).await?;
 
     Ok(result > 0)
 }
 
 /// Complete a registration (decrement pending, increment completed)
-pub fn complete_registration(token: &str) -> DataResult<bool> {
-    let mut conn = connect()?;
+pub async fn complete_registration(token: &str) -> DataResult<bool> {
+    let mut conn = connect().await?;
     let pending = user_registration_tokens::table
         .filter(user_registration_tokens::token.eq(token))
         .select(user_registration_tokens::pending)
         .first::<i64>(&mut conn)
+        .await
         .optional()?;
     let Some(pending) = pending else {
         return Ok(false);
@@ -284,18 +289,19 @@ pub fn complete_registration(token: &str) -> DataResult<bool> {
         user_registration_tokens::pending.eq(new_pending),
         user_registration_tokens::completed.eq(user_registration_tokens::completed + 1),
     ))
-    .execute(&mut conn)?;
+    .execute(&mut conn).await?;
 
     Ok(result > 0)
 }
 
 /// Cancel a pending registration (decrement pending)
-pub fn cancel_registration(token: &str) -> DataResult<bool> {
-    let mut conn = connect()?;
+pub async fn cancel_registration(token: &str) -> DataResult<bool> {
+    let mut conn = connect().await?;
     let pending = user_registration_tokens::table
         .filter(user_registration_tokens::token.eq(token))
         .select(user_registration_tokens::pending)
         .first::<i64>(&mut conn)
+        .await
         .optional()?;
     let Some(pending) = pending else {
         return Ok(false);
@@ -306,7 +312,7 @@ pub fn cancel_registration(token: &str) -> DataResult<bool> {
         user_registration_tokens::table.filter(user_registration_tokens::token.eq(token)),
     )
     .set(user_registration_tokens::pending.eq(new_pending))
-    .execute(&mut conn)?;
+    .execute(&mut conn).await?;
 
     Ok(result > 0)
 }

--- a/crates/data/src/user/registration_token.rs
+++ b/crates/data/src/user/registration_token.rs
@@ -181,6 +181,10 @@ pub async fn update_registration_token(
         .execute(&mut conn).await?;
     }
 
+    // Release the connection before the nested read below, which checks out its
+    // own connection. Holding both at once would pin two connections per call.
+    drop(conn);
+
     // Return updated token
     get_registration_token(token).await
 }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -46,6 +46,7 @@ diesel = { workspace = true, features = [
     "chrono",
     "serde_json",
 ] }
+diesel-async = { workspace = true, features = ["postgres"] }
 diesel_migrations = { workspace = true }
 dotenvy = { workspace = true }
 either = { workspace = true, features = ["serde"] }

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -137,11 +137,13 @@ pub(crate) struct RoomInfo {
     pub(crate) name: String,
 }
 
-pub(crate) fn get_room_info(room_id: &RoomId) -> RoomInfo {
+pub(crate) async fn get_room_info(room_id: &RoomId) -> RoomInfo {
     RoomInfo {
         id: room_id.to_owned(),
-        joined_members: crate::room::joined_member_count(room_id).unwrap_or(0),
-        name: crate::room::get_name(room_id).unwrap_or_else(|_| room_id.to_string()),
+        joined_members: crate::room::joined_member_count(room_id).await.unwrap_or(0),
+        name: crate::room::get_name(room_id)
+            .await
+            .unwrap_or_else(|_| room_id.to_string()),
     }
 }
 

--- a/crates/server/src/admin/appservice.rs
+++ b/crates/server/src/admin/appservice.rs
@@ -61,6 +61,7 @@ pub(super) async fn register(ctx: &Context<'_>) -> AppResult<()> {
             )));
         }
         Ok(registration) => match crate::appservice::register_appservice(registration.clone())
+            .await
             .map(|_| registration.id)
         {
             Err(e) => {
@@ -75,7 +76,7 @@ pub(super) async fn register(ctx: &Context<'_>) -> AppResult<()> {
 }
 
 pub(super) async fn unregister(ctx: &Context<'_>, appservice_identifier: String) -> AppResult<()> {
-    match crate::appservice::unregister_appservice(&appservice_identifier) {
+    match crate::appservice::unregister_appservice(&appservice_identifier).await {
         Err(e) => {
             return Err(AppError::public(format!(
                 "Failed to unregister appservice: {e}"
@@ -90,7 +91,7 @@ pub(super) async fn show_appservice_config(
     ctx: &Context<'_>,
     appservice_identifier: String,
 ) -> AppResult<()> {
-    match crate::appservice::get_registration(&appservice_identifier)? {
+    match crate::appservice::get_registration(&appservice_identifier).await? {
         None => return Err(AppError::public("Appservice does not exist.")),
         Some(config) => {
             let config_str = serde_saphyr::to_string(&config)?;
@@ -104,7 +105,7 @@ pub(super) async fn show_appservice_config(
 }
 
 pub(super) async fn list_registered(ctx: &Context<'_>) -> AppResult<()> {
-    let appservices = crate::appservice::all()?;
+    let appservices = crate::appservice::all().await?;
     let list = appservices.keys().collect::<Vec<_>>();
     let len = appservices.len();
     { write!(ctx, "Appservices ({len}): {list:?}") }.await?;

--- a/crates/server/src/admin/debug.rs
+++ b/crates/server/src/admin/debug.rs
@@ -24,7 +24,7 @@ pub(super) async fn echo(ctx: &Context<'_>, message: Vec<String>) -> AppResult<(
 }
 
 pub(super) async fn get_auth_chain(ctx: &Context<'_>, event_id: OwnedEventId) -> AppResult<()> {
-    let Ok(Some(event)) = timeline::get_pdu_json(&event_id) else {
+    let Ok(Some(event)) = timeline::get_pdu_json(&event_id).await else {
         return Err(AppError::public("Event not found."));
     };
 
@@ -37,7 +37,9 @@ pub(super) async fn get_auth_chain(ctx: &Context<'_>, event_id: OwnedEventId) ->
         .map_err(|_| Err(AppError::public("Invalid room id field in event in database")))?;
 
     let start = Instant::now();
-    let count = crate::room::auth_chain::get_auth_chain_ids(room_id, once(event_id.as_ref())).len();
+    let count = crate::room::auth_chain::get_auth_chain_ids(room_id, once(event_id.as_ref()))
+        .await
+        .len();
 
     let elapsed = start.elapsed();
     let out = format!("Loaded auth chain with length {count} in {elapsed:?}");
@@ -80,7 +82,7 @@ pub(super) async fn get_pdu(ctx: &Context<'_>, event_id: OwnedEventId) -> AppRes
 
     if pdu_json.is_err() {
         outlier = true;
-        pdu_json = timeline::get_pdu_json(&event_id);
+        pdu_json = timeline::get_pdu_json(&event_id).await;
     }
 
     match pdu_json {
@@ -294,8 +296,8 @@ pub(super) async fn ping(ctx: &Context<'_>, server: OwnedServerName) -> AppResul
 
 pub(super) async fn force_device_list_updates(ctx: &Context<'_>) -> AppResult<()> {
     // Force E2EE device list updates for all users
-    for user_id in crate::data::user::all_user_ids() {
-        if let Err(e) = crate::user::mark_device_key_update(user_id) {
+    for user_id in crate::data::user::all_user_ids().await {
+        if let Err(e) = crate::user::mark_device_key_update(user_id).await {
             warn!("Failed to mark device key update for user {user_id}: {e}");
         }
     }
@@ -391,7 +393,7 @@ pub(super) async fn verify_json(ctx: &Context<'_>, room_version: &RoomVersionId)
 pub(super) async fn verify_pdu(ctx: &Context<'_>, event_id: OwnedEventId, room_version: &RoomVersionId) -> AppResult<()> {
     use crate::core::signatures::Verified;
 
-    let Some(mut event) = timeline::get_pdu_json(&event_id)? else {
+    let Some(mut event) = timeline::get_pdu_json(&event_id).await? else {
         return Err(AppError::public("pdu not found in our database."));
     };
 
@@ -406,7 +408,7 @@ pub(super) async fn verify_pdu(ctx: &Context<'_>, event_id: OwnedEventId, room_v
 }
 
 pub(super) async fn first_pdu_in_room(ctx: &Context<'_>, room_id: OwnedRoomId) -> AppResult<()> {
-    if !crate::room::is_server_joined(config::server_name(), &room_id)? {
+    if !crate::room::is_server_joined(config::server_name(), &room_id).await? {
         return Err(AppError::public(
             "We are not participating in the room / we don't know about the room ID.",
         ));
@@ -422,13 +424,14 @@ pub(super) async fn first_pdu_in_room(ctx: &Context<'_>, room_id: OwnedRoomId) -
 }
 
 pub(super) async fn latest_pdu_in_room(ctx: &Context<'_>, room_id: OwnedRoomId) -> AppResult<()> {
-    if !crate::room::is_server_joined(config::server_name(), &room_id)? {
+    if !crate::room::is_server_joined(config::server_name(), &room_id).await? {
         return Err(AppError::public(
             "We are not participating in the room / we don't know about the room ID.",
         ));
     }
 
-    let latest_pdu = timeline::latest_pdu_in_room(&room_id)?
+    let latest_pdu = timeline::latest_pdu_in_room(&room_id)
+        .await?
         .map_err(|_| AppError::public("Failed to find the latest PDU in database"))?;
 
     let out = format!("{latest_pdu:?}");
@@ -440,7 +443,7 @@ pub(super) async fn force_set_room_state_from_server(
     room_id: OwnedRoomId,
     server_name: OwnedServerName,
 ) -> AppResult<()> {
-    if !crate::room::is_server_joined(config::server_name(), &room_id)? {
+    if !crate::room::is_server_joined(config::server_name(), &room_id).await? {
         return Err(AppError::public(
             "We are not participating in the room / we don't know about the room ID.",
         ));
@@ -450,7 +453,7 @@ pub(super) async fn force_set_room_state_from_server(
         .await
         .map_err(|_| AppError::public("Failed to find the latest PDU in database"))?;
 
-    let room_version = crate::room::get_version(&room_id)?;
+    let room_version = crate::room::get_version(&room_id).await?;
 
     let mut state: HashMap<u64, OwnedEventId> = HashMap::new();
 
@@ -527,17 +530,18 @@ pub(super) async fn force_set_room_state_from_server(
         shortstatehash: short_state_hash,
         added,
         removed,
-    } = crate::room::state::save_state(room_id.clone().as_ref(), new_room_state)?;
+    } = crate::room::state::save_state(room_id.clone().as_ref(), new_room_state).await?;
 
     let state_lock = crate::room::lock_state(&*room_id).await;
 
-    crate::room::state::force_state(room_id.clone().as_ref(), short_state_hash, added, removed)?;
+    crate::room::state::force_state(room_id.clone().as_ref(), short_state_hash, added, removed)
+        .await?;
 
     info!(
         "Updating joined counts for room just in case (e.g. we may have found a difference in \
 		 the room's m.room.member state"
     );
-    crate::room::update_currents(&room_id)?;
+    crate::room::update_currents(&room_id).await?;
     drop(state_lock);
     ctx.write_str("Successfully forced the room state from the requested remote server.")
         .await
@@ -571,7 +575,7 @@ pub(super) async fn get_signing_keys(
 pub(super) async fn get_verify_keys(ctx: &Context<'_>, server_name: Option<OwnedServerName>) -> AppResult<()> {
     let server_name = server_name.unwrap_or_else(|| config::server_name().to_owned());
 
-    let keys = crate::server_key::verify_keys_for(&server_name);
+    let keys = crate::server_key::verify_keys_for(&server_name).await;
 
     let mut out = String::new();
     writeln!(out, "| Key ID | Public Key |")?;

--- a/crates/server/src/admin/executor.rs
+++ b/crates/server/src/admin/executor.rs
@@ -155,7 +155,7 @@ impl Executor {
             return Ok(());
         };
 
-        let Ok(pdu) = timeline::get_pdu(&in_reply_to.event_id) else {
+        let Ok(pdu) = timeline::get_pdu(&in_reply_to.event_id).await else {
             error!(
                 event_id = ?in_reply_to.event_id,
                 "Missing admin command in_reply_to event"
@@ -163,7 +163,7 @@ impl Executor {
             return Ok(());
         };
 
-        let response_sender = if crate::room::is_admin_room(&pdu.room_id)? {
+        let response_sender = if crate::room::is_admin_room(&pdu.room_id).await? {
             config::server_user_id()
         } else {
             &pdu.sender
@@ -195,7 +195,7 @@ pub async fn send_text(body: &str) -> AppResult<()> {
 /// convenience).
 pub async fn send_message(message_content: RoomMessageEventContent) -> AppResult<()> {
     let user_id = &config::server_user_id();
-    let room_id = crate::room::get_admin_room()?;
+    let room_id = crate::room::get_admin_room().await?;
     respond_to_room(message_content, &room_id, user_id).await
 }
 
@@ -228,7 +228,7 @@ async fn respond_to_room(
     room_id: &RoomId,
     user_id: &UserId,
 ) -> AppResult<()> {
-    assert!(crate::room::is_admin_room(room_id)?, "sender is not admin");
+    assert!(crate::room::is_admin_room(room_id).await?, "sender is not admin");
 
     let state_lock = crate::room::lock_state(room_id).await;
 
@@ -236,7 +236,7 @@ async fn respond_to_room(
         PduBuilder::timeline(&content),
         user_id,
         room_id,
-        &crate::room::get_version(room_id)?,
+        &crate::room::get_version(room_id).await?,
         &state_lock,
     )
     .await
@@ -263,7 +263,7 @@ async fn handle_response_error(
         PduBuilder::timeline(&content),
         user_id,
         room_id,
-        &crate::room::get_version(room_id)?,
+        &crate::room::get_version(room_id).await?,
         state_lock,
     )
     .await?;

--- a/crates/server/src/admin/federation.rs
+++ b/crates/server/src/admin/federation.rs
@@ -30,12 +30,12 @@ pub(crate) enum FederationCommand {
 }
 
 pub(super) async fn disable_room(ctx: &Context<'_>, room_id: OwnedRoomId) -> AppResult<()> {
-    crate::room::disable_room(&room_id, true)?;
+    crate::room::disable_room(&room_id, true).await?;
     ctx.write_str("Room disabled.").await
 }
 
 pub(super) async fn enable_room(ctx: &Context<'_>, room_id: OwnedRoomId) -> AppResult<()> {
-    crate::room::disable_room(&room_id, false)?;
+    crate::room::disable_room(&room_id, false).await?;
     ctx.write_str("Room enabled.").await
 }
 
@@ -88,16 +88,16 @@ pub(super) async fn remote_user_in_rooms(ctx: &Context<'_>, user_id: OwnedUserId
         ));
     }
 
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(AppError::public(
             "Remote user does not exist in our database.",
         ));
     }
 
-    let mut rooms: Vec<RoomInfo> = data::user::joined_rooms(&user_id)?
-        .into_iter()
-        .map(|room_id| get_room_info(&room_id))
-        .collect();
+    let mut rooms: Vec<RoomInfo> = Vec::new();
+    for room_id in data::user::joined_rooms(&user_id).await? {
+        rooms.push(get_room_info(&room_id).await);
+    }
 
     if rooms.is_empty() {
         return Err(AppError::public("User is not in any rooms."));

--- a/crates/server/src/admin/media/cmd.rs
+++ b/crates/server/src/admin/media/cmd.rs
@@ -21,7 +21,7 @@ pub(super) async fn delete_media(
 
     if let Some(mxc) = mxc {
         trace!("Got MXC URL: {mxc}");
-        data::media::delete_media(mxc.server_name()?, mxc.media_id()?)?;
+        data::media::delete_media(mxc.server_name()?, mxc.media_id()?).await?;
 
         return Err(AppError::public(
             "Deleted the MXC from our database and on our filesystem.",
@@ -34,7 +34,7 @@ pub(super) async fn delete_media(
         let mut mxc_urls = Vec::with_capacity(4);
 
         // parsing the PDU for any MXC URLs begins here
-        match timeline::get_pdu_json(&event_id) {
+        match timeline::get_pdu_json(&event_id).await {
             Ok(Some(event_json)) => {
                 if let Some(content_key) = event_json.get("content") {
                     debug!("Event ID has \"content\".");
@@ -147,7 +147,7 @@ pub(super) async fn delete_media(
                 server_name,
                 media_id,
             } = mxc_url.as_str().try_into()?;
-            match data::media::delete_media(server_name, media_id) {
+            match data::media::delete_media(server_name, media_id).await {
                 Ok(()) => {
                     info!("Successfully deleted {mxc_url} from filesystem and database");
                     mxc_deletion_count = mxc_deletion_count.saturating_add(1);
@@ -204,7 +204,7 @@ pub(super) async fn delete_media_list(ctx: &Context<'_>) -> AppResult<()> {
 
     for mxc in &mxc_list {
         trace!(%failed_parsed_mxcs, %mxc_deletion_count, "Deleting MXC {mxc} in bulk");
-        match data::media::delete_media(mxc.server_name, mxc.media_id) {
+        match data::media::delete_media(mxc.server_name, mxc.media_id).await {
             Ok(()) => {
                 info!("Successfully deleted {mxc} from filesystem and database");
                 mxc_deletion_count = mxc_deletion_count.saturating_add(1);
@@ -277,6 +277,7 @@ pub(super) async fn delete_all_media_from_server(
     }
 
     let Ok(all_mxcs) = crate::media::get_all_mxcs()
+        .await
         .inspect_err(|e| error!("Failed to get MXC URIs from our database: {e}"))
     else {
         return Err(AppError::public("Failed to get MXC URIs from our database"));
@@ -323,7 +324,7 @@ pub(super) async fn get_file_info(ctx: &Context<'_>, mxc: OwnedMxcUri) -> AppRes
         server_name,
         media_id,
     } = mxc.as_str().try_into()?;
-    let metadata = data::media::get_metadata(server_name, media_id)?;
+    let metadata = data::media::get_metadata(server_name, media_id).await?;
 
     ctx.write_str(&format!("```\n{metadata:#?}\n```")).await
 }

--- a/crates/server/src/admin/room.rs
+++ b/crates/server/src/admin/room.rs
@@ -65,12 +65,16 @@ pub(super) async fn list_rooms(
 ) -> AppResult<()> {
     // TODO: i know there's a way to do this with clap, but i can't seem to find it
     let page = page.unwrap_or(1);
-    let mut rooms = crate::room::all_room_ids()?
-        .iter()
-        .filter(|room_id| !exclude_disabled || !crate::room::is_disabled(room_id).unwrap_or(false))
-        .filter(|room_id| !exclude_banned || !data::room::is_banned(room_id).unwrap_or(true))
-        .map(|room_id| get_room_info(room_id))
-        .collect::<Vec<_>>();
+    let mut rooms = Vec::new();
+    for room_id in crate::room::all_room_ids().await?.iter() {
+        if exclude_disabled && crate::room::is_disabled(room_id).await.unwrap_or(false) {
+            continue;
+        }
+        if exclude_banned && data::room::is_banned(room_id).await.unwrap_or(true) {
+            continue;
+        }
+        rooms.push(get_room_info(room_id).await);
+    }
 
     rooms.sort_by_key(|r| r.joined_members);
     rooms.reverse();
@@ -105,7 +109,7 @@ pub(super) async fn list_rooms(
 }
 
 pub(super) async fn exists(ctx: &Context<'_>, room_id: OwnedRoomId) -> AppResult<()> {
-    let result = crate::room::room_exists(&room_id)?;
+    let result = crate::room::room_exists(&room_id).await?;
 
     ctx.write_str(&format!("{result}")).await
 }

--- a/crates/server/src/admin/room/alias.rs
+++ b/crates/server/src/admin/room/alias.rs
@@ -42,7 +42,7 @@ pub(crate) enum RoomAliasCommand {
 }
 
 pub(super) async fn process(command: RoomAliasCommand, context: &Context<'_>) -> AppResult<()> {
-    let server_user = config::server_user();
+    let server_user = config::server_user().await;
 
     match command {
         RoomAliasCommand::Set {
@@ -64,9 +64,10 @@ pub(super) async fn process(command: RoomAliasCommand, context: &Context<'_>) ->
             };
             match command {
                 RoomAliasCommand::Set { force, room_id, .. } => {
-                    match (force, crate::room::resolve_local_alias(&room_alias)) {
+                    match (force, crate::room::resolve_local_alias(&room_alias).await) {
                         (true, Ok(id)) => {
-                            match crate::room::set_alias(&room_id, &room_alias, &server_user.id) {
+                            match crate::room::set_alias(&room_id, &room_alias, &server_user.id).await
+                            {
                                 Err(err) => {
                                     Err(AppError::public(format!("Failed to remove alias: {err}")))
                                 }
@@ -84,7 +85,8 @@ pub(super) async fn process(command: RoomAliasCommand, context: &Context<'_>) ->
 							 overwrite"
                         ))),
                         (_, Err(_)) => {
-                            match crate::room::set_alias(&room_id, &room_alias, &server_user.id) {
+                            match crate::room::set_alias(&room_id, &room_alias, &server_user.id).await
+                            {
                                 Err(err) => {
                                     Err(AppError::public(format!("Failed to remove alias: {err}")))
                                 }
@@ -94,7 +96,7 @@ pub(super) async fn process(command: RoomAliasCommand, context: &Context<'_>) ->
                     }
                 }
                 RoomAliasCommand::Remove { .. } => {
-                    match crate::room::resolve_local_alias(&room_alias) {
+                    match crate::room::resolve_local_alias(&room_alias).await {
                         Err(_) => Err(AppError::public("Alias isn't in use.")),
                         Ok(id) => {
                             match crate::room::remove_alias(&room_alias, &server_user).await {
@@ -109,7 +111,7 @@ pub(super) async fn process(command: RoomAliasCommand, context: &Context<'_>) ->
                     }
                 }
                 RoomAliasCommand::Which { .. } => {
-                    match crate::room::resolve_local_alias(&room_alias) {
+                    match crate::room::resolve_local_alias(&room_alias).await {
                         Err(_) => Err(AppError::public("Alias isn't in use.")),
                         Ok(id) => context.write_str(&format!("Alias resolves to {id}")).await,
                     }
@@ -119,7 +121,8 @@ pub(super) async fn process(command: RoomAliasCommand, context: &Context<'_>) ->
         }
         RoomAliasCommand::List { room_id } => {
             if let Some(room_id) = room_id {
-                let aliases: Vec<OwnedRoomAliasId> = crate::room::local_aliases_for_room(&room_id)?;
+                let aliases: Vec<OwnedRoomAliasId> =
+                    crate::room::local_aliases_for_room(&room_id).await?;
 
                 let plain_list = aliases.iter().fold(String::new(), |mut output, alias| {
                     writeln!(output, "- {alias}")
@@ -130,7 +133,7 @@ pub(super) async fn process(command: RoomAliasCommand, context: &Context<'_>) ->
                 let plain = format!("Aliases for {room_id}:\n{plain_list}");
                 context.write_str(&plain).await
             } else {
-                let aliases = crate::room::all_local_aliases()?;
+                let aliases = crate::room::all_local_aliases().await?;
 
                 let server_name = config::server_name();
                 let plain_list = aliases

--- a/crates/server/src/admin/room/directory.rs
+++ b/crates/server/src/admin/room/directory.rs
@@ -25,20 +25,20 @@ pub(crate) enum RoomDirectoryCommand {
 pub(super) async fn process(command: RoomDirectoryCommand, context: &Context<'_>) -> AppResult<()> {
     match command {
         RoomDirectoryCommand::Publish { room_id } => {
-            crate::room::directory::set_public(&room_id, true)?;
+            crate::room::directory::set_public(&room_id, true).await?;
             context.write_str("Room published").await
         }
         RoomDirectoryCommand::Unpublish { room_id } => {
-            crate::room::directory::set_public(&room_id, false)?;
+            crate::room::directory::set_public(&room_id, false).await?;
             context.write_str("Room unpublished").await
         }
         RoomDirectoryCommand::List { page } => {
             // TODO: i know there's a way to do this with clap, but i can't seem to find it
             let page = page.unwrap_or(1);
-            let mut rooms: Vec<_> = crate::room::public_room_ids()?
-                .into_iter()
-                .map(|room_id| get_room_info(&room_id))
-                .collect();
+            let mut rooms: Vec<_> = Vec::new();
+            for room_id in crate::room::public_room_ids().await?.into_iter() {
+                rooms.push(get_room_info(&room_id).await);
+            }
 
             rooms.sort_by_key(|r| r.joined_members);
             rooms.reverse();

--- a/crates/server/src/admin/room/info.rs
+++ b/crates/server/src/admin/room/info.rs
@@ -28,21 +28,22 @@ async fn list_joined_members(
     room_id: OwnedRoomId,
     local_only: bool,
 ) -> AppResult<()> {
-    let room_name = crate::room::get_name(&room_id).unwrap_or_else(|_| room_id.to_string());
+    let room_name = crate::room::get_name(&room_id)
+        .await
+        .unwrap_or_else(|_| room_id.to_string());
 
-    let member_info: Vec<_> = crate::room::joined_users(&room_id, None)?
-        .into_iter()
-        .filter(|user_id| if local_only { user_id.is_local() } else { true })
-        .map(|user_id| {
-            (
-                data::user::display_name(&user_id)
-                    .ok()
-                    .flatten()
-                    .unwrap_or_else(|| user_id.to_string()),
-                user_id,
-            )
-        })
-        .collect();
+    let mut member_info: Vec<_> = Vec::new();
+    for user_id in crate::room::joined_users(&room_id, None).await?.into_iter() {
+        if local_only && !user_id.is_local() {
+            continue;
+        }
+        let displayname = data::user::display_name(&user_id)
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| user_id.to_string());
+        member_info.push((displayname, user_id));
+    }
 
     let num = member_info.len();
     let body = member_info
@@ -58,7 +59,7 @@ async fn list_joined_members(
 }
 
 async fn view_room_topic(ctx: &Context<'_>, room_id: OwnedRoomId) -> AppResult<()> {
-    let Ok(room_topic) = crate::room::get_topic(&room_id) else {
+    let Ok(room_topic) = crate::room::get_topic(&room_id).await else {
         return Err(AppError::public("Room does not have a room topic set."));
     };
 

--- a/crates/server/src/admin/room/moderation.rs
+++ b/crates/server/src/admin/room/moderation.rs
@@ -43,7 +43,7 @@ async fn ban_room(ctx: &Context<'_>, room: OwnedRoomOrAliasId) -> AppResult<()> 
 
     let admin_room_alias = config::admin_alias();
 
-    if let Ok(admin_room_id) = crate::room::get_admin_room()
+    if let Ok(admin_room_id) = crate::room::get_admin_room().await
         && (room.to_string().eq(&admin_room_id) || room.to_string().eq(admin_room_alias))
     {
         return Err(AppError::public("Not allowed to ban the admin room."));
@@ -62,7 +62,7 @@ async fn ban_room(ctx: &Context<'_>, room: OwnedRoomOrAliasId) -> AppResult<()> 
         };
 
         debug!("Room specified is a room ID, banning room ID");
-        crate::room::ban_room(&room_id, true)?;
+        crate::room::ban_room(&room_id, true).await?;
 
         room_id.to_owned()
     } else if room.is_room_alias_id() {
@@ -82,7 +82,7 @@ async fn ban_room(ctx: &Context<'_>, room: OwnedRoomOrAliasId) -> AppResult<()> 
 			 locally, if not using get_alias_helper to fetch room ID remotely"
         );
 
-        let room_id = match crate::room::alias::resolve_local_alias(&room_alias) {
+        let room_id = match crate::room::alias::resolve_local_alias(&room_alias).await {
             Ok(room_id) => room_id,
             _ => {
                 debug!(
@@ -108,7 +108,7 @@ async fn ban_room(ctx: &Context<'_>, room: OwnedRoomOrAliasId) -> AppResult<()> 
             }
         };
 
-        crate::room::ban_room(&room_id, true)?;
+        crate::room::ban_room(&room_id, true).await?;
 
         room_id
     } else {
@@ -156,9 +156,9 @@ async fn ban_room(ctx: &Context<'_>, room: OwnedRoomOrAliasId) -> AppResult<()> 
     //     .await;
 
     // unpublish from room directory
-    crate::room::directory::set_public(&room_id, false)?;
+    crate::room::directory::set_public(&room_id, false).await?;
 
-    crate::room::disable_room(&room_id, true)?;
+    crate::room::disable_room(&room_id, true).await?;
 
     ctx.write_str(
         "Room banned, removed all our local users, and disabled incoming federation with room.",
@@ -190,7 +190,7 @@ async fn ban_list_of_rooms(ctx: &Context<'_>) -> AppResult<()> {
     for &room in &rooms_s {
         match <&RoomOrAliasId>::try_from(room) {
             Ok(room_alias_or_id) => {
-                if let Ok(admin_room_id) = crate::room::get_admin_room()
+                if let Ok(admin_room_id) = crate::room::get_admin_room().await
                     && (room.to_owned().eq(&admin_room_id) || room.to_owned().eq(admin_room_alias))
                 {
                     warn!("User specified admin room in bulk ban list, ignoring");
@@ -216,8 +216,8 @@ async fn ban_list_of_rooms(ctx: &Context<'_>) -> AppResult<()> {
                 if room_alias_or_id.is_room_alias_id() {
                     match RoomAliasId::parse(room_alias_or_id) {
                         Ok(room_alias) => {
-                            let room_id = match crate::room::alias::resolve_local_alias(&room_alias)
-                            {
+                            let room_id =
+                                match crate::room::alias::resolve_local_alias(&room_alias).await {
                                 Ok(room_id) => room_id,
                                 _ => {
                                     debug!(
@@ -270,13 +270,14 @@ async fn ban_list_of_rooms(ctx: &Context<'_>) -> AppResult<()> {
     }
 
     for room_id in room_ids {
-        crate::room::ban_room(&room_id, true)?;
+        crate::room::ban_room(&room_id, true).await?;
 
         debug!("Banned {room_id} successfully");
         room_ban_count = room_ban_count.saturating_add(1);
 
         debug!("Making all users leave the room {room_id} and forgetting it");
-        let users = crate::room::joined_users(&room_id, None)?
+        let users = crate::room::joined_users(&room_id, None)
+            .await?
             .into_iter()
             .filter(|user| user.is_local())
             .collect::<Vec<_>>();
@@ -291,7 +292,7 @@ async fn ban_list_of_rooms(ctx: &Context<'_>) -> AppResult<()> {
                 warn!("Failed to leave room: {e}");
             }
 
-            membership::forget_room(user_id, &room_id)?;
+            membership::forget_room(user_id, &room_id).await?;
         }
 
         // TODO: admin
@@ -309,8 +310,8 @@ async fn ban_list_of_rooms(ctx: &Context<'_>) -> AppResult<()> {
         //     .await;
 
         // unpublish from room directory, ignore errors
-        crate::room::directory::set_public(&room_id, false)?;
-        crate::room::disable_room(&room_id, true)?;
+        crate::room::directory::set_public(&room_id, false).await?;
+        crate::room::disable_room(&room_id, true).await?;
     }
 
     ctx.write_str(&format!(
@@ -334,7 +335,7 @@ async fn unban_room(ctx: &Context<'_>, room: OwnedRoomOrAliasId) -> AppResult<()
         };
 
         debug!("Room specified is a room ID, unbanning room ID");
-        crate::room::ban_room(&room_id, false)?;
+        crate::room::ban_room(&room_id, false).await?;
 
         room_id.to_owned()
     } else if room.is_room_alias_id() {
@@ -354,7 +355,7 @@ async fn unban_room(ctx: &Context<'_>, room: OwnedRoomOrAliasId) -> AppResult<()
 			 locally, if not using get_alias_helper to fetch room ID remotely"
         );
 
-        let room_id = match crate::room::alias::resolve_local_alias(&room_alias) {
+        let room_id = match crate::room::alias::resolve_local_alias(&room_alias).await {
             Ok(room_id) => room_id,
             _ => {
                 debug!(
@@ -380,7 +381,7 @@ async fn unban_room(ctx: &Context<'_>, room: OwnedRoomOrAliasId) -> AppResult<()
             }
         };
 
-        crate::room::ban_room(&room_id, false)?;
+        crate::room::ban_room(&room_id, false).await?;
 
         room_id
     } else {
@@ -391,22 +392,22 @@ async fn unban_room(ctx: &Context<'_>, room: OwnedRoomOrAliasId) -> AppResult<()
         ));
     };
 
-    crate::room::disable_room(&room_id, false)?;
+    crate::room::disable_room(&room_id, false).await?;
     ctx.write_str("Room unbanned and federation re-enabled.")
         .await
 }
 
 async fn list_banned_rooms(ctx: &Context<'_>, no_details: bool) -> AppResult<()> {
-    let room_ids: Vec<OwnedRoomId> = crate::room::list_banned_rooms()?;
+    let room_ids: Vec<OwnedRoomId> = crate::room::list_banned_rooms().await?;
 
     if room_ids.is_empty() {
         return Err(AppError::public("No rooms are banned."));
     }
 
-    let mut rooms = room_ids
-        .iter()
-        .map(|room_id| get_room_info(room_id))
-        .collect::<Vec<_>>();
+    let mut rooms = Vec::new();
+    for room_id in room_ids.iter() {
+        rooms.push(get_room_info(room_id).await);
+    }
 
     rooms.sort_by_key(|r| r.joined_members);
     rooms.reverse();

--- a/crates/server/src/admin/user/cmd.rs
+++ b/crates/server/src/admin/user/cmd.rs
@@ -12,7 +12,7 @@ const AUTO_GEN_PASSWORD_LENGTH: usize = 25;
 const BULK_JOIN_REASON: &str = "Bulk force joining this room as initiated by the server admin.";
 
 pub(super) async fn list_users(ctx: &Context<'_>) -> AppResult<()> {
-    let users: Vec<_> = crate::user::list_local_users()?;
+    let users: Vec<_> = crate::user::list_local_users().await?;
 
     let mut plain_msg = format!("Found {} local user account(s):\n```\n", users.len());
     plain_msg += users
@@ -43,14 +43,14 @@ pub(super) async fn create_user(
         )));
     }
 
-    if data::user::user_exists(&user_id)? {
+    if data::user::user_exists(&user_id).await? {
         return Err(AppError::public(format!("User {user_id} already exists")));
     }
 
     let password = password.unwrap_or_else(|| utils::random_string(AUTO_GEN_PASSWORD_LENGTH));
 
     // Create user
-    crate::user::create_user(&user_id, Some(password.as_str()))?;
+    crate::user::create_user(&user_id, Some(password.as_str())).await?;
 
     // Default to pretty displayname
     let display_name = user_id.localpart().to_owned();
@@ -65,7 +65,7 @@ pub(super) async fn create_user(
     //     )?;
     // }
 
-    crate::data::user::set_display_name(&user_id, &display_name)?;
+    crate::data::user::set_display_name(&user_id, &display_name).await?;
 
     // Initial account data
     crate::user::set_data(
@@ -77,7 +77,8 @@ pub(super) async fn create_user(
                 global: crate::core::push::Ruleset::server_default(&user_id),
             },
         })?,
-    )?;
+    )
+    .await?;
 
     if !conf.auto_join_rooms.is_empty() {
         for room in &conf.auto_join_rooms {
@@ -89,13 +90,13 @@ pub(super) async fn create_user(
                 continue;
             };
 
-            if !crate::room::is_server_joined(config::server_name(), &room_id)? {
+            if !crate::room::is_server_joined(config::server_name(), &room_id).await? {
                 warn!("Skipping room {room} to automatically join as we have never joined before.");
                 continue;
             }
 
             if let Ok(room_server_name) = room.server_name() {
-                let user = data::user::get_user(&user_id)?;
+                let user = data::user::get_user(&user_id).await?;
                 match membership::join_room(
                     &user,
                     None,
@@ -132,9 +133,12 @@ pub(super) async fn create_user(
 
     // if this account creation is from the CLI / --execute, invite the first user
     // to admin room
-    if let Ok(admin_room) = crate::room::get_admin_room() {
-        if crate::room::joined_member_count(&admin_room).is_ok_and(|c| c == 1) {
-            crate::user::make_user_admin(&user_id)?;
+    if let Ok(admin_room) = crate::room::get_admin_room().await {
+        if crate::room::joined_member_count(&admin_room)
+            .await
+            .is_ok_and(|c| c == 1)
+        {
+            crate::user::make_user_admin(&user_id).await?;
             warn!("Granting {user_id} admin privileges as the first user");
         }
     } else {
@@ -171,7 +175,7 @@ pub(super) async fn deactivate(
         ))
         .await?;
 
-        let all_joined_rooms: Vec<OwnedRoomId> = data::user::joined_rooms(&user_id)?;
+        let all_joined_rooms: Vec<OwnedRoomId> = data::user::joined_rooms(&user_id).await?;
 
         full_user_deactivate(&user_id, &all_joined_rooms).await?;
 
@@ -197,7 +201,7 @@ pub(super) async fn reset_password(
 
     let new_password = password.unwrap_or_else(|| utils::random_string(AUTO_GEN_PASSWORD_LENGTH));
 
-    match crate::user::set_password(&user_id, new_password.as_str()) {
+    match crate::user::set_password(&user_id, new_password.as_str()).await {
         Err(e) => {
             return Err(AppError::public(format!(
                 "Couldn't reset the password for user {user_id}: {e}"
@@ -245,7 +249,7 @@ pub(super) async fn deactivate_all(
                 continue;
             }
             Ok(user_id) => {
-                if crate::data::user::is_admin(&user_id)? && !force {
+                if crate::data::user::is_admin(&user_id).await? && !force {
                     crate::admin::send_text(&format!(
                         "{username} is an admin and --force is not set, skipping over"
                     ))
@@ -281,7 +285,7 @@ pub(super) async fn deactivate_all(
                 deactivation_count = deactivation_count.saturating_add(1);
                 if !no_leave_rooms {
                     info!("Forcing user {user_id} to leave all rooms apart of deactivate-all");
-                    let all_joined_rooms = data::user::joined_rooms(&user_id)?;
+                    let all_joined_rooms = data::user::joined_rooms(&user_id).await?;
 
                     full_user_deactivate(&user_id, &all_joined_rooms).await?;
 
@@ -308,10 +312,10 @@ pub(super) async fn list_joined_rooms(ctx: &Context<'_>, user_id: String) -> App
     // Validate user id
     let user_id = parse_local_user_id(&user_id)?;
 
-    let mut rooms: Vec<_> = data::user::joined_rooms(&user_id)?
-        .iter()
-        .map(|room_id| get_room_info(room_id))
-        .collect();
+    let mut rooms: Vec<_> = Vec::new();
+    for room_id in data::user::joined_rooms(&user_id).await?.iter() {
+        rooms.push(get_room_info(room_id).await);
+    }
 
     if rooms.is_empty() {
         return Err(AppError::public("User is not in any rooms."));
@@ -359,7 +363,7 @@ pub(super) async fn force_join_list_of_local_users(
         ));
     }
 
-    let Ok(admin_room) = crate::room::get_admin_room() else {
+    let Ok(admin_room) = crate::room::get_admin_room().await else {
         return Err(AppError::public(
             "There is not an admin room to check for server admins.",
         ));
@@ -367,13 +371,14 @@ pub(super) async fn force_join_list_of_local_users(
 
     let (room_id, servers) = crate::room::alias::resolve_with_servers(&room_id, None).await?;
 
-    if !crate::room::is_server_joined(config::server_name(), &room_id)? {
+    if !crate::room::is_server_joined(config::server_name(), &room_id).await? {
         return Err(AppError::public("We are not joined in this room."));
     }
 
-    let server_admins: Vec<_> = crate::room::active_local_users_in_room(&admin_room)?;
+    let server_admins: Vec<_> = crate::room::active_local_users_in_room(&admin_room).await?;
 
-    if !crate::room::joined_users(&room_id, None)?
+    if !crate::room::joined_users(&room_id, None)
+        .await?
         .iter()
         .any(|user_id| server_admins.contains(&user_id.to_owned()))
     {
@@ -420,7 +425,7 @@ pub(super) async fn force_join_list_of_local_users(
     let mut successful_joins: usize = 0;
 
     for user_id in user_ids {
-        let user = data::user::get_user(&user_id)?;
+        let user = data::user::get_user(&user_id).await?;
         match membership::join_room(
             &user,
             None,
@@ -462,7 +467,7 @@ pub(super) async fn force_join_all_local_users(
         ));
     }
 
-    let Ok(admin_room) = crate::room::get_admin_room() else {
+    let Ok(admin_room) = crate::room::get_admin_room().await else {
         return Err(AppError::public(
             "There is not an admin room to check for server admins.",
         ));
@@ -470,13 +475,14 @@ pub(super) async fn force_join_all_local_users(
 
     let (room_id, servers) = crate::room::alias::resolve_with_servers(&room_id, None).await?;
 
-    if !crate::room::is_server_joined(config::server_name(), &room_id)? {
+    if !crate::room::is_server_joined(config::server_name(), &room_id).await? {
         return Err(AppError::public("we are not joined in this room"));
     }
 
-    let server_admins: Vec<_> = crate::room::active_local_users_in_room(&admin_room)?;
+    let server_admins: Vec<_> = crate::room::active_local_users_in_room(&admin_room).await?;
 
-    if !crate::room::joined_users(&room_id, None)?
+    if !crate::room::joined_users(&room_id, None)
+        .await?
         .iter()
         .any(|user_id| server_admins.contains(&user_id.to_owned()))
     {
@@ -488,8 +494,8 @@ pub(super) async fn force_join_all_local_users(
     let mut failed_joins: usize = 0;
     let mut successful_joins: usize = 0;
 
-    for user_id in &data::user::list_local_users()? {
-        let user = data::user::get_user(user_id)?;
+    for user_id in &data::user::list_local_users().await? {
+        let user = data::user::get_user(user_id).await?;
         match membership::join_room(
             &user,
             None,
@@ -528,7 +534,7 @@ pub(super) async fn force_join_room(
     let (room_id, servers) = crate::room::alias::resolve_with_servers(&room_id, None).await?;
 
     assert!(user_id.is_local(), "parsed user_id must be a local user");
-    let user = data::user::get_user(&user_id)?;
+    let user = data::user::get_user(&user_id).await?;
     membership::join_room(
         &user,
         None,
@@ -555,7 +561,7 @@ pub(super) async fn force_leave_room(
 
     assert!(user_id.is_local(), "parsed user_id must be a local user");
 
-    if !crate::room::user::is_joined(&user_id, &room_id)? {
+    if !crate::room::user::is_joined(&user_id, &room_id).await? {
         return Err(AppError::public("{user_id} is not joined in the room"));
     }
 
@@ -572,18 +578,18 @@ pub(super) async fn force_demote(
 ) -> AppResult<()> {
     let user_id = parse_local_user_id(&user_id)?;
     let room_id = crate::room::alias::resolve(&room_id).await?;
-    let room_version = crate::room::get_version(&room_id)?;
+    let room_version = crate::room::get_version(&room_id).await?;
     let version_rule = crate::room::get_version_rules(&room_version)?;
 
     assert!(user_id.is_local(), "parsed user_id must be a local user");
     let state_lock = crate::room::lock_state(&room_id).await;
     let room_power_levels = crate::room::get_power_levels(&room_id).await.ok();
 
-    let user_can_demote_self =
-        room_power_levels.as_ref().is_some_and(|power_levels| {
-            power_levels.user_can_change_user_power_level(&user_id, &user_id)
-        }) || crate::room::get_state(&room_id, &StateEventType::RoomCreate, "", None)
-            .is_ok_and(|event| event.sender == user_id);
+    let user_can_demote_self = room_power_levels.as_ref().is_some_and(|power_levels| {
+        power_levels.user_can_change_user_power_level(&user_id, &user_id)
+    }) || crate::room::get_state(&room_id, &StateEventType::RoomCreate, "", None)
+        .await
+        .is_ok_and(|event| event.sender == user_id);
 
     if !user_can_demote_self {
         return Err(AppError::public(
@@ -618,7 +624,7 @@ pub(super) async fn make_user_admin(ctx: &Context<'_>, user_id: String) -> AppRe
     let user_id = parse_local_user_id(&user_id)?;
     assert!(user_id.is_local(), "Parsed user_id must be a local user");
 
-    crate::user::make_user_admin(&user_id)?;
+    crate::user::make_user_admin(&user_id).await?;
 
     ctx.write_str(&format!("{user_id} has been granted admin privileges.",))
         .await
@@ -636,6 +642,7 @@ pub(super) async fn put_room_tag(
         Some(&room_id),
         &RoomAccountDataEventType::Tag.to_string(),
     )
+    .await
     .unwrap_or_default();
 
     tags_event_content
@@ -647,7 +654,8 @@ pub(super) async fn put_room_tag(
         Some(room_id.clone()),
         &RoomAccountDataEventType::Tag.to_string(),
         serde_json::to_value(tags_event_content).expect("to json value always works"),
-    )?;
+    )
+    .await?;
 
     ctx.write_str(&format!(
         "Successfully updated room account data for {user_id} and room {room_id} with tag {tag}"
@@ -667,6 +675,7 @@ pub(super) async fn delete_room_tag(
         Some(&room_id),
         &RoomAccountDataEventType::Tag.to_string(),
     )
+    .await
     .unwrap_or_default();
 
     tags_event_content.tags.remove(&tag.clone().into());
@@ -676,7 +685,8 @@ pub(super) async fn delete_room_tag(
         Some(room_id.clone()),
         &RoomAccountDataEventType::Tag.to_string(),
         serde_json::to_value(tags_event_content).expect("to json value always works"),
-    )?;
+    )
+    .await?;
 
     ctx.write_str(&format!(
         "Successfully updated room account data for {user_id} and room {room_id}, deleting room \
@@ -696,6 +706,7 @@ pub(super) async fn get_room_tags(
         Some(&room_id),
         &RoomAccountDataEventType::Tag.to_string(),
     )
+    .await
     .unwrap_or_default();
 
     ctx.write_str(&format!("```\n{:#?}\n```", tags_event_content.tags))
@@ -703,7 +714,7 @@ pub(super) async fn get_room_tags(
 }
 
 pub(super) async fn redact_event(ctx: &Context<'_>, event_id: OwnedEventId) -> AppResult<()> {
-    let Ok(Some(event)) = timeline::get_non_outlier_pdu(&event_id) else {
+    let Ok(Some(event)) = timeline::get_non_outlier_pdu(&event_id).await else {
         return Err(AppError::public("event does not exist in our database"));
     };
 
@@ -734,7 +745,7 @@ pub(super) async fn redact_event(ctx: &Context<'_>, event_id: OwnedEventId) -> A
             },
             &event.sender,
             &event.room_id,
-            &crate::room::get_version(&event.room_id)?,
+            &crate::room::get_version(&event.room_id).await?,
             &state_lock,
         )
         .await?

--- a/crates/server/src/admin/utils.rs
+++ b/crates/server/src/admin/utils.rs
@@ -35,13 +35,13 @@ pub(crate) fn parse_local_user_id(user_id: &str) -> AppResult<OwnedUserId> {
 pub(crate) async fn parse_active_local_user_id(user_id: &str) -> AppResult<OwnedUserId> {
     let user_id = parse_local_user_id(user_id)?;
 
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(AppError::public(
             "user {user_id:?} does not exist on this server.",
         ));
     }
 
-    if data::user::is_deactivated(&user_id)? {
+    if data::user::is_deactivated(&user_id).await? {
         return Err(AppError::public("user {user_id:?} is deactivated."));
     }
 

--- a/crates/server/src/appservice.rs
+++ b/crates/server/src/appservice.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::time::Duration;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use regex::RegexSet;
 use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
@@ -271,11 +272,12 @@ impl TryFrom<DbRegistration> for Registration {
 }
 
 /// Registers an appservice and returns the ID to the caller
-pub fn register_appservice(registration: Registration) -> AppResult<String> {
+pub async fn register_appservice(registration: Registration) -> AppResult<String> {
     let db_registration: DbRegistration = registration.into();
     diesel::insert_into(appservice_registrations::table)
         .values(&db_registration)
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(db_registration.id)
 }
 
@@ -284,22 +286,27 @@ pub fn register_appservice(registration: Registration) -> AppResult<String> {
 /// # Arguments
 ///
 /// * `service_name` - the name you send to register the service previously
-pub fn unregister_appservice(id: &str) -> AppResult<()> {
-    diesel::delete(appservice_registrations::table.find(id)).execute(&mut connect()?)?;
+pub async fn unregister_appservice(id: &str) -> AppResult<()> {
+    diesel::delete(appservice_registrations::table.find(id))
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
 /// Set the `disabled` flag on an appservice. Returns true if a row was updated.
-pub fn set_appservice_disabled(id: &str, disabled: bool) -> AppResult<bool> {
+pub async fn set_appservice_disabled(id: &str, disabled: bool) -> AppResult<bool> {
     let affected = diesel::update(appservice_registrations::table.find(id))
         .set(appservice_registrations::disabled.eq(disabled))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(affected > 0)
 }
 
 /// List all registrations in the database, including disabled ones.
-pub fn list_all_registrations() -> AppResult<Vec<(DbRegistration, bool)>> {
-    let regs = appservice_registrations::table.load::<DbRegistration>(&mut connect()?)?;
+pub async fn list_all_registrations() -> AppResult<Vec<(DbRegistration, bool)>> {
+    let regs = appservice_registrations::table
+        .load::<DbRegistration>(&mut connect().await?)
+        .await?;
     Ok(regs
         .into_iter()
         .map(|r| {
@@ -309,10 +316,11 @@ pub fn list_all_registrations() -> AppResult<Vec<(DbRegistration, bool)>> {
         .collect())
 }
 
-pub fn get_registration(id: &str) -> AppResult<Option<Registration>> {
+pub async fn get_registration(id: &str) -> AppResult<Option<Registration>> {
     if let Some(registration) = appservice_registrations::table
         .find(id)
-        .first::<DbRegistration>(&mut connect()?)
+        .first::<DbRegistration>(&mut connect().await?)
+        .await
         .optional()?
     {
         Ok(Some(registration.try_into()?))
@@ -323,7 +331,8 @@ pub fn get_registration(id: &str) -> AppResult<Option<Registration>> {
 pub async fn find_from_token(token: &str) -> AppResult<Option<RegistrationInfo>> {
     // Constant-time comparison so we don't leak `as_token` bytes via
     // response timing. The same pattern is used in `hoops/auth.rs`.
-    Ok(all()?
+    Ok(all()
+        .await?
         .values()
         .find(|info| {
             info.registration
@@ -336,8 +345,8 @@ pub async fn find_from_token(token: &str) -> AppResult<Option<RegistrationInfo>>
 }
 
 // Checks if a given user id matches any exclusive appservice regex
-pub fn is_exclusive_user_id(user_id: &UserId) -> AppResult<bool> {
-    for info in all()?.values() {
+pub async fn is_exclusive_user_id(user_id: &UserId) -> AppResult<bool> {
+    for info in all().await?.values() {
         if info.is_exclusive_user_match(user_id) {
             return Ok(true);
         }
@@ -347,7 +356,7 @@ pub fn is_exclusive_user_id(user_id: &UserId) -> AppResult<bool> {
 
 // Checks if a given room alias matches any exclusive appservice regex
 pub async fn is_exclusive_alias(alias: &RoomAliasId) -> AppResult<bool> {
-    for info in all()?.values() {
+    for info in all().await?.values() {
         if info.aliases.is_exclusive_match(alias.as_str()) {
             return Ok(true);
         }
@@ -357,7 +366,7 @@ pub async fn is_exclusive_alias(alias: &RoomAliasId) -> AppResult<bool> {
 
 // Checks if a given room id matches any exclusive appservice regex
 pub async fn is_exclusive_room_id(room_id: &RoomId) -> AppResult<bool> {
-    for info in all()?.values() {
+    for info in all().await?.values() {
         if info.rooms.is_exclusive_match(room_id.as_str()) {
             return Ok(true);
         }
@@ -365,10 +374,11 @@ pub async fn is_exclusive_room_id(room_id: &RoomId) -> AppResult<bool> {
     Ok(false)
 }
 
-pub fn all() -> AppResult<BTreeMap<String, RegistrationInfo>> {
+pub async fn all() -> AppResult<BTreeMap<String, RegistrationInfo>> {
     let registrations = appservice_registrations::table
         .filter(appservice_registrations::disabled.eq(false))
-        .load::<DbRegistration>(&mut connect()?)?;
+        .load::<DbRegistration>(&mut connect().await?)
+        .await?;
     Ok(registrations
         .into_iter()
         .filter_map(|db_registration| {
@@ -420,7 +430,8 @@ pub(crate) async fn send_request(
     *request.timeout_mut() = Some(Duration::from_secs(30));
 
     let url = request.url().clone();
-    let response = match sending::default_client().execute(request).await {
+    let client = sending::default_client();
+    let response = match reqwest::Client::execute(&client, request).await {
         Ok(r) => r,
         Err(e) => {
             warn!(

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -231,8 +231,8 @@ pub fn server_user_id() -> &'static UserId {
     })
 }
 
-pub fn server_user() -> crate::data::user::DbUser {
-    crate::data::user::get_user(server_user_id()).expect("server user should exist in the database")
+pub async fn server_user() -> crate::data::user::DbUser {
+    crate::data::user::get_user(server_user_id()).await.expect("server user should exist in the database")
 }
 
 pub fn server_name() -> &'static ServerName {

--- a/crates/server/src/directory.rs
+++ b/crates/server/src/directory.rs
@@ -36,11 +36,11 @@ pub async fn get_public_rooms(
 
         Ok(body)
     } else {
-        get_local_public_rooms(limit, since, filter, network)
+        get_local_public_rooms(limit, since, filter, network).await
     }
 }
 
-fn get_local_public_rooms(
+async fn get_local_public_rooms(
     limit: Option<usize>,
     since: Option<&str>,
     filter: &PublicRoomFilter,
@@ -71,71 +71,72 @@ fn get_local_public_rooms(
         .generic_search_term
         .as_ref()
         .map(|q| q.to_lowercase());
-    let public_room_ids = room::public_room_ids()?;
-    let mut all_rooms: Vec<_> = public_room_ids
-        .into_iter()
-        .map(|room_id| {
+    let public_room_ids = room::public_room_ids().await?;
+    let mut all_rooms: Vec<PublicRoomsChunk> = Vec::new();
+    for room_id in public_room_ids.into_iter() {
+        let build_chunk = async {
             let chunk = PublicRoomsChunk {
-                canonical_alias: room::get_canonical_alias(&room_id).ok().flatten(),
-                name: room::get_name(&room_id).ok(),
-                num_joined_members: room::joined_member_count(&room_id).unwrap_or_else(|_| {
+                canonical_alias: room::get_canonical_alias(&room_id).await.ok().flatten(),
+                name: room::get_name(&room_id).await.ok(),
+                num_joined_members: room::joined_member_count(&room_id).await.unwrap_or_else(|_| {
                     warn!("Room {} has no member count", room_id);
                     0
                 }),
-                topic: room::get_topic(&room_id).ok(),
-                world_readable: room::is_world_readable(&room_id),
-                guest_can_join: room::guest_can_join(&room_id),
-                avatar_url: room::get_avatar_url(&room_id).ok().flatten(),
+                topic: room::get_topic(&room_id).await.ok(),
+                world_readable: room::is_world_readable(&room_id).await,
+                guest_can_join: room::guest_can_join(&room_id).await,
+                avatar_url: room::get_avatar_url(&room_id).await.ok().flatten(),
                 join_rule: room::get_state_content::<RoomJoinRulesEventContent>(
                     &room_id,
                     &StateEventType::RoomJoinRules,
                     "",
                     None,
                 )
-                .map(|c| match c.join_rule {
+                .await.map(|c| match c.join_rule {
                     JoinRule::Public => Some(PublicRoomJoinRule::Public),
                     JoinRule::Knock => Some(PublicRoomJoinRule::Knock),
                     JoinRule::KnockRestricted(..) => Some(PublicRoomJoinRule::KnockRestricted),
                     _ => None,
                 })?
                 .ok_or_else(|| AppError::public("Missing room join rule event for room."))?,
-                room_type: room::get_room_type(&room_id).ok().flatten(),
+                room_type: room::get_room_type(&room_id).await.ok().flatten(),
                 room_id,
             };
-            Ok(chunk)
-        })
-        .filter_map(|r: AppResult<_>| r.ok()) // Filter out buggy rooms
-        .filter(|chunk| {
-            if let Some(search_term) = &search_term {
-                if let Some(name) = &chunk.name
-                    && name.as_str().to_lowercase().contains(search_term)
-                {
-                    return true;
-                }
+            Ok::<_, AppError>(chunk)
+        };
 
-                if let Some(topic) = &chunk.topic
-                    && topic.to_lowercase().contains(search_term)
-                {
-                    return true;
-                }
+        // Filter out buggy rooms
+        let Ok(chunk) = build_chunk.await else {
+            continue;
+        };
 
-                if let Some(canonical_alias) = &chunk.canonical_alias
-                    && canonical_alias
+        let matches = if let Some(search_term) = &search_term {
+            if let Some(name) = &chunk.name
+                && name.as_str().to_lowercase().contains(search_term)
+            {
+                true
+            } else if let Some(topic) = &chunk.topic
+                && topic.to_lowercase().contains(search_term)
+            {
+                true
+            } else {
+                chunk.canonical_alias.as_ref().is_some_and(|canonical_alias| {
+                    canonical_alias
                         .as_str()
                         .to_lowercase()
                         .contains(search_term)
-                {
-                    return true;
-                }
-
-                false
-            } else {
-                // No search term
-                true
+                })
             }
-        })
-        // We need to collect all, so we can sort by member count
-        .collect();
+        } else {
+            // No search term
+            true
+        };
+
+        if matches {
+            // We need to collect all, so we can sort by member count
+            all_rooms.push(chunk);
+        }
+    }
 
     all_rooms.sort_by(|l, r| r.num_joined_members.cmp(&l.num_joined_members));
 

--- a/crates/server/src/event.rs
+++ b/crates/server/src/event.rs
@@ -273,7 +273,7 @@ pub fn parse_fetched_pdu(
             // Event could not be converted to canonical json
             error!(value = ?value, "error generating event id for fetched pdu: {:?}", e);
             return Err(
-                MatrixError::invalid_param("could not convert event to canonical json").into(),
+                MatrixError::bad_json("could not convert event to canonical json").into(),
             );
         }
     };

--- a/crates/server/src/event.rs
+++ b/crates/server/src/event.rs
@@ -10,6 +10,7 @@ pub mod search;
 use std::collections::BTreeSet;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 pub use outlier::*;
 
 use crate::core::identifiers::*;
@@ -46,14 +47,15 @@ pub fn gen_event_id(
     Ok(event_id)
 }
 
-pub fn ensure_event_sn(
+pub async fn ensure_event_sn(
     room_id: &RoomId,
     event_id: &EventId,
 ) -> AppResult<(Seqnum, Option<SeqnumQueueGuard>)> {
     if let Some(sn) = event_points::table
         .find(event_id)
         .select(event_points::event_sn)
-        .first::<Seqnum>(&mut connect()?)
+        .first::<Seqnum>(&mut connect().await?)
+        .await
         .optional()?
     {
         Ok((sn, None))
@@ -65,62 +67,70 @@ pub fn ensure_event_sn(
             ))
             .on_conflict_do_nothing()
             .returning(event_points::event_sn)
-            .get_result::<Seqnum>(&mut connect()?)?;
+            .get_result::<Seqnum>(&mut connect().await?)
+            .await?;
 
         diesel::update(events::table.find(event_id))
             .set(events::sn.eq(sn))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
 
         diesel::update(event_datas::table.find(event_id))
             .set(event_datas::event_sn.eq(sn))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
 
         Ok((sn, Some(crate::queue_seqnum(sn))))
     }
 }
 /// Returns the `count` of this pdu's id.
-pub fn get_event_sn(event_id: &EventId) -> AppResult<Seqnum> {
+pub async fn get_event_sn(event_id: &EventId) -> AppResult<Seqnum> {
     event_points::table
         .find(event_id)
         .select(event_points::event_sn)
-        .first::<Seqnum>(&mut connect()?)
+        .first::<Seqnum>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
-pub fn get_live_token(event_id: &EventId) -> AppResult<BatchToken> {
+pub async fn get_live_token(event_id: &EventId) -> AppResult<BatchToken> {
     events::table
         .find(event_id)
         .select((events::sn, events::depth))
-        .first::<(Seqnum, i64)>(&mut connect()?)
+        .first::<(Seqnum, i64)>(&mut connect().await?)
+        .await
         .map(|(sn, _depth)| BatchToken::new_live(sn))
         .map_err(Into::into)
 }
-pub fn get_historic_token(event_id: &EventId) -> AppResult<BatchToken> {
+pub async fn get_historic_token(event_id: &EventId) -> AppResult<BatchToken> {
     events::table
         .find(event_id)
         .select((events::sn, events::depth))
-        .first::<(Seqnum, i64)>(&mut connect()?)
+        .first::<(Seqnum, i64)>(&mut connect().await?)
+        .await
         .map(|(sn, depth)| BatchToken::new_historic(sn, depth))
         .map_err(Into::into)
 }
-pub fn get_historic_token_by_sn(event_sn: Seqnum) -> AppResult<BatchToken> {
+pub async fn get_historic_token_by_sn(event_sn: Seqnum) -> AppResult<BatchToken> {
     events::table
         .filter(events::sn.eq(event_sn))
         .select((events::sn, events::depth))
-        .first::<(Seqnum, i64)>(&mut connect()?)
+        .first::<(Seqnum, i64)>(&mut connect().await?)
+        .await
         .map(|(sn, depth)| BatchToken::new_historic(sn, depth))
         .map_err(Into::into)
 }
 
-pub fn get_event_id_by_sn(event_sn: Seqnum) -> AppResult<OwnedEventId> {
+pub async fn get_event_id_by_sn(event_sn: Seqnum) -> AppResult<OwnedEventId> {
     event_points::table
         .filter(event_points::event_sn.eq(event_sn))
         .select(event_points::event_id)
-        .first::<OwnedEventId>(&mut connect()?)
+        .first::<OwnedEventId>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
-pub fn get_event_for_timestamp(
+pub async fn get_event_for_timestamp(
     room_id: &RoomId,
     timestamp: UnixMillis,
     dir: Direction,
@@ -138,7 +148,8 @@ pub fn get_event_for_timestamp(
                     events::stream_ordering.asc(),
                 ))
                 .select((events::id, events::origin_server_ts))
-                .first::<(OwnedEventId, UnixMillis)>(&mut connect()?)?;
+                .first::<(OwnedEventId, UnixMillis)>(&mut connect().await?)
+                .await?;
             Ok((local_event_id, origin_server_ts))
         }
         Direction::Backward => {
@@ -153,7 +164,8 @@ pub fn get_event_for_timestamp(
                     events::stream_ordering.desc(),
                 ))
                 .select((events::id, events::origin_server_ts))
-                .first::<(OwnedEventId, UnixMillis)>(&mut connect()?)?;
+                .first::<(OwnedEventId, UnixMillis)>(&mut connect().await?)
+                .await?;
             Ok((local_event_id, origin_server_ts))
         }
     }
@@ -165,30 +177,33 @@ pub fn get_event_for_timestamp(
     // let local_event = None;
 }
 
-pub fn get_event_sn_and_ty(event_id: &EventId) -> AppResult<(Seqnum, String)> {
+pub async fn get_event_sn_and_ty(event_id: &EventId) -> AppResult<(Seqnum, String)> {
     let (sn, ty) = events::table
         .find(event_id)
         .select((events::sn, events::ty))
-        .first::<(Seqnum, String)>(&mut connect()?)?;
+        .first::<(Seqnum, String)>(&mut connect().await?)
+        .await?;
     Ok((sn, ty))
 }
 
-pub fn get_db_event(event_id: &EventId) -> AppResult<DbEvent> {
+pub async fn get_db_event(event_id: &EventId) -> AppResult<DbEvent> {
     events::table
         .find(event_id)
-        .first::<DbEvent>(&mut connect()?)
+        .first::<DbEvent>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
-pub fn get_frame_id(room_id: &RoomId, event_sn: Seqnum) -> AppResult<i64> {
+pub async fn get_frame_id(room_id: &RoomId, event_sn: Seqnum) -> AppResult<i64> {
     event_points::table
         .filter(event_points::room_id.eq(room_id))
         .filter(event_points::event_sn.eq(event_sn))
         .select(event_points::frame_id)
-        .first::<Option<i64>>(&mut connect()?)?
+        .first::<Option<i64>>(&mut connect().await?)
+        .await?
         .ok_or(MatrixError::not_found("room frame id is not found").into())
 }
-pub fn get_last_frame_id(room_id: &RoomId, before_sn: Option<Seqnum>) -> AppResult<i64> {
+pub async fn get_last_frame_id(room_id: &RoomId, before_sn: Option<Seqnum>) -> AppResult<i64> {
     if let Some(before_sn) = before_sn {
         event_points::table
             .filter(event_points::room_id.eq(room_id))
@@ -196,7 +211,8 @@ pub fn get_last_frame_id(room_id: &RoomId, before_sn: Option<Seqnum>) -> AppResu
             .filter(event_points::frame_id.is_not_null())
             .select(event_points::frame_id)
             .order_by(event_points::event_sn.desc())
-            .first::<Option<i64>>(&mut connect()?)?
+            .first::<Option<i64>>(&mut connect().await?)
+            .await?
             .ok_or(MatrixError::not_found("room last frame id is not found").into())
     } else {
         event_points::table
@@ -204,24 +220,27 @@ pub fn get_last_frame_id(room_id: &RoomId, before_sn: Option<Seqnum>) -> AppResu
             .filter(event_points::frame_id.is_not_null())
             .select(event_points::frame_id)
             .order_by(event_points::event_sn.desc())
-            .first::<Option<i64>>(&mut connect()?)?
+            .first::<Option<i64>>(&mut connect().await?)
+            .await?
             .ok_or(MatrixError::not_found("room last frame id is not found").into())
     }
 }
-pub fn update_frame_id(event_id: &EventId, frame_id: i64) -> AppResult<()> {
+pub async fn update_frame_id(event_id: &EventId, frame_id: i64) -> AppResult<()> {
     diesel::update(event_points::table.find(event_id))
         .set(event_points::frame_id.eq(frame_id))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     // diesel::update(events::table.find(event_id))
     //     .set(events::stream_ordering.eq(frame_id))
     //     .execute(&mut connect()?)?;
     Ok(())
 }
 
-pub fn update_frame_id_by_sn(event_sn: Seqnum, frame_id: i64) -> AppResult<()> {
+pub async fn update_frame_id_by_sn(event_sn: Seqnum, frame_id: i64) -> AppResult<()> {
     diesel::update(event_points::table.filter(event_points::event_sn.eq(event_sn)))
         .set(event_points::frame_id.eq(frame_id))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     // diesel::update(events::table.filter(events::sn.eq(event_sn)))
     //     .set(events::stream_ordering.eq(frame_id))
     //     .execute(&mut connect()?)?;
@@ -261,7 +280,7 @@ pub fn parse_fetched_pdu(
     Ok((event_id, value))
 }
 
-pub fn parse_incoming_pdu(
+pub async fn parse_incoming_pdu(
     raw_value: &RawJsonValue,
 ) -> AppResult<(
     OwnedEventId,
@@ -278,7 +297,7 @@ pub fn parse_incoming_pdu(
         .and_then(|id| RoomId::parse(id.as_str()?).ok())
         .ok_or(MatrixError::invalid_param("invalid room id in pdu"))?;
 
-    let room_version_id = crate::room::get_version(&room_id).map_err(|_| {
+    let room_version_id = crate::room::get_version(&room_id).await.map_err(|_| {
         MatrixError::invalid_param(format!(
             "server is not in room `{room_id}` when parse incoming event"
         ))
@@ -296,7 +315,7 @@ pub fn parse_incoming_pdu(
     Ok((event_id, value, room_id, room_version_id))
 }
 
-pub fn seen_event_ids(
+pub async fn seen_event_ids(
     room_id: &RoomId,
     event_ids: &[OwnedEventId],
 ) -> AppResult<Vec<OwnedEventId>> {
@@ -304,13 +323,14 @@ pub fn seen_event_ids(
         .filter(events::room_id.eq(room_id))
         .filter(events::id.eq_any(event_ids))
         .select(events::id)
-        .load::<OwnedEventId>(&mut connect()?)?;
+        .load::<OwnedEventId>(&mut connect().await?)
+        .await?;
     Ok(seen_events)
 }
 #[inline]
-pub fn ignored_filter(item: PdusIterItem, user_id: &UserId) -> bool {
+pub async fn ignored_filter(item: PdusIterItem<'_>, user_id: &UserId) -> bool {
     let (_, pdu) = item;
-    !is_ignored_pdu(pdu, user_id)
+    !is_ignored_pdu(pdu, user_id).await
 }
 
 #[inline]
@@ -322,8 +342,8 @@ pub fn ignored_filter_with_ignored_users(
     !is_ignored_pdu_by_ignored_users(pdu, ignored_users)
 }
 
-pub fn is_ignored_pdu(pdu: &SnPduEvent, user_id: &UserId) -> bool {
-    let ignored_users = crate::user::ignored_users(user_id);
+pub async fn is_ignored_pdu(pdu: &SnPduEvent, user_id: &UserId) -> bool {
+    let ignored_users = crate::user::ignored_users(user_id).await;
     is_ignored_pdu_by_ignored_users(pdu, &ignored_users)
 }
 
@@ -340,8 +360,8 @@ pub fn is_ignored_pdu_by_ignored_users(
     is_ignored_sender_pdu_by_ignored_users(pdu, ignored_users)
 }
 
-pub fn is_ignored_sender_pdu(pdu: &SnPduEvent, user_id: &UserId) -> bool {
-    let ignored_users = crate::user::ignored_users(user_id);
+pub async fn is_ignored_sender_pdu(pdu: &SnPduEvent, user_id: &UserId) -> bool {
+    let ignored_users = crate::user::ignored_users(user_id).await;
     is_ignored_sender_pdu_by_ignored_users(pdu, &ignored_users)
 }
 

--- a/crates/server/src/event/fetching.rs
+++ b/crates/server/src/event/fetching.rs
@@ -42,7 +42,15 @@ pub async fn fetch_and_process_missing_events(
         .unwrap_or(0);
     let mut fetched_events = IndexMap::with_capacity(10);
 
-    let earliest_events = room::state::get_forward_extremities(room_id).await?;
+    let mut earliest_events = Vec::new();
+    for event_id in room::state::get_forward_extremities(room_id).await? {
+        let Ok(pdu) = timeline::get_pdu(&event_id).await else {
+            continue;
+        };
+        if !pdu.is_outlier && !pdu.soft_failed && !pdu.rejected() {
+            earliest_events.push(event_id);
+        }
+    }
     let mut known_events = HashSet::new();
     let mut missing_events = Vec::with_capacity(incoming_pdu.prev_events.len());
     for prev_id in &incoming_pdu.prev_events {

--- a/crates/server/src/event/fetching.rs
+++ b/crates/server/src/event/fetching.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use indexmap::IndexMap;
 use salvo::http::StatusError;
 
@@ -35,16 +36,17 @@ pub async fn fetch_and_process_missing_events(
     is_backfill: bool,
 ) -> AppResult<()> {
     let min_depth = timeline::first_pdu_in_room(room_id)
+        .await
         .ok()
         .and_then(|pdu| pdu.map(|p| p.depth))
         .unwrap_or(0);
     let mut fetched_events = IndexMap::with_capacity(10);
 
-    let earliest_events = room::state::get_forward_extremities(room_id)?;
+    let earliest_events = room::state::get_forward_extremities(room_id).await?;
     let mut known_events = HashSet::new();
     let mut missing_events = Vec::with_capacity(incoming_pdu.prev_events.len());
     for prev_id in &incoming_pdu.prev_events {
-        let pdu = timeline::get_pdu(prev_id);
+        let pdu = timeline::get_pdu(prev_id).await;
         if let Ok(pdu) = &pdu {
             if pdu.rejected() {
                 missing_events.push(prev_id.to_owned());
@@ -81,7 +83,7 @@ pub async fn fetch_and_process_missing_events(
             continue;
         }
 
-        if fetched_events.contains_key(&event_id) || timeline::get_pdu(&event_id).is_ok() {
+        if fetched_events.contains_key(&event_id) || timeline::get_pdu(&event_id).await.is_ok() {
             known_events.insert(event_id.clone());
             continue;
         }
@@ -100,7 +102,7 @@ pub async fn fetch_and_process_missing_events(
             events::table
                 .filter(events::id.eq(&event_id))
                 .filter(events::room_id.eq(&room_id)),
-            &mut connect()?
+            &mut connect().await?
         )?;
         if is_exists {
             continue;
@@ -144,7 +146,7 @@ pub async fn fetch_and_process_auth_chain(
     for event in res_body.auth_chain {
         let (event_id, event_value) =
             crate::event::parse_fetched_pdu(room_id, room_version, &event)?;
-        if let Ok(pdu) = timeline::get_pdu(&event_id) {
+        if let Ok(pdu) = timeline::get_pdu(&event_id).await {
             auth_events.push(pdu);
             continue;
         }
@@ -152,7 +154,7 @@ pub async fn fetch_and_process_auth_chain(
             events::table
                 .filter(events::id.eq(&event_id))
                 .filter(events::room_id.eq(&room_id)),
-            &mut connect()?
+            &mut connect().await?
         )? {
             let Some(outlier_pdu) = process_to_outlier_pdu(
                 remote_server,
@@ -165,7 +167,7 @@ pub async fn fetch_and_process_auth_chain(
             else {
                 continue;
             };
-            let pdu = outlier_pdu.save_to_database(true)?.0;
+            let pdu = outlier_pdu.save_to_database(true).await?.0;
             auth_events.push(pdu);
         }
     }
@@ -196,7 +198,7 @@ pub(super) async fn fetch_and_process_missing_state_by_ids(
 
     let desired_count = desired_events.len();
     let mut failed_missing_events = Vec::new();
-    let seen_events = seen_event_ids(room_id, &desired_events)?;
+    let seen_events = seen_event_ids(room_id, &desired_events).await?;
     let missing_events: Vec<_> = desired_events
         .into_iter()
         .filter(|e| !seen_events.contains(e))
@@ -255,7 +257,7 @@ pub async fn fetch_and_process_missing_state(
             Some(v) => v.as_str().unwrap_or(""),
             None => continue,
         };
-        let field_id = ensure_field_id(&event_type.into(), state_key)?;
+        let field_id = ensure_field_id(&event_type.into(), state_key).await?;
         state_events.insert(field_id, event_id);
     }
 
@@ -269,7 +271,7 @@ pub async fn fetch_and_process_missing_state(
             Some(v) => v.as_str().unwrap_or(""),
             None => continue,
         };
-        let field_id = ensure_field_id(&event_type.into(), state_key)?;
+        let field_id = ensure_field_id(&event_type.into(), state_key).await?;
         auth_events.insert(field_id, event_id);
     }
 
@@ -359,6 +361,6 @@ pub async fn fetch_and_process_event(
     else {
         return Ok(());
     };
-    outlier_pdu.save_to_database(true)?;
+    outlier_pdu.save_to_database(true).await?;
     Ok(())
 }

--- a/crates/server/src/event/handler.rs
+++ b/crates/server/src/event/handler.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use indexmap::IndexMap;
 use palpo_core::Direction;
 
@@ -40,19 +41,20 @@ pub(crate) async fn process_incoming_pdu(
     is_timeline_event: bool,
     is_backfill: bool,
 ) -> AppResult<()> {
-    if !crate::room::room_exists(room_id)? {
+    if !crate::room::room_exists(room_id).await? {
         return Err(MatrixError::not_found("room is unknown to this server").into());
     }
 
     let event = events::table
         .filter(events::id.eq(event_id))
-        .first::<DbEvent>(&mut connect()?);
+        .first::<DbEvent>(&mut connect().await?)
+        .await;
     if let Ok(event) = event {
         if !event.is_outlier {
             return Ok(());
         }
         if event.is_rejected || event.soft_failed {
-            if let Err(e) = diesel::delete(&event).execute(&mut connect()?) {
+            if let Err(e) = diesel::delete(&event).execute(&mut connect().await?).await {
                 warn!(
                     "failed to delete rejected/soft-failed event {}: {}",
                     event_id, e
@@ -60,13 +62,15 @@ pub(crate) async fn process_incoming_pdu(
             }
             if let Err(e) =
                 diesel::delete(event_points::table.filter(event_points::event_id.eq(event_id)))
-                    .execute(&mut connect()?)
+                    .execute(&mut connect().await?)
+                    .await
             {
                 warn!("failed to delete event_points for {}: {}", event_id, e);
             }
             if let Err(e) =
                 diesel::delete(event_datas::table.filter(event_datas::event_id.eq(event_id)))
-                    .execute(&mut connect()?)
+                    .execute(&mut connect().await?)
+                    .await
             {
                 warn!("failed to delete event_datas for {}: {}", event_id, e);
             }
@@ -74,7 +78,7 @@ pub(crate) async fn process_incoming_pdu(
     }
 
     // 1.2 Check if the room is disabled
-    if crate::room::is_disabled(room_id)? {
+    if crate::room::is_disabled(room_id).await? {
         return Err(MatrixError::forbidden(
             "federation of this room is currently disabled on this server",
             None,
@@ -83,7 +87,7 @@ pub(crate) async fn process_incoming_pdu(
     }
 
     // 1.3.1 Check room ACL on origin field/server
-    handler::acl_check(remote_server, room_id)?;
+    handler::acl_check(remote_server, room_id).await?;
 
     // 1.3.2 Check room ACL on sender's server name
     let sender: OwnedUserId = serde_json::from_value(
@@ -96,10 +100,10 @@ pub(crate) async fn process_incoming_pdu(
     .map_err(|_| MatrixError::bad_json("user id in sender is invalid."))?;
 
     if sender.server_name().ne(remote_server) {
-        handler::acl_check(sender.server_name(), room_id)?;
+        handler::acl_check(sender.server_name(), room_id).await?;
     }
     // 1. Skip the PDU if we already have it as a timeline event
-    if state::get_pdu_frame_id(event_id).is_ok() {
+    if state::get_pdu_frame_id(event_id).await.is_ok() {
         return Ok(());
     }
 
@@ -138,8 +142,8 @@ pub(crate) async fn process_incoming_pdu(
         error!("failed to process incoming pdu to timeline {}", e);
     } else {
         debug!("succeed to process incoming pdu to timeline {}", event_id);
-        let pdu = timeline::get_pdu(event_id)?;
-        update_backward_extremities(&pdu)?;
+        let pdu = timeline::get_pdu(event_id).await?;
+        update_backward_extremities(&pdu).await?;
     }
     drop(event_guard);
     if let Ok(mut guard) = crate::ROOM_ID_FEDERATION_HANDLE_TIME.write() {
@@ -158,7 +162,7 @@ pub(crate) async fn process_pulled_pdu(
     is_backfill: bool,
 ) -> AppResult<()> {
     // 1.3.1 Check room ACL on origin field/server
-    handler::acl_check(remote_server, room_id)?;
+    handler::acl_check(remote_server, room_id).await?;
 
     // 1.3.2 Check room ACL on sender's server name
     let sender: OwnedUserId = serde_json::from_value(
@@ -171,11 +175,11 @@ pub(crate) async fn process_pulled_pdu(
     .map_err(|_| MatrixError::bad_json("user id in sender is invalid"))?;
 
     if sender.server_name().ne(remote_server) {
-        handler::acl_check(sender.server_name(), room_id)?;
+        handler::acl_check(sender.server_name(), room_id).await?;
     }
 
     // 1. Skip the PDU if we already have it as a timeline event
-    if state::get_pdu_frame_id(event_id).is_ok() {
+    if state::get_pdu_frame_id(event_id).await.is_ok() {
         return Ok(());
     }
 
@@ -196,14 +200,15 @@ pub(crate) async fn process_pulled_pdu(
         error!("failed to process pulled pdu to timeline: {}", e);
     } else {
         debug!("succeed to process incoming pdu to timeline {}", event_id);
-        let pdu = timeline::get_pdu(event_id)?;
-        update_backward_extremities(&pdu)?;
+        let pdu = timeline::get_pdu(event_id).await?;
+        update_backward_extremities(&pdu).await?;
 
         let mut next_ids = event_missings::table
             .filter(event_missings::room_id.eq(&pdu.room_id))
             .filter(event_missings::missing_id.eq(&pdu.event_id))
             .select(event_missings::event_id)
-            .load::<OwnedEventId>(&mut connect()?)?;
+            .load::<OwnedEventId>(&mut connect().await?)
+            .await?;
         while !next_ids.is_empty() {
             let mut new_timlined_event_ids = Vec::new();
             for next_id in next_ids {
@@ -213,21 +218,23 @@ pub(crate) async fn process_pulled_pdu(
                         .filter(event_missings::event_id.eq(&next_id))
                         .filter(event_missings::missing_id.eq(&pdu.event_id)),
                 )
-                .execute(&mut connect()?)?;
+                .execute(&mut connect().await?)
+                .await?;
                 let query = event_missings::table.filter(event_missings::event_id.eq(&next_id));
-                if !diesel_exists!(query, &mut connect()?)? {
+                if !diesel_exists!(query, &mut connect().await?)? {
                     diesel::delete(
                         timeline_gaps::table
                             .filter(timeline_gaps::room_id.eq(&pdu.room_id))
                             .filter(timeline_gaps::event_id.eq(&next_id)),
                     )
-                    .execute(&mut connect()?)?;
+                    .execute(&mut connect().await?)
+                    .await?;
 
                     // let query = event_phases::table
                     //     .filter(event_phases::event_id.eq(&event_id))
                     //     .filter(event_phases::goal.eq("timeline"));
                     // if diesel_exists!(query, &mut connect()?)? {
-                    if let Ok(pdu) = timeline::get_pdu(&next_id)
+                    if let Ok(pdu) = timeline::get_pdu(&next_id).await
                         && pdu.is_outlier
                         && !pdu.rejected()
                     {
@@ -267,10 +274,11 @@ pub async fn process_to_outlier_pdu(
             event_datas::event_sn,
             event_datas::json_data,
         ))
-        .first::<(OwnedRoomId, Seqnum, JsonValue)>(&mut connect()?)
+        .first::<(OwnedRoomId, Seqnum, JsonValue)>(&mut connect().await?)
+        .await
         .optional()?
         && let Ok(val) = serde_json::from_value::<CanonicalJsonObject>(event_data.clone())
-        && let Ok(pdu) = timeline::get_pdu(event_id)
+        && let Ok(pdu) = timeline::get_pdu(event_id).await
         && !pdu.soft_failed
         && !pdu.is_outlier
         && !pdu.rejected()
@@ -317,7 +325,7 @@ pub async fn process_to_outlier_pdu(
             };
 
             // Skip the PDU if it is redacted and we already have it as an outlier event
-            if timeline::get_pdu_json(event_id)?.is_some() {
+            if timeline::get_pdu_json(event_id).await?.is_some() {
                 return Err(MatrixError::invalid_param(
                     "event was redacted and we already knew about it",
                 )
@@ -348,7 +356,8 @@ pub async fn process_to_outlier_pdu(
 
     check_room_id(room_id, &incoming_pdu)?;
 
-    let server_joined = crate::room::is_server_joined(crate::config::server_name(), room_id)?;
+    let server_joined =
+        crate::room::is_server_joined(crate::config::server_name(), room_id).await?;
     if !server_joined {
         if let Some(_state_key) = incoming_pdu.state_key.as_deref()
             && incoming_pdu.event_ty == TimelineEventType::RoomMember
@@ -372,7 +381,7 @@ pub async fn process_to_outlier_pdu(
 
     let mut soft_failed = false;
     let (prev_events, missing_prev_event_ids) =
-        timeline::get_may_missing_pdus(room_id, &incoming_pdu.prev_events)?;
+        timeline::get_may_missing_pdus(room_id, &incoming_pdu.prev_events).await?;
     if !missing_prev_event_ids.is_empty() {
         warn!(
             "process event to outlier missing prev events {}: {:?}",
@@ -398,7 +407,7 @@ pub async fn process_to_outlier_pdu(
     }
 
     let (auth_events, missing_auth_event_ids) =
-        timeline::get_may_missing_pdus(room_id, &incoming_pdu.auth_events)?;
+        timeline::get_may_missing_pdus(room_id, &incoming_pdu.auth_events).await?;
     if !missing_auth_event_ids.is_empty() {
         warn!(
             "process event to outlier missing auth events {}: {:?}",
@@ -495,14 +504,14 @@ pub async fn process_to_timeline_pdu(
         ));
     }
     debug!("process to timeline event {}", incoming_pdu.event_id);
-    let room_version_id = &room::get_version(&incoming_pdu.room_id)?;
+    let room_version_id = &room::get_version(&incoming_pdu.room_id).await?;
     let version_rules = crate::room::get_version_rules(room_version_id)?;
 
     // 10. Fetch missing state and auth chain events by calling /state_ids at backwards extremities
     //     doing all the checks in this list starting at 1. These are not timeline events.
     debug!("resolving state at event");
     let server_joined =
-        crate::room::is_server_joined(crate::config::server_name(), &incoming_pdu.room_id)?;
+        crate::room::is_server_joined(crate::config::server_name(), &incoming_pdu.room_id).await?;
 
     if !server_joined {
         if let Some(state_key) = incoming_pdu.state_key.as_deref()
@@ -523,25 +532,25 @@ pub async fn process_to_timeline_pdu(
             // We use the `state_at_event` instead of `state_after` so we accurately
             // represent the state for this event.
             debug!("compressing state at event");
-            let compressed_state_ids = Arc::new(
-                state_at_incoming_event
-                    .iter()
-                    .map(|(field_id, event_id)| {
-                        state::compress_event(
-                            &incoming_pdu.room_id,
-                            *field_id,
-                            crate::event::ensure_event_sn(&incoming_pdu.room_id, event_id)?.0,
-                        )
-                    })
-                    .collect::<AppResult<_>>()?,
-            );
+            let mut compressed_state_ids_set = CompressedState::new();
+            for (field_id, event_id) in state_at_incoming_event.iter() {
+                compressed_state_ids_set.insert(state::compress_event(
+                    &incoming_pdu.room_id,
+                    *field_id,
+                    crate::event::ensure_event_sn(&incoming_pdu.room_id, event_id)
+                        .await?
+                        .0,
+                )?);
+            }
+            let compressed_state_ids = Arc::new(compressed_state_ids_set);
             debug!("preparing for stateres to derive new room state");
 
             // We also add state after incoming event to the fork states
             // let mut state_after = state_at_incoming_event.clone();
 
             let state_key_id =
-                state::ensure_field_id(&incoming_pdu.event_ty.to_string().into(), state_key)?;
+                state::ensure_field_id(&incoming_pdu.event_ty.to_string().into(), state_key)
+                    .await?;
 
             let compressed_event =
                 state::compress_event(&incoming_pdu.room_id, state_key_id, incoming_pdu.event_sn)?;
@@ -554,9 +563,9 @@ pub async fn process_to_timeline_pdu(
                 frame_id,
                 appended,
                 disposed,
-            } = state::save_state(&incoming_pdu.room_id, Arc::new(new_room_state))?;
+            } = state::save_state(&incoming_pdu.room_id, Arc::new(new_room_state)).await?;
 
-            state::force_state(&incoming_pdu.room_id, frame_id, appended, disposed)?;
+            state::force_state(&incoming_pdu.room_id, frame_id, appended, disposed).await?;
 
             debug!("appended incoming pdu");
             timeline::append_pdu(&incoming_pdu, json_data, &state_lock).await?;
@@ -565,7 +574,8 @@ pub async fn process_to_timeline_pdu(
                 incoming_pdu.event_sn,
                 &incoming_pdu.room_id,
                 compressed_state_ids,
-            )?;
+            )
+            .await?;
             drop(state_lock);
         }
         return Ok(());
@@ -619,18 +629,17 @@ pub async fn process_to_timeline_pdu(
     // id), Ok(true)));
 
     debug!("compressing state at event");
-    let compressed_state_ids = Arc::new(
-        state_at_incoming_event
-            .iter()
-            .map(|(field_id, event_id)| {
-                state::compress_event(
-                    &incoming_pdu.room_id,
-                    *field_id,
-                    crate::event::ensure_event_sn(&incoming_pdu.room_id, event_id)?.0,
-                )
-            })
-            .collect::<AppResult<_>>()?,
-    );
+    let mut compressed_state_ids_set = CompressedState::new();
+    for (field_id, event_id) in state_at_incoming_event.iter() {
+        compressed_state_ids_set.insert(state::compress_event(
+            &incoming_pdu.room_id,
+            *field_id,
+            crate::event::ensure_event_sn(&incoming_pdu.room_id, event_id)
+                .await?
+                .0,
+        )?);
+    }
+    let compressed_state_ids = Arc::new(compressed_state_ids_set);
 
     let guards = if let Some(state_key) = &incoming_pdu.state_key {
         debug!("preparing for stateres to derive new room state");
@@ -638,7 +647,7 @@ pub async fn process_to_timeline_pdu(
         // We also add state after incoming event to the fork states
         let mut state_after = state_at_incoming_event.clone();
         let state_key_id =
-            state::ensure_field_id(&incoming_pdu.event_ty.to_string().into(), state_key)?;
+            state::ensure_field_id(&incoming_pdu.event_ty.to_string().into(), state_key).await?;
         state_after.insert(state_key_id, incoming_pdu.event_id.clone());
         let (new_room_state, guards) =
             resolve_state(&incoming_pdu.room_id, room_version_id, state_after).await?;
@@ -650,9 +659,9 @@ pub async fn process_to_timeline_pdu(
             frame_id,
             appended,
             disposed,
-        } = state::save_state(&incoming_pdu.room_id, new_room_state)?;
+        } = state::save_state(&incoming_pdu.room_id, new_room_state).await?;
 
-        state::force_state(&incoming_pdu.room_id, frame_id, appended, disposed)?;
+        state::force_state(&incoming_pdu.room_id, frame_id, appended, disposed).await?;
         guards
     } else {
         vec![]
@@ -670,9 +679,11 @@ pub async fn process_to_timeline_pdu(
         // Now we calculate the set of extremities this room has after the incoming event has been
         // applied. We start with the previous extremities (aka leaves)
         debug!("calculating extremities");
-        let mut extremities: BTreeSet<_> = state::get_forward_extremities(&incoming_pdu.room_id)?
-            .into_iter()
-            .collect();
+        let mut extremities: BTreeSet<_> =
+            state::get_forward_extremities(&incoming_pdu.room_id)
+                .await?
+                .into_iter()
+                .collect();
 
         // Remove any forward extremities that are referenced by this incoming event's prev_events
         extremities.retain(|event_id| !incoming_pdu.prev_events.contains(event_id));
@@ -681,11 +692,11 @@ pub async fn process_to_timeline_pdu(
             .iter()
             .map(Borrow::borrow)
             .chain(once(event_id.borrow()));
-        state::set_forward_extremities(&incoming_pdu.room_id, extremities, &state_lock)?;
-        state::update_backward_extremities(&incoming_pdu)?;
+        state::set_forward_extremities(&incoming_pdu.room_id, extremities, &state_lock).await?;
+        state::update_backward_extremities(&incoming_pdu).await?;
         // Soft fail, we keep the event as an outlier but don't add it to the timeline
         warn!("event was soft failed: {:?}", incoming_pdu);
-        crate::room::pdu_metadata::mark_event_soft_failed(&incoming_pdu.event_id)?;
+        crate::room::pdu_metadata::mark_event_soft_failed(&incoming_pdu.event_id).await?;
         return Err(MatrixError::invalid_param("event has been soft failed").into());
     } else {
         debug!("appended incoming pdu");
@@ -695,7 +706,8 @@ pub async fn process_to_timeline_pdu(
             incoming_pdu.event_sn,
             &incoming_pdu.room_id,
             compressed_state_ids,
-        )?;
+        )
+        .await?;
     }
     drop(guards);
 
@@ -790,11 +802,11 @@ pub async fn auth_check(
             auth_rules,
             incoming_pdu,
             &async |event_id| {
-                timeline::get_pdu( &event_id).map(|e|e.into_inner())
+                timeline::get_pdu( &event_id).await.map(|e|e.into_inner())
                     .map_err(|_| StateError::other("missing pdu in auth check event fetch"))
             },
             &async |k, s| {
-                let Ok(state_key_id) = state::ensure_field_id(&k.to_string().into(), &s) else {
+                let Ok(state_key_id) = state::ensure_field_id(&k.to_string().into(), &s).await else {
                     warn!("missing field id for state type: {k}, state_key: {s}");
                     return Err(StateError::other(format!(
                         "missing field id for state type: {k}, state_key: {s}"
@@ -802,7 +814,7 @@ pub async fn auth_check(
                 };
 
                 match state_at_incoming_event.get(&state_key_id) {
-                    Some(event_id) => match timeline::get_pdu(event_id) {
+                    Some(event_id) => match timeline::get_pdu(event_id).await {
                         Ok(pdu) => Ok(pdu.into_inner()),
                         Err(e) => {
                             warn!("failed to get pdu for state resolution: {}", e);
@@ -816,7 +828,7 @@ pub async fn auth_check(
                         // Fallback: state_at_incoming_event resolution may be incomplete
                         // (e.g., for events whose prev_events point to an early room frame).
                         // Try looking up the state event directly from the room's current state.
-                        if let Ok(state_pdu) = crate::room::get_state(&incoming_pdu.room_id, &k, &s, None) {
+                        if let Ok(state_pdu) = crate::room::get_state(&incoming_pdu.room_id, &k, &s, None).await {
                             return Ok(state_pdu.pdu);
                         }
                         warn!(
@@ -841,12 +853,13 @@ pub async fn auth_check(
         incoming_pdu.state_key.as_deref(),
         &incoming_pdu.content,
         auth_rules,
-    )?;
+    )
+    .await?;
     event_auth::auth_check(
         auth_rules,
         incoming_pdu,
         &async |event_id| {
-            timeline::get_pdu(&event_id).map(|e|e.into_inner()).map_err(|_| StateError::other("missing pdu 3"))
+            timeline::get_pdu(&event_id).await.map(|e|e.into_inner()).map_err(|_| StateError::other("missing pdu 3"))
         },
         &async |k, s| {
             if let Some(pdu) = auth_events.get(&(k.clone(), s.to_string())).cloned() {
@@ -854,6 +867,7 @@ pub async fn auth_check(
             }
             if auth_rules.room_create_event_id_as_room_id && k == StateEventType::RoomCreate {
                 let pdu = crate::room::get_create(&incoming_pdu.room_id)
+                    .await
                     .map_err(|_| StateError::other("missing create event"))?;
                 if pdu.room_id != incoming_pdu.room_id {
                     Err(StateError::other("mismatched room id in create event"))
@@ -871,8 +885,8 @@ pub async fn auth_check(
     Ok(())
 }
 /// Returns Ok if the acl allows the server
-pub fn acl_check(server_name: &ServerName, room_id: &RoomId) -> AppResult<()> {
-    let acl_event = match room::get_state(room_id, &StateEventType::RoomServerAcl, "", None) {
+pub async fn acl_check(server_name: &ServerName, room_id: &RoomId) -> AppResult<()> {
+    let acl_event = match room::get_state(room_id, &StateEventType::RoomServerAcl, "", None).await {
         Ok(acl) => acl,
         Err(_) => return Ok(()),
     };

--- a/crates/server/src/event/outlier.rs
+++ b/crates/server/src/event/outlier.rs
@@ -1,6 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::core::events::TimelineEventType;
 use crate::core::identifiers::*;
@@ -107,7 +108,7 @@ impl crate::core::state::Event for OutlierPdu {
 }
 
 impl OutlierPdu {
-    pub fn save_to_database(
+    pub async fn save_to_database(
         self,
         is_backfill: bool,
     ) -> AppResult<(SnPduEvent, CanonicalJsonObject, Option<SeqnumQueueGuard>)> {
@@ -132,7 +133,7 @@ impl OutlierPdu {
                 None,
             ));
         }
-        let (event_sn, event_guard) = ensure_event_sn(&room_id, &pdu.event_id)?;
+        let (event_sn, event_guard) = ensure_event_sn(&room_id, &pdu.event_id).await?;
         let mut db_event = NewDbEvent::from_canonical_json_with_room_id(
             &pdu.event_id,
             event_sn,
@@ -144,7 +145,7 @@ impl OutlierPdu {
         db_event.soft_failed = soft_failed;
         db_event.is_rejected = pdu.rejection_reason.is_some();
         db_event.rejection_reason = pdu.rejection_reason.clone();
-        db_event.save()?;
+        db_event.save().await?;
         DbEventData {
             event_id: pdu.event_id.clone(),
             event_sn,
@@ -153,7 +154,8 @@ impl OutlierPdu {
             json_data: serde_json::to_value(&json_data)?,
             format_version: None,
         }
-        .save()?;
+        .save()
+        .await?;
         let pdu = SnPduEvent {
             pdu,
             event_sn,
@@ -161,7 +163,7 @@ impl OutlierPdu {
             soft_failed,
             is_backfill,
         };
-        update_backward_extremities(&pdu)?;
+        update_backward_extremities(&pdu).await?;
         Ok((pdu, json_data, event_guard))
     }
 
@@ -175,7 +177,7 @@ impl OutlierPdu {
                 && self.rejected_prev_events.is_empty()
                 && self.rejected_auth_events.is_empty())
         {
-            return self.save_to_database(is_backfill);
+            return self.save_to_database(is_backfill).await;
         }
 
         // Fetch any missing prev events doing all checks listed here starting at 1. These are
@@ -193,7 +195,7 @@ impl OutlierPdu {
                 if *kind == core::error::ErrorKind::BadJson {
                     self.rejection_reason = Some(format!("bad prev events: {}", e));
                     let _state_lock = crate::room::lock_state(&self.room_id).await;
-                    return self.save_to_database(is_backfill);
+                    return self.save_to_database(is_backfill).await;
                 } else {
                     self.soft_failed = true;
                 }
@@ -205,17 +207,17 @@ impl OutlierPdu {
         self.process_pulled(remote_server, is_backfill).await
     }
 
-    fn any_auth_event_rejected(&self) -> AppResult<bool> {
+    async fn any_auth_event_rejected(&self) -> AppResult<bool> {
         let query = events::table
             .filter(events::id.eq_any(&self.pdu.auth_events))
             .filter(events::is_rejected.eq(true));
-        Ok(diesel_exists!(query, &mut connect()?)?)
+        Ok(diesel_exists!(query, &mut connect().await?)?)
     }
-    fn any_prev_event_rejected(&self) -> AppResult<bool> {
+    async fn any_prev_event_rejected(&self) -> AppResult<bool> {
         let query = events::table
             .filter(events::id.eq_any(&self.pdu.prev_events))
             .filter(events::is_rejected.eq(true));
-        Ok(diesel_exists!(query, &mut connect()?)?)
+        Ok(diesel_exists!(query, &mut connect().await?)?)
     }
 
     pub async fn process_pulled(
@@ -226,14 +228,14 @@ impl OutlierPdu {
         let version_rules = crate::room::get_version_rules(&self.room_version)?;
 
         if !self.soft_failed || self.rejected() {
-            return self.save_to_database(is_backfill);
+            return self.save_to_database(is_backfill).await;
         }
 
-        if self.any_prev_event_rejected()? {
+        if self.any_prev_event_rejected().await? {
             self.rejection_reason = Some("one or more prev events are rejected".to_string());
-            return self.save_to_database(is_backfill);
+            return self.save_to_database(is_backfill).await;
         }
-        if self.any_auth_event_rejected()?
+        if self.any_auth_event_rejected().await?
             && let Err(e) = fetch_and_process_auth_chain(
                 &self.remote_server,
                 &self.room_id,
@@ -247,10 +249,10 @@ impl OutlierPdu {
             } else {
                 self.rejection_reason = Some("one or more auth events are rejected".to_string());
             }
-            return self.save_to_database(is_backfill);
+            return self.save_to_database(is_backfill).await;
         }
         let (_prev_events, missing_prev_event_ids) =
-            timeline::get_may_missing_pdus(&self.room_id, &self.pdu.prev_events)?;
+            timeline::get_may_missing_pdus(&self.room_id, &self.pdu.prev_events).await?;
 
         if !missing_prev_event_ids.is_empty() {
             for event_id in &missing_prev_event_ids {
@@ -332,6 +334,6 @@ impl OutlierPdu {
                 self.soft_failed = false;
             }
         }
-        self.save_to_database(is_backfill)
+        self.save_to_database(is_backfill).await
     }
 }

--- a/crates/server/src/event/pdu.rs
+++ b/crates/server/src/event/pdu.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use std::ops::{Deref, DerefMut};
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_json::value::to_raw_value;
@@ -74,22 +75,22 @@ impl SnPduEvent {
         }
     }
 
-    pub fn user_can_see(&self, user_id: &UserId) -> AppResult<bool> {
+    pub async fn user_can_see(&self, user_id: &UserId) -> AppResult<bool> {
         if self.event_ty == TimelineEventType::RoomMember
             && self.state_key.as_deref() == Some(user_id.as_str())
         {
             return Ok(true);
         }
         if self.is_room_state() {
-            if room::is_world_readable(&self.room_id) {
-                return Ok(!room::user::is_banned(user_id, &self.room_id)?);
-            } else if room::user::is_joined(user_id, &self.room_id)? {
+            if room::is_world_readable(&self.room_id).await {
+                return Ok(!room::user::is_banned(user_id, &self.room_id).await?);
+            } else if room::user::is_joined(user_id, &self.room_id).await? {
                 return Ok(true);
             }
         }
-        let frame_id = match state::get_pdu_frame_id(&self.event_id) {
+        let frame_id = match state::get_pdu_frame_id(&self.event_id).await {
             Ok(frame_id) => frame_id,
-            Err(_) => match state::get_room_frame_id(&self.room_id, None) {
+            Err(_) => match state::get_room_frame_id(&self.room_id, None).await {
                 Ok(frame_id) => frame_id,
                 Err(_) => {
                     return Ok(false);
@@ -110,6 +111,7 @@ impl SnPduEvent {
             &StateEventType::RoomHistoryVisibility,
             "",
         )
+        .await
         .map_or(
             HistoryVisibility::Shared,
             |c: RoomHistoryVisibilityEventContent| c.history_visibility,
@@ -118,20 +120,20 @@ impl SnPduEvent {
         let visibility = match history_visibility {
             HistoryVisibility::WorldReadable => true,
             HistoryVisibility::Shared => {
-                let Ok(membership) = state::user_membership(frame_id, user_id) else {
-                    return crate::room::user::is_joined(user_id, &self.room_id);
+                let Ok(membership) = state::user_membership(frame_id, user_id).await else {
+                    return crate::room::user::is_joined(user_id, &self.room_id).await;
                 };
                 membership == MembershipState::Join
-                    || crate::room::user::is_joined(user_id, &self.room_id)?
+                    || crate::room::user::is_joined(user_id, &self.room_id).await?
             }
             HistoryVisibility::Invited => {
                 // Allow if any member on requesting server was AT LEAST invited, else deny
-                state::user_was_invited(frame_id, user_id)
+                state::user_was_invited(frame_id, user_id).await
             }
             HistoryVisibility::Joined => {
                 // Allow if any member on requested server was joined, else deny
-                state::user_was_joined(frame_id, user_id)
-                    || state::user_was_joined(frame_id - 1, user_id)
+                state::user_was_joined(frame_id, user_id).await
+                    || state::user_was_joined(frame_id - 1, user_id).await
             }
             _ => {
                 error!("unknown history visibility {history_visibility}");
@@ -146,7 +148,7 @@ impl SnPduEvent {
         Ok(visibility)
     }
 
-    pub fn add_unsigned_membership(&mut self, user_id: &UserId) -> AppResult<()> {
+    pub async fn add_unsigned_membership(&mut self, user_id: &UserId) -> AppResult<()> {
         #[derive(Deserialize)]
         struct ExtractMemebership {
             membership: String,
@@ -157,8 +159,9 @@ impl SnPduEvent {
             self.get_content::<ExtractMemebership>()
                 .map(|m| m.membership)
                 .ok()
-        } else if let Ok(frame_id) = crate::event::get_frame_id(&self.room_id, self.event_sn) {
+        } else if let Ok(frame_id) = crate::event::get_frame_id(&self.room_id, self.event_sn).await {
             state::user_membership(frame_id, user_id)
+                .await
                 .ok()
                 .map(|m| m.to_string())
         } else {
@@ -586,9 +589,10 @@ impl PduEvent {
     }
 
     #[tracing::instrument]
-    pub fn to_stripped_state_event(&self) -> RawJson<AnyStrippedStateEvent> {
+    pub async fn to_stripped_state_event(&self) -> RawJson<AnyStrippedStateEvent> {
         if self.event_ty == TimelineEventType::RoomCreate {
             let version_rules = crate::room::get_version(&self.room_id)
+                .await
                 .and_then(|version| crate::room::get_version_rules(&version));
             if let Ok(version_rules) = version_rules
                 && version_rules.authorization.room_create_event_id_as_room_id
@@ -836,7 +840,7 @@ impl PduBuilder {
         _state_lock: &RoomMutexGuard,
     ) -> AppResult<(SnPduEvent, CanonicalJsonObject, Option<SeqnumQueueGuard>)> {
         let (pdu, pdu_json) = self.hash_sign(sender_id, room_id, room_version).await?;
-        let (event_sn, event_guard) = crate::event::ensure_event_sn(room_id, &pdu.event_id)?;
+        let (event_sn, event_guard) = crate::event::ensure_event_sn(room_id, &pdu.event_id).await?;
         let content_value: JsonValue = serde_json::from_str(pdu.content.get())?;
         NewDbEvent {
             id: pdu.event_id.to_owned(),
@@ -858,7 +862,8 @@ impl PduBuilder {
             is_rejected: false,
             rejection_reason: None,
         }
-        .save()?;
+        .save()
+        .await?;
         DbEventData {
             event_id: pdu.event_id.clone(),
             event_sn,
@@ -867,7 +872,8 @@ impl PduBuilder {
             json_data: serde_json::to_value(&pdu_json)?,
             format_version: None,
         }
-        .save()?;
+        .save()
+        .await?;
 
         Ok((
             SnPduEvent {
@@ -898,7 +904,8 @@ impl PduBuilder {
             ..
         } = self;
 
-        let prev_events: Vec<_> = state::get_forward_extremities(room_id)?
+        let prev_events: Vec<_> = state::get_forward_extremities(room_id)
+            .await?
             .into_iter()
             .take(20)
             .collect();
@@ -926,19 +933,22 @@ impl PduBuilder {
             state_key.as_deref(),
             &content,
             auth_rules,
-        )?;
+        )
+        .await?;
 
         // Our depth is the maximum depth of prev_events + 1
-        let depth = prev_events
-            .iter()
-            .filter_map(|event_id| Some(get_pdu(event_id).ok()?.depth))
-            .max()
-            .unwrap_or(0)
-            + 1;
+        let mut max_depth = 0;
+        for event_id in &prev_events {
+            if let Ok(prev_pdu) = get_pdu(event_id).await {
+                max_depth = max_depth.max(prev_pdu.depth);
+            }
+        }
+        let depth = max_depth + 1;
 
         if let Some(state_key) = &state_key
             && let Ok(prev_pdu) =
                 crate::room::get_state(room_id, &event_type.to_string().into(), state_key, None)
+                    .await
         {
             unsigned.insert("prev_content".to_owned(), prev_pdu.content.clone());
             unsigned.insert(
@@ -980,6 +990,7 @@ impl PduBuilder {
 
         let fetch_event = async |event_id: OwnedEventId| {
             get_pdu(&event_id)
+                .await
                 .map(|s| s.pdu)
                 .map_err(|_| StateError::other("missing PDU 6"))
         };
@@ -992,6 +1003,7 @@ impl PduBuilder {
             }
             if auth_rules.room_create_event_id_as_room_id && k == StateEventType::RoomCreate {
                 let pdu = crate::room::get_create(room_id)
+                    .await
                     .map_err(|_| StateError::other("missing create event"))?
                     .into_inner();
                 if pdu.room_id != *room_id {
@@ -1002,7 +1014,7 @@ impl PduBuilder {
             } else {
                 // If the state event is not found in auth_events, try to look it up
                 // directly from room state as a fallback.
-                if let Ok(state_pdu) = crate::room::get_state(room_id, &k, &s, None) {
+                if let Ok(state_pdu) = crate::room::get_state(room_id, &k, &s, None).await {
                     return Ok(state_pdu.pdu);
                 }
                 warn!(
@@ -1064,7 +1076,8 @@ impl PduBuilder {
                     .filter(event_forward_extremities::room_id.eq(room_id)),
             )
             .set(event_forward_extremities::room_id.eq(&pdu.room_id))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         }
 
         pdu_json.insert(

--- a/crates/server/src/event/resolver.rs
+++ b/crates/server/src/event/resolver.rs
@@ -76,29 +76,28 @@ pub async fn resolve_state(
                 .map_err(|_| StateError::other("missing pdu 4"))
         },
         |map| {
-            tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current().block_on(async {
-                    let mut subgraph = HashSet::new();
-                    for event_ids in map.values() {
-                        for event_id in event_ids {
-                            if let Ok(pdu) = timeline::get_pdu(event_id).await {
-                                subgraph.extend(pdu.auth_events.iter().cloned());
-                                subgraph.extend(pdu.prev_events.iter().cloned());
-                            }
-                        }
+            // Snapshot the event ids synchronously so the returned future owns its
+            // data (no borrow of `map` across the await, no blocking the runtime).
+            let event_ids: Vec<OwnedEventId> = map.values().flatten().cloned().collect();
+            async move {
+                let mut subgraph = HashSet::new();
+                for event_id in &event_ids {
+                    if let Ok(pdu) = timeline::get_pdu(event_id).await {
+                        subgraph.extend(pdu.auth_events.iter().cloned());
+                        subgraph.extend(pdu.prev_events.iter().cloned());
                     }
-                    let subgraph = events::table
-                        .filter(events::id.eq_any(subgraph))
-                        .filter(events::state_key.is_not_null())
-                        .select(events::id)
-                        .load::<OwnedEventId>(&mut connect().await.unwrap())
-                        .await
-                        .unwrap()
-                        .into_iter()
-                        .collect::<HashSet<_>>();
-                    Some(subgraph)
-                })
-            })
+                }
+                let subgraph = events::table
+                    .filter(events::id.eq_any(subgraph))
+                    .filter(events::state_key.is_not_null())
+                    .select(events::id)
+                    .load::<OwnedEventId>(&mut connect().await.ok()?)
+                    .await
+                    .ok()?
+                    .into_iter()
+                    .collect::<HashSet<_>>();
+                Some(subgraph)
+            }
         },
     )
     .await
@@ -274,20 +273,19 @@ pub(super) async fn resolve_state_at_incoming(
                 .map_err(|_| StateError::other("missing pdu 5"))
         },
         |map| {
-            tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current().block_on(async {
-                    let mut subgraph = HashSet::new();
-                    for event_ids in map.values() {
-                        for event_id in event_ids {
-                            if let Ok(pdu) = timeline::get_pdu(event_id).await {
-                                subgraph.extend(pdu.auth_events.iter().cloned());
-                                subgraph.extend(pdu.prev_events.iter().cloned());
-                            }
-                        }
+            // Snapshot the event ids synchronously so the returned future owns its
+            // data (no borrow of `map` across the await, no blocking the runtime).
+            let event_ids: Vec<OwnedEventId> = map.values().flatten().cloned().collect();
+            async move {
+                let mut subgraph = HashSet::new();
+                for event_id in &event_ids {
+                    if let Ok(pdu) = timeline::get_pdu(event_id).await {
+                        subgraph.extend(pdu.auth_events.iter().cloned());
+                        subgraph.extend(pdu.prev_events.iter().cloned());
                     }
-                    Some(subgraph)
-                })
-            })
+                }
+                Some(subgraph)
+            }
         },
     )
     .await;

--- a/crates/server/src/event/resolver.rs
+++ b/crates/server/src/event/resolver.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use indexmap::IndexMap;
 
 use crate::core::identifiers::*;
@@ -21,43 +22,40 @@ pub async fn resolve_state(
     incoming_state: IndexMap<i64, OwnedEventId>,
 ) -> AppResult<(Arc<CompressedState>, Vec<SeqnumQueueGuard>)> {
     debug!("loading current room state ids");
-    let current_state_ids = if let Ok(current_frame_id) = crate::room::get_frame_id(room_id, None) {
-        state::get_full_state_ids(current_frame_id)?
-    } else {
-        IndexMap::new()
-    };
+    let current_state_ids =
+        if let Ok(current_frame_id) = crate::room::get_frame_id(room_id, None).await {
+            state::get_full_state_ids(current_frame_id).await?
+        } else {
+            IndexMap::new()
+        };
 
     debug!("loading fork states");
     let fork_states = [current_state_ids, incoming_state];
 
     let mut auth_chain_sets = Vec::new();
     for state in &fork_states {
-        auth_chain_sets.push(crate::room::auth_chain::get_auth_chain_ids(
-            room_id,
-            state.values().map(|e| &**e),
-        )?);
+        auth_chain_sets.push(
+            crate::room::auth_chain::get_auth_chain_ids(room_id, state.values().map(|e| &**e))
+                .await?,
+        );
     }
 
-    let fork_states: Vec<_> = fork_states
-        .into_iter()
-        .map(|map| {
-            map.into_iter()
-                .filter_map(|(k, event_id)| {
-                    state::get_field(k)
-                        .map(
-                            |DbRoomStateField {
-                                 event_ty,
-                                 state_key,
-                                 ..
-                             }| {
-                                ((event_ty.to_string().into(), state_key), event_id)
-                            },
-                        )
-                        .ok()
-                })
-                .collect::<StateMap<_>>()
-        })
-        .collect();
+    let mut resolved_fork_states: Vec<StateMap<_>> = Vec::with_capacity(fork_states.len());
+    for map in fork_states {
+        let mut state_map = StateMap::new();
+        for (k, event_id) in map {
+            if let Ok(DbRoomStateField {
+                event_ty,
+                state_key,
+                ..
+            }) = state::get_field(k).await
+            {
+                state_map.insert((event_ty.to_string().into(), state_key), event_id);
+            }
+        }
+        resolved_fork_states.push(state_map);
+    }
+    let fork_states = resolved_fork_states;
     debug!("resolving state");
 
     let version_rules = crate::room::get_version_rules(room_version_id)?;
@@ -72,26 +70,35 @@ pub async fn resolve_state(
             .iter()
             .map(|set| set.iter().map(|id| id.to_owned()).collect::<HashSet<_>>())
             .collect::<Vec<_>>(),
-        &async |id| timeline::get_pdu(&id).map_err(|_| StateError::other("missing pdu 4")),
+        &async |id| {
+            timeline::get_pdu(&id)
+                .await
+                .map_err(|_| StateError::other("missing pdu 4"))
+        },
         |map| {
-            let mut subgraph = HashSet::new();
-            for event_ids in map.values() {
-                for event_id in event_ids {
-                    if let Ok(pdu) = timeline::get_pdu(event_id) {
-                        subgraph.extend(pdu.auth_events.iter().cloned());
-                        subgraph.extend(pdu.prev_events.iter().cloned());
+            tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async {
+                    let mut subgraph = HashSet::new();
+                    for event_ids in map.values() {
+                        for event_id in event_ids {
+                            if let Ok(pdu) = timeline::get_pdu(event_id).await {
+                                subgraph.extend(pdu.auth_events.iter().cloned());
+                                subgraph.extend(pdu.prev_events.iter().cloned());
+                            }
+                        }
                     }
-                }
-            }
-            let subgraph = events::table
-                .filter(events::id.eq_any(subgraph))
-                .filter(events::state_key.is_not_null())
-                .select(events::id)
-                .load::<OwnedEventId>(&mut connect().unwrap())
-                .unwrap()
-                .into_iter()
-                .collect::<HashSet<_>>();
-            Some(subgraph)
+                    let subgraph = events::table
+                        .filter(events::id.eq_any(subgraph))
+                        .filter(events::state_key.is_not_null())
+                        .select(events::id)
+                        .load::<OwnedEventId>(&mut connect().await.unwrap())
+                        .await
+                        .unwrap()
+                        .into_iter()
+                        .collect::<HashSet<_>>();
+                    Some(subgraph)
+                })
+            })
         },
     )
     .await
@@ -109,8 +116,8 @@ pub async fn resolve_state(
     let mut new_room_state = BTreeSet::new();
     let mut guards = Vec::new();
     for ((event_type, state_key), event_id) in state {
-        let state_key_id = state::ensure_field_id(&event_type.to_string().into(), &state_key)?;
-        let (event_sn, guard) = crate::event::ensure_event_sn(room_id, &event_id)?;
+        let state_key_id = state::ensure_field_id(&event_type.to_string().into(), &state_key).await?;
+        let (event_sn, guard) = crate::event::ensure_event_sn(room_id, &event_id).await?;
         if let Some(guard) = guard {
             guards.push(guard);
         }
@@ -164,7 +171,7 @@ pub(super) async fn resolve_state_at_incoming(
 
     for prev_event_id in &incoming_pdu.prev_events {
         had_prev_events = true;
-        let Ok(prev_event) = timeline::get_pdu(prev_event_id) else {
+        let Ok(prev_event) = timeline::get_pdu(prev_event_id).await else {
             // Truly unknown prev event — don't fall back to current state. The
             // caller (e.g. process_incoming) needs to keep the event soft-failed
             // so the missing-events fetch path runs. Returning None here
@@ -178,7 +185,7 @@ pub(super) async fn resolve_state_at_incoming(
             continue;
         }
 
-        if let Ok(frame_id) = state::get_pdu_frame_id(prev_event_id) {
+        if let Ok(frame_id) = state::get_pdu_frame_id(prev_event_id).await {
             extremity_state_hashes.insert(frame_id, prev_event);
         } else {
             // Outlier (not yet promoted to a timeline event) — treat as if
@@ -198,9 +205,9 @@ pub(super) async fn resolve_state_at_incoming(
     if had_prev_events
         && extremity_state_hashes.is_empty()
         && had_in_db_unresolvable
-        && let Ok(frame_id) = state::get_room_frame_id(&incoming_pdu.room_id, None)
+        && let Ok(frame_id) = state::get_room_frame_id(&incoming_pdu.room_id, None).await
     {
-        let state = state::get_full_state_ids(frame_id)?;
+        let state = state::get_full_state_ids(frame_id).await?;
         return Ok(Some(state));
     }
 
@@ -208,11 +215,11 @@ pub(super) async fn resolve_state_at_incoming(
     let mut auth_chain_sets = Vec::with_capacity(extremity_state_hashes.len());
 
     for (frame_id, prev_event) in extremity_state_hashes {
-        let mut leaf_state = state::get_full_state_ids(frame_id)?;
+        let mut leaf_state = state::get_full_state_ids(frame_id).await?;
 
         if let Some(state_key) = &prev_event.state_key {
             let state_key_id =
-                state::ensure_field_id(&prev_event.event_ty.to_string().into(), state_key)?;
+                state::ensure_field_id(&prev_event.event_ty.to_string().into(), state_key).await?;
             leaf_state.insert(state_key_id, prev_event.event_id.clone());
             // Now it's the state after the pdu
         }
@@ -225,7 +232,7 @@ pub(super) async fn resolve_state_at_incoming(
                 event_ty,
                 state_key,
                 ..
-            }) = state::get_field(k)
+            }) = state::get_field(k).await
             {
                 // FIXME: Undo .to_string().into() when StateMap is updated to use StateEventType
                 state.insert((event_ty.to_string().into(), state_key), id.clone());
@@ -236,10 +243,13 @@ pub(super) async fn resolve_state_at_incoming(
         }
 
         for starting_event in starting_events {
-            auth_chain_sets.push(crate::room::auth_chain::get_auth_chain_ids(
-                &incoming_pdu.room_id,
-                [&*starting_event].into_iter(),
-            )?);
+            auth_chain_sets.push(
+                crate::room::auth_chain::get_auth_chain_ids(
+                    &incoming_pdu.room_id,
+                    [&*starting_event].into_iter(),
+                )
+                .await?,
+            );
         }
 
         fork_states.push(state);
@@ -259,37 +269,40 @@ pub(super) async fn resolve_state_at_incoming(
             .collect::<Vec<_>>(),
         &async |event_id| {
             timeline::get_pdu(&event_id)
+                .await
                 .map(|s| s.pdu)
                 .map_err(|_| StateError::other("missing pdu 5"))
         },
         |map| {
-            let mut subgraph = HashSet::new();
-            for event_ids in map.values() {
-                for event_id in event_ids {
-                    if let Ok(pdu) = timeline::get_pdu(event_id) {
-                        subgraph.extend(pdu.auth_events.iter().cloned());
-                        subgraph.extend(pdu.prev_events.iter().cloned());
+            tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async {
+                    let mut subgraph = HashSet::new();
+                    for event_ids in map.values() {
+                        for event_id in event_ids {
+                            if let Ok(pdu) = timeline::get_pdu(event_id).await {
+                                subgraph.extend(pdu.auth_events.iter().cloned());
+                                subgraph.extend(pdu.prev_events.iter().cloned());
+                            }
+                        }
                     }
-                }
-            }
-            Some(subgraph)
+                    Some(subgraph)
+                })
+            })
         },
     )
     .await;
     drop(state_lock);
 
     match result {
-        Ok(new_state) => Ok(Some(
-            new_state
-                .into_iter()
-                .map(|((event_type, state_key), event_id)| {
-                    let state_key_id =
-                        state::ensure_field_id(&event_type.to_string().into(), &state_key)?;
-                    Ok((state_key_id, event_id))
-                })
-                //  .chain(outlier_state.into_iter().map(|(k, v)| Ok((k, v))))
-                .collect::<AppResult<_>>()?,
-        )),
+        Ok(new_state) => {
+            let mut resolved = IndexMap::new();
+            for ((event_type, state_key), event_id) in new_state {
+                let state_key_id =
+                    state::ensure_field_id(&event_type.to_string().into(), &state_key).await?;
+                resolved.insert(state_key_id, event_id);
+            }
+            Ok(Some(resolved))
+        }
         Err(e) => {
             warn!("state resolution on prev events failed: {}", e);
             Ok(None)

--- a/crates/server/src/event/search.rs
+++ b/crates/server/src/event/search.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use palpo_core::Seqnum;
 
 use crate::core::client::search::{
@@ -18,23 +19,23 @@ use crate::event::BatchToken;
 use crate::room::{state, timeline};
 use crate::{AppResult, MatrixError, SnPduEvent};
 
-pub fn search_pdus(
+pub async fn search_pdus(
     user_id: &UserId,
     criteria: &Criteria,
     next_batch: Option<&str>,
 ) -> AppResult<ResultRoomEvents> {
     let filter = &criteria.filter;
 
-    let room_ids = filter
-        .rooms
-        .clone()
-        .unwrap_or_else(|| data::user::joined_rooms(user_id).unwrap_or_default());
+    let room_ids = match filter.rooms.clone() {
+        Some(rooms) => rooms,
+        None => data::user::joined_rooms(user_id).await.unwrap_or_default(),
+    };
 
     // Use limit or else 10, with maximum 100
     let limit = filter.limit.unwrap_or(10).min(100);
 
     for room_id in &room_ids {
-        if !crate::room::user::is_joined(user_id, room_id)? {
+        if !crate::room::user::is_joined(user_id, room_id).await? {
             return Err(MatrixError::forbidden(
                 "you don't have permission to view this room",
                 None,
@@ -70,17 +71,19 @@ pub fn search_pdus(
     let items = if criteria.order_by == Some(OrderBy::Rank) {
         data_query
             .order_by(diesel::dsl::sql::<diesel::sql_types::Int8>("1"))
-            .load::<(f32, OwnedEventId, i64, i64)>(&mut connect()?)?
+            .load::<(f32, OwnedEventId, i64, i64)>(&mut connect().await?)
+            .await?
     } else {
         data_query
             .order_by(event_searches::origin_server_ts.desc())
             .then_order_by(event_searches::event_sn.desc())
-            .load::<(f32, OwnedEventId, i64, i64)>(&mut connect()?)?
+            .load::<(f32, OwnedEventId, i64, i64)>(&mut connect().await?)
+            .await?
     };
     // let _ids: Vec<i64> = event_searches::table
     //     .select(event_searches::id)
     //     .load(&mut connect()?)?;
-    let count: i64 = base_query.count().first(&mut connect()?)?;
+    let count: i64 = base_query.count().first(&mut connect().await?).await?;
     let next_batch = if items.len() < limit {
         None
     } else if let Some(last) = items.last() {
@@ -93,23 +96,25 @@ pub fn search_pdus(
         None
     };
 
-    let results: Vec<_> = items
-        .into_iter()
-        .filter_map(|(rank, event_id, ..)| {
-            let pdu = timeline::get_pdu(&event_id).ok()?;
-            if state::user_can_see_event(user_id, &pdu.event_id).unwrap_or(false) {
-                Some((rank, pdu))
-            } else {
-                None
-            }
-        })
-        .map(|(rank, pdu)| SearchResult {
+    let mut results: Vec<_> = Vec::new();
+    for (rank, event_id, ..) in items {
+        let Ok(pdu) = timeline::get_pdu(&event_id).await else {
+            continue;
+        };
+        if !state::user_can_see_event(user_id, &pdu.event_id)
+            .await
+            .unwrap_or(false)
+        {
+            continue;
+        }
+        results.push(SearchResult {
             context: calc_event_context(user_id, &pdu.room_id, pdu.event_sn, 10, 10, false)
+                .await
                 .unwrap_or_default(),
             rank: Some(rank as f64),
             result: Some(pdu.to_room_event()),
-        })
-        .collect();
+        });
+    }
 
     Ok(ResultRoomEvents {
         count: Some(count as u64),
@@ -126,7 +131,7 @@ pub fn search_pdus(
 }
 
 // Calculates the contextual events for any search results.
-fn calc_event_context(
+async fn calc_event_context(
     user_id: &UserId,
     room_id: &RoomId,
     event_sn: Seqnum,
@@ -141,7 +146,8 @@ fn calc_event_context(
         None,
         None,
         before_limit,
-    )?;
+    )
+    .await?;
     let after_pdus = timeline::stream::load_pdus_forward(
         Some(user_id),
         room_id,
@@ -149,14 +155,16 @@ fn calc_event_context(
         None,
         None,
         after_limit,
-    )?;
+    )
+    .await?;
     let mut profile = BTreeMap::new();
-    if include_profile && let Ok(frame_id) = crate::event::get_frame_id(room_id, event_sn) {
+    if include_profile && let Ok(frame_id) = crate::event::get_frame_id(room_id, event_sn).await {
         let RoomMemberEventContent {
             display_name,
             avatar_url,
             ..
-        } = state::get_state_content(frame_id, &StateEventType::RoomMember, user_id.as_str())?;
+        } = state::get_state_content(frame_id, &StateEventType::RoomMember, user_id.as_str())
+            .await?;
         if let Some(display_name) = display_name {
             profile.insert("displayname".to_string(), display_name);
         }
@@ -166,7 +174,7 @@ fn calc_event_context(
     }
 
     let context = EventContextResult {
-        start: before_pdus.first().map(|(sn, _)| sn.to_string()),
+        start: before_pdus.iter().next().map(|(sn, _)| sn.to_string()),
         end: after_pdus.last().map(|(sn, _)| sn.to_string()),
         events_before: before_pdus
             .into_iter()
@@ -182,7 +190,7 @@ fn calc_event_context(
     Ok(context)
 }
 
-pub fn save_pdu(pdu: &SnPduEvent, pdu_json: &CanonicalJsonObject) -> AppResult<()> {
+pub async fn save_pdu(pdu: &SnPduEvent, pdu_json: &CanonicalJsonObject) -> AppResult<()> {
     let Some(CanonicalJsonValue::Object(content)) = pdu_json.get("content") else {
         return Ok(());
     };
@@ -219,7 +227,8 @@ pub fn save_pdu(pdu: &SnPduEvent, pdu_json: &CanonicalJsonObject) -> AppResult<(
         .bind::<diesel::sql_types::Int8, _>(pdu.origin_server_ts)
         .bind::<diesel::sql_types::Text, _>(vector)
         .bind::<diesel::sql_types::Int8, _>(pdu.origin_server_ts)
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
 
     Ok(())
 }

--- a/crates/server/src/federation.rs
+++ b/crates/server/src/federation.rs
@@ -163,12 +163,12 @@ pub(crate) async fn user_can_perform_restricted_join(
         return Ok(false);
     }
 
-    if room::user::is_joined(user_id, room_id).unwrap_or(false) {
+    if room::user::is_joined(user_id, room_id).await.unwrap_or(false) {
         // joining user is already joined, there is nothing we need to do
         return Ok(false);
     }
 
-    if room::user::is_invited(user_id, room_id).unwrap_or(false) {
+    if room::user::is_invited(user_id, room_id).await.unwrap_or(false) {
         return Ok(true);
     }
 
@@ -176,7 +176,7 @@ pub(crate) async fn user_can_perform_restricted_join(
         Some(rule) => rule.to_owned(),
         None => {
             // If no join rule is provided, we need to fetch it from the room state
-            let Ok(join_rule) = room::get_join_rule(room_id) else {
+            let Ok(join_rule) = room::get_join_rule(room_id).await else {
                 return Ok(false);
             };
             join_rule
@@ -192,20 +192,22 @@ pub(crate) async fn user_can_perform_restricted_join(
         return Ok(false);
     }
 
-    if r.allow
-        .iter()
-        .filter_map(|rule| {
-            if let AllowRule::RoomMembership(membership) = rule {
-                Some(membership)
-            } else {
-                None
-            }
-        })
-        .any(|m| {
-            room::is_server_joined(&config::get().server_name, &m.room_id).unwrap_or(false)
-                && room::user::is_joined(user_id, &m.room_id).unwrap_or(false)
-        })
-    {
+    let mut authorized = false;
+    for m in r.allow.iter().filter_map(|rule| {
+        if let AllowRule::RoomMembership(membership) = rule {
+            Some(membership)
+        } else {
+            None
+        }
+    }) {
+        if room::is_server_joined(&config::get().server_name, &m.room_id).await.unwrap_or(false)
+            && room::user::is_joined(user_id, &m.room_id).await.unwrap_or(false)
+        {
+            authorized = true;
+            break;
+        }
+    }
+    if authorized {
         Ok(true)
     } else {
         Err(MatrixError::unable_to_authorize_join(

--- a/crates/server/src/federation/access_check.rs
+++ b/crates/server/src/federation/access_check.rs
@@ -3,12 +3,12 @@ use crate::core::{EventId, MatrixError, RoomId, ServerName};
 use crate::event::handler;
 use crate::room::{self, state};
 
-pub fn access_check(
+pub async fn access_check(
     origin: &ServerName,
     room_id: &RoomId,
     event_id: Option<&EventId>,
 ) -> AppResult<()> {
-    if !room::is_server_joined(origin, room_id)? {
+    if !room::is_server_joined(origin, room_id).await? {
         return Err(MatrixError::forbidden(
             format!("server `{origin}` is not in room `{room_id}`"),
             None,
@@ -16,7 +16,7 @@ pub fn access_check(
         .into());
     }
 
-    handler::acl_check(origin, room_id)?;
+    handler::acl_check(origin, room_id).await?;
 
     // let world_readable = crate::room::is_world_readable(room_id);
 
@@ -25,7 +25,7 @@ pub fn access_check(
     // let user_is_knocking = crate::room::members_knocked(room_id).count();
 
     if let Some(event_id) = event_id
-        && !state::server_can_see_event(origin, room_id, event_id)?
+        && !state::server_can_see_event(origin, room_id, event_id).await?
     {
         return Err(MatrixError::forbidden("server is not allowed to see event", None).into());
     }

--- a/crates/server/src/federation/membership/join.rs
+++ b/crates/server/src/federation/membership/join.rs
@@ -12,17 +12,17 @@ pub async fn send_join_v1(
     room_id: &RoomId,
     pdu: &RawJsonValue,
 ) -> AppResult<RoomStateV1> {
-    if !room::room_exists(room_id)? {
+    if !room::room_exists(room_id).await? {
         return Err(MatrixError::not_found("room is unknown to this server.").into());
     }
 
-    handler::acl_check(origin, room_id)?;
+    handler::acl_check(origin, room_id).await?;
 
     // We need to return the state prior to joining, let's keep a reference to that here
-    let frame_id = room::get_frame_id(room_id, None).unwrap_or_default();
+    let frame_id = room::get_frame_id(room_id, None).await.unwrap_or_default();
 
     // We do not add the event_id field to the pdu here because of signature and hashes checks
-    let room_version_id = room::get_version(room_id)?;
+    let room_version_id = room::get_version(room_id).await?;
 
     let (event_id, mut value) = gen_event_id_canonical_json(pdu, &room_version_id)
         .map_err(|_| MatrixError::invalid_param("could not convert event to canonical json"))?;
@@ -84,11 +84,11 @@ pub async fn send_join_v1(
     )
     .map_err(|e| MatrixError::bad_json(format!("sender property is not a valid user id: {e}")))?;
 
-    if room::user::is_banned(&sender, room_id)? {
+    if room::user::is_banned(&sender, room_id).await? {
         return Err(MatrixError::forbidden("user is banned from the room", None).into());
     }
 
-    handler::acl_check(sender.server_name(), room_id)?;
+    handler::acl_check(sender.server_name(), room_id).await?;
 
     // check if origin server is trying to send for another server
     if sender.server_name() != origin {
@@ -130,7 +130,7 @@ pub async fn send_join_v1(
             .into());
         }
 
-        if !room::user::is_joined(&authorising_user, room_id)? {
+        if !room::user::is_joined(&authorising_user, room_id).await? {
             return Err(MatrixError::invalid_param(
                 "authorising user {authorising_user} is not in the room you are trying to join, \
 				 they cannot authorise your join",
@@ -177,21 +177,23 @@ pub async fn send_join_v1(
     )
     .await?;
 
-    let state_ids = state::get_full_state_ids(frame_id)?;
-    let state = state_ids
-        .iter()
-        .filter_map(|(_, id)| timeline::get_pdu_json(id).ok().flatten())
-        .map(crate::sending::convert_to_outgoing_federation_event)
-        .collect();
+    let state_ids = state::get_full_state_ids(frame_id).await?;
+    let mut state = Vec::new();
+    for (_, id) in state_ids.iter() {
+        if let Some(pdu_json) = timeline::get_pdu_json(id).await.ok().flatten() {
+            state.push(crate::sending::convert_to_outgoing_federation_event(pdu_json).await);
+        }
+    }
     let auth_chain_ids =
-        room::auth_chain::get_auth_chain_ids(room_id, state_ids.values().map(|id| &**id))?;
-    let auth_chain = auth_chain_ids
-        .into_iter()
-        .filter_map(|id| timeline::get_pdu_json(&id).ok().flatten())
-        .map(crate::sending::convert_to_outgoing_federation_event)
-        .collect();
+        room::auth_chain::get_auth_chain_ids(room_id, state_ids.values().map(|id| &**id)).await?;
+    let mut auth_chain = Vec::new();
+    for id in auth_chain_ids.into_iter() {
+        if let Some(pdu_json) = timeline::get_pdu_json(&id).await.ok().flatten() {
+            auth_chain.push(crate::sending::convert_to_outgoing_federation_event(pdu_json).await);
+        }
+    }
 
-    if let Err(e) = sending::send_pdu_room(room_id, &event_id, &[], &[origin.to_owned()]) {
+    if let Err(e) = sending::send_pdu_room(room_id, &event_id, &[], &[origin.to_owned()]).await {
         error!("failed to notify user joined to servers: {e}");
     }
 

--- a/crates/server/src/global.rs
+++ b/crates/server/src/global.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, LazyLock, OnceLock, RwLock};
 use std::time::Instant;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use hickory_resolver::Resolver as HickoryResolver;
 use hickory_resolver::config::*;
 use hickory_resolver::net::runtime::TokioRuntimeProvider;
@@ -112,12 +113,12 @@ pub fn dns_resolver() -> &'static HickoryResolver<TokioRuntimeProvider> {
     })
 }
 
-pub fn appservices() -> &'static Vec<Registration> {
+pub async fn appservices() -> &'static Vec<Registration> {
     use figment::Figment;
     use figment::providers::{Format, Toml, Yaml};
-    static APPSERVICES: OnceLock<Vec<Registration>> = OnceLock::new();
+    static APPSERVICES: tokio::sync::OnceCell<Vec<Registration>> = tokio::sync::OnceCell::const_new();
 
-    APPSERVICES.get_or_init(|| {
+    APPSERVICES.get_or_init(|| async {
         let mut appservices = vec![];
         let Some(registration_dir) = crate::config::appservice_registration_dir() else {
             return appservices;
@@ -182,7 +183,7 @@ pub fn appservices() -> &'static Vec<Registration> {
             // Ensure the appservice registration is in the database so that
             // event forwarding (via appservice::all()) can find it.
             let db_registration: DbRegistration = registration.clone().into();
-            let mut conn = connect().expect("db connect failed");
+            let mut conn = connect().await.expect("db connect failed");
             if let Err(e) = diesel::insert_into(appservice_registrations::table)
                 .values(&db_registration)
                 .on_conflict(appservice_registrations::id)
@@ -202,6 +203,7 @@ pub fn appservices() -> &'static Vec<Registration> {
                         .eq(&db_registration.device_management),
                 ))
                 .execute(&mut conn)
+                .await
             {
                 tracing::error!("Failed to save appservice registration to database: {e}");
             }
@@ -213,7 +215,7 @@ pub fn appservices() -> &'static Vec<Registration> {
                 crate::config::get().server_name
             ))
             .unwrap();
-            let mut conn = connect().expect("db connect failed");
+            let mut conn = connect().await.expect("db connect failed");
             if !diesel_exists!(users::table.filter(users::id.eq(&user_id)), &mut conn)
                 .expect("db query failed")
             {
@@ -230,6 +232,7 @@ pub fn appservices() -> &'static Vec<Registration> {
                         created_at: UnixMillis::now(),
                     })
                     .execute(&mut conn)
+                    .await
                     .expect("db query failed");
             }
 
@@ -251,21 +254,24 @@ pub fn appservices() -> &'static Vec<Registration> {
                         created_at: UnixMillis::now(),
                     })
                     .execute(&mut conn)
+                    .await
                     .expect("db query failed");
             }
         }
         appservices
     })
+    .await
 }
 
-pub fn add_signing_key_from_trusted_server(
+pub async fn add_signing_key_from_trusted_server(
     from_server: &ServerName,
     new_keys: ServerSigningKeys,
 ) -> AppResult<SigningKeys> {
     let key_data = server_signing_keys::table
         .filter(server_signing_keys::server_id.eq(from_server))
         .select(server_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect()?)
+        .first::<JsonValue>(&mut connect().await?)
+        .await
         .optional()?;
 
     let prev_keys: Option<ServerSigningKeys> = key_data.map(serde_json::from_value).transpose()?;
@@ -294,7 +300,8 @@ pub fn add_signing_key_from_trusted_server(
                 server_signing_keys::key_data.eq(serde_json::to_value(&prev_keys)?),
                 server_signing_keys::updated_at.eq(UnixMillis::now()),
             ))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         Ok(prev_keys.into())
     } else {
         diesel::insert_into(server_signing_keys::table)
@@ -310,18 +317,20 @@ pub fn add_signing_key_from_trusted_server(
                 server_signing_keys::key_data.eq(serde_json::to_value(&new_keys)?),
                 server_signing_keys::updated_at.eq(UnixMillis::now()),
             ))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         Ok(new_keys.into())
     }
 }
-pub fn add_signing_key_from_origin(
+pub async fn add_signing_key_from_origin(
     origin: &ServerName,
     new_keys: ServerSigningKeys,
 ) -> AppResult<SigningKeys> {
     let key_data = server_signing_keys::table
         .filter(server_signing_keys::server_id.eq(origin))
         .select(server_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect()?)
+        .first::<JsonValue>(&mut connect().await?)
+        .await
         .optional()?;
 
     let prev_keys: Option<ServerSigningKeys> = key_data.map(serde_json::from_value).transpose()?;
@@ -359,7 +368,8 @@ pub fn add_signing_key_from_origin(
                 server_signing_keys::key_data.eq(serde_json::to_value(&prev_keys)?),
                 server_signing_keys::updated_at.eq(UnixMillis::now()),
             ))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         Ok(prev_keys.into())
     } else {
         diesel::insert_into(server_signing_keys::table)
@@ -375,7 +385,8 @@ pub fn add_signing_key_from_origin(
                 server_signing_keys::key_data.eq(serde_json::to_value(&new_keys)?),
                 server_signing_keys::updated_at.eq(UnixMillis::now()),
             ))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         Ok(new_keys.into())
     }
 }

--- a/crates/server/src/hoops/auth.rs
+++ b/crates/server/src/hoops/auth.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::iter::FromIterator;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use salvo::http::headers::HeaderMapExt;
 use salvo::http::headers::authorization::Authorization;
 use salvo::prelude::*;
@@ -59,7 +60,8 @@ async fn auth_by_access_token_inner(aa: AuthArgs, depot: &mut Depot) -> AppResul
 
     let access_token = match user_access_tokens::table
         .filter(user_access_tokens::token.eq(token))
-        .first::<DbAccessToken>(&mut connect()?)
+        .first::<DbAccessToken>(&mut connect().await?)
+        .await
     {
         Ok(token) => Some(token),
         Err(diesel::result::Error::NotFound) => None,
@@ -71,13 +73,15 @@ async fn auth_by_access_token_inner(aa: AuthArgs, depot: &mut Depot) -> AppResul
     if let Some(access_token) = access_token {
         let user = users::table
             .find(&access_token.user_id)
-            .first::<DbUser>(&mut connect()?)
+            .first::<DbUser>(&mut connect().await?)
+            .await
             .map_err(|_| MatrixError::unknown_token("User not found", true))?;
         crate::user::ensure_account_usable(&user)?;
         let user_device = user_devices::table
             .filter(user_devices::device_id.eq(&access_token.device_id))
             .filter(user_devices::user_id.eq(&user.id))
-            .first::<DbUserDevice>(&mut connect()?)
+            .first::<DbUserDevice>(&mut connect().await?)
+            .await
             .map_err(|_| MatrixError::unknown_token("User device not found", true))?;
 
         depot.inject(AuthedInfo {
@@ -88,7 +92,7 @@ async fn auth_by_access_token_inner(aa: AuthArgs, depot: &mut Depot) -> AppResul
         });
         Ok(())
     } else {
-        let appservices = crate::appservices();
+        let appservices = crate::appservices().await;
         for appservice in appservices {
             // Use constant-time comparison to prevent timing attacks
             if appservice
@@ -114,18 +118,20 @@ async fn auth_by_access_token_inner(aa: AuthArgs, depot: &mut Depot) -> AppResul
                     }
 
                     // Get or create the masqueraded user
-                    let user = get_or_create_appservice_user(&user_id, &appservice.id)?;
+                    let user = get_or_create_appservice_user(&user_id, &appservice.id).await?;
                     let user_device =
-                        get_or_create_appservice_device(&user_id, aa.device_id.as_deref())?;
+                        get_or_create_appservice_device(&user_id, aa.device_id.as_deref()).await?;
                     (user, user_device)
                 } else {
                     // Use the appservice's main user
                     let user = users::table
                         .filter(users::appservice_id.eq(&appservice.id))
-                        .first::<DbUser>(&mut connect()?)?;
+                        .first::<DbUser>(&mut connect().await?)
+                        .await?;
                     let user_device = user_devices::table
                         .filter(user_devices::user_id.eq(&user.id))
-                        .first::<DbUserDevice>(&mut connect()?)?;
+                        .first::<DbUserDevice>(&mut connect().await?)
+                        .await?;
                     (user, user_device)
                 };
 
@@ -163,10 +169,11 @@ async fn auth_by_delegated_token(token: &str, aa: &AuthArgs, depot: &mut Depot) 
     // User should already be provisioned by the auth service via MAS admin endpoints
     let mut user = users::table
         .find(&user_id)
-        .first::<DbUser>(&mut connect()?)
+        .first::<DbUser>(&mut connect().await?)
+        .await
         .map_err(|_| MatrixError::unknown_token("User not found (not yet provisioned?)", true))?;
     if user.is_guest {
-        crate::data::user::set_guest(&user_id, false)?;
+        crate::data::user::set_guest(&user_id, false).await?;
         user.is_guest = false;
     }
     crate::user::ensure_account_usable(&user)?;
@@ -187,7 +194,8 @@ async fn auth_by_delegated_token(token: &str, aa: &AuthArgs, depot: &mut Depot) 
         user_devices::table
             .filter(user_devices::user_id.eq(&user_id))
             .filter(user_devices::device_id.eq(&device_id))
-            .first::<DbUserDevice>(&mut connect()?)
+            .first::<DbUserDevice>(&mut connect().await?)
+            .await
             .map_err(|_| {
                 MatrixError::unknown_token("Device not found (not yet provisioned?)", true)
             })?
@@ -195,7 +203,8 @@ async fn auth_by_delegated_token(token: &str, aa: &AuthArgs, depot: &mut Depot) 
         // No device_id — use first available device for this user
         user_devices::table
             .filter(user_devices::user_id.eq(&user_id))
-            .first::<DbUserDevice>(&mut connect()?)
+            .first::<DbUserDevice>(&mut connect().await?)
+            .await
             .map_err(|_| MatrixError::unknown_token("No device found for user", true))?
     };
 
@@ -209,9 +218,13 @@ async fn auth_by_delegated_token(token: &str, aa: &AuthArgs, depot: &mut Depot) 
 }
 
 /// Get or create a user for an appservice
-fn get_or_create_appservice_user(user_id: &UserId, appservice_id: &str) -> AppResult<DbUser> {
+async fn get_or_create_appservice_user(user_id: &UserId, appservice_id: &str) -> AppResult<DbUser> {
     // Try to get existing user
-    if let Ok(user) = users::table.find(user_id).first::<DbUser>(&mut connect()?) {
+    if let Ok(user) = users::table
+        .find(user_id)
+        .first::<DbUser>(&mut connect().await?)
+        .await
+    {
         return Ok(user);
     }
 
@@ -233,11 +246,12 @@ fn get_or_create_appservice_user(user_id: &UserId, appservice_id: &str) -> AppRe
         .on_conflict(users::id)
         .do_update()
         .set(&new_user)
-        .get_result::<DbUser>(&mut connect()?)?;
+        .get_result::<DbUser>(&mut connect().await?)
+        .await?;
 
     // Create a profile for the user
     let display_name = user_id.localpart().to_owned();
-    if let Err(e) = crate::data::user::set_display_name(user_id, &display_name) {
+    if let Err(e) = crate::data::user::set_display_name(user_id, &display_name).await {
         tracing::warn!(
             "failed to set profile for appservice user (non-fatal): {}",
             e
@@ -248,7 +262,7 @@ fn get_or_create_appservice_user(user_id: &UserId, appservice_id: &str) -> AppRe
 }
 
 /// Get or create a device for an appservice user
-fn get_or_create_appservice_device(
+async fn get_or_create_appservice_device(
     user_id: &UserId,
     device_id: Option<&str>,
 ) -> AppResult<DbUserDevice> {
@@ -260,7 +274,8 @@ fn get_or_create_appservice_device(
     if let Ok(device) = user_devices::table
         .filter(user_devices::user_id.eq(user_id))
         .filter(user_devices::device_id.eq(&device_id))
-        .first::<DbUserDevice>(&mut connect()?)
+        .first::<DbUserDevice>(&mut connect().await?)
+        .await
     {
         return Ok(device);
     }
@@ -279,7 +294,8 @@ fn get_or_create_appservice_device(
 
     let device = diesel::insert_into(user_devices::table)
         .values(&new_device)
-        .get_result::<DbUserDevice>(&mut connect()?)?;
+        .get_result::<DbUserDevice>(&mut connect().await?)
+        .await?;
 
     Ok(device)
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -137,8 +137,17 @@ pub(crate) struct Args {
     pub(crate) server: bool,
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+const TOKIO_WORKER_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_stack_size(TOKIO_WORKER_STACK_SIZE)
+        .build()?
+        .block_on(async_main())
+}
+
+async fn async_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Install rustls CryptoProvider for TLS (federation + outbound HTTPS)
     let _ = rustls::crypto::ring::default_provider().install_default();
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code, missing_docs)]
+#![recursion_limit = "512"]
 // #![deny(unused_crate_dependencies)]
 // #[macro_use]
 // extern crate diesel;

--- a/crates/server/src/media.rs
+++ b/crates/server/src/media.rs
@@ -4,6 +4,7 @@ use std::cmp;
 use std::num::Saturating;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 pub use preview::*;
 pub use remote::*;
 
@@ -122,7 +123,7 @@ pub fn media_storage_key(server_name: &ServerName, media_id: &str) -> String {
 }
 
 pub async fn delete_media(server_name: &ServerName, media_id: &str) -> AppResult<()> {
-    data::media::delete_media(server_name, media_id)?;
+    data::media::delete_media(server_name, media_id).await?;
     let key = media_storage_key(server_name, media_id);
     if let Err(e) = storage::delete(&key).await {
         tracing::error!("failed to delete media file '{key}': {e}");
@@ -166,10 +167,11 @@ pub fn validate_thumbnail_dimensions(width: u32, height: u32) -> AppResult<()> {
     Ok(())
 }
 
-pub fn get_all_mxcs() -> AppResult<Vec<OwnedMxcUri>> {
+pub async fn get_all_mxcs() -> AppResult<Vec<OwnedMxcUri>> {
     let mxcs = media_metadatas::table
         .select((media_metadatas::origin_server, media_metadatas::media_id))
-        .load::<(String, String)>(&mut connect()?)?
+        .load::<(String, String)>(&mut connect().await?)
+        .await?
         .into_iter()
         .map(|(origin_server, media_id)| {
             OwnedMxcUri::from(format!("mxc://{origin_server}/{media_id}"))
@@ -203,7 +205,8 @@ pub async fn save_thumbnail(
         .values(&db_thumbnail)
         .on_conflict_do_nothing()
         .returning(media_thumbnails::id)
-        .get_result::<i64>(&mut connect()?)
+        .get_result::<i64>(&mut connect().await?)
+        .await
         .optional()?;
 
     if let Some(id) = id {

--- a/crates/server/src/media/preview.rs
+++ b/crates/server/src/media/preview.rs
@@ -255,7 +255,7 @@ pub fn url_preview_allowed(url: &Url) -> bool {
 }
 
 pub async fn get_url_preview(url: &Url) -> AppResult<UrlPreviewData> {
-    if let Ok(preview) = data::media::get_url_preview(url.as_str()) {
+    if let Ok(preview) = data::media::get_url_preview(url.as_str()).await {
         return Ok(preview.into());
     }
 
@@ -263,7 +263,7 @@ pub async fn get_url_preview(url: &Url) -> AppResult<UrlPreviewData> {
     let mutex = get_url_preview_mutex(url.as_str()).await;
     let _request_lock = mutex.lock().await;
 
-    match data::media::get_url_preview(url.as_str()) {
+    match data::media::get_url_preview(url.as_str()).await {
         Ok(preview) => Ok(preview.into()),
         Err(_) => request_url_preview(url).await,
     }
@@ -311,7 +311,7 @@ async fn request_url_preview(url: &Url) -> AppResult<UrlPreviewData> {
         img if img.starts_with("image/") => download_image(url).await?,
         _ => return Err(MatrixError::unknown("unsupported content-type").into()),
     };
-    crate::data::media::set_url_preview(&data.clone().into_new_db_url_preview(url.as_str()))?;
+    crate::data::media::set_url_preview(&data.clone().into_new_db_url_preview(url.as_str())).await?;
 
     Ok(data)
 }
@@ -350,7 +350,7 @@ async fn download_image(url: &Url) -> AppResult<UrlPreviewData> {
             created_at: UnixMillis::now(),
         };
 
-        crate::data::media::insert_metadata(&metadata)?;
+        crate::data::media::insert_metadata(&metadata).await?;
     }
 
     let cursor = std::io::Cursor::new(&image);

--- a/crates/server/src/media/remote.rs
+++ b/crates/server/src/media/remote.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use salvo::Response;
 
 use super::{Dimension, FileMeta};
@@ -535,13 +536,15 @@ pub async fn delete_past_remote_media(
             .filter(media_metadatas::origin_server.ne(config::server_name()))
             .filter(media_metadatas::created_at.lt(time as i64))
             .select((media_metadatas::origin_server, media_metadatas::media_id))
-            .load::<(OwnedServerName, String)>(&mut connect()?)?
+            .load::<(OwnedServerName, String)>(&mut connect().await?)
+            .await?
     } else {
         media_metadatas::table
             .filter(media_metadatas::origin_server.eq(config::server_name()))
             .filter(media_metadatas::created_at.gt(time as i64))
             .select((media_metadatas::origin_server, media_metadatas::media_id))
-            .load::<(OwnedServerName, String)>(&mut connect()?)?
+            .load::<(OwnedServerName, String)>(&mut connect().await?)
+            .await?
     };
     let mut count = 0;
     for (origin_server, media_id) in &mxcs {
@@ -562,7 +565,7 @@ pub async fn delete_remote_media(
     media_id: &str,
     yes_i_want_to_delete_local_media: bool,
 ) -> AppResult<()> {
-    crate::data::media::delete_media(server_name, media_id)?;
+    crate::data::media::delete_media(server_name, media_id).await?;
 
     if !yes_i_want_to_delete_local_media {
         return Ok(());

--- a/crates/server/src/membership.rs
+++ b/crates/server/src/membership.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::time::Duration;
 
 use diesel::prelude::*;
+use diesel_async::{AsyncConnection, RunQueryDsl};
 use tokio::sync::RwLock;
 
 use crate::core::events::direct::DirectEventContent;
@@ -103,7 +104,7 @@ async fn validate_and_add_event_id(
 
 /// Update current membership data.
 #[tracing::instrument(skip(last_state))]
-pub fn update_membership(
+pub async fn update_membership(
     event_id: &EventId,
     event_sn: i64,
     room_id: &RoomId,
@@ -114,8 +115,10 @@ pub fn update_membership(
 ) -> AppResult<()> {
     let conf = crate::config::get();
     // Keep track what remote users exist by adding them as "deactivated" users
-    if user_id.server_name() != conf.server_name && !crate::data::user::user_exists(user_id)? {
-        crate::user::create_user(user_id, None)?;
+    if user_id.server_name() != conf.server_name
+        && !crate::data::user::user_exists(user_id).await?
+    {
+        crate::user::create_user(user_id, None).await?;
         // TODO: display_name, avatar url
     }
 
@@ -128,7 +131,8 @@ pub fn update_membership(
     match &membership {
         MembershipState::Join => {
             // Check if the user never joined this room
-            if !(room::user::is_joined(user_id, room_id)? || room::user::is_left(user_id, room_id)?)
+            if !(room::user::is_joined(user_id, room_id).await?
+                || room::user::is_left(user_id, room_id).await?)
             {
                 // Check if the room has a predecessor
                 if let Ok(Some(predecessor)) = room::get_state_content::<RoomCreateEventContent>(
@@ -137,6 +141,7 @@ pub fn update_membership(
                     "",
                     None,
                 )
+                .await
                 .map(|c| c.predecessor)
                 {
                     // Copy user settings from predecessor to the current room:
@@ -169,13 +174,16 @@ pub fn update_membership(
                         user_id,
                         &predecessor.room_id,
                         &RoomAccountDataEventType::Tag.to_string(),
-                    )? {
+                    )
+                    .await?
+                    {
                         crate::data::user::set_data(
                             user_id,
                             Some(room_id.to_owned()),
                             &RoomAccountDataEventType::Tag.to_string(),
                             tag_event_content,
                         )
+                        .await
                         .ok();
                     };
 
@@ -186,6 +194,7 @@ pub fn update_membership(
                             None,
                             &GlobalAccountDataEventType::Direct.to_string(),
                         )
+                        .await
                     {
                         let mut room_ids_updated = false;
 
@@ -202,48 +211,47 @@ pub fn update_membership(
                                 None,
                                 &GlobalAccountDataEventType::Direct.to_string(),
                                 serde_json::to_value(&direct_event_content)?,
-                            )?;
+                            )
+                            .await?;
                         }
                     };
                 }
             }
-            connect()?.transaction::<_, AppError, _>(|conn| {
-                // let forgotten = room_users::table
-                //     .filter(room_users::room_id.eq(room_id))
-                //     .filter(room_users::user_id.eq(user_id))
-                //     .select(room_users::forgotten)
-                //     .first::<bool>(conn)
-                //     .optional()?
-                //     .unwrap_or_default();
-                diesel::delete(
-                    room_users::table
-                        .filter(room_users::room_id.eq(room_id))
-                        .filter(room_users::user_id.eq(user_id)),
-                )
-                .execute(conn)?;
-                diesel::insert_into(room_users::table)
-                    .values(&NewDbRoomUser {
-                        room_id: room_id.to_owned(),
-                        room_server_id: room_id.server_name().ok().map(|v| v.to_owned()),
-                        user_id: user_id.to_owned(),
-                        user_server_id: user_id.server_name().to_owned(),
-                        event_id: event_id.to_owned(),
-                        event_sn,
-                        sender_id: sender_id.to_owned(),
-                        membership: membership.to_string(),
-                        forgotten: false,
-                        display_name: None,
-                        avatar_url: None,
-                        state_data,
-                        created_at: UnixMillis::now(),
-                    })
-                    .execute(conn)?;
-                Ok(())
-            })?;
+            connect()
+                .await?
+                .transaction::<_, AppError, _>(async |conn| {
+                    diesel::delete(
+                        room_users::table
+                            .filter(room_users::room_id.eq(room_id))
+                            .filter(room_users::user_id.eq(user_id)),
+                    )
+                    .execute(conn)
+                    .await?;
+                    diesel::insert_into(room_users::table)
+                        .values(&NewDbRoomUser {
+                            room_id: room_id.to_owned(),
+                            room_server_id: room_id.server_name().ok().map(|v| v.to_owned()),
+                            user_id: user_id.to_owned(),
+                            user_server_id: user_id.server_name().to_owned(),
+                            event_id: event_id.to_owned(),
+                            event_sn,
+                            sender_id: sender_id.to_owned(),
+                            membership: membership.to_string(),
+                            forgotten: false,
+                            display_name: None,
+                            avatar_url: None,
+                            state_data,
+                            created_at: UnixMillis::now(),
+                        })
+                        .execute(conn)
+                        .await?;
+                    Ok(())
+                })
+                .await?;
         }
         MembershipState::Invite | MembershipState::Knock => {
             // We want to know if the sender is ignored by the receiver
-            if crate::user::user_is_ignored(sender_id, user_id) {
+            if crate::user::user_is_ignored(sender_id, user_id).await {
                 return Ok(());
             }
             if let Some(last_state) = &last_state {
@@ -254,78 +262,74 @@ pub fn update_membership(
                 }
             }
             let _ = ensure_field(&StateEventType::RoomMember, user_id.as_str());
-            connect()?.transaction::<_, AppError, _>(|conn| {
-                // let forgotten = room_users::table
-                //     .filter(room_users::room_id.eq(room_id))
-                //     .filter(room_users::user_id.eq(user_id))
-                //     .select(room_users::forgotten)
-                //     .first::<bool>(conn)
-                //     .optional()?
-                //     .unwrap_or_default();
-                diesel::delete(
-                    room_users::table
-                        .filter(room_users::room_id.eq(room_id))
-                        .filter(room_users::user_id.eq(user_id)),
-                )
-                .execute(conn)?;
-                diesel::insert_into(room_users::table)
-                    .values(&NewDbRoomUser {
-                        room_id: room_id.to_owned(),
-                        room_server_id: room_id.server_name().ok().map(|v| v.to_owned()),
-                        user_id: user_id.to_owned(),
-                        user_server_id: user_id.server_name().to_owned(),
-                        event_id: event_id.to_owned(),
-                        event_sn,
-                        sender_id: sender_id.to_owned(),
-                        membership: membership.to_string(),
-                        forgotten: false,
-                        display_name: None,
-                        avatar_url: None,
-                        state_data,
-                        created_at: UnixMillis::now(),
-                    })
-                    .execute(conn)?;
-                Ok(())
-            })?;
+            connect()
+                .await?
+                .transaction::<_, AppError, _>(async |conn| {
+                    diesel::delete(
+                        room_users::table
+                            .filter(room_users::room_id.eq(room_id))
+                            .filter(room_users::user_id.eq(user_id)),
+                    )
+                    .execute(conn)
+                    .await?;
+                    diesel::insert_into(room_users::table)
+                        .values(&NewDbRoomUser {
+                            room_id: room_id.to_owned(),
+                            room_server_id: room_id.server_name().ok().map(|v| v.to_owned()),
+                            user_id: user_id.to_owned(),
+                            user_server_id: user_id.server_name().to_owned(),
+                            event_id: event_id.to_owned(),
+                            event_sn,
+                            sender_id: sender_id.to_owned(),
+                            membership: membership.to_string(),
+                            forgotten: false,
+                            display_name: None,
+                            avatar_url: None,
+                            state_data,
+                            created_at: UnixMillis::now(),
+                        })
+                        .execute(conn)
+                        .await?;
+                    Ok(())
+                })
+                .await?;
         }
         MembershipState::Leave | MembershipState::Ban => {
-            connect()?.transaction::<_, AppError, _>(|conn| {
-                // let forgotten = room_users::table
-                //     .filter(room_users::room_id.eq(room_id))
-                //     .filter(room_users::user_id.eq(user_id))
-                //     .select(room_users::forgotten)
-                //     .first::<bool>(conn)
-                //     .optional()?
-                //     .unwrap_or_default();
-                diesel::delete(
-                    room_users::table
-                        .filter(room_users::room_id.eq(room_id))
-                        .filter(room_users::user_id.eq(user_id)),
-                )
-                .execute(conn)?;
-                diesel::insert_into(room_users::table)
-                    .values(&NewDbRoomUser {
-                        room_id: room_id.to_owned(),
-                        room_server_id: room_id.server_name().ok().map(|v| v.to_owned()),
-                        user_id: user_id.to_owned(),
-                        user_server_id: user_id.server_name().to_owned(),
-                        event_id: event_id.to_owned(),
-                        event_sn,
-                        sender_id: sender_id.to_owned(),
-                        membership: membership.to_string(),
-                        forgotten: false,
-                        display_name: None,
-                        avatar_url: None,
-                        state_data,
-                        created_at: UnixMillis::now(),
-                    })
-                    .execute(conn)?;
-                Ok(())
-            })?;
+            connect()
+                .await?
+                .transaction::<_, AppError, _>(async |conn| {
+                    diesel::delete(
+                        room_users::table
+                            .filter(room_users::room_id.eq(room_id))
+                            .filter(room_users::user_id.eq(user_id)),
+                    )
+                    .execute(conn)
+                    .await?;
+                    diesel::insert_into(room_users::table)
+                        .values(&NewDbRoomUser {
+                            room_id: room_id.to_owned(),
+                            room_server_id: room_id.server_name().ok().map(|v| v.to_owned()),
+                            user_id: user_id.to_owned(),
+                            user_server_id: user_id.server_name().to_owned(),
+                            event_id: event_id.to_owned(),
+                            event_sn,
+                            sender_id: sender_id.to_owned(),
+                            membership: membership.to_string(),
+                            forgotten: false,
+                            display_name: None,
+                            avatar_url: None,
+                            state_data,
+                            created_at: UnixMillis::now(),
+                        })
+                        .execute(conn)
+                        .await?;
+                    Ok(())
+                })
+                .await?;
         }
         _ => {}
     }
-    crate::room::update_joined_servers(room_id)?;
-    crate::room::update_currents(room_id)?;
+    crate::room::update_joined_servers(room_id).await?;
+    crate::room::update_currents(room_id).await?;
     Ok(())
 }

--- a/crates/server/src/membership/banned.rs
+++ b/crates/server/src/membership/banned.rs
@@ -14,13 +14,13 @@ pub async fn banned_room_check(
     server_name: Option<&ServerName>,
     client_addr: &SocketAddr,
 ) -> AppResult<()> {
-    if data::user::is_admin(user_id)? {
+    if data::user::is_admin(user_id).await? {
         return Ok(());
     }
 
     let conf = crate::config::get();
     if let Some(room_id) = room_id {
-        if data::room::is_disabled(room_id)?
+        if data::room::is_disabled(room_id).await?
             || (room_id.server_name().is_ok()
                 && conf.forbidden_remote_server_names.is_match(
                     room_id
@@ -48,7 +48,7 @@ pub async fn banned_room_check(
                     .ok();
                 }
 
-                let all_joined_rooms: Vec<OwnedRoomId> = data::user::joined_rooms(user_id)?;
+                let all_joined_rooms: Vec<OwnedRoomId> = data::user::joined_rooms(user_id).await?;
 
                 crate::user::full_user_deactivate(user_id, &all_joined_rooms).await?;
             }
@@ -78,7 +78,7 @@ pub async fn banned_room_check(
                 .ok();
             }
 
-            let all_joined_rooms = data::user::joined_rooms(user_id)?;
+            let all_joined_rooms = data::user::joined_rooms(user_id).await?;
             crate::user::full_user_deactivate(user_id, &all_joined_rooms).await?;
         }
 

--- a/crates/server/src/membership/forget.rs
+++ b/crates/server/src/membership/forget.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::core::identifiers::*;
 use crate::data::schema::*;
@@ -7,13 +8,13 @@ use crate::{AppResult, MatrixError};
 
 /// Makes a user forget a room.
 #[tracing::instrument]
-pub fn forget_room(user_id: &UserId, room_id: &RoomId) -> AppResult<()> {
+pub async fn forget_room(user_id: &UserId, room_id: &RoomId) -> AppResult<()> {
     if diesel_exists!(
         room_users::table
             .filter(room_users::user_id.eq(user_id))
             .filter(room_users::room_id.eq(room_id))
             .filter(room_users::membership.eq("join")),
-        &mut connect()?
+        &mut connect().await?
     )? {
         return Err(MatrixError::unknown("The user has not left the room.").into());
     }
@@ -23,6 +24,7 @@ pub fn forget_room(user_id: &UserId, room_id: &RoomId) -> AppResult<()> {
             .filter(room_users::room_id.eq(room_id)),
     )
     .set(room_users::forgotten.eq(true))
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }

--- a/crates/server/src/membership/invite.rs
+++ b/crates/server/src/membership/invite.rs
@@ -15,7 +15,7 @@ pub async fn invite_user(
     reason: Option<String>,
     is_direct: bool,
 ) -> AppResult<()> {
-    if !room::user::is_joined(inviter_id, room_id)? {
+    if !room::user::is_joined(inviter_id, room_id).await? {
         return Err(MatrixError::forbidden(
             "you must be joined in the room you are trying to invite from",
             None,
@@ -49,18 +49,18 @@ pub async fn invite_user(
                     inviter_id,
                     room_id,
                     crate::room::get_version(room_id)
-                        .as_ref()
+                        .await.as_ref()
                         .unwrap_or(&conf.default_room_version),
                     &state_lock,
                 )
                 .await?;
             drop(state_lock);
 
-            let invite_room_state = state::summary_stripped(&pdu)?;
+            let invite_room_state = state::summary_stripped(&pdu).await?;
 
             (pdu, pdu_json, invite_room_state)
         };
-        let room_version_id = room::get_version(room_id)?;
+        let room_version_id = room::get_version(room_id).await?;
 
         crate::membership::update_membership(
             &pdu.event_id,
@@ -70,7 +70,7 @@ pub async fn invite_user(
             MembershipState::Invite,
             inviter_id,
             Some(invite_room_state.clone()),
-        )?;
+        ).await?;
 
         let invite_request = crate::core::federation::membership::invite_user_request_v2(
             &invitee_id.server_name().origin().await,
@@ -80,9 +80,9 @@ pub async fn invite_user(
             },
             InviteUserReqBodyV2 {
                 room_version: room_version_id.clone(),
-                event: sending::convert_to_outgoing_federation_event(pdu_json.clone()),
+                event: sending::convert_to_outgoing_federation_event(pdu_json.clone()).await,
                 invite_room_state,
-                via: state::servers_route_via(room_id).ok(),
+                via: state::servers_route_via(room_id).await.ok(),
             },
         )?
         .into_inner();
@@ -144,7 +144,7 @@ pub async fn invite_user(
             &event_id,
             &[invitee_id.server_name().to_owned()],
             &[],
-        );
+        ).await;
     }
 
     timeline::build_and_append_pdu(
@@ -152,11 +152,11 @@ pub async fn invite_user(
             event_type: TimelineEventType::RoomMember,
             content: to_raw_json_value(&RoomMemberEventContent {
                 membership: MembershipState::Invite,
-                display_name: data::user::display_name(invitee_id)?,
-                avatar_url: data::user::avatar_url(invitee_id)?,
+                display_name: data::user::display_name(invitee_id).await?,
+                avatar_url: data::user::avatar_url(invitee_id).await?,
                 is_direct: Some(is_direct),
                 third_party_invite: None,
-                blurhash: data::user::blurhash(invitee_id)?,
+                blurhash: data::user::blurhash(invitee_id).await?,
                 reason,
                 join_authorized_via_users_server: None,
                 #[cfg(feature = "unstable-msc4293")]
@@ -169,7 +169,7 @@ pub async fn invite_user(
         },
         inviter_id,
         room_id,
-        &crate::room::get_version(room_id)?,
+        &crate::room::get_version(room_id).await?,
         &room::lock_state(room_id).await,
     )
     .await?;

--- a/crates/server/src/membership/join.rs
+++ b/crates/server/src/membership/join.rs
@@ -332,7 +332,19 @@ pub async fn join_room(
         let (event_id, event_value) = parse_fetched_pdu(room_id, &room_version, state)?;
         parsed_pdus.insert(event_id, event_value);
     }
-    for (event_id, event_value) in parsed_pdus {
+    // Process the trusted send_join auth_chain/state events in topological
+    // (depth) order so that each event's prev_events are already stored by the
+    // time it is handled. Processing them in arbitrary order makes an event
+    // whose ancestors haven't been stored yet look like it has missing
+    // prev_events, which drives the incoming-PDU pipeline to fire
+    // `get_missing_events`/`state_ids`/`state` federation requests back at the
+    // remote. Against servers that only answer make/send_join (e.g. Complement
+    // test servers) those 404 and needlessly congest the outbound send queue,
+    // delaying real traffic such as a redaction we're trying to deliver.
+    let mut ordered_pdus: Vec<_> = parsed_pdus.into_iter().collect();
+    ordered_pdus
+        .sort_by_key(|(_, value)| value.get("depth").and_then(|v| v.as_integer()).unwrap_or(0));
+    for (event_id, event_value) in ordered_pdus {
         if let Err(e) = process_incoming_pdu(
             &remote_server,
             &event_id,

--- a/crates/server/src/membership/join.rs
+++ b/crates/server/src/membership/join.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use indexmap::IndexMap;
 use palpo_core::serde::JsonValue;
 use palpo_data::user::DbUser;
@@ -52,19 +53,19 @@ pub async fn join_room(
     appservice: Option<&RegistrationInfo>,
     extra_data: BTreeMap<String, JsonValue>,
 ) -> AppResult<JoinRoomResBody> {
-    if sender.is_guest && appservice.is_none() && !room::guest_can_join(room_id) {
+    if sender.is_guest && appservice.is_none() && !room::guest_can_join(room_id).await {
         return Err(
             MatrixError::forbidden("guests are not allowed to join this room", None).into(),
         );
     }
     let sender_id = &sender.id;
-    if room::user::is_joined(sender_id, room_id)? {
+    if room::user::is_joined(sender_id, room_id).await? {
         return Ok(JoinRoomResBody {
             room_id: room_id.into(),
         });
     }
 
-    if let Ok(membership) = room::get_member(room_id, sender_id, None)
+    if let Ok(membership) = room::get_member(room_id, sender_id, None).await
         && membership.membership == MembershipState::Ban
     {
         tracing::warn!(
@@ -80,15 +81,15 @@ pub async fn join_room(
 
     if !should_remote {
         info!("we can join locally");
-        let join_rule = room::get_join_rule(room_id)?;
+        let join_rule = room::get_join_rule(room_id).await?;
 
         let event = RoomMemberEventContent {
             membership: MembershipState::Join,
-            display_name: data::user::display_name(sender_id).ok().flatten(),
-            avatar_url: data::user::avatar_url(sender_id).ok().flatten(),
+            display_name: data::user::display_name(sender_id).await.ok().flatten(),
+            avatar_url: data::user::avatar_url(sender_id).await.ok().flatten(),
             is_direct: None,
             third_party_invite: None,
-            blurhash: data::user::blurhash(sender_id).ok().flatten(),
+            blurhash: data::user::blurhash(sender_id).await.ok().flatten(),
             reason: reason.clone(),
             join_authorized_via_users_server: get_first_user_can_issue_invite(
                 room_id,
@@ -110,7 +111,7 @@ pub async fn join_room(
             },
             sender_id,
             room_id,
-            &crate::room::get_version(room_id)?,
+            &crate::room::get_version(room_id).await?,
             &room::lock_state(room_id).await,
         )
         .await
@@ -121,10 +122,11 @@ pub async fn join_room(
                         sender_id,
                         device_id,
                         &[room_id.to_owned()],
-                    )?;
+                    )
+                    .await?;
                 }
 
-                if let Err(e) = sending::send_pdu_room(room_id, &pdu.event_id, &[], &[]) {
+                if let Err(e) = sending::send_pdu_room(room_id, &pdu.event_id, &[], &[]).await {
                     error!("failed to notify banned user server: {e}");
                 }
                 return Ok(JoinRoomResBody::new(room_id.to_owned()));
@@ -180,11 +182,11 @@ pub async fn join_room(
         // canonical JSON, so map the error instead of panicking.
         to_canonical_value(RoomMemberEventContent {
             membership: MembershipState::Join,
-            display_name: data::user::display_name(sender_id)?,
-            avatar_url: data::user::avatar_url(sender_id)?,
+            display_name: data::user::display_name(sender_id).await?,
+            avatar_url: data::user::avatar_url(sender_id).await?,
             is_direct: None,
             third_party_invite: None,
-            blurhash: data::user::blurhash(sender_id)?,
+            blurhash: data::user::blurhash(sender_id).await?,
             reason,
             join_authorized_via_users_server,
             #[cfg(feature = "unstable-msc4293")]
@@ -221,9 +223,9 @@ pub async fn join_room(
     // up the room version — this room isn't in our DB yet during a federation join.
     let mut outgoing = join_event.clone();
     maybe_strip_event_id(&mut outgoing, &room_version);
-    let body = SendJoinReqBody(crate::sending::convert_to_outgoing_federation_event(
-        outgoing,
-    ));
+    let body = SendJoinReqBody(
+        crate::sending::convert_to_outgoing_federation_event(outgoing).await,
+    );
     info!("asking {remote_server} for send_join");
     let send_join_request = crate::core::federation::membership::send_join_request(
         &remote_server.origin().await,
@@ -291,7 +293,7 @@ pub async fn join_room(
         }
     }
 
-    room::ensure_room(room_id, &room_version)?;
+    room::ensure_room(room_id, &room_version).await?;
 
     let parsed_join_pdu = PduEvent::from_canonical_object(room_id, &event_id, join_event.clone())
         .map_err(|e| {
@@ -299,7 +301,7 @@ pub async fn join_room(
         AppError::public("invalid join event pdu")
     })?;
     let join_event_id = parsed_join_pdu.event_id.clone();
-    let (join_event_sn, event_guard) = ensure_event_sn(room_id, &join_event_id)?;
+    let (join_event_sn, event_guard) = ensure_event_sn(room_id, &join_event_id).await?;
 
     let mut state = HashMap::new();
     let pub_key_map = RwLock::new(BTreeMap::new());
@@ -318,7 +320,8 @@ pub async fn join_room(
         MembershipState::Join,
         sender_id,
         None,
-    )?;
+    )
+    .await?;
 
     let mut parsed_pdus = IndexMap::new();
     for auth_pdu in resp_auth {
@@ -357,10 +360,10 @@ pub async fn join_room(
             Err(_) => continue,
         };
 
-        let pdu = if let Some(pdu) = timeline::get_pdu(&event_id).optional()? {
+        let pdu = if let Some(pdu) = timeline::get_pdu(&event_id).await.optional()? {
             pdu
         } else {
-            let (event_sn, event_guard) = ensure_event_sn(room_id, &event_id)?;
+            let (event_sn, event_guard) = ensure_event_sn(room_id, &event_id).await?;
             let pdu = SnPduEvent::from_canonical_object(
                 room_id,
                 &event_id,
@@ -378,7 +381,8 @@ pub async fn join_room(
             NewDbEvent::from_canonical_json_with_room_id(
                 &event_id, event_sn, &value, false, room_id,
             )?
-            .save()?;
+            .save()
+            .await?;
             DbEventData {
                 event_id: pdu.event_id.to_owned(),
                 event_sn,
@@ -387,14 +391,16 @@ pub async fn join_room(
                 json_data: serde_json::to_value(&value)?,
                 format_version: None,
             }
-            .save()?;
+            .save()
+            .await?;
 
             drop(event_guard);
             pdu
         };
 
         if let Some(state_key) = &pdu.state_key {
-            let state_key_id = state::ensure_field_id(&pdu.event_ty.to_string().into(), state_key)?;
+            let state_key_id =
+                state::ensure_field_id(&pdu.event_ty.to_string().into(), state_key).await?;
             state.insert(state_key_id, (pdu.event_id.clone(), pdu.event_sn));
         }
     }
@@ -411,12 +417,13 @@ pub async fn join_room(
             Err(_) => continue,
         };
 
-        if !timeline::has_pdu(&event_id) {
-            let (event_sn, event_guard) = ensure_event_sn(room_id, &event_id)?;
+        if !timeline::has_pdu(&event_id).await {
+            let (event_sn, event_guard) = ensure_event_sn(room_id, &event_id).await?;
             NewDbEvent::from_canonical_json_with_room_id(
                 &event_id, event_sn, &value, false, room_id,
             )?
-            .save()?;
+            .save()
+            .await?;
             DbEventData {
                 event_id: event_id.to_owned(),
                 event_sn,
@@ -425,7 +432,8 @@ pub async fn join_room(
                 json_data: serde_json::to_value(&value)?,
                 format_version: None,
             }
-            .save()?;
+            .save()
+            .await?;
             drop(event_guard);
         }
     }
@@ -465,9 +473,10 @@ pub async fn join_room(
                 .map(|(k, (_event_id, event_sn))| Ok(CompressedEvent::new(k, event_sn)))
                 .collect::<AppResult<_>>()?,
         ),
-    )?;
+    )
+    .await?;
 
-    state::force_state(room_id, frame_id, appended, disposed)?;
+    state::force_state(room_id, frame_id, appended, disposed).await?;
     info!("appending new room join event");
     diesel::insert_into(events::table)
         .values(NewDbEvent::from_canonical_json_with_room_id(
@@ -478,7 +487,8 @@ pub async fn join_room(
             room_id,
         )?)
         .on_conflict_do_nothing()
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
 
     let join_pdu = SnPduEvent {
         pdu: parsed_join_pdu,
@@ -489,13 +499,13 @@ pub async fn join_room(
     };
 
     timeline::append_pdu(&join_pdu, join_event, &state_lock).await?;
-    let frame_id_after_join = state::append_to_state(&join_pdu)?;
+    let frame_id_after_join = state::append_to_state(&join_pdu).await?;
     drop(event_guard);
 
     info!("setting final room state for new room");
     // We set the room state after inserting the pdu, so that we never have a moment in time
     // where events in the current room state do not exist
-    state::set_room_state(room_id, frame_id_after_join)?;
+    state::set_room_state(room_id, frame_id_after_join).await?;
     drop(state_lock);
 
     if let Some(device_id) = device_id
@@ -505,14 +515,14 @@ pub async fn join_room(
             .filter(room_users::room_id.ne(room_id))
             .filter(room_users::user_id.eq(sender_id))
             .filter(room_users::room_server_id.eq(room_server_id));
-        if !diesel_exists!(query, &mut connect()?)? {
+        if !diesel_exists!(query, &mut connect().await?)? {
             let content = DeviceListUpdateContent::new(
                 sender_id.to_owned(),
                 device_id.to_owned(),
-                data::next_sn()? as u64,
+                data::next_sn().await? as u64,
             );
             let edu = Edu::DeviceListUpdate(content);
-            send_edu_server(room_server_id, &edu)?;
+            send_edu_server(room_server_id, &edu).await?;
         }
     }
 
@@ -524,9 +534,16 @@ pub async fn get_first_user_can_issue_invite(
     invitee_id: &UserId,
     restriction_rooms: &[OwnedRoomId],
 ) -> AppResult<OwnedUserId> {
-    let invitee_in_restriction_room = restriction_rooms.iter().any(|restriction_room_id| {
-        room::user::is_joined(invitee_id, restriction_room_id).unwrap_or(false)
-    });
+    let mut invitee_in_restriction_room = false;
+    for restriction_room_id in restriction_rooms.iter() {
+        if room::user::is_joined(invitee_id, restriction_room_id)
+            .await
+            .unwrap_or(false)
+        {
+            invitee_in_restriction_room = true;
+            break;
+        }
+    }
     if !invitee_in_restriction_room {
         debug!(
             "get_first_user_can_issue_invite: invitee {invitee_id} not in any restriction room {:?}",
@@ -534,7 +551,7 @@ pub async fn get_first_user_can_issue_invite(
         );
     }
     if invitee_in_restriction_room {
-        let joined_users: Vec<_> = room::joined_users(room_id, None)?;
+        let joined_users: Vec<_> = room::joined_users(room_id, None).await?;
         for joined_user in &joined_users {
             if joined_user.server_name() == config::get().server_name
                 && room::user_can_invite(room_id, joined_user, invitee_id).await
@@ -556,10 +573,18 @@ pub async fn get_users_can_issue_invite(
     restriction_rooms: &[OwnedRoomId],
 ) -> AppResult<Vec<OwnedUserId>> {
     let mut users = vec![];
-    if restriction_rooms.iter().any(|restriction_room_id| {
-        room::user::is_joined(invitee_id, restriction_room_id).unwrap_or(false)
-    }) {
-        for joined_user in room::joined_users(room_id, None)? {
+    let mut invitee_in_restriction_room = false;
+    for restriction_room_id in restriction_rooms.iter() {
+        if room::user::is_joined(invitee_id, restriction_room_id)
+            .await
+            .unwrap_or(false)
+        {
+            invitee_in_restriction_room = true;
+            break;
+        }
+    }
+    if invitee_in_restriction_room {
+        for joined_user in room::joined_users(room_id, None).await? {
             if joined_user.server_name() == config::get().server_name
                 && room::user_can_invite(room_id, &joined_user, invitee_id).await
             {
@@ -575,7 +600,7 @@ async fn make_join_request(
     room_id: &RoomId,
     servers: &[OwnedServerName],
 ) -> AppResult<(MakeJoinResBody, OwnedServerName)> {
-    let invited_locally = room::user::is_invited(user_id, room_id).unwrap_or(false);
+    let invited_locally = room::user::is_invited(user_id, room_id).await.unwrap_or(false);
     let mut last_join_error = Err(StatusError::bad_request()
         .brief("no server available to assist in joining")
         .into());

--- a/crates/server/src/membership/knock.rs
+++ b/crates/server/src/membership/knock.rs
@@ -23,7 +23,7 @@ pub async fn knock_room(
     reason: Option<String>,
     servers: &[OwnedServerName],
 ) -> AppResult<Option<SnPduEvent>> {
-    if room::user::is_invited(sender_id, room_id)? {
+    if room::user::is_invited(sender_id, room_id).await? {
         warn!("{sender_id} is already invited in {room_id} but attempted to knock");
         return Err(MatrixError::forbidden(
             "you cannot knock on a room you are already invited/accepted to.",
@@ -32,7 +32,7 @@ pub async fn knock_room(
         .into());
     }
 
-    if room::user::is_joined(sender_id, room_id)? {
+    if room::user::is_joined(sender_id, room_id).await? {
         warn!("{sender_id} is already joined in {room_id} but attempted to knock");
         return Err(MatrixError::forbidden(
             "you cannot knock on a room you are already joined in.",
@@ -41,12 +41,12 @@ pub async fn knock_room(
         .into());
     }
 
-    if room::user::is_knocked(sender_id, room_id)? {
+    if room::user::is_knocked(sender_id, room_id).await? {
         warn!("{sender_id} is already knocked in {room_id}");
         return Ok(None);
     }
 
-    if let Ok(memeber) = room::get_member(room_id, sender_id, None)
+    if let Ok(memeber) = room::get_member(room_id, sender_id, None).await
         && memeber.membership == MembershipState::Ban
     {
         warn!("{sender_id} is banned from {room_id} but attempted to knock");
@@ -58,10 +58,10 @@ pub async fn knock_room(
     }
 
     let conf = config::get();
-    if room::is_server_joined(&conf.server_name, room_id).unwrap_or(false) {
+    if room::is_server_joined(&conf.server_name, room_id).await.unwrap_or(false) {
         use RoomVersionId::*;
         info!("we can knock locally");
-        let room_version = room::get_version(room_id)?;
+        let room_version = room::get_version(room_id).await?;
         if matches!(room_version, V1 | V2 | V3 | V4 | V5 | V6) {
             return Err(MatrixError::forbidden(
                 "this room version does not support knocking",
@@ -70,7 +70,7 @@ pub async fn knock_room(
             .into());
         }
 
-        let join_rule = room::get_join_rule(room_id)?;
+        let join_rule = room::get_join_rule(room_id).await?;
         if !matches!(
             join_rule,
             JoinRule::Invite | JoinRule::Knock | JoinRule::KnockRestricted(..)
@@ -79,9 +79,9 @@ pub async fn knock_room(
         }
 
         let content = RoomMemberEventContent {
-            display_name: crate::data::user::display_name(sender_id).ok().flatten(),
-            avatar_url: crate::data::user::avatar_url(sender_id).ok().flatten(),
-            blurhash: crate::data::user::blurhash(sender_id).ok().flatten(),
+            display_name: crate::data::user::display_name(sender_id).await.ok().flatten(),
+            avatar_url: crate::data::user::avatar_url(sender_id).await.ok().flatten(),
+            blurhash: crate::data::user::blurhash(sender_id).await.ok().flatten(),
             reason: reason.clone(),
             ..RoomMemberEventContent::new(MembershipState::Knock)
         };
@@ -91,7 +91,7 @@ pub async fn knock_room(
             PduBuilder::state(sender_id.to_string(), &content),
             sender_id,
             room_id,
-            &crate::room::get_version(room_id)?,
+            &crate::room::get_version(room_id).await?,
             &room::lock_state(room_id).await,
         )
         .await
@@ -102,7 +102,7 @@ pub async fn knock_room(
                     &pdu.event_id,
                     &[sender_id.server_name().to_owned()],
                     &[],
-                ) {
+                ).await {
                     error!("failed to notify banned user server: {e}");
                 }
                 return Ok(Some(pdu));
@@ -129,7 +129,7 @@ pub async fn knock_room(
             .brief("remote room version {room_version} is not supported by palpo")
             .into());
     }
-    crate::room::ensure_room(room_id, &room_version)?;
+    crate::room::ensure_room(room_id, &room_version).await?;
 
     let mut knock_event_stub: CanonicalJsonObject =
         serde_json::from_str(make_knock_response.event.get()).map_err(|e| {
@@ -145,9 +145,9 @@ pub async fn knock_room(
     knock_event_stub.insert(
         "content".to_owned(),
         to_canonical_value(RoomMemberEventContent {
-            display_name: crate::data::user::display_name(sender_id).ok().flatten(),
-            avatar_url: crate::data::user::avatar_url(sender_id).ok().flatten(),
-            blurhash: crate::data::user::blurhash(sender_id).ok().flatten(),
+            display_name: crate::data::user::display_name(sender_id).await.ok().flatten(),
+            avatar_url: crate::data::user::avatar_url(sender_id).await.ok().flatten(),
+            blurhash: crate::data::user::blurhash(sender_id).await.ok().flatten(),
             reason,
             ..RoomMemberEventContent::new(MembershipState::Knock)
         })
@@ -179,7 +179,7 @@ pub async fn knock_room(
         },
         SendKnockReqBody::new(crate::sending::convert_to_outgoing_federation_event(
             knock_event.clone(),
-        )),
+        ).await),
     )?
     .into_inner();
 
@@ -200,7 +200,7 @@ pub async fn knock_room(
 
     info!("appending room knock event locally");
     let event_id = parsed_knock_pdu.event_id.clone();
-    let (event_sn, event_guard) = ensure_event_sn(room_id, &event_id)?;
+    let (event_sn, event_guard) = ensure_event_sn(room_id, &event_id).await?;
     NewDbEvent {
         id: event_id.to_owned(),
         sn: event_sn,
@@ -221,7 +221,7 @@ pub async fn knock_room(
         is_rejected: false,
         rejection_reason: None,
     }
-    .save()?;
+    .save().await?;
     let knock_pdu = SnPduEvent {
         pdu: parsed_knock_pdu,
         event_sn,

--- a/crates/server/src/membership/leave.rs
+++ b/crates/server/src/membership/leave.rs
@@ -18,10 +18,10 @@ use crate::{
 
 // Make a user leave all their joined rooms
 pub async fn leave_all_rooms(user_id: &UserId) -> AppResult<()> {
-    let all_room_ids = data::user::joined_rooms(user_id)?
+    let all_room_ids = data::user::joined_rooms(user_id).await?
         .into_iter()
         .chain(
-            data::user::invited_rooms(user_id, 0)?
+            data::user::invited_rooms(user_id, 0).await?
                 .into_iter()
                 .map(|t| t.0),
         )
@@ -40,7 +40,7 @@ pub async fn leave_room(
     // Ask a remote server if we don't have this room
     let conf = config::get();
 
-    if room::is_server_joined(&conf.server_name, room_id)? {
+    if room::is_server_joined(&conf.server_name, room_id).await? {
         // If only this server in room, leave locally.
         if let Err(e) = leave_room_local(user_id, room_id, reason.clone()).await {
             warn!("failed to leave room {} locally: {}", user_id, e);
@@ -50,7 +50,7 @@ pub async fn leave_room(
     }
     match leave_room_remote(user_id, room_id).await {
         Ok((event_id, event_sn)) => {
-            let last_state = state::get_user_state(user_id, room_id)?;
+            let last_state = state::get_user_state(user_id, room_id).await?;
 
             // We always drop the invite, we can't rely on other servers
             membership::update_membership(
@@ -61,12 +61,12 @@ pub async fn leave_room(
                 MembershipState::Leave,
                 user_id,
                 last_state,
-            )?;
+            ).await?;
             Ok(())
         }
         Err(e) => {
             warn!("failed to leave room {} remotely: {}", user_id, e);
-            if !room::has_any_other_server(room_id, &conf.server_name)? {
+            if !room::has_any_other_server(room_id, &conf.server_name).await? {
                 leave_room_local(user_id, room_id, reason).await?;
                 Ok(())
             } else {
@@ -82,7 +82,7 @@ async fn leave_room_local(
     reason: Option<String>,
 ) -> AppResult<(OwnedEventId, Seqnum)> {
     let member_event =
-        room::get_state(room_id, &StateEventType::RoomMember, user_id.as_str(), None)?;
+        room::get_state(room_id, &StateEventType::RoomMember, user_id.as_str(), None).await?;
     let mut event_content = member_event
         .get_content::<RoomMemberEventContent>()
         .map_err(|_| AppError::public("invalid member event in database"))?;
@@ -101,7 +101,7 @@ async fn leave_room_local(
         },
         user_id,
         room_id,
-        &crate::room::get_version(room_id)?,
+        &crate::room::get_version(room_id).await?,
         &room::lock_state(room_id).await,
     )
     .await?;
@@ -124,7 +124,7 @@ async fn leave_room_remote(
 ) -> AppResult<(OwnedEventId, Seqnum)> {
     let mut make_leave_response_and_server =
         Err(AppError::public("no server available to assist in leaving"));
-    let invite_state = state::get_user_state(user_id, room_id)?
+    let invite_state = state::get_user_state(user_id, room_id).await?
         .ok_or(MatrixError::bad_state("user is not invited"))?;
 
     let servers: HashSet<_> = invite_state
@@ -203,7 +203,7 @@ async fn leave_room_remote(
         CanonicalJsonValue::String(event_id.as_str().to_owned()),
     );
 
-    let (event_sn, event_guard) = ensure_event_sn(room_id, &event_id)?;
+    let (event_sn, event_guard) = ensure_event_sn(room_id, &event_id).await?;
     NewDbEvent {
         id: event_id.to_owned(),
         sn: event_sn,
@@ -224,7 +224,7 @@ async fn leave_room_remote(
         is_rejected: false,
         rejection_reason: None,
     }
-    .save()?;
+    .save().await?;
 
     DbEventData {
         event_id: event_id.clone(),
@@ -234,7 +234,7 @@ async fn leave_room_remote(
         json_data: serde_json::to_value(&leave_event_stub)?,
         format_version: None,
     }
-    .save()?;
+    .save().await?;
     let parsed_leave_pdu =
         PduEvent::from_canonical_object(room_id, &event_id, leave_event_stub.clone()).map_err(
             |e| {
@@ -267,7 +267,7 @@ async fn leave_room_remote(
         },
         SendLeaveReqBody(crate::sending::convert_to_outgoing_federation_event(
             leave_event.clone(),
-        )),
+        ).await),
     )?
     .into_inner();
     crate::sending::send_federation_request(&remote_server, request, None).await?;

--- a/crates/server/src/room.rs
+++ b/crates/server/src/room.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::sync::OnceLock;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use serde::de::DeserializeOwned;
 
 use crate::appservice::RegistrationInfo;
@@ -59,15 +60,19 @@ pub async fn lock_state(room_id: &RoomId) -> RoomMutexGuard {
         .await
 }
 
-pub fn create_room(new_room: NewDbRoom) -> AppResult<OwnedRoomId> {
+pub async fn create_room(new_room: NewDbRoom) -> AppResult<OwnedRoomId> {
     diesel::insert_into(rooms::table)
         .values(&new_room)
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(new_room.id)
 }
 
-pub fn ensure_room(id: &RoomId, room_version_id: &RoomVersionId) -> AppResult<OwnedRoomId> {
-    if room_exists(id)? {
+pub async fn ensure_room(
+    id: &RoomId,
+    room_version_id: &RoomVersionId,
+) -> AppResult<OwnedRoomId> {
+    if room_exists(id).await? {
         Ok(id.to_owned())
     } else {
         create_room(NewDbRoom {
@@ -78,28 +83,32 @@ pub fn ensure_room(id: &RoomId, room_version_id: &RoomVersionId) -> AppResult<Ow
             has_auth_chain_index: false,
             created_at: UnixMillis::now(),
         })
+        .await
     }
 }
 
 /// Checks if a room exists.
-pub fn room_exists(room_id: &RoomId) -> AppResult<bool> {
-    diesel_exists!(rooms::table.filter(rooms::id.eq(room_id)), &mut connect()?).map_err(Into::into)
+pub async fn room_exists(room_id: &RoomId) -> AppResult<bool> {
+    diesel_exists!(rooms::table.filter(rooms::id.eq(room_id)), &mut connect().await?)
+        .map_err(Into::into)
 }
 
-pub fn get_room_sn(room_id: &RoomId) -> AppResult<Seqnum> {
+pub async fn get_room_sn(room_id: &RoomId) -> AppResult<Seqnum> {
     let room_sn = rooms::table
         .filter(rooms::id.eq(room_id))
         .select(rooms::sn)
-        .first::<Seqnum>(&mut connect()?)?;
+        .first::<Seqnum>(&mut connect().await?)
+        .await?;
     Ok(room_sn)
 }
 
 /// Returns the room's version.
-pub fn get_version(room_id: &RoomId) -> AppResult<RoomVersionId> {
+pub async fn get_version(room_id: &RoomId) -> AppResult<RoomVersionId> {
     if let Some(room_version) = rooms::table
         .find(room_id)
         .select(rooms::version)
-        .first::<String>(&mut connect()?)
+        .first::<String>(&mut connect().await?)
+        .await
         .optional()?
     {
         return Ok(RoomVersionId::try_from(&*room_version)?);
@@ -109,62 +118,70 @@ pub fn get_version(room_id: &RoomId) -> AppResult<RoomVersionId> {
         &StateEventType::RoomCreate,
         "",
         None,
-    )?;
+    ).await?;
     Ok(create_event_content.room_version)
 }
 
-pub fn get_current_frame_id(room_id: &RoomId) -> AppResult<Option<i64>> {
+pub async fn get_current_frame_id(room_id: &RoomId) -> AppResult<Option<i64>> {
     rooms::table
         .find(room_id)
         .select(rooms::state_frame_id)
-        .first(&mut connect()?)
+        .first(&mut connect().await?)
+        .await
         .optional()
         .map(|v| v.flatten())
         .map_err(Into::into)
 }
 
-pub fn is_disabled(room_id: &RoomId) -> AppResult<bool> {
+pub async fn is_disabled(room_id: &RoomId) -> AppResult<bool> {
     rooms::table
         .filter(rooms::id.eq(room_id))
         .select(rooms::disabled)
-        .first(&mut connect()?)
+        .first(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
-pub fn disable_room(room_id: &RoomId, disabled: bool) -> AppResult<()> {
+pub async fn disable_room(room_id: &RoomId, disabled: bool) -> AppResult<()> {
     diesel::update(rooms::table.filter(rooms::id.eq(room_id)))
         .set(rooms::disabled.eq(disabled))
-        .execute(&mut connect()?)
+        .execute(&mut connect().await?)
+        .await
         .map(|_| ())
         .map_err(Into::into)
 }
 
-pub fn update_currents(room_id: &RoomId) -> AppResult<()> {
+pub async fn update_currents(room_id: &RoomId) -> AppResult<()> {
     let joined_members = room_users::table
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::membership.eq("join"))
         .count()
-        .get_result::<i64>(&mut connect()?)?;
+        .get_result::<i64>(&mut connect().await?)
+        .await?;
     let invited_members = room_users::table
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::membership.eq("invite"))
         .count()
-        .get_result::<i64>(&mut connect()?)?;
+        .get_result::<i64>(&mut connect().await?)
+        .await?;
     let left_members = room_users::table
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::membership.eq("leave"))
         .count()
-        .get_result::<i64>(&mut connect()?)?;
+        .get_result::<i64>(&mut connect().await?)
+        .await?;
     let banned_members = room_users::table
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::membership.eq("banned"))
         .count()
-        .get_result::<i64>(&mut connect()?)?;
+        .get_result::<i64>(&mut connect().await?)
+        .await?;
     let knocked_members = room_users::table
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::membership.eq("knocked"))
         .count()
-        .get_result::<i64>(&mut connect()?)?;
+        .get_result::<i64>(&mut connect().await?)
+        .await?;
 
     let current = DbRoomCurrent {
         room_id: room_id.to_owned(),
@@ -182,18 +199,20 @@ pub fn update_currents(room_id: &RoomId) -> AppResult<()> {
         .on_conflict(stats_room_currents::room_id)
         .do_update()
         .set(&current)
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
 
     Ok(())
 }
 
-pub fn update_joined_servers(room_id: &RoomId) -> AppResult<()> {
+pub async fn update_joined_servers(room_id: &RoomId) -> AppResult<()> {
     let joined_servers = room_users::table
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::membership.eq("join"))
         .select(room_users::user_id)
         .distinct()
-        .load::<OwnedUserId>(&mut connect()?)?
+        .load::<OwnedUserId>(&mut connect().await?)
+        .await?
         .into_iter()
         .map(|user_id| user_id.server_name().to_owned())
         .collect::<HashSet<OwnedServerName>>()
@@ -205,22 +224,27 @@ pub fn update_joined_servers(room_id: &RoomId) -> AppResult<()> {
             .filter(room_joined_servers::room_id.eq(room_id))
             .filter(room_joined_servers::server_id.ne_all(&joined_servers)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
 
     for joined_server in joined_servers {
-        data::room::add_joined_server(room_id, &joined_server)?;
+        data::room::add_joined_server(room_id, &joined_server).await?;
     }
     Ok(())
 }
-pub fn get_our_real_users(room_id: &RoomId) -> AppResult<Vec<OwnedUserId>> {
+pub async fn get_our_real_users(room_id: &RoomId) -> AppResult<Vec<OwnedUserId>> {
     room_users::table
         .filter(room_users::room_id.eq(room_id))
         .select(room_users::user_id)
-        .load::<OwnedUserId>(&mut connect()?)
+        .load::<OwnedUserId>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
-pub fn appservice_in_room(room_id: &RoomId, appservice: &RegistrationInfo) -> AppResult<bool> {
+pub async fn appservice_in_room(
+    room_id: &RoomId,
+    appservice: &RegistrationInfo,
+) -> AppResult<bool> {
     let maybe = APPSERVICE_IN_ROOM_CACHE
         .read()
         .unwrap()
@@ -237,15 +261,17 @@ pub fn appservice_in_room(room_id: &RoomId, appservice: &RegistrationInfo) -> Ap
         )
         .ok();
 
-        let bridge_user_joined = bridge_user_id
-            .as_ref()
-            .is_some_and(|id| user::is_joined(id, room_id).unwrap_or(false));
+        let bridge_user_joined = match bridge_user_id.as_ref() {
+            Some(id) => user::is_joined(id, room_id).await.unwrap_or(false),
+            None => false,
+        };
 
         let in_room = bridge_user_joined || {
             let user_ids = room_users::table
                 .filter(room_users::room_id.eq(room_id))
                 .select(room_users::user_id)
-                .load::<String>(&mut connect()?)?;
+                .load::<String>(&mut connect().await?)
+                .await?;
             user_ids
                 .iter()
                 .any(|user_id| appservice.users.is_match(user_id.as_str()))
@@ -261,10 +287,10 @@ pub fn appservice_in_room(room_id: &RoomId, appservice: &RegistrationInfo) -> Ap
         Ok(in_room)
     }
 }
-pub fn is_room_exists(room_id: &RoomId) -> AppResult<bool> {
+pub async fn is_room_exists(room_id: &RoomId) -> AppResult<bool> {
     diesel_exists!(
         rooms::table.filter(rooms::id.eq(room_id)).select(rooms::id),
-        &mut connect()?
+        &mut connect().await?
     )
     .map_err(Into::into)
 }
@@ -276,10 +302,13 @@ pub async fn should_join_on_remote_servers(
     if room_id.is_local() {
         return Ok((false, vec![]));
     }
-    if !is_server_joined(&config::get().server_name, room_id).unwrap_or(false) {
+    if !is_server_joined(&config::get().server_name, room_id)
+        .await
+        .unwrap_or(false)
+    {
         return Ok((true, servers.to_vec()));
     }
-    let Ok(join_rule) = room::get_join_rule(room_id) else {
+    let Ok(join_rule) = room::get_join_rule(room_id).await else {
         return Ok((true, servers.to_vec()));
     };
 
@@ -300,7 +329,7 @@ pub async fn should_join_on_remote_servers(
     // No local authorizer — find remote servers that have users who could authorize.
     // Look at ALL joined users (not just local ones) to find candidate servers.
     let mut allowed_servers: Vec<OwnedServerName> = Vec::new();
-    if let Ok(joined) = room::joined_users(room_id, None) {
+    if let Ok(joined) = room::joined_users(room_id, None).await {
         for u in joined {
             let server = u.server_name();
             if server == local_server {
@@ -330,78 +359,90 @@ pub async fn should_join_on_remote_servers(
     }
     Ok((true, allowed_servers))
 }
-pub fn is_server_joined(server: &ServerName, room_id: &RoomId) -> AppResult<bool> {
+pub async fn is_server_joined(server: &ServerName, room_id: &RoomId) -> AppResult<bool> {
     let query = room_joined_servers::table
         .filter(room_joined_servers::room_id.eq(room_id))
         .filter(room_joined_servers::server_id.eq(server));
-    diesel_exists!(query, &mut connect()?).map_err(Into::into)
+    diesel_exists!(query, &mut connect().await?).map_err(Into::into)
 }
-pub fn joined_servers(room_id: &RoomId) -> AppResult<Vec<OwnedServerName>> {
+pub async fn joined_servers(room_id: &RoomId) -> AppResult<Vec<OwnedServerName>> {
     room_joined_servers::table
         .filter(room_joined_servers::room_id.eq(room_id))
         .select(room_joined_servers::server_id)
-        .load::<OwnedServerName>(&mut connect()?)
+        .load::<OwnedServerName>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
-pub fn has_any_other_server(room_id: &RoomId, server: &ServerName) -> AppResult<bool> {
+pub async fn has_any_other_server(room_id: &RoomId, server: &ServerName) -> AppResult<bool> {
     let query = room_joined_servers::table
         .filter(room_joined_servers::room_id.eq(room_id))
         .filter(room_joined_servers::server_id.ne(server));
-    diesel_exists!(query, &mut connect()?).map_err(Into::into)
+    diesel_exists!(query, &mut connect().await?).map_err(Into::into)
 }
 
 #[tracing::instrument(level = "trace")]
-pub fn lookup_servers(room_id: &RoomId) -> AppResult<Vec<OwnedServerName>> {
+pub async fn lookup_servers(room_id: &RoomId) -> AppResult<Vec<OwnedServerName>> {
     room_lookup_servers::table
         .filter(room_lookup_servers::room_id.eq(room_id))
         .select(room_lookup_servers::server_id)
-        .load::<OwnedServerName>(&mut connect()?)
+        .load::<OwnedServerName>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
-pub fn joined_member_count(room_id: &RoomId) -> AppResult<u64> {
+pub async fn joined_member_count(room_id: &RoomId) -> AppResult<u64> {
     stats_room_currents::table
         .find(room_id)
         .select(stats_room_currents::joined_members)
-        .first::<i64>(&mut connect()?)
+        .first::<i64>(&mut connect().await?)
+        .await
         .optional()
         .map(|c| c.unwrap_or_default() as u64)
         .map_err(Into::into)
 }
 
 #[tracing::instrument]
-pub fn invited_member_count(room_id: &RoomId) -> AppResult<u64> {
+pub async fn invited_member_count(room_id: &RoomId) -> AppResult<u64> {
     stats_room_currents::table
         .find(room_id)
         .select(stats_room_currents::invited_members)
-        .first::<i64>(&mut connect()?)
+        .first::<i64>(&mut connect().await?)
+        .await
         .optional()
         .map(|c| c.unwrap_or_default() as u64)
         .map_err(Into::into)
 }
 
-pub fn joined_users(room_id: &RoomId, until_sn: Option<i64>) -> AppResult<Vec<OwnedUserId>> {
-    get_state_users(room_id, &MembershipState::Join, until_sn)
+pub async fn joined_users(
+    room_id: &RoomId,
+    until_sn: Option<i64>,
+) -> AppResult<Vec<OwnedUserId>> {
+    get_state_users(room_id, &MembershipState::Join, until_sn).await
 }
-pub fn invited_users(room_id: &RoomId, until_sn: Option<i64>) -> AppResult<Vec<OwnedUserId>> {
-    get_state_users(room_id, &MembershipState::Invite, until_sn)
+pub async fn invited_users(
+    room_id: &RoomId,
+    until_sn: Option<i64>,
+) -> AppResult<Vec<OwnedUserId>> {
+    get_state_users(room_id, &MembershipState::Invite, until_sn).await
 }
-pub fn active_local_users_in_room(room_id: &RoomId) -> AppResult<Vec<OwnedUserId>> {
+pub async fn active_local_users_in_room(room_id: &RoomId) -> AppResult<Vec<OwnedUserId>> {
     // TODO: only active user?
-    Ok(get_state_users(room_id, &MembershipState::Join, None)?
+    Ok(get_state_users(room_id, &MembershipState::Join, None)
+        .await?
         .into_iter()
         .filter(|user_id| user_id.is_local())
         .collect())
 }
 
-pub fn list_banned_rooms() -> AppResult<Vec<OwnedRoomId>> {
+pub async fn list_banned_rooms() -> AppResult<Vec<OwnedRoomId>> {
     let room_ids = banned_rooms::table
         .select(banned_rooms::room_id)
-        .load(&mut connect()?)?;
+        .load(&mut connect().await?)
+        .await?;
     Ok(room_ids)
 }
 
-pub fn get_state_users(
+pub async fn get_state_users(
     room_id: &RoomId,
     state: &MembershipState,
     until_sn: Option<i64>,
@@ -412,27 +453,29 @@ pub fn get_state_users(
             .filter(room_users::room_id.eq(room_id))
             .filter(room_users::membership.eq(state.to_string()))
             .select(room_users::user_id)
-            .load(&mut connect()?)
+            .load(&mut connect().await?)
+            .await
             .map_err(Into::into)
     } else {
         room_users::table
             .filter(room_users::room_id.eq(room_id))
             .filter(room_users::membership.eq(state.to_string()))
             .select(room_users::user_id)
-            .load(&mut connect()?)
+            .load(&mut connect().await?)
+            .await
             .map_err(Into::into)
     }
 }
-pub fn server_name(room_id: &RoomId) -> AppResult<OwnedServerName> {
+pub async fn server_name(room_id: &RoomId) -> AppResult<OwnedServerName> {
     if let Ok(server_name) = room_id.server_name() {
         return Ok(server_name.to_owned());
     }
-    let create_event = get_create(room_id)?;
+    let create_event = get_create(room_id).await?;
     Ok(create_event.creator()?.server_name().to_owned())
 }
 
 /// Returns an list of all servers participating in this room.
-pub fn participating_servers(
+pub async fn participating_servers(
     room_id: &RoomId,
     include_self_server: bool,
 ) -> AppResult<Vec<OwnedServerName>> {
@@ -440,19 +483,21 @@ pub fn participating_servers(
         room_joined_servers::table
             .filter(room_joined_servers::room_id.eq(room_id))
             .select(room_joined_servers::server_id)
-            .load(&mut connect()?)
+            .load(&mut connect().await?)
+            .await
             .map_err(Into::into)
     } else {
         room_joined_servers::table
             .filter(room_joined_servers::room_id.eq(room_id))
             .filter(room_joined_servers::server_id.ne(config::server_name()))
             .select(room_joined_servers::server_id)
-            .load(&mut connect()?)
+            .load(&mut connect().await?)
+            .await
             .map_err(Into::into)
     }
 }
 
-pub fn admin_servers(
+pub async fn admin_servers(
     room_id: &RoomId,
     include_self_server: bool,
 ) -> AppResult<Vec<OwnedServerName>> {
@@ -461,7 +506,8 @@ pub fn admin_servers(
         &StateEventType::RoomPowerLevels,
         "",
         None,
-    )?;
+    )
+    .await?;
     let mut admin_servers = power_levels
         .users
         .iter()
@@ -474,42 +520,47 @@ pub fn admin_servers(
     Ok(admin_servers.into_iter().map(|s| s.to_owned()).collect())
 }
 
-pub fn public_room_ids() -> AppResult<Vec<OwnedRoomId>> {
+pub async fn public_room_ids() -> AppResult<Vec<OwnedRoomId>> {
     rooms::table
         .filter(rooms::is_public.eq(true))
         .select(rooms::id)
         .order_by(rooms::sn.desc())
-        .load(&mut connect()?)
+        .load(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
-pub fn all_room_ids() -> AppResult<Vec<OwnedRoomId>> {
+pub async fn all_room_ids() -> AppResult<Vec<OwnedRoomId>> {
     rooms::table
         .select(rooms::id)
-        .load(&mut connect()?)
+        .load(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
-pub fn filter_rooms<'a>(
+pub async fn filter_rooms<'a>(
     rooms: &[&'a RoomId],
     filter: &[RoomTypeFilter],
     negate: bool,
 ) -> Vec<&'a RoomId> {
-    rooms
-        .iter()
-        .filter_map(|r| {
-            let r = *r;
-            let room_type = get_room_type(r).ok()?;
-            let room_type_filter = RoomTypeFilter::from(room_type);
+    let mut result = Vec::new();
+    for r in rooms {
+        let r = *r;
+        let Ok(room_type) = get_room_type(r).await else {
+            continue;
+        };
+        let room_type_filter = RoomTypeFilter::from(room_type);
 
-            let include = if negate {
-                !filter.contains(&room_type_filter)
-            } else {
-                filter.is_empty() || filter.contains(&room_type_filter)
-            };
+        let include = if negate {
+            !filter.contains(&room_type_filter)
+        } else {
+            filter.is_empty() || filter.contains(&room_type_filter)
+        };
 
-            include.then_some(r)
-        })
-        .collect()
+        if include {
+            result.push(r);
+        }
+    }
+    result
 }
 
 pub async fn room_available_servers(
@@ -518,7 +569,7 @@ pub async fn room_available_servers(
     pre_servers: Vec<OwnedServerName>,
 ) -> AppResult<Vec<OwnedServerName>> {
     // find active servers in room state cache to suggest
-    let mut servers: Vec<OwnedServerName> = joined_servers(room_id)?;
+    let mut servers: Vec<OwnedServerName> = joined_servers(room_id).await?;
 
     // push any servers we want in the list already (e.g. responded remote alias
     // servers, room alias server itself)
@@ -554,17 +605,17 @@ pub async fn room_available_servers(
     Ok(servers)
 }
 
-pub fn get_state(
+pub async fn get_state(
     room_id: &RoomId,
     event_type: &StateEventType,
     state_key: &str,
     until_sn: Option<Seqnum>,
 ) -> AppResult<SnPduEvent> {
-    let frame_id = get_frame_id(room_id, until_sn)?;
-    state::get_state(frame_id, event_type, state_key)
+    let frame_id = get_frame_id(room_id, until_sn).await?;
+    state::get_state(frame_id, event_type, state_key).await
 }
 
-pub fn get_state_content<T>(
+pub async fn get_state_content<T>(
     room_id: &RoomId,
     event_type: &StateEventType,
     state_key: &str,
@@ -573,25 +624,29 @@ pub fn get_state_content<T>(
 where
     T: DeserializeOwned,
 {
-    let frame_id = get_frame_id(room_id, until_sn)?;
-    state::get_state_content(frame_id, event_type, state_key)
+    let frame_id = get_frame_id(room_id, until_sn).await?;
+    state::get_state_content(frame_id, event_type, state_key).await
 }
 
-pub fn get_create(room_id: &RoomId) -> AppResult<RoomCreateEvent<SnPduEvent>> {
-    get_state(room_id, &StateEventType::RoomCreate, "", None).map(RoomCreateEvent::new)
+pub async fn get_create(room_id: &RoomId) -> AppResult<RoomCreateEvent<SnPduEvent>> {
+    get_state(room_id, &StateEventType::RoomCreate, "", None)
+        .await
+        .map(RoomCreateEvent::new)
 }
 
-pub fn get_name(room_id: &RoomId) -> AppResult<String> {
+pub async fn get_name(room_id: &RoomId) -> AppResult<String> {
     get_state_content::<RoomNameEventContent>(room_id, &StateEventType::RoomName, "", None)
+        .await
         .map(|c| c.name)
 }
 
-pub fn get_avatar_url(room_id: &RoomId) -> AppResult<Option<OwnedMxcUri>> {
+pub async fn get_avatar_url(room_id: &RoomId) -> AppResult<Option<OwnedMxcUri>> {
     get_state_content::<RoomAvatarEventContent>(room_id, &StateEventType::RoomAvatar, "", None)
+        .await
         .map(|c| c.url)
 }
 
-pub fn get_member(
+pub async fn get_member(
     room_id: &RoomId,
     user_id: &UserId,
     until_sn: Option<Seqnum>,
@@ -602,83 +657,93 @@ pub fn get_member(
         user_id.as_str(),
         until_sn,
     )
+    .await
 }
-pub fn get_topic(room_id: &RoomId) -> AppResult<String> {
-    get_topic_content(room_id).map(|c| c.topic)
+pub async fn get_topic(room_id: &RoomId) -> AppResult<String> {
+    get_topic_content(room_id).await.map(|c| c.topic)
 }
-pub fn get_topic_content(room_id: &RoomId) -> AppResult<RoomTopicEventContent> {
-    get_state_content::<RoomTopicEventContent>(room_id, &StateEventType::RoomTopic, "", None)
+pub async fn get_topic_content(room_id: &RoomId) -> AppResult<RoomTopicEventContent> {
+    get_state_content::<RoomTopicEventContent>(room_id, &StateEventType::RoomTopic, "", None).await
 }
-pub fn get_canonical_alias(room_id: &RoomId) -> AppResult<Option<OwnedRoomAliasId>> {
+pub async fn get_canonical_alias(room_id: &RoomId) -> AppResult<Option<OwnedRoomAliasId>> {
     get_state_content::<RoomCanonicalAliasEventContent>(
         room_id,
         &StateEventType::RoomCanonicalAlias,
         "",
         None,
     )
+    .await
     .map(|c| c.alias)
 }
-pub fn get_join_rule(room_id: &RoomId) -> AppResult<JoinRule> {
+pub async fn get_join_rule(room_id: &RoomId) -> AppResult<JoinRule> {
     get_state_content::<RoomJoinRulesEventContent>(
         room_id,
         &StateEventType::RoomJoinRules,
         "",
         None,
     )
+    .await
     .map(|c| c.join_rule)
 }
 pub async fn get_power_levels(room_id: &RoomId) -> AppResult<RoomPowerLevels> {
-    let create = get_create(room_id)?;
+    let create = get_create(room_id).await?;
     let room_version = create.room_version()?;
     let version_rules = crate::room::get_version_rules(&room_version)?;
     let creators = create.creators()?;
 
-    let content = get_power_levels_event_content(room_id)?;
+    let content = get_power_levels_event_content(room_id).await?;
     let power_levels = RoomPowerLevels::new(content.into(), &version_rules.authorization, creators);
     Ok(power_levels)
 }
-pub fn get_power_levels_event_content(room_id: &RoomId) -> AppResult<RoomPowerLevelsEventContent> {
+pub async fn get_power_levels_event_content(
+    room_id: &RoomId,
+) -> AppResult<RoomPowerLevelsEventContent> {
     get_state_content::<RoomPowerLevelsEventContent>(
         room_id,
         &StateEventType::RoomPowerLevels,
         "",
         None,
     )
+    .await
 }
 
-pub fn get_room_type(room_id: &RoomId) -> AppResult<Option<RoomType>> {
+pub async fn get_room_type(room_id: &RoomId) -> AppResult<Option<RoomType>> {
     get_state_content::<RoomCreateEventContent>(room_id, &StateEventType::RoomCreate, "", None)
+        .await
         .map(|c| c.room_type)
 }
 
-pub fn get_history_visibility(room_id: &RoomId) -> AppResult<HistoryVisibility> {
+pub async fn get_history_visibility(room_id: &RoomId) -> AppResult<HistoryVisibility> {
     get_state_content::<RoomHistoryVisibilityEventContent>(
         room_id,
         &StateEventType::RoomHistoryVisibility,
         "",
         None,
     )
+    .await
     .map(|c| c.history_visibility)
 }
 
-pub fn is_world_readable(room_id: &RoomId) -> bool {
+pub async fn is_world_readable(room_id: &RoomId) -> bool {
     get_history_visibility(room_id)
+        .await
         .map(|visibility| visibility == HistoryVisibility::WorldReadable)
         .unwrap_or(false)
 }
-pub fn guest_can_join(room_id: &RoomId) -> bool {
+pub async fn guest_can_join(room_id: &RoomId) -> bool {
     get_state_content::<RoomGuestAccessEventContent>(
         room_id,
         &StateEventType::RoomGuestAccess,
         "",
         None,
     )
+    .await
     .map(|c| c.guest_access == GuestAccess::CanJoin)
     .unwrap_or(false)
 }
 
 pub async fn user_can_invite(room_id: &RoomId, sender_id: &UserId, _target_user: &UserId) -> bool {
-    if let Ok(create_event) = crate::room::get_create(room_id)
+    if let Ok(create_event) = crate::room::get_create(room_id).await
         && let Ok(creators) = create_event.creators()
         && creators.contains(sender_id)
     {
@@ -691,24 +756,27 @@ pub async fn user_can_invite(room_id: &RoomId, sender_id: &UserId, _target_user:
     }
 }
 
-pub fn get_encryption(room_id: &RoomId) -> AppResult<EventEncryptionAlgorithm> {
+pub async fn get_encryption(room_id: &RoomId) -> AppResult<EventEncryptionAlgorithm> {
     get_state_content(room_id, &StateEventType::RoomEncryption, "", None)
+        .await
         .map(|content: RoomEncryptionEventContent| content.algorithm)
 }
 
-pub fn is_encrypted(room_id: &RoomId) -> bool {
-    get_state(room_id, &StateEventType::RoomEncryption, "", None).is_ok()
+pub async fn is_encrypted(room_id: &RoomId) -> bool {
+    get_state(room_id, &StateEventType::RoomEncryption, "", None)
+        .await
+        .is_ok()
 }
 
 /// Gets the room ID of the admin room
 ///
 /// Errors are propagated from the database, and will have None if there is no admin room
-pub fn get_admin_room() -> AppResult<OwnedRoomId> {
-    crate::room::resolve_local_alias(config::admin_alias())
+pub async fn get_admin_room() -> AppResult<OwnedRoomId> {
+    crate::room::resolve_local_alias(config::admin_alias()).await
 }
 
-pub fn is_admin_room(room_id: &RoomId) -> AppResult<bool> {
-    let result = get_admin_room();
+pub async fn is_admin_room(room_id: &RoomId) -> AppResult<bool> {
+    let result = get_admin_room().await;
     match result {
         Ok(admin_room_id) => Ok(admin_room_id == room_id),
         Err(e) => {
@@ -725,39 +793,42 @@ pub fn is_admin_room(room_id: &RoomId) -> AppResult<bool> {
 /// deactivated/guests
 #[tracing::instrument(level = "debug")]
 // TODO: local?
-pub fn local_users_in_room(room_id: &RoomId) -> AppResult<Vec<OwnedUserId>> {
+pub async fn local_users_in_room(room_id: &RoomId) -> AppResult<Vec<OwnedUserId>> {
     room_users::table
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::user_server_id.eq(&config::get().server_name))
         .select(room_users::user_id)
-        .load::<OwnedUserId>(&mut connect()?)
+        .load::<OwnedUserId>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
 /// Returns an iterator of all our local users in the room, even if they're
 /// deactivated/guests
 #[tracing::instrument(level = "debug")]
-pub fn get_members(room_id: &RoomId) -> AppResult<Vec<OwnedUserId>> {
+pub async fn get_members(room_id: &RoomId) -> AppResult<Vec<OwnedUserId>> {
     room_users::table
         .filter(room_users::room_id.eq(room_id))
         .select(room_users::user_id)
-        .load::<OwnedUserId>(&mut connect()?)
+        .load::<OwnedUserId>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
 /// Returns a limited number of members in the room.
 /// Useful for hero calculation where only a few members are needed.
 #[tracing::instrument(level = "debug")]
-pub fn get_members_limit(room_id: &RoomId, limit: i64) -> AppResult<Vec<OwnedUserId>> {
+pub async fn get_members_limit(room_id: &RoomId, limit: i64) -> AppResult<Vec<OwnedUserId>> {
     room_users::table
         .filter(room_users::room_id.eq(room_id))
         .select(room_users::user_id)
         .limit(limit)
-        .load::<OwnedUserId>(&mut connect()?)
+        .load::<OwnedUserId>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
-pub fn keys_changed_users(
+pub async fn keys_changed_users(
     room_id: &RoomId,
     since_sn: i64,
     until_sn: Option<i64>,
@@ -768,19 +839,21 @@ pub fn keys_changed_users(
             .filter(e2e_key_changes::occur_sn.ge(since_sn))
             .filter(e2e_key_changes::occur_sn.le(until_sn))
             .select(e2e_key_changes::user_id)
-            .load::<OwnedUserId>(&mut connect()?)
+            .load::<OwnedUserId>(&mut connect().await?)
+            .await
             .map_err(Into::into)
     } else {
         e2e_key_changes::table
             .filter(e2e_key_changes::room_id.eq(room_id.as_str()))
             .filter(e2e_key_changes::occur_sn.ge(since_sn))
             .select(e2e_key_changes::user_id)
-            .load::<OwnedUserId>(&mut connect()?)
+            .load::<OwnedUserId>(&mut connect().await?)
+            .await
             .map_err(Into::into)
     }
 }
 
-pub fn ban_room(room_id: &RoomId, banned: bool) -> AppResult<()> {
+pub async fn ban_room(room_id: &RoomId, banned: bool) -> AppResult<()> {
     if banned {
         diesel::insert_into(banned_rooms::table)
             .values((
@@ -788,12 +861,14 @@ pub fn ban_room(room_id: &RoomId, banned: bool) -> AppResult<()> {
                 banned_rooms::created_at.eq(UnixMillis::now()),
             ))
             .on_conflict_do_nothing()
-            .execute(&mut connect()?)
+            .execute(&mut connect().await?)
+            .await
             .map(|_| ())
             .map_err(Into::into)
     } else {
         diesel::delete(banned_rooms::table.filter(banned_rooms::room_id.eq(room_id)))
-            .execute(&mut connect()?)
+            .execute(&mut connect().await?)
+            .await
             .map(|_| ())
             .map_err(Into::into)
     }

--- a/crates/server/src/room.rs
+++ b/crates/server/src/room.rs
@@ -836,7 +836,7 @@ pub async fn keys_changed_users(
     if let Some(until_sn) = until_sn {
         e2e_key_changes::table
             .filter(e2e_key_changes::room_id.eq(room_id))
-            .filter(e2e_key_changes::occur_sn.ge(since_sn))
+            .filter(e2e_key_changes::occur_sn.gt(since_sn))
             .filter(e2e_key_changes::occur_sn.le(until_sn))
             .select(e2e_key_changes::user_id)
             .load::<OwnedUserId>(&mut connect().await?)
@@ -845,7 +845,7 @@ pub async fn keys_changed_users(
     } else {
         e2e_key_changes::table
             .filter(e2e_key_changes::room_id.eq(room_id.as_str()))
-            .filter(e2e_key_changes::occur_sn.ge(since_sn))
+            .filter(e2e_key_changes::occur_sn.gt(since_sn))
             .select(e2e_key_changes::user_id)
             .load::<OwnedUserId>(&mut connect().await?)
             .await

--- a/crates/server/src/room.rs
+++ b/crates/server/src/room.rs
@@ -836,7 +836,7 @@ pub async fn keys_changed_users(
     if let Some(until_sn) = until_sn {
         e2e_key_changes::table
             .filter(e2e_key_changes::room_id.eq(room_id))
-            .filter(e2e_key_changes::occur_sn.gt(since_sn))
+            .filter(e2e_key_changes::occur_sn.ge(since_sn))
             .filter(e2e_key_changes::occur_sn.le(until_sn))
             .select(e2e_key_changes::user_id)
             .load::<OwnedUserId>(&mut connect().await?)
@@ -845,7 +845,7 @@ pub async fn keys_changed_users(
     } else {
         e2e_key_changes::table
             .filter(e2e_key_changes::room_id.eq(room_id.as_str()))
-            .filter(e2e_key_changes::occur_sn.gt(since_sn))
+            .filter(e2e_key_changes::occur_sn.ge(since_sn))
             .select(e2e_key_changes::user_id)
             .load::<OwnedUserId>(&mut connect().await?)
             .await

--- a/crates/server/src/room/alias.rs
+++ b/crates/server/src/room/alias.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use rand::seq::SliceRandom;
 use serde_json::value::to_raw_value;
 
@@ -66,7 +67,7 @@ pub async fn resolve_alias(
         return remote_resolve(room_alias, servers.unwrap_or_default()).await;
     }
 
-    let room_id = match resolve_local_alias(room_alias) {
+    let room_id = match resolve_local_alias(room_alias).await {
         Ok(r) => r,
         Err(_) => resolve_appservice_alias(room_alias).await?,
     };
@@ -75,17 +76,18 @@ pub async fn resolve_alias(
 }
 
 #[tracing::instrument(level = "debug")]
-pub fn resolve_local_alias(alias_id: &RoomAliasId) -> AppResult<OwnedRoomId> {
+pub async fn resolve_local_alias(alias_id: &RoomAliasId) -> AppResult<OwnedRoomId> {
     let room_id = room_aliases::table
         .filter(room_aliases::alias_id.eq(alias_id))
         .select(room_aliases::room_id)
-        .first::<String>(&mut connect()?)?;
+        .first::<String>(&mut connect().await?)
+        .await?;
 
     RoomId::parse(room_id).map_err(|_| AppError::public("Room ID is invalid."))
 }
 
 async fn resolve_appservice_alias(room_alias: &RoomAliasId) -> AppResult<OwnedRoomId> {
-    for appservice in crate::appservice::all()?.values() {
+    for appservice in crate::appservice::all().await?.values() {
         if appservice.aliases.is_match(room_alias.as_str())
             && let Some(url) = &appservice.registration.url
         {
@@ -105,7 +107,7 @@ async fn resolve_appservice_alias(room_alias: &RoomAliasId) -> AppResult<OwnedRo
             {
                 Ok(Some(_)) => {
                     // Appservice acknowledged the alias, try resolving locally now
-                    match resolve_local_alias(room_alias) {
+                    match resolve_local_alias(room_alias).await {
                         Ok(room_id) => return Ok(room_id),
                         Err(e) => {
                             warn!(
@@ -134,35 +136,40 @@ async fn resolve_appservice_alias(room_alias: &RoomAliasId) -> AppResult<OwnedRo
     Err(MatrixError::not_found("resolve appservice alias not found").into())
 }
 
-pub fn local_aliases_for_room(room_id: &RoomId) -> AppResult<Vec<OwnedRoomAliasId>> {
+pub async fn local_aliases_for_room(room_id: &RoomId) -> AppResult<Vec<OwnedRoomAliasId>> {
     room_aliases::table
         .filter(room_aliases::room_id.eq(room_id))
         .select(room_aliases::alias_id)
-        .load::<OwnedRoomAliasId>(&mut connect()?)
+        .load::<OwnedRoomAliasId>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
-pub fn all_local_aliases() -> AppResult<Vec<(OwnedRoomId, String)>> {
+pub async fn all_local_aliases() -> AppResult<Vec<(OwnedRoomId, String)>> {
     let lists = room_aliases::table
         .select((room_aliases::room_id, room_aliases::alias_id))
-        .load::<(OwnedRoomId, OwnedRoomAliasId)>(&mut connect()?)?
+        .load::<(OwnedRoomId, OwnedRoomAliasId)>(&mut connect().await?)
+        .await?
         .into_iter()
         .map(|(room_id, alias_id)| (room_id, alias_id.alias().to_owned()))
         .collect::<Vec<_>>();
     Ok(lists)
 }
 
-pub fn is_admin_room(room_id: &RoomId) -> bool {
-    admin_room_id().is_ok_and(|admin_room_id| admin_room_id == room_id)
+pub async fn is_admin_room(room_id: &RoomId) -> bool {
+    admin_room_id()
+        .await
+        .is_ok_and(|admin_room_id| admin_room_id == room_id)
 }
 
-pub fn admin_room_id() -> AppResult<OwnedRoomId> {
+pub async fn admin_room_id() -> AppResult<OwnedRoomId> {
     crate::room::resolve_local_alias(
         <&RoomAliasId>::try_from(format!("#admins:{}", &config::get().server_name).as_str())
             .expect("#admins:server_name is a valid room alias"),
     )
+    .await
 }
 
-pub fn set_alias(
+pub async fn set_alias(
     room_id: impl Into<OwnedRoomId>,
     alias_id: impl Into<OwnedRoomAliasId>,
     created_by: impl Into<OwnedUserId>,
@@ -178,7 +185,8 @@ pub fn set_alias(
             created_at: UnixMillis::now(),
         })
         .on_conflict_do_nothing()
-        .execute(&mut connect()?)
+        .execute(&mut connect().await?)
+        .await
         .map(|_| ())
         .map_err(Into::into)
 }
@@ -199,10 +207,10 @@ pub async fn get_alias_response(room_alias: OwnedRoomAliasId) -> AppResult<Alias
     }
 
     let mut room_id = None;
-    match resolve_local_alias(&room_alias) {
+    match resolve_local_alias(&room_alias).await {
         Ok(r) => room_id = Some(r),
         Err(_) => {
-            for appservice in crate::appservice::all()?.values() {
+            for appservice in crate::appservice::all().await?.values() {
                 let url = appservice
                     .registration
                     .build_url(&format!("app/v1/rooms/{room_alias}"))?;
@@ -212,7 +220,7 @@ pub async fn get_alias_response(room_alias: OwnedRoomAliasId) -> AppResult<Alias
                         Ok(Some(_opt_result))
                     )
                 {
-                    room_id = Some(resolve_local_alias(&room_alias).map_err(|_| {
+                    room_id = Some(resolve_local_alias(&room_alias).await.map_err(|_| {
                         AppError::public("Appservice lied to us. Room does not exist.")
                     })?);
                     break;
@@ -234,12 +242,12 @@ pub async fn get_alias_response(room_alias: OwnedRoomAliasId) -> AppResult<Alias
 
 #[tracing::instrument]
 pub async fn remove_alias(alias_id: &RoomAliasId, user: &DbUser) -> AppResult<()> {
-    let room_id = resolve_local_alias(alias_id)?;
-    let room_version = crate::room::get_version(&room_id)?;
+    let room_id = resolve_local_alias(alias_id).await?;
+    let room_version = crate::room::get_version(&room_id).await?;
     if user_can_remove_alias(alias_id, user).await? {
         let state_alias = super::get_canonical_alias(&room_id);
 
-        if state_alias.is_ok() {
+        if state_alias.await.is_ok() {
             timeline::build_and_append_pdu(
                 PduBuilder {
                     event_type: TimelineEventType::RoomCanonicalAlias,
@@ -260,7 +268,8 @@ pub async fn remove_alias(alias_id: &RoomAliasId, user: &DbUser) -> AppResult<()
             .ok();
         }
         diesel::delete(room_aliases::table.filter(room_aliases::alias_id.eq(alias_id)))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
 
         Ok(())
     } else {
@@ -269,11 +278,12 @@ pub async fn remove_alias(alias_id: &RoomAliasId, user: &DbUser) -> AppResult<()
 }
 #[tracing::instrument]
 async fn user_can_remove_alias(alias_id: &RoomAliasId, user: &DbUser) -> AppResult<bool> {
-    let room_id = resolve_local_alias(alias_id)?;
+    let room_id = resolve_local_alias(alias_id).await?;
 
     let alias = room_aliases::table
         .find(alias_id)
-        .first::<DbRoomAlias>(&mut connect()?)?;
+        .first::<DbRoomAlias>(&mut connect().await?)
+        .await?;
 
     // The creator of an alias can remove it
     if alias.created_by == user.id
@@ -287,7 +297,7 @@ async fn user_can_remove_alias(alias_id: &RoomAliasId, user: &DbUser) -> AppResu
     } else if let Ok(power_levels) = super::get_power_levels(&room_id).await {
         Ok(power_levels.user_can_send_state(&user.id, StateEventType::RoomCanonicalAlias))
     // If there is no power levels event, only the room creator can change canonical aliases
-    } else if let Ok(event) = super::get_state(&room_id, &StateEventType::RoomCreate, "", None) {
+    } else if let Ok(event) = super::get_state(&room_id, &StateEventType::RoomCreate, "", None).await {
         Ok(event.sender == user.id)
     } else {
         error!("Room {} has no m.room.create event (VERY BAD)!", room_id);

--- a/crates/server/src/room/auth_chain.rs
+++ b/crates/server/src/room/auth_chain.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Instant;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use lru_cache::LruCache;
 
 use crate::core::Seqnum;
@@ -19,23 +20,24 @@ type Bucket<'a> = BTreeSet<(Seqnum, &'a EventId)>;
 static AUTH_CHAIN_CACHE: LazyLock<Mutex<LruCache<Vec<i64>, Arc<Vec<Seqnum>>>>> =
     LazyLock::new(|| Mutex::new(LruCache::new(100_000)));
 
-pub fn get_auth_chain_ids<'a, I>(
+pub async fn get_auth_chain_ids<'a, I>(
     room_id: &'a RoomId,
     starting_event_ids: I,
 ) -> AppResult<Vec<OwnedEventId>>
 where
     I: Iterator<Item = &'a EventId> + Clone + Debug + Send,
 {
-    let chain_sns = get_auth_chain_sns(room_id, starting_event_ids)?;
+    let chain_sns = get_auth_chain_sns(room_id, starting_event_ids).await?;
 
     let full_auth_chain = events::table
         .filter(events::sn.eq_any(&chain_sns))
         .order_by(events::sn.asc())
         .select(events::id)
-        .load::<OwnedEventId>(&mut connect()?)?;
+        .load::<OwnedEventId>(&mut connect().await?)
+        .await?;
     Ok(full_auth_chain)
 }
-pub fn get_auth_chain_sns<'a, I>(
+pub async fn get_auth_chain_sns<'a, I>(
     room_id: &'a RoomId,
     starting_event_ids: I,
 ) -> AppResult<Vec<Seqnum>>
@@ -50,7 +52,8 @@ where
         .filter(events::id.eq_any(starting_event_ids.clone()))
         .filter(events::sn.is_not_null())
         .select((events::id, events::sn))
-        .load::<(OwnedEventId, Seqnum)>(&mut connect()?)?
+        .load::<(OwnedEventId, Seqnum)>(&mut connect().await?)
+        .await?
         .into_iter()
         .collect::<Vec<_>>();
 
@@ -74,20 +77,20 @@ where
             continue;
         }
 
-        if let Ok(Some(cached)) = get_cached_auth_chain(&bucket_key) {
+        if let Ok(Some(cached)) = get_cached_auth_chain(&bucket_key).await {
             full_auth_chain.extend(cached.to_vec());
             continue;
         }
 
         let mut bucket_cache: Vec<_> = vec![];
         for (event_sn, event_id) in bucket {
-            if let Ok(Some(cached)) = get_cached_auth_chain(&[event_sn]) {
+            if let Ok(Some(cached)) = get_cached_auth_chain(&[event_sn]).await {
                 bucket_cache.extend(cached.to_vec());
                 continue;
             }
 
-            let auth_chain = get_event_auth_chain(room_id, event_id)?;
-            let _ = cache_auth_chain(vec![event_sn], auth_chain.as_slice());
+            let auth_chain = get_event_auth_chain(room_id, event_id).await?;
+            let _ = cache_auth_chain(vec![event_sn], auth_chain.as_slice()).await;
             bucket_cache.extend(auth_chain);
             debug!(
                 ?event_id,
@@ -96,7 +99,7 @@ where
             );
         }
 
-        let _ = cache_auth_chain(bucket_key, bucket_cache.as_slice());
+        let _ = cache_auth_chain(bucket_key, bucket_cache.as_slice()).await;
         debug!(
             bucket_cache_length = ?bucket_cache.len(),
             elapsed = ?started.elapsed(),
@@ -117,14 +120,14 @@ where
 }
 
 #[tracing::instrument(level = "trace", skip(room_id))]
-fn get_event_auth_chain(room_id: &RoomId, event_id: &EventId) -> AppResult<Vec<Seqnum>> {
+async fn get_event_auth_chain(room_id: &RoomId, event_id: &EventId) -> AppResult<Vec<Seqnum>> {
     let mut todo: VecDeque<_> = [event_id.to_owned()].into();
     let mut found = HashSet::new();
 
     while let Some(event_id) = todo.pop_front() {
         trace!(?event_id, "processing auth event");
 
-        let pdu = timeline::get_pdu(&event_id)?;
+        let pdu = timeline::get_pdu(&event_id).await?;
         if pdu.room_id != room_id {
             tracing::error!(
                 ?event_id,
@@ -139,7 +142,8 @@ fn get_event_auth_chain(room_id: &RoomId, event_id: &EventId) -> AppResult<Vec<S
             .filter(events::sn.is_not_null())
             .filter(events::id.eq_any(pdu.auth_events.iter().map(|e| &**e)))
             .select((events::id, events::sn))
-            .load::<(OwnedEventId, Seqnum)>(&mut connect()?)?;
+            .load::<(OwnedEventId, Seqnum)>(&mut connect().await?)
+            .await?;
         for (auth_event_id, auth_event_sn) in auth_events {
             if found.insert(auth_event_sn) {
                 tracing::trace!(
@@ -156,7 +160,7 @@ fn get_event_auth_chain(room_id: &RoomId, event_id: &EventId) -> AppResult<Vec<S
     Ok(found.into_iter().collect())
 }
 
-fn get_cached_auth_chain(cache_key: &[Seqnum]) -> AppResult<Option<Arc<Vec<Seqnum>>>> {
+async fn get_cached_auth_chain(cache_key: &[Seqnum]) -> AppResult<Option<Arc<Vec<Seqnum>>>> {
     // Check RAM cache
     if let Some(result) = AUTH_CHAIN_CACHE
         .lock()
@@ -169,7 +173,8 @@ fn get_cached_auth_chain(cache_key: &[Seqnum]) -> AppResult<Option<Arc<Vec<Seqnu
     let chain_sns = event_auth_chains::table
         .find(cache_key)
         .select(event_auth_chains::chain_sns)
-        .first::<Vec<Option<Seqnum>>>(&mut connect()?)
+        .first::<Vec<Option<Seqnum>>>(&mut connect().await?)
+        .await
         .optional()?;
 
     if let Some(chain_sns) = chain_sns {
@@ -186,7 +191,7 @@ fn get_cached_auth_chain(cache_key: &[Seqnum]) -> AppResult<Option<Arc<Vec<Seqnu
     Ok(None)
 }
 
-pub fn cache_auth_chain(cache_key: Vec<Seqnum>, chain_sns: &[Seqnum]) -> AppResult<()> {
+pub async fn cache_auth_chain(cache_key: Vec<Seqnum>, chain_sns: &[Seqnum]) -> AppResult<()> {
     diesel::insert_into(event_auth_chains::table)
         .values((
             event_auth_chains::cache_key.eq(&cache_key),
@@ -195,7 +200,8 @@ pub fn cache_auth_chain(cache_key: Vec<Seqnum>, chain_sns: &[Seqnum]) -> AppResu
         .on_conflict(event_auth_chains::cache_key)
         .do_update()
         .set(event_auth_chains::chain_sns.eq(chain_sns))
-        .execute(&mut connect()?)
+        .execute(&mut connect().await?)
+        .await
         .ok();
 
     let chain_sns = chain_sns.to_vec();

--- a/crates/server/src/room/current.rs
+++ b/crates/server/src/room/current.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::AppResult;
 use crate::core::identifiers::*;
@@ -20,30 +21,33 @@ pub struct RoomCurrent {
 }
 
 #[tracing::instrument]
-pub fn get_current(room_id: &RoomId) -> AppResult<Option<RoomCurrent>> {
+pub async fn get_current(room_id: &RoomId) -> AppResult<Option<RoomCurrent>> {
     stats_room_currents::table
         .filter(stats_room_currents::room_id.eq(room_id))
-        .first::<RoomCurrent>(&mut connect()?)
+        .first::<RoomCurrent>(&mut connect().await?)
+        .await
         .optional()
         .map_err(Into::into)
 }
 
 #[tracing::instrument]
-pub fn invite_count(room_id: &RoomId, user_id: &UserId) -> AppResult<Option<u64>> {
+pub async fn invite_count(room_id: &RoomId, user_id: &UserId) -> AppResult<Option<u64>> {
     let count = stats_room_currents::table
         .filter(stats_room_currents::room_id.eq(room_id))
         .select(stats_room_currents::invited_members)
-        .first::<i64>(&mut connect()?)
+        .first::<i64>(&mut connect().await?)
+        .await
         .optional()?;
     Ok(count.map(|c| c as u64))
 }
 
 #[tracing::instrument]
-pub fn left_count(room_id: &RoomId, user_id: &UserId) -> AppResult<Option<u64>> {
+pub async fn left_count(room_id: &RoomId, user_id: &UserId) -> AppResult<Option<u64>> {
     let count = stats_room_currents::table
         .filter(stats_room_currents::room_id.eq(room_id))
         .select(stats_room_currents::left_members)
-        .first::<i64>(&mut connect()?)
+        .first::<i64>(&mut connect().await?)
+        .await
         .optional()?;
     Ok(count.map(|c| c as u64))
 }

--- a/crates/server/src/room/directory.rs
+++ b/crates/server/src/room/directory.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::AppResult;
 use crate::core::RoomId;
@@ -7,25 +8,27 @@ use crate::data::connect;
 use crate::data::schema::*;
 
 #[tracing::instrument]
-pub fn set_public(room_id: &RoomId, value: bool) -> AppResult<()> {
+pub async fn set_public(room_id: &RoomId, value: bool) -> AppResult<()> {
     diesel::update(rooms::table.find(room_id))
         .set(rooms::is_public.eq(value))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
 #[tracing::instrument]
-pub fn is_public(room_id: &RoomId) -> AppResult<bool> {
+pub async fn is_public(room_id: &RoomId) -> AppResult<bool> {
     rooms::table
         .find(room_id)
         .select(rooms::is_public)
-        .first::<bool>(&mut connect()?)
+        .first::<bool>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
 #[tracing::instrument]
-pub fn visibility(room_id: &RoomId) -> Visibility {
-    if is_public(room_id).unwrap_or(false) {
+pub async fn visibility(room_id: &RoomId) -> Visibility {
+    if is_public(room_id).await.unwrap_or(false) {
         Visibility::Public
     } else {
         Visibility::Private

--- a/crates/server/src/room/lazy_loading.rs
+++ b/crates/server/src/room/lazy_loading.rs
@@ -34,19 +34,23 @@ pub async fn lazy_load_mark_sent(
     lazy_load: HashSet<OwnedUserId>,
     _until_sn: Seqnum,
 ) {
+    // Check out a single connection and reuse it for every insert. The loop body
+    // performs no nested connection acquisition, so holding one connection here
+    // is safe and avoids one checkout/release round-trip per confirmed user.
+    let Ok(mut conn) = connect().await else {
+        return;
+    };
     for confirmed_user_id in lazy_load {
-        if let Ok(mut conn) = connect().await {
-            let _ = diesel::insert_into(lazy_load_deliveries::table)
-                .values((
-                    lazy_load_deliveries::user_id.eq(user_id),
-                    lazy_load_deliveries::device_id.eq(device_id),
-                    lazy_load_deliveries::room_id.eq(room_id),
-                    lazy_load_deliveries::confirmed_user_id.eq(confirmed_user_id),
-                ))
-                .on_conflict_do_nothing()
-                .execute(&mut conn)
-                .await;
-        }
+        let _ = diesel::insert_into(lazy_load_deliveries::table)
+            .values((
+                lazy_load_deliveries::user_id.eq(user_id),
+                lazy_load_deliveries::device_id.eq(device_id),
+                lazy_load_deliveries::room_id.eq(room_id),
+                lazy_load_deliveries::confirmed_user_id.eq(confirmed_user_id),
+            ))
+            .on_conflict_do_nothing()
+            .execute(&mut conn)
+            .await;
     }
 }
 

--- a/crates/server/src/room/lazy_loading.rs
+++ b/crates/server/src/room/lazy_loading.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use palpo_core::Seqnum;
 
 use crate::AppResult;
@@ -9,7 +10,7 @@ use crate::data::schema::*;
 use crate::data::{connect, diesel_exists};
 
 #[tracing::instrument]
-pub fn lazy_load_was_sent_before(
+pub async fn lazy_load_was_sent_before(
     user_id: &UserId,
     device_id: &DeviceId,
     room_id: &RoomId,
@@ -20,13 +21,13 @@ pub fn lazy_load_was_sent_before(
         .filter(lazy_load_deliveries::device_id.eq(device_id))
         .filter(lazy_load_deliveries::room_id.eq(room_id))
         .filter(lazy_load_deliveries::confirmed_user_id.eq(confirmed_user_id));
-    diesel_exists!(query, &mut connect()?).map_err(Into::into)
+    diesel_exists!(query, &mut connect().await?).map_err(Into::into)
 }
 
 /// Marks lazy load entries as sent by writing directly to the database.
 /// In a clustered environment, this ensures all instances see the same state.
 #[tracing::instrument]
-pub fn lazy_load_mark_sent(
+pub async fn lazy_load_mark_sent(
     user_id: &UserId,
     device_id: &DeviceId,
     room_id: &RoomId,
@@ -34,7 +35,7 @@ pub fn lazy_load_mark_sent(
     _until_sn: Seqnum,
 ) {
     for confirmed_user_id in lazy_load {
-        if let Ok(mut conn) = connect() {
+        if let Ok(mut conn) = connect().await {
             let _ = diesel::insert_into(lazy_load_deliveries::table)
                 .values((
                     lazy_load_deliveries::user_id.eq(user_id),
@@ -43,7 +44,8 @@ pub fn lazy_load_mark_sent(
                     lazy_load_deliveries::confirmed_user_id.eq(confirmed_user_id),
                 ))
                 .on_conflict_do_nothing()
-                .execute(&mut conn);
+                .execute(&mut conn)
+                .await;
         }
     }
 }
@@ -62,13 +64,18 @@ pub fn lazy_load_confirm_delivery(
 }
 
 #[tracing::instrument]
-pub fn lazy_load_reset(user_id: &UserId, device_id: &DeviceId, room_id: &RoomId) -> AppResult<()> {
+pub async fn lazy_load_reset(
+    user_id: &UserId,
+    device_id: &DeviceId,
+    room_id: &RoomId,
+) -> AppResult<()> {
     diesel::delete(
         lazy_load_deliveries::table
             .filter(lazy_load_deliveries::user_id.eq(user_id))
             .filter(lazy_load_deliveries::device_id.eq(device_id))
             .filter(lazy_load_deliveries::room_id.eq(room_id)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }

--- a/crates/server/src/room/pdu_metadata.rs
+++ b/crates/server/src/room/pdu_metadata.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use palpo_core::Seqnum;
 use serde::Deserialize;
 
@@ -25,14 +26,14 @@ struct ExtractRelatesToEventId {
 }
 
 #[tracing::instrument]
-pub fn add_relation(
+pub async fn add_relation(
     room_id: &RoomId,
     event_id: &EventId,
     child_id: &EventId,
     rel_type: Option<RelationType>,
 ) -> AppResult<()> {
-    let (event_sn, event_ty) = crate::event::get_event_sn_and_ty(event_id)?;
-    let (child_sn, child_ty) = crate::event::get_event_sn_and_ty(child_id)?;
+    let (event_sn, event_ty) = crate::event::get_event_sn_and_ty(event_id).await?;
+    let (child_sn, child_ty) = crate::event::get_event_sn_and_ty(child_id).await?;
     diesel::insert_into(event_relations::table)
         .values(&NewDbEventRelation {
             room_id: room_id.to_owned(),
@@ -44,11 +45,12 @@ pub fn add_relation(
             child_ty,
             rel_type: rel_type.map(|v| v.to_string()),
         })
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
-pub fn paginate_relations_with_filter(
+pub async fn paginate_relations_with_filter(
     user_id: &UserId,
     room_id: &RoomId,
     target: &EventId,
@@ -89,7 +91,8 @@ pub fn paginate_relations_with_filter(
         to.map(|t| t.event_sn()),
         dir,
         limit,
-    )?;
+    )
+    .await?;
 
     let next_token = match dir {
         Direction::Forward => events
@@ -113,7 +116,7 @@ pub fn paginate_relations_with_filter(
     })
 }
 
-pub fn get_relations(
+pub async fn get_relations(
     user_id: &UserId,
     room_id: &RoomId,
     event_id: &EventId,
@@ -152,14 +155,15 @@ pub fn get_relations(
     }
     let relations = query
         .limit(limit as i64)
-        .load::<DbEventRelation>(&mut connect()?)?;
+        .load::<DbEventRelation>(&mut connect().await?)
+        .await?;
     let mut pdus = Vec::with_capacity(relations.len());
     for relation in relations {
-        if let Ok(mut pdu) = timeline::get_pdu(&relation.child_id) {
+        if let Ok(mut pdu) = timeline::get_pdu(&relation.child_id).await {
             if pdu.sender != user_id {
                 pdu.remove_transaction_id()?;
             }
-            if pdu.user_can_see(user_id).unwrap_or(false) {
+            if pdu.user_can_see(user_id).await.unwrap_or(false) {
                 pdus.push((relation.child_sn, pdu));
             }
         }
@@ -185,17 +189,19 @@ pub fn get_relations(
 // }
 
 #[tracing::instrument(skip(event_id))]
-pub fn mark_event_soft_failed(event_id: &EventId) -> AppResult<()> {
+pub async fn mark_event_soft_failed(event_id: &EventId) -> AppResult<()> {
     diesel::update(events::table.filter(events::id.eq(event_id)))
         .set(events::soft_failed.eq(true))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
-pub fn is_event_soft_failed(event_id: &EventId) -> AppResult<bool> {
+pub async fn is_event_soft_failed(event_id: &EventId) -> AppResult<bool> {
     events::table
         .filter(events::id.eq(event_id))
         .select(events::soft_failed)
-        .first(&mut connect()?)
+        .first(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }

--- a/crates/server/src/room/push_action.rs
+++ b/crates/server/src/room/push_action.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::AppResult;
 use crate::core::Seqnum;
@@ -7,7 +8,7 @@ use crate::data::connect;
 use crate::data::room::NewDbEventPushAction;
 use crate::data::schema::*;
 
-pub fn increment_notification_counts(
+pub async fn increment_notification_counts(
     event_id: &EventId,
     notifies: Vec<OwnedUserId>,
     highlights: Vec<OwnedUserId>,
@@ -15,12 +16,14 @@ pub fn increment_notification_counts(
     let (room_id, thread_id) = event_points::table
         .find(event_id)
         .select((event_points::room_id, event_points::thread_id))
-        .first::<(OwnedRoomId, Option<OwnedEventId>)>(&mut connect()?)?;
+        .first::<(OwnedRoomId, Option<OwnedEventId>)>(&mut connect().await?)
+        .await?;
 
     let stream_ordering = events::table
         .find(event_id)
         .select(events::stream_ordering)
-        .first::<i64>(&mut connect()?)
+        .first::<i64>(&mut connect().await?)
+        .await
         .unwrap_or(1);
 
     for user_id in notifies {
@@ -35,7 +38,8 @@ pub fn increment_notification_counts(
                 event_push_summaries::notification_count
                     .eq(event_push_summaries::notification_count + 1),
             )
-            .execute(&mut connect()?)?
+            .execute(&mut connect().await?)
+            .await?
         } else {
             diesel::update(
                 event_push_summaries::table
@@ -47,7 +51,8 @@ pub fn increment_notification_counts(
                 event_push_summaries::notification_count
                     .eq(event_push_summaries::notification_count + 1),
             )
-            .execute(&mut connect()?)?
+            .execute(&mut connect().await?)
+            .await?
         };
         if rows == 0 {
             diesel::insert_into(event_push_summaries::table)
@@ -59,7 +64,8 @@ pub fn increment_notification_counts(
                     event_push_summaries::thread_id.eq(&thread_id),
                     event_push_summaries::stream_ordering.eq(stream_ordering),
                 ))
-                .execute(&mut connect()?)?;
+                .execute(&mut connect().await?)
+                .await?;
         }
     }
     for user_id in highlights {
@@ -73,7 +79,8 @@ pub fn increment_notification_counts(
             .set(
                 event_push_summaries::highlight_count.eq(event_push_summaries::highlight_count + 1),
             )
-            .execute(&mut connect()?)?
+            .execute(&mut connect().await?)
+            .await?
         } else {
             diesel::update(
                 event_push_summaries::table
@@ -84,7 +91,8 @@ pub fn increment_notification_counts(
             .set(
                 event_push_summaries::highlight_count.eq(event_push_summaries::highlight_count + 1),
             )
-            .execute(&mut connect()?)?
+            .execute(&mut connect().await?)
+            .await?
         };
         if rows == 0 {
             diesel::insert_into(event_push_summaries::table)
@@ -96,7 +104,8 @@ pub fn increment_notification_counts(
                     event_push_summaries::thread_id.eq(&thread_id),
                     event_push_summaries::stream_ordering.eq(stream_ordering),
                 ))
-                .execute(&mut connect()?)?;
+                .execute(&mut connect().await?)
+                .await?;
         }
     }
 
@@ -104,7 +113,7 @@ pub fn increment_notification_counts(
 }
 
 #[tracing::instrument]
-pub fn upsert_push_action(
+pub async fn upsert_push_action(
     room_id: &RoomId,
     event_id: &EventId,
     user_id: &UserId,
@@ -115,11 +124,13 @@ pub fn upsert_push_action(
     let (event_sn, thread_id) = event_points::table
         .find(event_id)
         .select((event_points::event_sn, event_points::thread_id))
-        .first::<(Seqnum, Option<OwnedEventId>)>(&mut connect()?)?;
+        .first::<(Seqnum, Option<OwnedEventId>)>(&mut connect().await?)
+        .await?;
     let (topological_ordering, stream_ordering) = events::table
         .find(event_id)
         .select((events::topological_ordering, events::stream_ordering))
-        .first::<(i64, i64)>(&mut connect()?)?;
+        .first::<(i64, i64)>(&mut connect().await?)
+        .await?;
 
     crate::data::room::event::upsert_push_action(&NewDbEventPushAction {
         room_id: room_id.to_owned(),
@@ -134,12 +145,13 @@ pub fn upsert_push_action(
         highlight,
         unread: false,
         thread_id,
-    })?;
+    })
+    .await?;
 
     Ok(())
 }
 
-pub fn remove_actions_until(
+pub async fn remove_actions_until(
     user_id: &UserId,
     room_id: &RoomId,
     event_sn: Seqnum,
@@ -153,7 +165,8 @@ pub fn remove_actions_until(
                 .filter(event_push_actions::thread_id.eq(thread_id))
                 .filter(event_push_actions::event_sn.le(event_sn)),
         )
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     } else {
         diesel::delete(
             event_push_actions::table
@@ -161,28 +174,31 @@ pub fn remove_actions_until(
                 .filter(event_push_actions::room_id.eq(room_id))
                 .filter(event_push_actions::event_sn.le(event_sn)),
         )
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     }
     Ok(())
 }
 
-pub fn remove_actions_for_room(user_id: &UserId, room_id: &RoomId) -> AppResult<()> {
+pub async fn remove_actions_for_room(user_id: &UserId, room_id: &RoomId) -> AppResult<()> {
     diesel::delete(
         event_push_actions::table
             .filter(event_push_actions::user_id.eq(user_id))
             .filter(event_push_actions::room_id.eq(room_id)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }
 
-pub fn refresh_notify_summary(user_id: &UserId, room_id: &RoomId) -> AppResult<()> {
+pub async fn refresh_notify_summary(user_id: &UserId, room_id: &RoomId) -> AppResult<()> {
     let thread_ids = event_push_actions::table
         .filter(event_push_actions::user_id.eq(user_id))
         .filter(event_push_actions::room_id.eq(room_id))
         .select(event_push_actions::thread_id)
         .distinct()
-        .load::<Option<OwnedEventId>>(&mut connect()?)?
+        .load::<Option<OwnedEventId>>(&mut connect().await?)
+        .await?
         .into_iter()
         .flatten()
         .collect::<Vec<_>>();
@@ -193,7 +209,8 @@ pub fn refresh_notify_summary(user_id: &UserId, room_id: &RoomId) -> AppResult<(
             .filter(event_push_actions::thread_id.is_not_null())
             .filter(event_push_actions::thread_id.ne_all(&thread_ids)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     diesel::delete(
         event_push_summaries::table
             .filter(event_push_summaries::user_id.eq(user_id))
@@ -201,7 +218,8 @@ pub fn refresh_notify_summary(user_id: &UserId, room_id: &RoomId) -> AppResult<(
             .filter(event_push_summaries::thread_id.is_not_null())
             .filter(event_push_summaries::thread_id.ne_all(&thread_ids)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     // Get the latest stream_ordering for this room's push actions
     let latest_stream_ordering: i64 = event_push_actions::table
         .filter(event_push_actions::user_id.eq(user_id))
@@ -209,7 +227,8 @@ pub fn refresh_notify_summary(user_id: &UserId, room_id: &RoomId) -> AppResult<(
         .filter(event_push_actions::stream_ordering.is_not_null())
         .order(event_push_actions::stream_ordering.desc())
         .select(event_push_actions::stream_ordering)
-        .first::<Option<i64>>(&mut connect()?)
+        .first::<Option<i64>>(&mut connect().await?)
+        .await
         .ok()
         .flatten()
         .unwrap_or(1);
@@ -222,15 +241,18 @@ pub fn refresh_notify_summary(user_id: &UserId, room_id: &RoomId) -> AppResult<(
         let notification_count = query
             .filter(event_push_actions::notify.eq(true))
             .count()
-            .get_result::<i64>(&mut connect()?)?;
+            .get_result::<i64>(&mut connect().await?)
+            .await?;
         let highlight_count = query
             .filter(event_push_actions::highlight.eq(true))
             .count()
-            .get_result::<i64>(&mut connect()?)?;
+            .get_result::<i64>(&mut connect().await?)
+            .await?;
         let unread_count = query
             .filter(event_push_actions::unread.eq(true))
             .count()
-            .get_result::<i64>(&mut connect()?)?;
+            .get_result::<i64>(&mut connect().await?)
+            .await?;
 
         let rows = diesel::update(
             event_push_summaries::table
@@ -243,7 +265,8 @@ pub fn refresh_notify_summary(user_id: &UserId, room_id: &RoomId) -> AppResult<(
             event_push_summaries::highlight_count.eq(highlight_count),
             event_push_summaries::unread_count.eq(unread_count),
         ))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
         if rows == 0 {
             diesel::insert_into(event_push_summaries::table)
                 .values((
@@ -255,7 +278,8 @@ pub fn refresh_notify_summary(user_id: &UserId, room_id: &RoomId) -> AppResult<(
                     event_push_summaries::unread_count.eq(unread_count),
                     event_push_summaries::stream_ordering.eq(latest_stream_ordering),
                 ))
-                .execute(&mut connect()?)?;
+                .execute(&mut connect().await?)
+                .await?;
         }
     }
 
@@ -266,15 +290,18 @@ pub fn refresh_notify_summary(user_id: &UserId, room_id: &RoomId) -> AppResult<(
     let notification_count = query
         .filter(event_push_actions::notify.eq(true))
         .count()
-        .get_result::<i64>(&mut connect()?)?;
+        .get_result::<i64>(&mut connect().await?)
+        .await?;
     let highlight_count = query
         .filter(event_push_actions::highlight.eq(true))
         .count()
-        .get_result::<i64>(&mut connect()?)?;
+        .get_result::<i64>(&mut connect().await?)
+        .await?;
     let unread_count = query
         .filter(event_push_actions::unread.eq(true))
         .count()
-        .get_result::<i64>(&mut connect()?)?;
+        .get_result::<i64>(&mut connect().await?)
+        .await?;
 
     let rows = diesel::update(
         event_push_summaries::table
@@ -287,7 +314,8 @@ pub fn refresh_notify_summary(user_id: &UserId, room_id: &RoomId) -> AppResult<(
         event_push_summaries::highlight_count.eq(highlight_count),
         event_push_summaries::unread_count.eq(unread_count),
     ))
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     if rows == 0 {
         diesel::insert_into(event_push_summaries::table)
             .values((
@@ -298,7 +326,8 @@ pub fn refresh_notify_summary(user_id: &UserId, room_id: &RoomId) -> AppResult<(
                 event_push_summaries::unread_count.eq(unread_count),
                 event_push_summaries::stream_ordering.eq(latest_stream_ordering),
             ))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     }
     Ok(())
 }

--- a/crates/server/src/room/receipt.rs
+++ b/crates/server/src/room/receipt.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::core::UnixMillis;
 use crate::core::events::receipt::{
@@ -16,17 +17,17 @@ use crate::{AppResult, sending};
 
 /// Replaces the previous read receipt.
 #[tracing::instrument]
-pub fn update_read(
+pub async fn update_read(
     user_id: &UserId,
     room_id: &RoomId,
     event: &ReceiptEvent,
     broadcast: bool,
 ) -> AppResult<()> {
     for (event_id, receipts) in event.content.clone() {
-        let Ok(event_sn) = crate::event::get_event_sn(&event_id) else {
+        let Ok(event_sn) = crate::event::get_event_sn(&event_id).await else {
             continue;
         };
-        let mut conn = connect()?;
+        let mut conn = connect().await?;
         for (receipt_ty, user_receipts) in receipts {
             if let Some(receipt) = user_receipts.get(user_id) {
                 let thread_id = match &receipt.thread {
@@ -35,7 +36,7 @@ pub fn update_read(
                 };
                 let receipt_at = receipt.ts.unwrap_or_else(UnixMillis::now);
                 let receipt = DbReceipt {
-                    sn: next_sn()?,
+                    sn: next_sn().await?,
                     ty: receipt_ty.to_string(),
                     room_id: room_id.to_owned(),
                     user_id: user_id.to_owned(),
@@ -48,6 +49,7 @@ pub fn update_read(
                 if let Err(e) = diesel::insert_into(event_receipts::table)
                     .values(&receipt)
                     .execute(&mut conn)
+                    .await
                 {
                     error!("failed to insert receipt: {}", e);
                 }
@@ -67,20 +69,24 @@ pub fn update_read(
     )]);
     let edu = Edu::Receipt(ReceiptContent::new(receipts));
     if broadcast {
-        sending::send_edu_room(room_id, &edu)?;
+        sending::send_edu_room(room_id, &edu).await?;
     }
     Ok(())
 }
 
 /// Gets the latest private read receipt from the user in the room
-pub fn last_private_read(user_id: &UserId, room_id: &RoomId) -> AppResult<ReceiptEventContent> {
+pub async fn last_private_read(
+    user_id: &UserId,
+    room_id: &RoomId,
+) -> AppResult<ReceiptEventContent> {
     let event_id = event_receipts::table
         .filter(event_receipts::room_id.eq(room_id))
         .filter(event_receipts::user_id.eq(user_id))
         .filter(event_receipts::ty.eq(ReceiptType::ReadPrivate.to_string()))
         .order_by(event_receipts::sn.desc())
         .select(event_receipts::event_id)
-        .first::<OwnedEventId>(&mut connect()?)?;
+        .first::<OwnedEventId>(&mut connect().await?)
+        .await?;
 
     // let room_sn = crate::room::get_room_sn(room_id)
     //     .map_err(|e| MatrixError::bad_state(format!("room does not exist in database for

--- a/crates/server/src/room/receipt.rs
+++ b/crates/server/src/room/receipt.rs
@@ -27,7 +27,6 @@ pub async fn update_read(
         let Ok(event_sn) = crate::event::get_event_sn(&event_id).await else {
             continue;
         };
-        let mut conn = connect().await?;
         for (receipt_ty, user_receipts) in receipts {
             if let Some(receipt) = user_receipts.get(user_id) {
                 let thread_id = match &receipt.thread {
@@ -46,9 +45,13 @@ pub async fn update_read(
                     json_data: serde_json::to_value(receipt)?,
                     receipt_at,
                 };
+                // Acquire the connection inline for the insert only. Holding a
+                // named `conn` across `next_sn()` above (which checks out its
+                // own connection) would pin two connections at once and risk
+                // exhausting the pool on this fairly hot receipt path.
                 if let Err(e) = diesel::insert_into(event_receipts::table)
                     .values(&receipt)
-                    .execute(&mut conn)
+                    .execute(&mut connect().await?)
                     .await
                 {
                     error!("failed to insert receipt: {}", e);

--- a/crates/server/src/room/space.rs
+++ b/crates/server/src/room/space.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeSet, VecDeque};
 use std::str::FromStr;
-use std::sync::{LazyLock, Mutex, MutexGuard};
+use std::sync::{LazyLock, Mutex};
 
 use lru_cache::LruCache;
 
@@ -54,22 +54,37 @@ pub async fn get_summary_and_children_local(
     identifier: &Identifier<'_>,
     suggested_only: bool,
 ) -> AppResult<Option<SummaryAccessibility>> {
-    match ROOM_ID_SPACE_CHUNK_CACHE
-        .lock()
-        .unwrap()
-        .get_mut(&(current_room.to_owned(), suggested_only))
-        .as_ref()
-    {
-        None => (), // cache miss
-        Some(None) => return Ok(None),
-        Some(Some(cached)) => {
+    // Snapshot the cache entry and drop the guard before any `.await` so the
+    // `MutexGuard` is never held across an await point.
+    enum CacheLookup {
+        Miss,
+        Negative,
+        Hit(SpaceHierarchyParentSummary),
+    }
+    let lookup = {
+        let mut cache = ROOM_ID_SPACE_CHUNK_CACHE.lock().unwrap();
+        match cache
+            .get_mut(&(current_room.to_owned(), suggested_only))
+            .as_ref()
+        {
+            None => CacheLookup::Miss, // cache miss
+            Some(None) => CacheLookup::Negative,
+            Some(Some(cached)) => CacheLookup::Hit(cached.summary.clone()),
+        }
+    };
+    match lookup {
+        CacheLookup::Miss => (), // cache miss
+        CacheLookup::Negative => return Ok(None),
+        CacheLookup::Hit(summary) => {
             let accessibility = if is_accessible_child(
                 current_room,
-                &cached.summary.join_rule,
+                &summary.join_rule,
                 identifier,
-                &cached.summary.allowed_room_ids,
-            ) {
-                SummaryAccessibility::Accessible(cached.summary.clone())
+                &summary.allowed_room_ids,
+            )
+            .await
+            {
+                SummaryAccessibility::Accessible(summary)
             } else {
                 SummaryAccessibility::Inaccessible
             };
@@ -77,7 +92,8 @@ pub async fn get_summary_and_children_local(
         }
     }
 
-    let children_pdus: Vec<_> = get_stripped_space_child_events(current_room, suggested_only)?;
+    let children_pdus: Vec<_> =
+        get_stripped_space_child_events(current_room, suggested_only).await?;
 
     let Ok(summary) = get_room_summary(current_room, children_pdus, identifier).await else {
         return Ok(None);
@@ -131,21 +147,16 @@ async fn get_summary_and_children_federation(
         return Ok(None);
     };
 
-    res_body
-        .children
-        .into_iter()
-        .filter_map(|child| {
-            if let Ok(mut cache) = ROOM_ID_SPACE_CHUNK_CACHE.lock() {
-                if !cache.contains_key(&(current_room.to_owned(), suggested_only)) {
-                    Some((child, cache))
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        })
-        .for_each(|(child, cache)| cache_insert(cache, current_room, child, suggested_only));
+    for child in res_body.children.into_iter() {
+        // Check (and short-circuit) without holding the guard across the await.
+        let should_insert = match ROOM_ID_SPACE_CHUNK_CACHE.lock() {
+            Ok(mut cache) => !cache.contains_key(&(current_room.to_owned(), suggested_only)),
+            Err(_) => false,
+        };
+        if should_insert {
+            cache_insert(current_room, child, suggested_only).await;
+        }
+    }
 
     let summary = res_body.room;
     let identifier = Identifier::UserId(user_id);
@@ -156,7 +167,7 @@ async fn get_summary_and_children_federation(
         &summary.allowed_room_ids,
     );
 
-    if is_accessible_child {
+    if is_accessible_child.await {
         return Ok(Some(SummaryAccessibility::Accessible(summary)));
     }
 
@@ -164,12 +175,13 @@ async fn get_summary_and_children_federation(
 }
 
 /// Simply returns the stripped m.space.child events of a room
-fn get_stripped_space_child_events(
+async fn get_stripped_space_child_events(
     room_id: &RoomId,
     suggested_only: bool,
 ) -> AppResult<Vec<RawJson<HierarchySpaceChildEvent>>> {
-    let frame_id = super::get_frame_id(room_id, None)?;
-    let child_events = get_full_state(frame_id)?
+    let frame_id = super::get_frame_id(room_id, None).await?;
+    let child_events = get_full_state(frame_id)
+        .await?
         .into_iter()
         .filter_map(|((state_event_type, state_key), pdu)| {
             if state_event_type == StateEventType::SpaceChild {
@@ -220,28 +232,28 @@ async fn get_room_summary(
         "",
         None,
     )
-    .map_or(JoinRule::Invite, |c: RoomJoinRulesEventContent| c.join_rule);
+    .await.map_or(JoinRule::Invite, |c: RoomJoinRulesEventContent| c.join_rule);
 
     let allowed_room_ids = state::allowed_room_ids(join_rule.clone());
 
     let join_rule: SpaceRoomJoinRule = join_rule.clone().into();
     let is_accessible_child =
-        is_accessible_child(room_id, &join_rule, identifier, &allowed_room_ids);
+        is_accessible_child(room_id, &join_rule, identifier, &allowed_room_ids).await;
 
     if !is_accessible_child {
         return Err(MatrixError::forbidden("User is not allowed to see the room", None).into());
     }
 
-    let name = super::get_name(room_id).ok();
-    let topic = super::get_topic(room_id).ok();
-    let room_type = super::get_room_type(room_id).ok().flatten();
-    let world_readable = super::is_world_readable(room_id);
-    let guest_can_join = super::guest_can_join(room_id);
-    let num_joined_members = super::joined_member_count(room_id).unwrap_or(0);
-    let canonical_alias = super::get_canonical_alias(room_id).ok().flatten();
-    let avatar_url = super::get_avatar_url(room_id).ok().flatten();
-    let room_version = super::get_version(room_id).ok();
-    let encryption = super::get_encryption(room_id).ok();
+    let name = super::get_name(room_id).await.ok();
+    let topic = super::get_topic(room_id).await.ok();
+    let room_type = super::get_room_type(room_id).await.ok().flatten();
+    let world_readable = super::is_world_readable(room_id).await;
+    let guest_can_join = super::guest_can_join(room_id).await;
+    let num_joined_members = super::joined_member_count(room_id).await.unwrap_or(0);
+    let canonical_alias = super::get_canonical_alias(room_id).await.ok().flatten();
+    let avatar_url = super::get_avatar_url(room_id).await.ok().flatten();
+    let room_version = super::get_version(room_id).await.ok();
+    let encryption = super::get_encryption(room_id).await.ok();
 
     Ok(SpaceHierarchyParentSummary {
         canonical_alias,
@@ -289,7 +301,7 @@ pub async fn get_room_hierarchy(
     let room_id = &args.room_id;
     let suggested_only = args.suggested_only;
     let mut queue: RoomDeque =
-        [(room_id.to_owned(), vec![crate::room::server_name(room_id)?])].into();
+        [(room_id.to_owned(), vec![crate::room::server_name(room_id).await?])].into();
 
     let mut rooms = Vec::with_capacity(limit);
     let mut parents = BTreeSet::new();
@@ -327,7 +339,7 @@ pub async fn get_room_hierarchy(
                 let populate = parents.len() >= room_sns.len();
 
                 let mut children = Vec::new();
-                let room_type = crate::room::get_room_type(&current_room).ok();
+                let room_type = crate::room::get_room_type(&current_room).await.ok();
                 if room_type.is_none() || Some(Some(RoomType::Space)) == room_type {
                     children = get_parent_children_via(&summary, suggested_only)
                         .into_iter()
@@ -361,10 +373,12 @@ pub async fn get_room_hierarchy(
     let next_batch = if let Some((room, _)) = queue.pop_front() {
         parents.insert(room);
 
-        let next_room_sns: Vec<_> = parents
-            .iter()
-            .filter_map(|room_id| crate::room::get_room_sn(room_id).ok())
-            .collect();
+        let mut next_room_sns: Vec<_> = Vec::new();
+        for room_id in parents.iter() {
+            if let Ok(sn) = crate::room::get_room_sn(room_id).await {
+                next_room_sns.push(sn);
+            }
+        }
 
         if !next_room_sns.is_empty() && next_room_sns.iter().ne(&room_sns) {
             Some(
@@ -386,7 +400,7 @@ pub async fn get_room_hierarchy(
 }
 
 /// With the given identifier, checks if a room is accessable
-fn is_accessible_child(
+async fn is_accessible_child(
     current_room: &RoomId,
     join_rule: &SpaceRoomJoinRule,
     identifier: &Identifier<'_>,
@@ -394,14 +408,14 @@ fn is_accessible_child(
 ) -> bool {
     // Checks if ACLs allow for the server to participate
     if let Identifier::ServerName(server_name) = identifier
-        && handler::acl_check(server_name, current_room).is_err()
+        && handler::acl_check(server_name, current_room).await.is_err()
     {
         return false;
     }
 
     if let Identifier::UserId(user_id) = identifier
-        && (crate::room::user::is_joined(user_id, current_room).unwrap_or(false)
-            || crate::room::user::is_invited(user_id, current_room).unwrap_or(false))
+        && (crate::room::user::is_joined(user_id, current_room).await.unwrap_or(false)
+            || crate::room::user::is_invited(user_id, current_room).await.unwrap_or(false))
     {
         return true;
     }
@@ -410,12 +424,22 @@ fn is_accessible_child(
         SpaceRoomJoinRule::Public
         | SpaceRoomJoinRule::Knock
         | SpaceRoomJoinRule::KnockRestricted => true,
-        SpaceRoomJoinRule::Restricted => allowed_room_ids.iter().any(|room| match identifier {
-            Identifier::UserId(user) => crate::room::user::is_joined(user, room).unwrap_or(false),
-            Identifier::ServerName(server) => {
-                crate::room::is_server_joined(server, room).unwrap_or(false)
+        SpaceRoomJoinRule::Restricted => {
+            for room in allowed_room_ids.iter() {
+                let accessible = match identifier {
+                    Identifier::UserId(user) => {
+                        crate::room::user::is_joined(user, room).await.unwrap_or(false)
+                    }
+                    Identifier::ServerName(server) => {
+                        crate::room::is_server_joined(server, room).await.unwrap_or(false)
+                    }
+                };
+                if accessible {
+                    return true;
+                }
             }
-        }),
+            false
+        }
 
         // Invite only, Private, or Custom join rule
         _ => false,
@@ -441,8 +465,7 @@ pub fn get_parent_children_via(
         .collect()
 }
 
-fn cache_insert(
-    mut cache: MutexGuard<'_, CacheItem>,
+async fn cache_insert(
     current_room: &RoomId,
     child: SpaceHierarchyChildSummary,
     suggested_only: bool,
@@ -463,6 +486,12 @@ fn cache_insert(
         encryption,
     } = child;
 
+    // Compute children_state before acquiring the lock so the MutexGuard is
+    // never held across the `.await`.
+    let children_state = get_stripped_space_child_events(&room_id, suggested_only)
+        .await
+        .unwrap_or_default();
+
     let summary = SpaceHierarchyParentSummary {
         canonical_alias,
         name,
@@ -475,16 +504,17 @@ fn cache_insert(
         room_type,
         allowed_room_ids,
         room_id: room_id.clone(),
-        children_state: get_stripped_space_child_events(&room_id, suggested_only)
-            .unwrap_or_default(),
+        children_state,
         room_version,
         encryption,
     };
 
-    cache.insert(
-        (current_room.to_owned(), suggested_only),
-        Some(CachedSpaceHierarchySummary { summary }),
-    );
+    if let Ok(mut cache) = ROOM_ID_SPACE_CHUNK_CACHE.lock() {
+        cache.insert(
+            (current_room.to_owned(), suggested_only),
+            Some(CachedSpaceHierarchySummary { summary }),
+        );
+    }
 }
 
 // Here because cannot implement `From` across palpo-federation-api and

--- a/crates/server/src/room/state.rs
+++ b/crates/server/src/room/state.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, Mutex};
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use indexmap::IndexMap;
 use lru_cache::LruCache;
 use serde::Deserialize;
@@ -59,27 +60,30 @@ pub struct DbRoomStateDelta {
 //     pub disposed: Vec<u8>,
 // }
 
-pub fn server_joined_rooms(server_name: &ServerName) -> AppResult<Vec<OwnedRoomId>> {
+pub async fn server_joined_rooms(server_name: &ServerName) -> AppResult<Vec<OwnedRoomId>> {
     room_joined_servers::table
         .filter(room_joined_servers::server_id.eq(server_name))
         .select(room_joined_servers::room_id)
-        .load::<OwnedRoomId>(&mut connect()?)
+        .load::<OwnedRoomId>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
 /// Set the room to the given state_hash and update caches.
-pub fn force_state(
+pub async fn force_state(
     room_id: &RoomId,
     frame_id: i64,
     appended: Arc<CompressedState>,
     _disposed_data: Arc<CompressedState>,
 ) -> AppResult<()> {
-    let event_ids = appended
-        .iter()
-        .filter_map(|new| new.split().ok().map(|(_, id)| id))
-        .collect::<Vec<_>>();
+    let mut event_ids = Vec::new();
+    for new in appended.iter() {
+        if let Ok((_, id)) = new.split().await {
+            event_ids.push(id);
+        }
+    }
     for event_id in &event_ids {
-        let pdu = match timeline::get_pdu(event_id) {
+        let pdu = match timeline::get_pdu(event_id).await {
             Ok(pdu) => pdu,
             _ => continue,
         };
@@ -114,7 +118,8 @@ pub fn force_state(
                     membership,
                     &pdu.sender,
                     None,
-                )?;
+                )
+                .await?;
             }
             TimelineEventType::SpaceChild => {
                 let mut cache = room::space::ROOM_ID_SPACE_CHUNK_CACHE.lock().unwrap();
@@ -125,16 +130,17 @@ pub fn force_state(
         }
     }
 
-    set_room_state(room_id, frame_id)?;
+    set_room_state(room_id, frame_id).await?;
 
     Ok(())
 }
 
 #[tracing::instrument]
-pub fn set_room_state(room_id: &RoomId, frame_id: i64) -> AppResult<()> {
+pub async fn set_room_state(room_id: &RoomId, frame_id: i64) -> AppResult<()> {
     diesel::update(rooms::table.find(room_id))
         .set(rooms::state_frame_id.eq(frame_id))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
@@ -142,21 +148,21 @@ pub fn set_room_state(room_id: &RoomId, frame_id: i64) -> AppResult<()> {
 ///
 /// This adds all current state events (not including the incoming event).
 #[tracing::instrument(skip(state_ids_compressed), level = "debug")]
-pub fn set_event_state(
+pub async fn set_event_state(
     event_id: &EventId,
     event_sn: i64,
     room_id: &RoomId,
     state_ids_compressed: Arc<CompressedState>,
 ) -> AppResult<i64> {
-    let prev_frame_id = get_room_frame_id(room_id, None).ok();
+    let prev_frame_id = get_room_frame_id(room_id, None).await.ok();
     let hash_data = utils::hash_keys(state_ids_compressed.iter().map(|s| &s[..]));
-    if let Ok(frame_id) = get_frame_id(room_id, &hash_data) {
-        update_frame_id(event_id, frame_id)?;
+    if let Ok(frame_id) = get_frame_id(room_id, &hash_data).await {
+        update_frame_id(event_id, frame_id).await?;
         Ok(frame_id)
     } else {
-        let frame_id = ensure_frame(room_id, hash_data)?;
+        let frame_id = ensure_frame(room_id, hash_data).await?;
         let states_parents = if let Some(prev_frame_id) = prev_frame_id {
-            load_frame_info(prev_frame_id)?
+            load_frame_info(prev_frame_id).await?
         } else {
             Vec::new()
         };
@@ -178,7 +184,7 @@ pub fn set_event_state(
             (state_ids_compressed, Arc::new(CompressedState::new()))
         };
 
-        update_frame_id(event_id, frame_id)?;
+        update_frame_id(event_id, frame_id).await?;
         calc_and_save_state_delta(
             room_id,
             frame_id,
@@ -186,7 +192,8 @@ pub fn set_event_state(
             disposed,
             1_000_000,
             states_parents,
-        )?;
+        )
+        .await?;
         Ok(frame_id)
     }
 }
@@ -195,13 +202,19 @@ pub fn set_event_state(
 ///
 /// This adds all current state events (not including the incoming event).
 #[tracing::instrument(skip(new_pdu))]
-pub fn append_to_state(new_pdu: &SnPduEvent) -> AppResult<i64> {
-    let prev_frame_id = get_room_frame_id(&new_pdu.room_id, None).ok();
+pub async fn append_to_state(new_pdu: &SnPduEvent) -> AppResult<i64> {
+    let prev_frame_id = get_room_frame_id(&new_pdu.room_id, None).await.ok();
 
     if let Some(state_key) = &new_pdu.state_key {
-        let states_parents = prev_frame_id.map_or_else(|| Ok(Vec::new()), load_frame_info)?;
+        let states_parents = if let Some(prev_frame_id) = prev_frame_id {
+            load_frame_info(prev_frame_id).await?
+        } else {
+            Vec::new()
+        };
 
-        let field_id = ensure_field(&new_pdu.event_ty.to_string().into(), state_key)?.id;
+        let field_id = ensure_field(&new_pdu.event_ty.to_string().into(), state_key)
+            .await?
+            .id;
 
         let new_compressed_event = CompressedEvent::new(field_id, new_pdu.event_sn);
 
@@ -230,8 +243,8 @@ pub fn append_to_state(new_pdu: &SnPduEvent) -> AppResult<i64> {
         }
 
         let hash_data = utils::hash_keys([new_compressed_event.as_bytes()].into_iter());
-        let frame_id = ensure_frame(&new_pdu.room_id, hash_data)?;
-        update_frame_id(&new_pdu.event_id, frame_id)?;
+        let frame_id = ensure_frame(&new_pdu.room_id, hash_data).await?;
+        update_frame_id(&new_pdu.event_id, frame_id).await?;
         calc_and_save_state_delta(
             &new_pdu.room_id,
             frame_id,
@@ -239,18 +252,21 @@ pub fn append_to_state(new_pdu: &SnPduEvent) -> AppResult<i64> {
             Arc::new(disposed),
             2,
             states_parents,
-        )?;
+        )
+        .await?;
         Ok(frame_id)
     } else {
         let frame_id = prev_frame_id
             .ok_or_else(|| MatrixError::invalid_param("Room previous point must exists."))?;
 
-        update_frame_id(&new_pdu.event_id, frame_id)?;
+        update_frame_id(&new_pdu.event_id, frame_id).await?;
         Ok(frame_id)
     }
 }
 
-pub fn summary_stripped(event: &PduEvent) -> AppResult<Vec<RawJson<AnyStrippedStateEvent>>> {
+pub async fn summary_stripped(
+    event: &PduEvent,
+) -> AppResult<Vec<RawJson<AnyStrippedStateEvent>>> {
     let cells: [(&StateEventType, &str); 8] = [
         (&StateEventType::RoomCreate, ""),
         (&StateEventType::RoomJoinRules, ""),
@@ -265,27 +281,28 @@ pub fn summary_stripped(event: &PduEvent) -> AppResult<Vec<RawJson<AnyStrippedSt
     let mut state = Vec::new();
     // Add recommended events
     for (event_type, state_key) in cells {
-        if let Ok(e) = super::get_state(&event.room_id, event_type, state_key, None) {
-            state.push(e.to_stripped_state_event());
+        if let Ok(e) = super::get_state(&event.room_id, event_type, state_key, None).await {
+            state.push(e.to_stripped_state_event().await);
         }
     }
 
-    state.push(event.to_stripped_state_event());
+    state.push(event.to_stripped_state_event().await);
     Ok(state)
 }
 
-pub fn get_forward_extremities(room_id: &RoomId) -> AppResult<Vec<OwnedEventId>> {
+pub async fn get_forward_extremities(room_id: &RoomId) -> AppResult<Vec<OwnedEventId>> {
     let event_ids = event_forward_extremities::table
         .filter(event_forward_extremities::room_id.eq(room_id))
         .select(event_forward_extremities::event_id)
         .distinct()
-        .load::<OwnedEventId>(&mut connect()?)?
+        .load::<OwnedEventId>(&mut connect().await?)
+        .await?
         .into_iter()
         .collect();
     Ok(event_ids)
 }
 
-pub fn set_forward_extremities<'a, I>(
+pub async fn set_forward_extremities<'a, I>(
     room_id: &RoomId,
     event_ids: I,
     _lock: &RoomMutexGuard,
@@ -299,7 +316,8 @@ where
             .filter(event_forward_extremities::room_id.eq(room_id))
             .filter(event_forward_extremities::event_id.ne_all(&event_ids)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     for event_id in event_ids {
         diesel::insert_into(event_forward_extremities::table)
             .values((
@@ -307,23 +325,25 @@ where
                 event_forward_extremities::event_id.eq(event_id),
             ))
             .on_conflict_do_nothing()
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     }
     Ok(())
 }
 
-pub fn get_backward_extremities(room_id: &RoomId) -> AppResult<Vec<OwnedEventId>> {
+pub async fn get_backward_extremities(room_id: &RoomId) -> AppResult<Vec<OwnedEventId>> {
     let event_ids = event_backward_extremities::table
         .filter(event_backward_extremities::room_id.eq(room_id))
         .select(event_backward_extremities::event_id)
         .distinct()
-        .load::<OwnedEventId>(&mut connect()?)?
+        .load::<OwnedEventId>(&mut connect().await?)
+        .await?
         .into_iter()
         .collect();
     Ok(event_ids)
 }
 
-pub fn update_backward_extremities(pdu: &SnPduEvent) -> AppResult<()> {
+pub async fn update_backward_extremities(pdu: &SnPduEvent) -> AppResult<()> {
     if pdu.is_outlier {
         diesel::insert_into(event_backward_extremities::table)
             .values((
@@ -331,13 +351,15 @@ pub fn update_backward_extremities(pdu: &SnPduEvent) -> AppResult<()> {
                 event_backward_extremities::event_id.eq(&pdu.event_id),
             ))
             .on_conflict_do_nothing()
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     } else {
         let existing_ids = events::table
             .filter(events::id.eq_any(&pdu.prev_events))
             .filter(events::is_outlier.eq(false))
             .select(events::id)
-            .load::<OwnedEventId>(&mut connect()?)?;
+            .load::<OwnedEventId>(&mut connect().await?)
+            .await?;
         let missing_ids: Vec<OwnedEventId> = pdu
             .prev_events
             .iter()
@@ -350,14 +372,16 @@ pub fn update_backward_extremities(pdu: &SnPduEvent) -> AppResult<()> {
                     .filter(event_backward_extremities::room_id.eq(&pdu.room_id))
                     .filter(event_backward_extremities::event_id.eq(&pdu.event_id)),
             )
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
 
             diesel::delete(
                 timeline_gaps::table
                     .filter(timeline_gaps::room_id.eq(&pdu.room_id))
                     .filter(timeline_gaps::event_sn.eq(pdu.event_sn)),
             )
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         } else {
             for event_id in &missing_ids {
                 diesel::insert_into(event_backward_extremities::table)
@@ -366,7 +390,8 @@ pub fn update_backward_extremities(pdu: &SnPduEvent) -> AppResult<()> {
                         event_backward_extremities::event_id.eq(event_id),
                     ))
                     .on_conflict_do_nothing()
-                    .execute(&mut connect()?)?;
+                    .execute(&mut connect().await?)
+                    .await?;
             }
             diesel::insert_into(event_backward_extremities::table)
                 .values((
@@ -374,21 +399,24 @@ pub fn update_backward_extremities(pdu: &SnPduEvent) -> AppResult<()> {
                     event_backward_extremities::event_id.eq(&pdu.event_id),
                 ))
                 .on_conflict_do_nothing()
-                .execute(&mut connect()?)?;
+                .execute(&mut connect().await?)
+                .await?;
             diesel::insert_into(timeline_gaps::table)
                 .values(NewDbTimelineGap {
                     room_id: pdu.room_id.clone(),
                     event_id: pdu.event_id.clone(),
                     event_sn: pdu.event_sn,
                 })
-                .execute(&mut connect()?)?;
+                .execute(&mut connect().await?)
+                .await?;
         }
     }
 
     let existing_ids = events::table
         .filter(events::id.eq_any(&pdu.prev_events))
         .select(events::id)
-        .load::<OwnedEventId>(&mut connect()?)?;
+        .load::<OwnedEventId>(&mut connect().await?)
+        .await?;
     let missing_ids: Vec<OwnedEventId> = pdu
         .prev_events
         .iter()
@@ -405,7 +433,8 @@ pub fn update_backward_extremities(pdu: &SnPduEvent) -> AppResult<()> {
                 missing_id: missing_id.clone(),
             })
             .on_conflict_do_nothing()
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     }
 
     Ok(())
@@ -413,7 +442,7 @@ pub fn update_backward_extremities(pdu: &SnPduEvent) -> AppResult<()> {
 
 /// This fetches auth events from the current state.
 #[tracing::instrument]
-pub fn get_auth_events(
+pub async fn get_auth_events(
     room_id: &RoomId,
     kind: &TimelineEventType,
     sender: &UserId,
@@ -421,7 +450,7 @@ pub fn get_auth_events(
     content: &serde_json::value::RawValue,
     auth_rules: &AuthorizationRules,
 ) -> AppResult<StateMap<SnPduEvent>> {
-    let frame_id = if let Ok(current_frame_id) = get_room_frame_id(room_id, None) {
+    let frame_id = if let Ok(current_frame_id) = get_room_frame_id(room_id, None).await {
         current_frame_id
     } else {
         return Ok(HashMap::new());
@@ -429,24 +458,23 @@ pub fn get_auth_events(
 
     let auth_types =
         crate::core::state::auth_types_for_event(kind, sender, state_key, content, auth_rules)?;
-    let mut sauth_events = auth_types
-        .into_iter()
-        .filter_map(|(event_type, state_key)| {
-            ensure_field_id(&event_type.to_string().into(), &state_key)
-                .ok()
-                .map(|field_id| (field_id, (event_type, state_key)))
-        })
-        .collect::<HashMap<_, _>>();
+    let mut sauth_events = HashMap::new();
+    for (event_type, state_key) in auth_types {
+        if let Ok(field_id) = ensure_field_id(&event_type.to_string().into(), &state_key).await {
+            sauth_events.insert(field_id, (event_type, state_key));
+        }
+    }
 
-    let full_state = load_frame_info(frame_id)?
+    let full_state = load_frame_info(frame_id)
+        .await?
         .pop()
         .expect("there is always one layer")
         .full_state;
     let mut state_map = StateMap::new();
     for state in full_state.iter() {
-        let (state_key_id, event_id) = state.split()?;
+        let (state_key_id, event_id) = state.split().await?;
         if let Some(key) = sauth_events.remove(&state_key_id) {
-            if let Ok(pdu) = timeline::get_pdu(&event_id) {
+            if let Ok(pdu) = timeline::get_pdu(&event_id).await {
                 state_map.insert(key, pdu);
             } else {
                 tracing::warn!("pdu is not found: {}", event_id);
@@ -458,29 +486,33 @@ pub fn get_auth_events(
 
 /// Builds a StateMap by iterating over all keys that start
 /// with state_hash, this gives the full state for the given state_hash.
-pub fn get_full_state_ids(frame_id: i64) -> AppResult<IndexMap<i64, OwnedEventId>> {
-    let full_state = load_frame_info(frame_id)?
+pub async fn get_full_state_ids(frame_id: i64) -> AppResult<IndexMap<i64, OwnedEventId>> {
+    let full_state = load_frame_info(frame_id)
+        .await?
         .pop()
         .expect("there is always one layer")
         .full_state;
     let mut map = IndexMap::new();
     for compressed in full_state.iter() {
-        let splited = compressed.split()?;
+        let splited = compressed.split().await?;
         map.insert(splited.0, splited.1);
     }
     Ok(map)
 }
 
-pub fn get_full_state(frame_id: i64) -> AppResult<IndexMap<(StateEventType, String), SnPduEvent>> {
-    let full_state = load_frame_info(frame_id)?
+pub async fn get_full_state(
+    frame_id: i64,
+) -> AppResult<IndexMap<(StateEventType, String), SnPduEvent>> {
+    let full_state = load_frame_info(frame_id)
+        .await?
         .pop()
         .expect("there is always one layer")
         .full_state;
 
     let mut result = IndexMap::new();
     for compressed in full_state.iter() {
-        let (_, event_id) = compressed.split()?;
-        if let Ok(pdu) = timeline::get_pdu(&event_id) {
+        let (_, event_id) = compressed.split().await?;
+        if let Ok(pdu) = timeline::get_pdu(&event_id).await {
             result.insert(
                 (
                     pdu.event_ty.to_string().into(),
@@ -501,33 +533,38 @@ pub fn get_full_state(frame_id: i64) -> AppResult<IndexMap<(StateEventType, Stri
 }
 
 /// Returns a single PDU from `room_id` with key (`event_type`, `state_key`).
-pub fn get_state_event_id(
+pub async fn get_state_event_id(
     frame_id: i64,
     event_type: &StateEventType,
     state_key: &str,
 ) -> AppResult<OwnedEventId> {
-    let state_key_id = get_field_id(event_type, state_key)?;
-    let full_state = load_frame_info(frame_id)?
+    let state_key_id = get_field_id(event_type, state_key).await?;
+    let full_state = load_frame_info(frame_id)
+        .await?
         .pop()
         .expect("there is always one layer")
         .full_state;
-    full_state
+    let compressed = full_state
         .iter()
-        .find(|bytes| bytes.starts_with(&state_key_id.to_be_bytes()))
-        .and_then(|compressed| compressed.split().ok().map(|(_, id)| id))
-        .ok_or(MatrixError::not_found("state event not found").into())
+        .find(|bytes| bytes.starts_with(&state_key_id.to_be_bytes()));
+    let event_id = if let Some(compressed) = compressed {
+        compressed.split().await.ok().map(|(_, id)| id)
+    } else {
+        None
+    };
+    event_id.ok_or(MatrixError::not_found("state event not found").into())
 }
 
 /// Returns a single PDU from `room_id` with key (`event_type`, `state_key`).
-pub fn get_state(
+pub async fn get_state(
     frame_id: i64,
     event_type: &StateEventType,
     state_key: &str,
 ) -> AppResult<SnPduEvent> {
-    let event_id = get_state_event_id(frame_id, event_type, state_key)?;
-    timeline::get_pdu(&event_id)
+    let event_id = get_state_event_id(frame_id, event_type, state_key).await?;
+    timeline::get_pdu(&event_id).await
 }
-pub fn get_state_content<T>(
+pub async fn get_state_content<T>(
     frame_id: i64,
     event_type: &StateEventType,
     state_key: &str,
@@ -535,30 +572,35 @@ pub fn get_state_content<T>(
 where
     T: DeserializeOwned,
 {
-    Ok(get_state(frame_id, event_type, state_key)?.get_content()?)
+    Ok(get_state(frame_id, event_type, state_key)
+        .await?
+        .get_content()?)
 }
 
 /// Get membership for given user in state
-pub fn user_membership(frame_id: i64, user_id: &UserId) -> AppResult<MembershipState> {
+pub async fn user_membership(frame_id: i64, user_id: &UserId) -> AppResult<MembershipState> {
     get_state_content::<RoomMemberEventContent>(
         frame_id,
         &StateEventType::RoomMember,
         user_id.as_str(),
     )
+    .await
     .map(|c: RoomMemberEventContent| c.membership)
 }
 
 /// The user was a joined member at this state (potentially in the past)
-pub fn user_was_joined(frame_id: i64, user_id: &UserId) -> bool {
+pub async fn user_was_joined(frame_id: i64, user_id: &UserId) -> bool {
     user_membership(frame_id, user_id)
+        .await
         .map(|s| s == MembershipState::Join)
         .unwrap_or_default() // Return sensible default, i.e. false
 }
 
 /// The user was an invited or joined room member at this state (potentially
 /// in the past)
-pub fn user_was_invited(frame_id: i64, user_id: &UserId) -> bool {
+pub async fn user_was_invited(frame_id: i64, user_id: &UserId) -> bool {
     user_membership(frame_id, user_id)
+        .await
         .map(|s| s == MembershipState::Join || s == MembershipState::Invite)
         .unwrap_or_default() // Return sensible default, i.e. false
 }
@@ -573,7 +615,7 @@ pub async fn user_can_redact(
     room_id: &RoomId,
     federation: bool,
 ) -> AppResult<bool> {
-    let redacting_event = timeline::get_pdu(redacts);
+    let redacting_event = timeline::get_pdu(redacts).await;
 
     if redacting_event
         .as_ref()
@@ -612,7 +654,9 @@ pub async fn user_can_redact(
                 })
     } else {
         // Falling back on m.room.create to judge power level
-        if let Ok(room_create) = super::get_state(room_id, &StateEventType::RoomCreate, "", None) {
+        if let Ok(room_create) =
+            super::get_state(room_id, &StateEventType::RoomCreate, "", None).await
+        {
             Ok(room_create.sender == sender
                 || redacting_event
                     .as_ref()
@@ -628,36 +672,60 @@ pub async fn user_can_redact(
 /// Whether a server is allowed to see an event through federation, based on
 /// the room's history_visibility at that event's state.
 #[tracing::instrument(skip(origin, room_id, event_id))]
-pub fn server_can_see_event(
+pub async fn server_can_see_event(
     origin: &ServerName,
     room_id: &RoomId,
     event_id: &EventId,
 ) -> AppResult<bool> {
-    let frame_id = match get_pdu_frame_id(event_id) {
+    let frame_id = match get_pdu_frame_id(event_id).await {
         Ok(frame_id) => frame_id,
         Err(_) => return Ok(true),
     };
-    let history_visibility = super::get_history_visibility(room_id)?;
+    let history_visibility = super::get_history_visibility(room_id).await?;
 
     let visibility = match history_visibility {
         HistoryVisibility::WorldReadable | HistoryVisibility::Shared => true,
         HistoryVisibility::Invited => {
             // Allow if any member on requesting server was AT LEAST invited, else deny
-            room::invited_users(room_id, None)?
+            let mut allowed = false;
+            for member in room::invited_users(room_id, None)
+                .await?
                 .into_iter()
                 .filter(|member| member.server_name() == origin)
-                .any(|member| user_was_invited(frame_id, &member))
-                || room::joined_users(room_id, None)?
+            {
+                if user_was_invited(frame_id, &member).await {
+                    allowed = true;
+                    break;
+                }
+            }
+            if !allowed {
+                for member in room::joined_users(room_id, None)
+                    .await?
                     .into_iter()
                     .filter(|member| member.server_name() == origin)
-                    .any(|member| user_was_joined(frame_id, &member))
+                {
+                    if user_was_joined(frame_id, &member).await {
+                        allowed = true;
+                        break;
+                    }
+                }
+            }
+            allowed
         }
         HistoryVisibility::Joined => {
             // Allow if any member on requested server was joined, else deny
-            room::joined_users(room_id, None)?
+            let mut allowed = false;
+            for member in room::joined_users(room_id, None)
+                .await?
                 .into_iter()
                 .filter(|member| member.server_name() == origin)
-                .any(|member| user_was_joined(frame_id, &member))
+            {
+                if user_was_joined(frame_id, &member).await {
+                    allowed = true;
+                    break;
+                }
+            }
+            allowed
         }
         _ => {
             error!("Unknown history visibility {history_visibility}");
@@ -674,54 +742,62 @@ pub fn server_can_see_event(
 }
 
 #[tracing::instrument(skip(origin, user_id))]
-pub fn server_can_see_user(origin: &ServerName, user_id: &UserId) -> AppResult<bool> {
-    Ok(server_joined_rooms(origin)?
-        .iter()
-        .any(|room_id| super::user::is_joined(user_id, room_id).unwrap_or(false)))
+pub async fn server_can_see_user(origin: &ServerName, user_id: &UserId) -> AppResult<bool> {
+    for room_id in server_joined_rooms(origin).await? {
+        if super::user::is_joined(user_id, &room_id)
+            .await
+            .unwrap_or(false)
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 #[tracing::instrument(skip(sender_id, user_id))]
-pub fn user_can_see_user(sender_id: &UserId, user_id: &UserId) -> AppResult<bool> {
+pub async fn user_can_see_user(sender_id: &UserId, user_id: &UserId) -> AppResult<bool> {
     super::user::shared_rooms(vec![sender_id.to_owned(), user_id.to_owned()])
+        .await
         .map(|rooms| !rooms.is_empty())
 }
 
 /// Whether a user is allowed to see an event, based on
 /// the room's history_visibility at that event's state.
 #[tracing::instrument(skip(user_id, event_id))]
-pub fn user_can_see_event(user_id: &UserId, event_id: &EventId) -> AppResult<bool> {
-    let pdu = timeline::get_pdu(event_id)?;
-    pdu.user_can_see(user_id)
+pub async fn user_can_see_event(user_id: &UserId, event_id: &EventId) -> AppResult<bool> {
+    let pdu = timeline::get_pdu(event_id).await?;
+    pdu.user_can_see(user_id).await
 }
 
 /// Whether a user is allowed to see an event, based on
 /// the room's history_visibility at that event's state.
 #[tracing::instrument(skip(user_id, room_id))]
-pub fn user_can_see_events(user_id: &UserId, room_id: &RoomId) -> AppResult<bool> {
-    if super::user::is_joined(user_id, room_id)? {
+pub async fn user_can_see_events(user_id: &UserId, room_id: &RoomId) -> AppResult<bool> {
+    if super::user::is_joined(user_id, room_id).await? {
         return Ok(true);
     }
 
-    let history_visibility = super::get_history_visibility(room_id)?;
+    let history_visibility = super::get_history_visibility(room_id).await?;
     match history_visibility {
-        HistoryVisibility::Invited => super::user::is_invited(user_id, room_id),
+        HistoryVisibility::Invited => super::user::is_invited(user_id, room_id).await,
         HistoryVisibility::WorldReadable => Ok(true),
         _ => Ok(false),
     }
 }
 
 /// Returns the new state_hash, and the state diff from the previous room state
-pub fn save_state(
+pub async fn save_state(
     room_id: &RoomId,
     new_compressed_events: Arc<CompressedState>,
 ) -> AppResult<DeltaInfo> {
-    let prev_frame_id = get_room_frame_id(room_id, None).ok();
+    let prev_frame_id = get_room_frame_id(room_id, None).await.ok();
 
     let hash_data = utils::hash_keys(new_compressed_events.iter().map(|bytes| &bytes[..]));
 
-    let (new_frame_id, frame_existed) = if let Ok(frame_id) = get_frame_id(room_id, &hash_data) {
+    let (new_frame_id, frame_existed) = if let Ok(frame_id) = get_frame_id(room_id, &hash_data).await
+    {
         (frame_id, true)
     } else {
-        let frame_id = ensure_frame(room_id, hash_data)?;
+        let frame_id = ensure_frame(room_id, hash_data).await?;
         (frame_id, false)
     };
 
@@ -733,10 +809,14 @@ pub fn save_state(
         });
     }
     for new_compressed_event in new_compressed_events.iter() {
-        update_frame_id_by_sn(new_compressed_event.event_sn(), new_frame_id)?;
+        update_frame_id_by_sn(new_compressed_event.event_sn(), new_frame_id).await?;
     }
 
-    let states_parents = prev_frame_id.map_or_else(|| Ok(Vec::new()), load_frame_info)?;
+    let states_parents = if let Some(prev_frame_id) = prev_frame_id {
+        load_frame_info(prev_frame_id).await?
+    } else {
+        Vec::new()
+    };
 
     let (appended, disposed) = if let Some(parent_state_info) = states_parents.last() {
         let appended: CompressedState = new_compressed_events
@@ -763,7 +843,8 @@ pub fn save_state(
             disposed.clone(),
             2, // every state change is 2 event changes on average
             states_parents,
-        )?;
+        )
+        .await?;
     };
 
     Ok(DeltaInfo {
@@ -774,7 +855,7 @@ pub fn save_state(
 }
 
 #[tracing::instrument]
-pub fn get_user_state(
+pub async fn get_user_state(
     user_id: &UserId,
     room_id: &RoomId,
 ) -> AppResult<Option<Vec<RawJson<AnyStrippedStateEvent>>>> {
@@ -782,7 +863,8 @@ pub fn get_user_state(
         .filter(room_users::user_id.eq(user_id))
         .filter(room_users::room_id.eq(room_id))
         .select(room_users::state_data)
-        .first::<Option<JsonValue>>(&mut connect()?)
+        .first::<Option<JsonValue>>(&mut connect().await?)
+        .await
         .optional()?
         .flatten()
     {
@@ -797,8 +879,8 @@ pub fn get_user_state(
 ///
 /// See <https://spec.matrix.org/latest/appendices/#routing>
 #[tracing::instrument(level = "trace")]
-pub fn servers_route_via(room_id: &RoomId) -> AppResult<Vec<OwnedServerName>> {
-    let Ok(pdu) = super::get_state(room_id, &StateEventType::RoomPowerLevels, "", None) else {
+pub async fn servers_route_via(room_id: &RoomId) -> AppResult<Vec<OwnedServerName>> {
+    let Ok(pdu) = super::get_state(room_id, &StateEventType::RoomPowerLevels, "", None).await else {
         return Ok(Vec::new());
     };
 
@@ -810,7 +892,8 @@ pub fn servers_route_via(room_id: &RoomId) -> AppResult<Vec<OwnedServerName>> {
         .and_then(|x| (*x.1 >= 50).then_some(x))
         .map(|(user, _power)| user.server_name().to_owned());
 
-    let mut servers: Vec<OwnedServerName> = super::joined_servers(room_id)?
+    let mut servers: Vec<OwnedServerName> = super::joined_servers(room_id)
+        .await?
         .into_iter()
         .take(5)
         .collect();

--- a/crates/server/src/room/state/diff.rs
+++ b/crates/server/src/room/state/diff.rs
@@ -4,6 +4,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use super::{DbRoomStateDelta, FrameInfo, room_state_deltas};
 use crate::core::{OwnedEventId, RoomId, Seqnum};
@@ -40,12 +41,13 @@ impl CompressedEvent {
         utils::i64_from_bytes(&self.0[size_of::<i64>()..]).expect("bytes have right length")
     }
     /// Returns state_key_id, event id
-    pub fn split(&self) -> AppResult<(i64, OwnedEventId)> {
+    pub async fn split(&self) -> AppResult<(i64, OwnedEventId)> {
         Ok((
             utils::i64_from_bytes(&self[0..size_of::<i64>()]).expect("bytes have right length"),
             crate::event::get_event_id_by_sn(
                 utils::i64_from_bytes(&self[size_of::<i64>()..]).expect("bytes have right length"),
-            )?,
+            )
+            .await?,
         ))
     }
     pub fn as_bytes(&self) -> &[u8] {
@@ -79,13 +81,14 @@ pub fn compress_event(
     Ok(CompressedEvent::new(field_id, event_sn))
 }
 
-pub fn get_detla(frame_id: i64) -> AppResult<DbRoomStateDelta> {
+pub async fn get_detla(frame_id: i64) -> AppResult<DbRoomStateDelta> {
     room_state_deltas::table
         .find(frame_id)
-        .first::<DbRoomStateDelta>(&mut connect()?)
+        .first::<DbRoomStateDelta>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
-pub fn load_state_diff(frame_id: i64) -> AppResult<StateDiff> {
+pub async fn load_state_diff(frame_id: i64) -> AppResult<StateDiff> {
     let DbRoomStateDelta {
         parent_id,
         appended,
@@ -93,7 +96,8 @@ pub fn load_state_diff(frame_id: i64) -> AppResult<StateDiff> {
         ..
     } = room_state_deltas::table
         .find(frame_id)
-        .first::<DbRoomStateDelta>(&mut connect()?)?;
+        .first::<DbRoomStateDelta>(&mut connect().await?)
+        .await?;
     Ok(StateDiff {
         parent_id,
         appended: Arc::new(
@@ -111,7 +115,7 @@ pub fn load_state_diff(frame_id: i64) -> AppResult<StateDiff> {
     })
 }
 
-pub fn save_state_delta(room_id: &RoomId, frame_id: i64, diff: StateDiff) -> AppResult<()> {
+pub async fn save_state_delta(room_id: &RoomId, frame_id: i64, diff: StateDiff) -> AppResult<()> {
     let StateDiff {
         parent_id,
         appended,
@@ -134,7 +138,8 @@ pub fn save_state_delta(room_id: &RoomId, frame_id: i64, diff: StateDiff) -> App
                 .collect::<Vec<_>>(),
         })
         .on_conflict_do_nothing()
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 /// Creates a new state_hash that often is just a diff to an already existing
@@ -152,7 +157,7 @@ pub fn save_state_delta(room_id: &RoomId, frame_id: i64, diff: StateDiff) -> App
 /// * `parent_states` - A stack with info on state_hash, full state, added diff and removed diff for
 ///   each parent layer
 #[tracing::instrument(skip(appended, disposed, diff_to_sibling, parent_states))]
-pub fn calc_and_save_state_delta(
+pub async fn calc_and_save_state_delta(
     room_id: &RoomId,
     frame_id: i64,
     appended: Arc<CompressedState>,
@@ -186,14 +191,15 @@ pub fn calc_and_save_state_delta(
             // Else it was removed in the parent and we added it again. We can forget this change
         }
 
-        return calc_and_save_state_delta(
+        return Box::pin(calc_and_save_state_delta(
             room_id,
             frame_id,
             Arc::new(parent_appended),
             Arc::new(parent_disposed),
             diff_sum,
             parent_states,
-        );
+        ))
+        .await;
     }
 
     if parent_states.is_empty() {
@@ -206,7 +212,8 @@ pub fn calc_and_save_state_delta(
                 appended,
                 disposed,
             },
-        );
+        )
+        .await;
     }
 
     // Else we have two options.
@@ -236,14 +243,15 @@ pub fn calc_and_save_state_delta(
             // Else it was removed in the parent and we added it again. We can forget this change
         }
 
-        calc_and_save_state_delta(
+        Box::pin(calc_and_save_state_delta(
             room_id,
             frame_id,
             Arc::new(parent_appended),
             Arc::new(parent_disposed),
             diff_sum,
             parent_states,
-        )
+        ))
+        .await
     } else {
         // Diff small enough, we add diff as layer on top of parent
         save_state_delta(
@@ -255,5 +263,6 @@ pub fn calc_and_save_state_delta(
                 disposed,
             },
         )
+        .await
     }
 }

--- a/crates/server/src/room/state/field.rs
+++ b/crates/server/src/room/state/field.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::AppResult;
 use crate::core::events::StateEventType;
@@ -13,21 +14,23 @@ pub struct DbRoomStateField {
     pub state_key: String,
 }
 
-pub fn get_field(field_id: i64) -> AppResult<DbRoomStateField> {
+pub async fn get_field(field_id: i64) -> AppResult<DbRoomStateField> {
     room_state_fields::table
         .find(field_id)
-        .first::<DbRoomStateField>(&mut connect()?)
+        .first::<DbRoomStateField>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
-pub fn get_field_id(event_ty: &StateEventType, state_key: &str) -> AppResult<i64> {
+pub async fn get_field_id(event_ty: &StateEventType, state_key: &str) -> AppResult<i64> {
     room_state_fields::table
         .filter(room_state_fields::event_ty.eq(event_ty))
         .filter(room_state_fields::state_key.eq(state_key))
         .select(room_state_fields::id)
-        .first::<i64>(&mut connect()?)
+        .first::<i64>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
-pub fn ensure_field_id(event_ty: &StateEventType, state_key: &str) -> AppResult<i64> {
+pub async fn ensure_field_id(event_ty: &StateEventType, state_key: &str) -> AppResult<i64> {
     let id = diesel::insert_into(room_state_fields::table)
         .values((
             room_state_fields::event_ty.eq(event_ty),
@@ -35,7 +38,8 @@ pub fn ensure_field_id(event_ty: &StateEventType, state_key: &str) -> AppResult<
         ))
         .on_conflict_do_nothing()
         .returning(room_state_fields::id)
-        .get_result::<i64>(&mut connect()?)
+        .get_result::<i64>(&mut connect().await?)
+        .await
         .optional()?;
     if let Some(id) = id {
         Ok(id)
@@ -44,11 +48,15 @@ pub fn ensure_field_id(event_ty: &StateEventType, state_key: &str) -> AppResult<
             .filter(room_state_fields::event_ty.eq(event_ty))
             .filter(room_state_fields::state_key.eq(state_key))
             .select(room_state_fields::id)
-            .first::<i64>(&mut connect()?)
+            .first::<i64>(&mut connect().await?)
+            .await
             .map_err(Into::into)
     }
 }
-pub fn ensure_field(event_ty: &StateEventType, state_key: &str) -> AppResult<DbRoomStateField> {
+pub async fn ensure_field(
+    event_ty: &StateEventType,
+    state_key: &str,
+) -> AppResult<DbRoomStateField> {
     let id = diesel::insert_into(room_state_fields::table)
         .values((
             room_state_fields::event_ty.eq(event_ty),
@@ -56,18 +64,21 @@ pub fn ensure_field(event_ty: &StateEventType, state_key: &str) -> AppResult<DbR
         ))
         .on_conflict_do_nothing()
         .returning(room_state_fields::id)
-        .get_result::<i64>(&mut connect()?)
+        .get_result::<i64>(&mut connect().await?)
+        .await
         .optional()?;
     if let Some(id) = id {
         room_state_fields::table
             .find(id)
-            .first::<DbRoomStateField>(&mut connect()?)
+            .first::<DbRoomStateField>(&mut connect().await?)
+            .await
             .map_err(Into::into)
     } else {
         room_state_fields::table
             .filter(room_state_fields::event_ty.eq(event_ty))
             .filter(room_state_fields::state_key.eq(state_key))
-            .first::<DbRoomStateField>(&mut connect()?)
+            .first::<DbRoomStateField>(&mut connect().await?)
+            .await
             .map_err(Into::into)
     }
 }

--- a/crates/server/src/room/state/frame.rs
+++ b/crates/server/src/room/state/frame.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, LazyLock, Mutex};
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use lru_cache::LruCache;
 
 use super::{CompressedState, StateDiff};
@@ -22,7 +23,7 @@ pub struct FrameInfo {
 
 /// Returns a stack with info on state_hash, full state, added diff and removed diff for the
 /// selected state_hash and each parent layer.
-pub fn load_frame_info(frame_id: i64) -> AppResult<Vec<FrameInfo>> {
+pub async fn load_frame_info(frame_id: i64) -> AppResult<Vec<FrameInfo>> {
     if let Some(r) = STATE_INFO_CACHE.lock().unwrap().get_mut(&frame_id) {
         return Ok(r.clone());
     }
@@ -31,10 +32,10 @@ pub fn load_frame_info(frame_id: i64) -> AppResult<Vec<FrameInfo>> {
         parent_id,
         appended,
         disposed,
-    } = super::load_state_diff(frame_id)?;
+    } = super::load_state_diff(frame_id).await?;
 
     if let Some(parent_id) = parent_id {
-        let mut info = load_frame_info(parent_id)?;
+        let mut info = Box::pin(load_frame_info(parent_id)).await?;
         let mut full_state = (*info.last().expect("at least one frame").full_state).clone();
         full_state.extend(appended.iter().copied());
         let disposed = (*disposed).clone();
@@ -69,7 +70,7 @@ pub fn load_frame_info(frame_id: i64) -> AppResult<Vec<FrameInfo>> {
     }
 }
 
-pub fn get_room_frame_id(room_id: &RoomId, until_sn: Option<i64>) -> AppResult<i64> {
+pub async fn get_room_frame_id(room_id: &RoomId, until_sn: Option<i64>) -> AppResult<i64> {
     let frame_id = if let Some(until_sn) = until_sn {
         event_points::table
             .filter(event_points::room_id.eq(room_id))
@@ -77,25 +78,28 @@ pub fn get_room_frame_id(room_id: &RoomId, until_sn: Option<i64>) -> AppResult<i
             .filter(event_points::frame_id.is_not_null())
             .select(event_points::frame_id)
             .order(event_points::event_sn.desc())
-            .first::<Option<i64>>(&mut connect()?)?
+            .first::<Option<i64>>(&mut connect().await?)
+            .await?
     } else {
         rooms::table
             .find(room_id)
             .select(rooms::state_frame_id)
-            .first::<Option<i64>>(&mut connect()?)?
+            .first::<Option<i64>>(&mut connect().await?)
+            .await?
     };
     frame_id.ok_or(MatrixError::not_found("room frame is not found").into())
 }
 
-pub fn get_pdu_frame_id(event_id: &EventId) -> AppResult<i64> {
+pub async fn get_pdu_frame_id(event_id: &EventId) -> AppResult<i64> {
     let frame_id = event_points::table
         .filter(event_points::event_id.eq(event_id))
         .select(event_points::frame_id)
-        .first::<Option<i64>>(&mut connect()?)?;
+        .first::<Option<i64>>(&mut connect().await?)
+        .await?;
     frame_id.ok_or(MatrixError::not_found("pdu frame is not found").into())
 }
 /// Returns (state_hash, already_existed)
-pub fn ensure_frame(room_id: &RoomId, hash_data: Vec<u8>) -> AppResult<i64> {
+pub async fn ensure_frame(room_id: &RoomId, hash_data: Vec<u8>) -> AppResult<i64> {
     diesel::insert_into(room_state_frames::table)
         .values((
             room_state_frames::room_id.eq(room_id),
@@ -103,15 +107,17 @@ pub fn ensure_frame(room_id: &RoomId, hash_data: Vec<u8>) -> AppResult<i64> {
         ))
         .on_conflict_do_nothing()
         .returning(room_state_frames::id)
-        .get_result(&mut connect()?)
+        .get_result(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
-pub fn get_frame_id(room_id: &RoomId, hash_data: &[u8]) -> AppResult<i64> {
+pub async fn get_frame_id(room_id: &RoomId, hash_data: &[u8]) -> AppResult<i64> {
     room_state_frames::table
         .filter(room_state_frames::room_id.eq(room_id))
         .filter(room_state_frames::hash_data.eq(hash_data))
         .select(room_state_frames::id)
-        .get_result(&mut connect()?)
+        .get_result(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }

--- a/crates/server/src/room/thread.rs
+++ b/crates/server/src/room/thread.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use serde_json::json;
 
 use crate::core::client::room::IncludeThreads;
@@ -11,7 +12,7 @@ use crate::data::schema::*;
 use crate::room::timeline;
 use crate::{AppResult, SnPduEvent};
 
-pub fn get_threads(
+pub async fn get_threads(
     room_id: &RoomId,
     _include: &IncludeThreads,
     limit: i64,
@@ -24,28 +25,30 @@ pub fn get_threads(
             .select((threads::event_id, threads::event_sn))
             .order_by(threads::last_sn.desc())
             .limit(limit)
-            .load::<(OwnedEventId, i64)>(&mut connect()?)?
+            .load::<(OwnedEventId, i64)>(&mut connect().await?)
+            .await?
     } else {
         threads::table
             .filter(threads::room_id.eq(room_id))
             .select((threads::event_id, threads::event_sn))
             .order_by(threads::last_sn.desc())
             .limit(limit)
-            .load::<(OwnedEventId, i64)>(&mut connect()?)?
+            .load::<(OwnedEventId, i64)>(&mut connect().await?)
+            .await?
     };
     let next_token = items.last().map(|(_, sn)| *sn - 1);
 
     let mut events = Vec::with_capacity(items.len());
     for (event_id, _) in items {
-        if let Ok(pdu) = timeline::get_pdu(&event_id) {
+        if let Ok(pdu) = timeline::get_pdu(&event_id).await {
             events.push((event_id, pdu));
         }
     }
     Ok((events, next_token))
 }
 
-pub fn add_to_thread(thread_id: &EventId, pdu: &SnPduEvent) -> AppResult<()> {
-    let (root_pdu, mut root_pdu_json) = timeline::get_pdu_and_data(thread_id)?;
+pub async fn add_to_thread(thread_id: &EventId, pdu: &SnPduEvent) -> AppResult<()> {
+    let (root_pdu, mut root_pdu_json) = timeline::get_pdu_and_data(thread_id).await?;
 
     if let CanonicalJsonValue::Object(unsigned) = root_pdu_json
         .entry("unsigned".to_owned())
@@ -89,12 +92,13 @@ pub fn add_to_thread(thread_id: &EventId, pdu: &SnPduEvent) -> AppResult<()> {
             );
         }
 
-        timeline::replace_pdu(thread_id, &root_pdu_json)?;
+        timeline::replace_pdu(thread_id, &root_pdu_json).await?;
     }
 
     diesel::update(event_points::table.find(&pdu.event_id))
         .set(event_points::thread_id.eq(thread_id))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
 
     diesel::insert_into(threads::table)
         .values(DbThread {
@@ -110,6 +114,7 @@ pub fn add_to_thread(thread_id: &EventId, pdu: &SnPduEvent) -> AppResult<()> {
             threads::last_id.eq(&pdu.event_id),
             threads::last_sn.eq(pdu.event_sn),
         ))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }

--- a/crates/server/src/room/timeline.rs
+++ b/crates/server/src/room/timeline.rs
@@ -2,6 +2,7 @@ use std::borrow::Borrow;
 use std::collections::{BTreeSet, HashSet};
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use serde::Deserialize;
 
 use crate::core::Seqnum;
@@ -33,12 +34,13 @@ pub use backfill::*;
 // All timeline counts are queried from the database directly.
 
 #[tracing::instrument]
-pub fn first_pdu_in_room(room_id: &RoomId) -> AppResult<Option<PduEvent>> {
+pub async fn first_pdu_in_room(room_id: &RoomId) -> AppResult<Option<PduEvent>> {
     event_datas::table
         .filter(event_datas::room_id.eq(room_id))
         .order(event_datas::event_sn.asc())
         .select((event_datas::event_id, event_datas::json_data))
-        .first::<(OwnedEventId, JsonValue)>(&mut connect()?)
+        .first::<(OwnedEventId, JsonValue)>(&mut connect().await?)
+        .await
         .optional()?
         .map(|(event_id, json)| {
             PduEvent::from_json_value(room_id, &event_id, json)
@@ -48,22 +50,24 @@ pub fn first_pdu_in_room(room_id: &RoomId) -> AppResult<Option<PduEvent>> {
 }
 
 #[tracing::instrument]
-pub fn last_event_sn(user_id: &UserId, room_id: &RoomId) -> AppResult<Seqnum> {
+pub async fn last_event_sn(user_id: &UserId, room_id: &RoomId) -> AppResult<Seqnum> {
     let event_sn = events::table
         .filter(events::room_id.eq(room_id))
         .filter(events::sn.is_not_null())
         .select(events::sn)
         .order(events::sn.desc())
-        .first::<Seqnum>(&mut connect()?)?;
+        .first::<Seqnum>(&mut connect().await?)
+        .await?;
     Ok(event_sn)
 }
 
 /// Returns the json of a pdu.
-pub fn get_pdu_json(event_id: &EventId) -> AppResult<Option<CanonicalJsonObject>> {
+pub async fn get_pdu_json(event_id: &EventId) -> AppResult<Option<CanonicalJsonObject>> {
     event_datas::table
         .filter(event_datas::event_id.eq(event_id))
         .select(event_datas::json_data)
-        .first::<JsonValue>(&mut connect()?)
+        .first::<JsonValue>(&mut connect().await?)
+        .await
         .optional()?
         .map(|json| {
             serde_json::from_value(json).map_err(|_e| AppError::internal("invalid pdu in db"))
@@ -72,12 +76,13 @@ pub fn get_pdu_json(event_id: &EventId) -> AppResult<Option<CanonicalJsonObject>
 }
 
 /// Returns the pdu.
-pub fn get_non_outlier_pdu(event_id: &EventId) -> AppResult<Option<SnPduEvent>> {
+pub async fn get_non_outlier_pdu(event_id: &EventId) -> AppResult<Option<SnPduEvent>> {
     let Some((event_sn, room_id, stream_ordering)) = events::table
         .filter(events::is_outlier.eq(false))
         .filter(events::id.eq(event_id))
         .select((events::sn, events::room_id, events::stream_ordering))
-        .first::<(Seqnum, OwnedRoomId, i64)>(&mut connect()?)
+        .first::<(Seqnum, OwnedRoomId, i64)>(&mut connect().await?)
+        .await
         .optional()?
     else {
         return Ok(None);
@@ -85,7 +90,8 @@ pub fn get_non_outlier_pdu(event_id: &EventId) -> AppResult<Option<SnPduEvent>> 
     let mut pdu = event_datas::table
         .filter(event_datas::event_id.eq(event_id))
         .select(event_datas::json_data)
-        .first::<JsonValue>(&mut connect()?)
+        .first::<JsonValue>(&mut connect().await?)
+        .await
         .optional()?
         .map(|json| {
             SnPduEvent::from_json_value(
@@ -103,7 +109,8 @@ pub fn get_non_outlier_pdu(event_id: &EventId) -> AppResult<Option<SnPduEvent>> 
     if let Some(pdu) = pdu.as_mut() {
         let event = events::table
             .filter(events::id.eq(event_id))
-            .first::<DbEvent>(&mut connect()?)?;
+            .first::<DbEvent>(&mut connect().await?)
+            .await?;
         pdu.is_outlier = event.is_outlier;
         pdu.soft_failed = event.soft_failed;
         pdu.rejection_reason = event.rejection_reason;
@@ -111,10 +118,11 @@ pub fn get_non_outlier_pdu(event_id: &EventId) -> AppResult<Option<SnPduEvent>> 
     Ok(pdu)
 }
 
-pub fn get_pdu(event_id: &EventId) -> AppResult<SnPduEvent> {
+pub async fn get_pdu(event_id: &EventId) -> AppResult<SnPduEvent> {
     let event = events::table
         .filter(events::id.eq(event_id))
-        .first::<DbEvent>(&mut connect()?)?;
+        .first::<DbEvent>(&mut connect().await?)
+        .await?;
     let (event_sn, room_id, json) = event_datas::table
         .filter(event_datas::event_id.eq(event_id))
         .select((
@@ -122,7 +130,8 @@ pub fn get_pdu(event_id: &EventId) -> AppResult<SnPduEvent> {
             event_datas::room_id,
             event_datas::json_data,
         ))
-        .first::<(Seqnum, OwnedRoomId, JsonValue)>(&mut connect()?)?;
+        .first::<(Seqnum, OwnedRoomId, JsonValue)>(&mut connect().await?)
+        .await?;
     let mut pdu = PduEvent::from_json_value(&room_id, event_id, json)
         .map_err(|_e| AppError::internal("invalid pdu in db"))?;
     pdu.rejection_reason = event.rejection_reason;
@@ -135,10 +144,11 @@ pub fn get_pdu(event_id: &EventId) -> AppResult<SnPduEvent> {
     })
 }
 
-pub fn get_pdu_and_data(event_id: &EventId) -> AppResult<(SnPduEvent, CanonicalJsonObject)> {
+pub async fn get_pdu_and_data(event_id: &EventId) -> AppResult<(SnPduEvent, CanonicalJsonObject)> {
     let event = events::table
         .filter(events::id.eq(event_id))
-        .first::<DbEvent>(&mut connect()?)?;
+        .first::<DbEvent>(&mut connect().await?)
+        .await?;
     let (event_sn, room_id, json) = event_datas::table
         .filter(event_datas::event_id.eq(event_id))
         .select((
@@ -146,7 +156,8 @@ pub fn get_pdu_and_data(event_id: &EventId) -> AppResult<(SnPduEvent, CanonicalJ
             event_datas::room_id,
             event_datas::json_data,
         ))
-        .first::<(Seqnum, OwnedRoomId, JsonValue)>(&mut connect()?)?;
+        .first::<(Seqnum, OwnedRoomId, JsonValue)>(&mut connect().await?)
+        .await?;
     let data = serde_json::from_value(json.clone())
         .map_err(|_e| AppError::internal("invalid pdu in db"))?;
     let mut pdu = PduEvent::from_json_value(&room_id, event_id, json)
@@ -164,7 +175,7 @@ pub fn get_pdu_and_data(event_id: &EventId) -> AppResult<(SnPduEvent, CanonicalJ
     ))
 }
 
-pub fn get_may_missing_pdus(
+pub async fn get_may_missing_pdus(
     room_id: &RoomId,
     event_ids: &[OwnedEventId],
 ) -> AppResult<(Vec<SnPduEvent>, Vec<OwnedEventId>)> {
@@ -172,12 +183,13 @@ pub fn get_may_missing_pdus(
         .filter(event_datas::room_id.eq(room_id))
         .filter(event_datas::event_id.eq_any(event_ids))
         .select(event_datas::event_id)
-        .load::<OwnedEventId>(&mut connect()?)?;
+        .load::<OwnedEventId>(&mut connect().await?)
+        .await?;
 
     let mut pdus = Vec::with_capacity(events.len());
     let mut missing_ids = event_ids.iter().cloned().collect::<HashSet<_>>();
     for event_id in events {
-        let Ok(pdu) = timeline::get_pdu(&event_id) else {
+        let Ok(pdu) = timeline::get_pdu(&event_id).await else {
             continue;
         };
         pdus.push(pdu);
@@ -186,8 +198,8 @@ pub fn get_may_missing_pdus(
     Ok((pdus, missing_ids.into_iter().collect()))
 }
 
-pub fn has_pdu(event_id: &EventId) -> bool {
-    if let Ok(mut conn) = connect() {
+pub async fn has_pdu(event_id: &EventId) -> bool {
+    if let Ok(mut conn) = connect().await {
         diesel_exists!(
             event_datas::table.filter(event_datas::event_id.eq(event_id)),
             &mut conn
@@ -200,10 +212,11 @@ pub fn has_pdu(event_id: &EventId) -> bool {
 
 /// Removes a pdu and creates a new one with the same id.
 #[tracing::instrument]
-pub fn replace_pdu(event_id: &EventId, pdu_json: &CanonicalJsonObject) -> AppResult<()> {
+pub async fn replace_pdu(event_id: &EventId, pdu_json: &CanonicalJsonObject) -> AppResult<()> {
     diesel::update(event_datas::table.filter(event_datas::event_id.eq(event_id)))
         .set(event_datas::json_data.eq(serde_json::to_value(pdu_json)?))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     // PDU_CACHE.lock().unwrap().remove(&(*pdu.event_id).to_owned());
 
     Ok(())
@@ -259,12 +272,13 @@ pub async fn append_pdu(
             // Third arm (`canonicalize_prev_content`) emits a WARN and yields
             // None when stored prev state has non-canonical JSON; in that case
             // we skip the whole prev_* trio rather than panic.
-            if let Ok(state_frame_id) = state::get_pdu_frame_id(&pdu.event_id)
+            if let Ok(state_frame_id) = state::get_pdu_frame_id(&pdu.event_id).await
                 && let Ok(prev_state) = state::get_state(
                     state_frame_id - 1,
                     &pdu.event_ty.to_string().into(),
                     state_key,
                 )
+                .await
                 && let Some(prev_content_obj) = canonicalize_prev_content(
                     &prev_state.content,
                     &pdu.event_id,
@@ -290,20 +304,22 @@ pub async fn append_pdu(
         }
     }
 
-    let mut leaves: BTreeSet<_> = state::get_forward_extremities(&pdu.room_id)?
+    let mut leaves: BTreeSet<_> = state::get_forward_extremities(&pdu.room_id)
+        .await?
         .into_iter()
         .collect();
     // Remove any forward extremities that are referenced by this incoming event's prev_events
     leaves.retain(|event_id| !pdu.prev_events.contains(event_id));
     if !diesel_exists!(
         event_edges::table.filter(event_edges::prev_id.eq(&pdu.event_id)),
-        &mut connect()?
+        &mut connect().await?
     )? {
         // Only add the incoming event as a forward extremity if it is not already in the DB
         leaves.insert(pdu.event_id.clone());
     }
-    state::set_forward_extremities(&pdu.room_id, leaves.iter().map(Borrow::borrow), state_lock)?;
-    state::update_backward_extremities(pdu)?;
+    state::set_forward_extremities(&pdu.room_id, leaves.iter().map(Borrow::borrow), state_lock)
+        .await?;
+    state::update_backward_extremities(pdu).await?;
 
     #[derive(Deserialize, Clone, Debug)]
     struct ExtractEventId {
@@ -326,7 +342,8 @@ pub async fn append_pdu(
                     &in_reply_to.event_id,
                     &pdu.event_id,
                     rel_type,
-                )?;
+                )
+                .await?;
                 relates_added = true;
             }
             Relation::Thread(thread) => {
@@ -335,10 +352,11 @@ pub async fn append_pdu(
                     &thread.event_id,
                     &pdu.event_id,
                     rel_type,
-                )?;
+                )
+                .await?;
                 relates_added = true;
                 // thread_id = Some(thread.event_id.clone());
-                super::thread::add_to_thread(&thread.event_id, pdu)?;
+                super::thread::add_to_thread(&thread.event_id, pdu).await?;
             }
             _ => {} // TODO: Aggregate other types
         }
@@ -349,7 +367,8 @@ pub async fn append_pdu(
             &content.relates_to.event_id,
             &pdu.event_id,
             None,
-        )?;
+        )
+        .await?;
     }
 
     let sync_pdu = pdu.to_sync_room_event();
@@ -359,7 +378,7 @@ pub async fn append_pdu(
     // Fetch power levels once for the room, outside the per-user loop
     let power_levels = crate::room::get_power_levels(pdu.room_id()).await.ok();
 
-    for user_id in super::get_our_real_users(&pdu.room_id)?.iter() {
+    for user_id in super::get_our_real_users(&pdu.room_id).await?.iter() {
         // Don't notify the user of their own events
         if user_id == &pdu.sender {
             continue;
@@ -368,7 +387,8 @@ pub async fn append_pdu(
         let rules_for_user = data::user::get_global_data::<PushRulesEventContent>(
             user_id,
             &GlobalAccountDataEventType::PushRules.to_string(),
-        )?
+        )
+        .await?
         .map(|content: PushRulesEventContent| content.global)
         .unwrap_or_else(|| Ruleset::server_default(user_id));
 
@@ -404,22 +424,23 @@ pub async fn append_pdu(
 
         if let Err(e) =
             push_action::upsert_push_action(&pdu.room_id, &pdu.event_id, user_id, notify, highlight)
+                .await
         {
             error!("failed to upsert event push action: {}", e);
         }
 
-        for push_key in data::user::pusher::get_push_keys(user_id)? {
-            crate::sending::send_push_pdu(&pdu.event_id, user_id, push_key)?;
+        for push_key in data::user::pusher::get_push_keys(user_id).await? {
+            crate::sending::send_push_pdu(&pdu.event_id, user_id, push_key).await?;
         }
     }
 
     // Refresh notification summary once after processing all users
-    push_action::refresh_notify_summary(&pdu.sender, &pdu.room_id)?;
+    push_action::refresh_notify_summary(&pdu.sender, &pdu.room_id).await?;
 
     match pdu.event_ty {
         TimelineEventType::RoomRedaction => {
             if let Some(redact_id) = &pdu.redacts {
-                redact_pdu(redact_id, pdu)?;
+                redact_pdu(redact_id, pdu).await?;
             }
         }
         TimelineEventType::SpaceChild => {
@@ -446,14 +467,14 @@ pub async fn append_pdu(
 
                 let stripped_state = match content.membership {
                     MembershipState::Invite | MembershipState::Knock => {
-                        let state = state::summary_stripped(pdu)?;
+                        let state = state::summary_stripped(pdu).await?;
                         Some(state)
                     }
                     _ => None,
                 };
 
                 if content.membership == MembershipState::Join {
-                    let _ = crate::user::ping_presence(&pdu.sender, &PresenceState::Online);
+                    let _ = crate::user::ping_presence(&pdu.sender, &PresenceState::Online).await;
                 }
                 // Update our membership info, we do this here incase a user is invited
                 // and immediately leaves we need the DB to record the invite event for auth
@@ -465,7 +486,8 @@ pub async fn append_pdu(
                     content.membership,
                     &pdu.sender,
                     stripped_state,
-                )?;
+                )
+                .await?;
 
                 // Invalidate appservice room cache when membership changes
                 // This ensures that when a bridge user joins a room, subsequent messages
@@ -491,6 +513,7 @@ pub async fn append_pdu(
                     <&RoomAliasId>::try_from(format!("#admins:{}", &conf.server_name).as_str())
                         .expect("#admins:server_name is a valid room alias"),
                 )
+                .await
             {
                 let server_user = config::server_user_id();
 
@@ -521,18 +544,20 @@ pub async fn append_pdu(
                 .map_err(|_| AppError::internal("invalid content in tombstone pdu"))?;
 
             if let Some(new_room_id) = content.replacement_room {
-                let local_user_ids = super::user::local_users(&pdu.room_id)?;
+                let local_user_ids = super::user::local_users(&pdu.room_id).await?;
                 for user_id in &local_user_ids {
                     super::user::copy_room_tags_and_direct_to_room(
                         user_id,
                         &pdu.room_id,
                         &new_room_id,
-                    )?;
+                    )
+                    .await?;
                     super::user::copy_push_rules_from_room_to_room(
                         user_id,
                         &pdu.room_id,
                         &new_room_id,
-                    )?;
+                    )
+                    .await?;
                 }
             }
         }
@@ -547,10 +572,12 @@ pub async fn append_pdu(
         json_data: serde_json::to_value(&pdu_json)?,
         format_version: None,
     }
-    .save()?;
+    .save()
+    .await?;
     diesel::update(events::table.find(&*pdu.event_id))
         .set(events::is_outlier.eq(false))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
 
     for prev_id in &pdu.prev_events {
         let new_edge = NewDbEventEdge {
@@ -560,7 +587,7 @@ pub async fn append_pdu(
             event_sn: pdu.event_sn,
             prev_id: prev_id.clone(),
         };
-        if let Err(e) = new_edge.save() {
+        if let Err(e) = new_edge.save().await {
             error!("failed to save event edge: {}", e);
         }
     }
@@ -572,22 +599,24 @@ pub async fn append_pdu(
         relates_to: Relation,
     }
 
-    crate::event::search::save_pdu(pdu, &pdu_json)?;
+    crate::event::search::save_pdu(pdu, &pdu_json).await?;
 
-    let frame_id = state::append_to_state(pdu)?;
+    let frame_id = state::append_to_state(pdu).await?;
     // We set the room state after inserting the pdu, so that we never have a moment in time
     // where events in the current room state do not exist
-    state::set_room_state(&pdu.room_id, frame_id)?;
+    state::set_room_state(&pdu.room_id, frame_id).await?;
 
-    if let Err(e) = push_action::increment_notification_counts(&pdu.event_id, notifies, highlights)
+    if let Err(e) =
+        push_action::increment_notification_counts(&pdu.event_id, notifies, highlights).await
     {
         error!("failed to increment notification counts: {}", e);
     }
 
-    let all_appservices = crate::appservice::all()?;
+    let all_appservices = crate::appservice::all().await?;
     for appservice in all_appservices.values() {
-        if super::appservice_in_room(&pdu.room_id, appservice)? {
-            crate::sending::send_pdu_appservice(appservice.registration.id.clone(), &pdu.event_id)?;
+        if super::appservice_in_room(&pdu.room_id, appservice).await? {
+            crate::sending::send_pdu_appservice(appservice.registration.id.clone(), &pdu.event_id)
+                .await?;
             continue;
         }
 
@@ -604,7 +633,8 @@ pub async fn append_pdu(
             )
             && state_key_uid == &appservice_uid
         {
-            crate::sending::send_pdu_appservice(appservice.registration.id.clone(), &pdu.event_id)?;
+            crate::sending::send_pdu_appservice(appservice.registration.id.clone(), &pdu.event_id)
+                .await?;
             continue;
         }
         let matching_users = || {
@@ -618,38 +648,37 @@ pub async fn append_pdu(
                         })
                     })
         };
-        let matching_aliases = || {
-            super::local_aliases_for_room(&pdu.room_id)
-                .unwrap_or_default()
-                .iter()
-                .any(|room_alias| appservice.aliases.is_match(room_alias.as_str()))
-                || if let Ok(pdu) =
-                    super::get_state(&pdu.room_id, &StateEventType::RoomCanonicalAlias, "", None)
-                {
-                    pdu.get_content::<RoomCanonicalAliasEventContent>()
-                        .is_ok_and(|content| {
-                            content
-                                .alias
-                                .is_some_and(|alias| appservice.aliases.is_match(alias.as_str()))
-                                || content
-                                    .alt_aliases
-                                    .iter()
-                                    .any(|alias| appservice.aliases.is_match(alias.as_str()))
-                        })
-                } else {
-                    false
-                }
-        };
+        let matching_aliases = super::local_aliases_for_room(&pdu.room_id)
+            .await
+            .unwrap_or_default()
+            .iter()
+            .any(|room_alias| appservice.aliases.is_match(room_alias.as_str()))
+            || if let Ok(pdu) =
+                super::get_state(&pdu.room_id, &StateEventType::RoomCanonicalAlias, "", None).await
+            {
+                pdu.get_content::<RoomCanonicalAliasEventContent>()
+                    .is_ok_and(|content| {
+                        content
+                            .alias
+                            .is_some_and(|alias| appservice.aliases.is_match(alias.as_str()))
+                            || content
+                                .alt_aliases
+                                .iter()
+                                .any(|alias| appservice.aliases.is_match(alias.as_str()))
+                    })
+            } else {
+                false
+            };
 
-        if matching_aliases() || appservice.rooms.is_match(pdu.room_id.as_str()) || matching_users()
-        {
-            crate::sending::send_pdu_appservice(appservice.registration.id.clone(), &pdu.event_id)?;
+        if matching_aliases || appservice.rooms.is_match(pdu.room_id.as_str()) || matching_users() {
+            crate::sending::send_pdu_appservice(appservice.registration.id.clone(), &pdu.event_id)
+                .await?;
         }
     }
     Ok(())
 }
 
-fn check_pdu_for_admin_room(pdu: &PduEvent, sender: &UserId) -> AppResult<()> {
+async fn check_pdu_for_admin_room(pdu: &PduEvent, sender: &UserId) -> AppResult<()> {
     let conf = crate::config::get();
     match pdu.event_type() {
         TimelineEventType::RoomEncryption => {
@@ -687,7 +716,8 @@ fn check_pdu_for_admin_room(pdu: &PduEvent, sender: &UserId) -> AppResult<()> {
                     .into());
                 }
 
-                let count = super::joined_users(pdu.room_id(), None)?
+                let count = super::joined_users(pdu.room_id(), None)
+                    .await?
                     .iter()
                     .filter(|m| m.server_name() == server_name)
                     .filter(|m| m.as_str() != target)
@@ -712,7 +742,8 @@ fn check_pdu_for_admin_room(pdu: &PduEvent, sender: &UserId) -> AppResult<()> {
                     .into());
                 }
 
-                let count = super::joined_users(pdu.room_id(), None)?
+                let count = super::joined_users(pdu.room_id(), None)
+                    .await?
                     .iter()
                     .filter(|m| m.server_name() == server_name)
                     .filter(|m| m.as_str() != target)
@@ -747,7 +778,7 @@ pub async fn build_and_append_pdu(
             &pdu_builder.event_type.to_string().into(),
             state_key,
             None,
-        )
+        ).await
         && curr_state.content.get() == pdu_builder.content.get()
     {
         return Ok(curr_state);
@@ -757,15 +788,15 @@ pub async fn build_and_append_pdu(
         .hash_sign_save(sender, room_id, room_version, state_lock)
         .await?;
     let room_id = &pdu.room_id;
-    crate::room::ensure_room(room_id, room_version)?;
+    crate::room::ensure_room(room_id, room_version).await?;
 
     // let conf = crate::config::get();
     // let admin_room = super::resolve_local_alias(
     //     <&RoomAliasId>::try_from(format!("#admins:{}", &conf.server_name).as_str())
     //         .expect("#admins:server_name is a valid room alias"),
     // )?;
-    if crate::room::is_admin_room(room_id)? {
-        check_pdu_for_admin_room(&pdu, sender)?;
+    if crate::room::is_admin_room(room_id).await? {
+        check_pdu_for_admin_room(&pdu, sender).await?;
     }
 
     append_pdu(&pdu, pdu_json, state_lock).await?;
@@ -777,45 +808,47 @@ pub async fn build_and_append_pdu(
     //     crate::room::update_currents(&room_id)?;
     // }
 
-    let servers = super::participating_servers(room_id, false)?;
-    crate::sending::send_pdu_servers(servers.into_iter(), &pdu.event_id)?;
+    let servers = super::participating_servers(room_id, false).await?;
+    crate::sending::send_pdu_servers(servers.into_iter(), &pdu.event_id).await?;
 
     Ok(pdu)
 }
 
 /// Replace a PDU with the redacted form.
 #[tracing::instrument(skip(reason))]
-pub fn redact_pdu(event_id: &EventId, reason: &PduEvent) -> AppResult<()> {
+pub async fn redact_pdu(event_id: &EventId, reason: &PduEvent) -> AppResult<()> {
     // TODO: Don't reserialize, keep original json
-    if let Ok(mut pdu) = get_pdu(event_id) {
+    if let Ok(mut pdu) = get_pdu(event_id).await {
         pdu.redact(reason)?;
-        replace_pdu(event_id, &to_canonical_object(&pdu)?)?;
+        replace_pdu(event_id, &to_canonical_object(&pdu)?).await?;
         diesel::update(events::table.filter(events::id.eq(event_id)))
             .set(events::is_redacted.eq(true))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         diesel::delete(event_searches::table.filter(event_searches::event_id.eq(event_id)))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     }
     // If event does not exist, just noop
     Ok(())
 }
 
-pub fn is_event_next_to_backward_gap(event: &PduEvent) -> AppResult<bool> {
+pub async fn is_event_next_to_backward_gap(event: &PduEvent) -> AppResult<bool> {
     let mut event_ids = event.prev_events.clone();
     event_ids.push(event.event_id().to_owned());
     let query = event_backward_extremities::table
         .filter(event_backward_extremities::room_id.eq(event.room_id()))
         .filter(event_backward_extremities::event_id.eq_any(event_ids));
-    Ok(diesel_exists!(query, &mut connect()?)?)
+    Ok(diesel_exists!(query, &mut connect().await?)?)
 }
 
-pub fn is_event_next_to_forward_gap(event: &PduEvent) -> AppResult<bool> {
+pub async fn is_event_next_to_forward_gap(event: &PduEvent) -> AppResult<bool> {
     let mut event_ids = event.prev_events.clone();
     event_ids.push(event.event_id().to_owned());
     let query = event_forward_extremities::table
         .filter(event_forward_extremities::room_id.eq(event.room_id()))
         .filter(event_forward_extremities::event_id.eq_any(event_ids));
-    Ok(diesel_exists!(query, &mut connect()?)?)
+    Ok(diesel_exists!(query, &mut connect().await?)?)
 }
 
 #[cfg(test)]

--- a/crates/server/src/room/timeline/backfill.rs
+++ b/crates/server/src/room/timeline/backfill.rs
@@ -108,6 +108,36 @@ pub async fn backfill_if_required(
     Ok(vec![])
 }
 
+/// Keep a backward `/messages` page contiguous after a federation backfill.
+///
+/// Backfilled events can sit above older local state events. If we return both
+/// sides of that gap in one page, the `end` token points below the gap and the
+/// next pagination misses the newly backfillable events.
+pub async fn trim_pdus_until_backfill_gap(
+    pdus: IndexMap<Seqnum, SnPduEvent>,
+) -> AppResult<IndexMap<Seqnum, SnPduEvent>> {
+    let mut trimmed = IndexMap::with_capacity(pdus.len());
+    for (event_sn, pdu) in pdus {
+        let has_missing_prev = if pdu.prev_events.is_empty() {
+            false
+        } else {
+            let existing: Vec<OwnedEventId> = events::table
+                .filter(events::id.eq_any(&pdu.prev_events))
+                .filter(events::is_outlier.eq(false))
+                .select(events::id)
+                .load(&mut connect().await?)
+                .await?;
+            pdu.prev_events.iter().any(|id| !existing.contains(id))
+        };
+
+        trimmed.insert(event_sn, pdu);
+        if has_missing_prev {
+            break;
+        }
+    }
+    Ok(trimmed)
+}
+
 /// Backfill events from the given backward extremities. Used when the messages
 /// endpoint returns fewer events than the limit and we need to fetch history
 /// from federation (e.g., after re-joining a room).
@@ -115,7 +145,7 @@ pub async fn backfill_if_required(
 pub async fn backfill_from_extremities(
     room_id: &RoomId,
     extremities: &[OwnedEventId],
-    limit: usize,
+    _limit: usize,
 ) -> AppResult<Vec<SnPduEvent>> {
     let admin_servers = room::admin_servers(room_id, false).await?;
     let room_version = room::get_version(room_id).await?;
@@ -127,10 +157,12 @@ pub async fn backfill_from_extremities(
             BackfillReqArgs {
                 room_id: room_id.to_owned(),
                 v: extremities.to_vec(),
-                // Synapse caps `/backfill` at 100 events per call, so asking
-                // for more is wasted; ask for the max so we make as much
-                // progress per round-trip as possible.
-                limit: limit.max(100),
+                // Synapse caps `/backfill` at 100 events per call. Use that
+                // bounded batch size regardless of the client page size: small
+                // `/messages` pages should still fetch enough history to
+                // continue locally, while large pages should not block on more
+                // than one federation batch.
+                limit: 100,
             },
         )?
         .into_inner();

--- a/crates/server/src/room/timeline/backfill.rs
+++ b/crates/server/src/room/timeline/backfill.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use serde::Deserialize;
@@ -49,7 +50,8 @@ pub async fn backfill_if_required(
         let existing: Vec<OwnedEventId> = events::table
             .filter(events::id.eq_any(&pdu.prev_events))
             .select(events::id)
-            .load(&mut connect()?)?;
+            .load(&mut connect().await?)
+            .await?;
         if pdu.prev_events.iter().any(|id| !existing.contains(id)) {
             return backfill_from_extremities(room_id, std::slice::from_ref(&pdu.event_id), limit)
                 .await;
@@ -74,11 +76,12 @@ pub async fn backfill_if_required(
             .filter(event_backward_extremities::room_id.eq(room_id))
             .select(event_backward_extremities::event_id)
             .distinct()
-            .load(&mut connect()?)?;
+            .load(&mut connect().await?)
+            .await?;
 
         let mut fill_from: Vec<OwnedEventId> = Vec::new();
         for ext_id in extremity_ids {
-            let Ok(pdu) = super::get_pdu(&ext_id) else {
+            let Ok(pdu) = super::get_pdu(&ext_id).await else {
                 // Event isn't locally known — it's a synthetic frontier marker
                 // for a parent we couldn't fetch yet. Use it as-is.
                 fill_from.push(ext_id);
@@ -90,7 +93,8 @@ pub async fn backfill_if_required(
             let existing: Vec<OwnedEventId> = events::table
                 .filter(events::id.eq_any(&pdu.prev_events))
                 .select(events::id)
-                .load(&mut connect()?)?;
+                .load(&mut connect().await?)
+                .await?;
             if pdu.prev_events.iter().any(|id| !existing.contains(id)) {
                 fill_from.push(ext_id);
             }
@@ -113,8 +117,8 @@ pub async fn backfill_from_extremities(
     extremities: &[OwnedEventId],
     limit: usize,
 ) -> AppResult<Vec<SnPduEvent>> {
-    let admin_servers = room::admin_servers(room_id, false)?;
-    let room_version = room::get_version(room_id)?;
+    let admin_servers = room::admin_servers(room_id, false).await?;
+    let room_version = room::get_version(room_id).await?;
 
     for backfill_server in &admin_servers {
         info!("asking {backfill_server} for backfill from extremities");
@@ -162,7 +166,7 @@ pub async fn backfill_from_extremities(
                         process_to_timeline_pdu(pdu, content, Some(backfill_server)).await
                     {
                         error!("failed to process backfill pdu to timeline {}", e);
-                    } else if let Ok(pdu) = super::get_pdu(&event_id) {
+                    } else if let Ok(pdu) = super::get_pdu(&event_id).await {
                         events.push(pdu);
                     }
                 }
@@ -185,9 +189,10 @@ pub async fn backfill_pdu(
 ) -> AppResult<(SnPduEvent, CanonicalJsonObject)> {
     let (event_id, value) = parse_fetched_pdu(room_id, room_version, &pdu)?;
     // Skip the PDU if we already have it as a timeline event
-    if let Ok(pdu) = super::get_pdu(&event_id) {
+    if let Ok(pdu) = super::get_pdu(&event_id).await {
         info!("we already know {event_id}, skipping backfill");
-        let value = super::get_pdu_json(&event_id)?
+        let value = super::get_pdu_json(&event_id)
+            .await?
             .ok_or_else(|| AppError::public("event json not found"))?;
         return Ok((pdu, value));
     }
@@ -197,7 +202,7 @@ pub async fn backfill_pdu(
     else {
         return Err(AppError::internal("failed to process backfilled pdu"));
     };
-    let (pdu, value, _) = outlier_pdu.save_to_database(true)?;
+    let (pdu, value, _) = outlier_pdu.save_to_database(true).await?;
 
     if pdu.event_ty == TimelineEventType::RoomMessage {
         #[derive(Deserialize)]

--- a/crates/server/src/room/timeline/stream.rs
+++ b/crates/server/src/room/timeline/stream.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use indexmap::IndexMap;
 
 use crate::core::client::filter::{RoomEventFilter, UrlFilter};
@@ -10,15 +11,15 @@ use crate::event::BatchToken;
 use crate::{AppResult, SnPduEvent, data, utils};
 
 /// Returns an iterator over all PDUs in a room.
-pub fn load_all_pdus(
+pub async fn load_all_pdus(
     user_id: Option<&UserId>,
     room_id: &RoomId,
     until_tk: Option<BatchToken>,
 ) -> AppResult<IndexMap<i64, SnPduEvent>> {
-    load_pdus_forward(user_id, room_id, None, until_tk, None, usize::MAX)
+    load_pdus_forward(user_id, room_id, None, until_tk, None, usize::MAX).await
 }
 
-pub fn load_pdus_forward(
+pub async fn load_pdus_forward(
     user_id: Option<&UserId>,
     room_id: &RoomId,
     since_tk: Option<BatchToken>,
@@ -35,8 +36,9 @@ pub fn load_pdus_forward(
         filter,
         Direction::Forward,
     )
+    .await
 }
-pub fn load_pdus_backward(
+pub async fn load_pdus_backward(
     user_id: Option<&UserId>,
     room_id: &RoomId,
     since_tk: Option<BatchToken>,
@@ -53,13 +55,14 @@ pub fn load_pdus_backward(
         filter,
         Direction::Backward,
     )
+    .await
 }
 
 /// Returns an iterator over all events and their tokens in a room that happened before the
 /// event with id `until` in reverse-chronological order.
 /// Skips events before user joined the room.
 #[tracing::instrument]
-pub fn load_pdus(
+pub async fn load_pdus(
     user_id: Option<&UserId>,
     room_id: &RoomId,
     since_tk: Option<BatchToken>,
@@ -69,7 +72,10 @@ pub fn load_pdus(
     dir: Direction,
 ) -> AppResult<IndexMap<Seqnum, SnPduEvent>> {
     let mut list: IndexMap<Seqnum, SnPduEvent> = IndexMap::with_capacity(limit.clamp(10, 100));
-    let ignored_users = user_id.map(crate::user::ignored_users);
+    let ignored_users = match user_id {
+        Some(user_id) => Some(crate::user::ignored_users(user_id).await),
+        None => None,
+    };
     let mut offset = 0;
     let mut start_sn = if dir == Direction::Forward {
         0
@@ -80,10 +86,12 @@ pub fn load_pdus(
         let max_in_room: Option<Seqnum> = events::table
             .filter(events::room_id.eq(room_id))
             .select(diesel::dsl::max(events::sn))
-            .first::<Option<Seqnum>>(&mut connect()?)?;
-        max_in_room
-            .map(|sn| sn + 1)
-            .unwrap_or_else(|| data::curr_sn().unwrap_or(0) + 1)
+            .first::<Option<Seqnum>>(&mut connect().await?)
+            .await?;
+        match max_in_room {
+            Some(sn) => sn + 1,
+            None => data::curr_sn().await.unwrap_or(0) + 1,
+        }
     };
 
     while list.len() < limit {
@@ -150,7 +158,8 @@ pub fn load_pdus(
                 .offset(offset)
                 .limit(utils::usize_to_i64(limit))
                 .select((events::id, events::sn))
-                .load::<(OwnedEventId, Seqnum)>(&mut connect()?)?
+                .load::<(OwnedEventId, Seqnum)>(&mut connect().await?)
+                .await?
                 .into_iter()
                 .rev()
                 .collect()
@@ -161,7 +170,8 @@ pub fn load_pdus(
                 .order(events::sn.desc())
                 .limit(utils::usize_to_i64(limit))
                 .select((events::id, events::sn))
-                .load::<(OwnedEventId, Seqnum)>(&mut connect()?)?
+                .load::<(OwnedEventId, Seqnum)>(&mut connect().await?)
+                .await?
                 .into_iter()
                 .collect()
         };
@@ -179,10 +189,10 @@ pub fn load_pdus(
             };
         }
         for (event_id, event_sn) in events {
-            match super::get_pdu(&event_id) {
+            match super::get_pdu(&event_id).await {
                 Ok(mut pdu) => {
                     if let Some(user_id) = user_id
-                        && !pdu.user_can_see(user_id).unwrap_or(false)
+                        && !pdu.user_can_see(user_id).await.unwrap_or(false)
                     {
                         continue;
                     }
@@ -195,7 +205,7 @@ pub fn load_pdus(
                         if pdu.sender != user_id {
                             pdu.remove_transaction_id()?;
                         }
-                        let _ = pdu.add_unsigned_membership(user_id);
+                        let _ = pdu.add_unsigned_membership(user_id).await;
                     }
                     let _ = pdu.add_age();
                     list.insert(event_sn, pdu);

--- a/crates/server/src/room/timeline/topolo.rs
+++ b/crates/server/src/room/timeline/topolo.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use indexmap::IndexMap;
 
 use crate::core::client::filter::{RoomEventFilter, UrlFilter};
@@ -9,7 +10,7 @@ use crate::data::schema::*;
 use crate::event::BatchToken;
 use crate::{AppResult, SnPduEvent, utils};
 
-pub fn load_pdus_forward(
+pub async fn load_pdus_forward(
     user_id: Option<&UserId>,
     room_id: &RoomId,
     since_tk: Option<BatchToken>,
@@ -26,8 +27,9 @@ pub fn load_pdus_forward(
         filter,
         Direction::Forward,
     )
+    .await
 }
-pub fn load_pdus_backward(
+pub async fn load_pdus_backward(
     user_id: Option<&UserId>,
     room_id: &RoomId,
     since_tk: Option<BatchToken>,
@@ -44,13 +46,14 @@ pub fn load_pdus_backward(
         filter,
         Direction::Backward,
     )
+    .await
 }
 
 /// Returns an iterator over all events and their tokens in a room that happened before the
 /// event with id `until` in reverse-chronological order.
 /// Skips events before user joined the room.
 #[tracing::instrument]
-pub fn load_pdus(
+pub async fn load_pdus(
     user_id: Option<&UserId>,
     room_id: &RoomId,
     since_tk: Option<BatchToken>,
@@ -60,7 +63,10 @@ pub fn load_pdus(
     dir: Direction,
 ) -> AppResult<IndexMap<Seqnum, SnPduEvent>> {
     let mut list: IndexMap<Seqnum, SnPduEvent> = IndexMap::with_capacity(limit.clamp(10, 100));
-    let ignored_users = user_id.map(crate::user::ignored_users);
+    let ignored_users = match user_id {
+        Some(user_id) => Some(crate::user::ignored_users(user_id).await),
+        None => None,
+    };
     let mut offset = 0;
     while list.len() < limit {
         let mut query = events::table
@@ -181,7 +187,8 @@ pub fn load_pdus(
                 .offset(offset)
                 .limit(utils::usize_to_i64(limit))
                 .select((events::id, events::sn, events::stream_ordering))
-                .load::<(OwnedEventId, Seqnum, i64)>(&mut connect()?)?
+                .load::<(OwnedEventId, Seqnum, i64)>(&mut connect().await?)
+                .await?
                 .into_iter()
                 .rev()
                 .collect()
@@ -196,7 +203,8 @@ pub fn load_pdus(
                 .limit(utils::usize_to_i64(limit));
             query
                 .select((events::id, events::sn, events::stream_ordering))
-                .load::<(OwnedEventId, Seqnum, i64)>(&mut connect()?)?
+                .load::<(OwnedEventId, Seqnum, i64)>(&mut connect().await?)
+                .await?
                 .into_iter()
                 .collect()
         };
@@ -207,9 +215,9 @@ pub fn load_pdus(
         offset += count as i64;
 
         for (event_id, event_sn, _) in events {
-            if let Ok(mut pdu) = super::get_pdu(&event_id) {
+            if let Ok(mut pdu) = super::get_pdu(&event_id).await {
                 if let Some(user_id) = user_id {
-                    if !pdu.user_can_see(user_id)? {
+                    if !pdu.user_can_see(user_id).await? {
                         continue;
                     }
                     if let Some(ignored_users) = &ignored_users
@@ -220,7 +228,7 @@ pub fn load_pdus(
                     if pdu.sender != user_id {
                         pdu.remove_transaction_id()?;
                     }
-                    pdu.add_unsigned_membership(user_id)?;
+                    pdu.add_unsigned_membership(user_id).await?;
                 }
                 pdu.add_age()?;
                 list.insert(event_sn, pdu);

--- a/crates/server/src/room/typing.rs
+++ b/crates/server/src/room/typing.rs
@@ -1,6 +1,7 @@
 use std::sync::LazyLock;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use tokio::sync::broadcast;
 
 use crate::core::UnixMillis;
@@ -25,7 +26,7 @@ pub async fn add_typing(
     timeout: u64,
     broadcast: bool,
 ) -> AppResult<()> {
-    let event_sn = data::next_sn()?;
+    let event_sn = data::next_sn().await?;
     diesel::insert_into(room_typings::table)
         .values((
             room_typings::room_id.eq(room_id),
@@ -39,7 +40,8 @@ pub async fn add_typing(
             room_typings::timeout_at.eq(timeout as i64),
             room_typings::occur_sn.eq(event_sn),
         ))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
 
     // Notify same-instance watchers immediately
     let _ = TYPING_UPDATE_SENDER.send(room_id.to_owned());
@@ -54,7 +56,7 @@ pub async fn add_typing(
 /// Instead of deleting the row, we set timeout_at=0 and bump occur_sn
 /// so that sync picks up the "typing stopped" change before cleanup.
 pub async fn remove_typing(user_id: &UserId, room_id: &RoomId, broadcast: bool) -> AppResult<()> {
-    let event_sn = data::next_sn()?;
+    let event_sn = data::next_sn().await?;
     diesel::update(
         room_typings::table
             .filter(room_typings::room_id.eq(room_id))
@@ -64,7 +66,8 @@ pub async fn remove_typing(user_id: &UserId, room_id: &RoomId, broadcast: bool) 
         room_typings::timeout_at.eq(0i64),
         room_typings::occur_sn.eq(event_sn),
     ))
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
 
     // Notify same-instance watchers immediately
     let _ = TYPING_UPDATE_SENDER.send(room_id.to_owned());
@@ -89,14 +92,15 @@ pub async fn wait_for_update(room_id: &RoomId) -> AppResult<()> {
 }
 
 /// Removes expired typing entries from the database.
-fn maintain_typings(room_id: &RoomId) -> AppResult<()> {
+async fn maintain_typings(room_id: &RoomId) -> AppResult<()> {
     let current_timestamp = UnixMillis::now().get() as i64;
     diesel::delete(
         room_typings::table
             .filter(room_typings::room_id.eq(room_id))
             .filter(room_typings::timeout_at.lt(current_timestamp)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }
 
@@ -108,7 +112,8 @@ pub async fn last_typing_update(room_id: &RoomId) -> AppResult<i64> {
     let sn = room_typings::table
         .filter(room_typings::room_id.eq(room_id))
         .select(diesel::dsl::max(room_typings::occur_sn))
-        .first::<Option<i64>>(&mut connect()?)
+        .first::<Option<i64>>(&mut connect().await?)
+        .await
         .unwrap_or(None)
         .unwrap_or_default();
     Ok(sn)
@@ -118,11 +123,12 @@ pub async fn last_typing_update(room_id: &RoomId) -> AppResult<i64> {
 pub async fn all_typings(
     room_id: &RoomId,
 ) -> AppResult<SyncEphemeralRoomEvent<TypingEventContent>> {
-    maintain_typings(room_id)?;
+    maintain_typings(room_id).await?;
     let user_ids = room_typings::table
         .filter(room_typings::room_id.eq(room_id))
         .select(room_typings::user_id)
-        .load::<OwnedUserId>(&mut connect()?)?;
+        .load::<OwnedUserId>(&mut connect().await?)
+        .await?;
 
     Ok(SyncEphemeralRoomEvent {
         content: TypingEventContent { user_ids },
@@ -141,7 +147,7 @@ async fn federation_send(room_id: &RoomId, user_id: &UserId, typing: bool) -> Ap
 
     let content = TypingContent::new(room_id.to_owned(), user_id.to_owned(), typing);
     let edu = Edu::Typing(content);
-    sending::send_edu_room(room_id, &edu)?;
+    sending::send_edu_room(room_id, &edu).await?;
 
     Ok(())
 }

--- a/crates/server/src/room/user.rs
+++ b/crates/server/src/room/user.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use indexmap::IndexMap;
 
 use crate::core::Seqnum;
@@ -88,42 +89,46 @@ impl From<Vec<DbEventPushSummary>> for UserNotifySummary {
     }
 }
 
-pub fn notify_summary(user_id: &UserId, room_id: &RoomId) -> AppResult<UserNotifySummary> {
+pub async fn notify_summary(user_id: &UserId, room_id: &RoomId) -> AppResult<UserNotifySummary> {
     let summaries = event_push_summaries::table
         .filter(event_push_summaries::user_id.eq(user_id))
         .filter(event_push_summaries::room_id.eq(room_id))
-        .load::<DbEventPushSummary>(&mut connect()?)?;
+        .load::<DbEventPushSummary>(&mut connect().await?)
+        .await?;
     Ok(summaries.into())
 }
 
-pub fn highlight_count(user_id: &UserId, room_id: &RoomId) -> AppResult<u64> {
+pub async fn highlight_count(user_id: &UserId, room_id: &RoomId) -> AppResult<u64> {
     let count = event_push_summaries::table
         .filter(event_push_summaries::user_id.eq(user_id))
         .filter(event_push_summaries::room_id.eq(room_id))
         .select(event_push_summaries::highlight_count)
-        .first::<i64>(&mut connect()?)
+        .first::<i64>(&mut connect().await?)
+        .await
         .unwrap_or_default();
     Ok(count as u64)
 }
 
-pub fn last_read_notification(user_id: &UserId, room_id: &RoomId) -> AppResult<Seqnum> {
+pub async fn last_read_notification(user_id: &UserId, room_id: &RoomId) -> AppResult<Seqnum> {
     let sn = event_receipts::table
         .filter(event_receipts::user_id.eq(user_id))
         .filter(event_receipts::room_id.eq(room_id))
         .order_by(event_receipts::event_sn.desc())
         .select(event_receipts::event_sn)
-        .first::<Seqnum>(&mut connect()?)
+        .first::<Seqnum>(&mut connect().await?)
+        .await
         .unwrap_or_default();
     Ok(sn)
 }
 
-pub fn shared_rooms(user_ids: Vec<OwnedUserId>) -> AppResult<Vec<OwnedRoomId>> {
+pub async fn shared_rooms(user_ids: Vec<OwnedUserId>) -> AppResult<Vec<OwnedRoomId>> {
     let mut user_rooms: Vec<(OwnedUserId, Vec<OwnedRoomId>)> = Vec::new();
     for user_id in user_ids {
         let room_ids = room_users::table
             .filter(room_users::user_id.eq(&user_id))
             .select(room_users::room_id)
-            .load::<OwnedRoomId>(&mut connect()?)?;
+            .load::<OwnedRoomId>(&mut connect().await?)
+            .await?;
         user_rooms.push((user_id, room_ids));
     }
 
@@ -142,116 +147,124 @@ pub fn shared_rooms(user_ids: Vec<OwnedUserId>) -> AppResult<Vec<OwnedRoomId>> {
     Ok(shared_rooms)
 }
 
-pub fn join_sn(user_id: &UserId, room_id: &RoomId) -> AppResult<Seqnum> {
+pub async fn join_sn(user_id: &UserId, room_id: &RoomId) -> AppResult<Seqnum> {
     room_users::table
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::user_id.eq(user_id))
         .filter(room_users::membership.eq("join"))
         .select(room_users::event_sn)
-        .first::<i64>(&mut connect()?)
+        .first::<i64>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
-pub fn join_depth(user_id: &UserId, room_id: &RoomId) -> AppResult<u64> {
-    let join_sn = join_sn(user_id, room_id)?;
+pub async fn join_depth(user_id: &UserId, room_id: &RoomId) -> AppResult<u64> {
+    let join_sn = join_sn(user_id, room_id).await?;
     events::table
         .filter(events::sn.eq(join_sn))
         .select(events::depth)
-        .first::<i64>(&mut connect()?)
+        .first::<i64>(&mut connect().await?)
+        .await
         .map(|depth| depth as u64)
         .map_err(Into::into)
 }
-pub fn join_count(room_id: &RoomId) -> AppResult<i64> {
+pub async fn join_count(room_id: &RoomId) -> AppResult<i64> {
     let count = room_users::table
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::membership.eq("join"))
         .select(room_users::user_id)
         .count()
-        .get_result(&mut connect()?)?;
+        .get_result(&mut connect().await?)
+        .await?;
     Ok(count)
 }
 
-pub fn knock_sn(user_id: &UserId, room_id: &RoomId) -> AppResult<i64> {
+pub async fn knock_sn(user_id: &UserId, room_id: &RoomId) -> AppResult<i64> {
     room_users::table
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::user_id.eq(user_id))
         .filter(room_users::membership.eq("knock"))
         .select(room_users::event_sn)
-        .first::<i64>(&mut connect()?)
+        .first::<i64>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
-pub fn knock_count(room_id: &RoomId) -> AppResult<i64> {
+pub async fn knock_count(room_id: &RoomId) -> AppResult<i64> {
     let count = room_users::table
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::membership.eq("knock"))
         .select(room_users::user_id)
         .count()
-        .get_result(&mut connect()?)?;
+        .get_result(&mut connect().await?)
+        .await?;
     Ok(count)
 }
-pub fn leave_sn(user_id: &UserId, room_id: &RoomId) -> AppResult<i64> {
+pub async fn leave_sn(user_id: &UserId, room_id: &RoomId) -> AppResult<i64> {
     room_users::table
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::user_id.eq(user_id))
         .filter(room_users::membership.eq("leave"))
         .select(room_users::event_sn)
-        .first::<i64>(&mut connect()?)
+        .first::<i64>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
 #[tracing::instrument]
-pub fn is_invited(user_id: &UserId, room_id: &RoomId) -> AppResult<bool> {
+pub async fn is_invited(user_id: &UserId, room_id: &RoomId) -> AppResult<bool> {
     let query = room_users::table
         .filter(room_users::user_id.eq(user_id))
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::membership.eq(MembershipState::Invite.to_string()));
-    diesel_exists!(query, &mut connect()?).map_err(Into::into)
+    diesel_exists!(query, &mut connect().await?).map_err(Into::into)
 }
 
 #[tracing::instrument]
-pub fn is_banned(user_id: &UserId, room_id: &RoomId) -> AppResult<bool> {
+pub async fn is_banned(user_id: &UserId, room_id: &RoomId) -> AppResult<bool> {
     let query = room_users::table
         .filter(room_users::user_id.eq(user_id))
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::membership.eq(MembershipState::Ban.to_string()));
-    diesel_exists!(query, &mut connect()?).map_err(Into::into)
+    diesel_exists!(query, &mut connect().await?).map_err(Into::into)
 }
 
 #[tracing::instrument]
-pub fn is_left(user_id: &UserId, room_id: &RoomId) -> AppResult<bool> {
+pub async fn is_left(user_id: &UserId, room_id: &RoomId) -> AppResult<bool> {
     let left = room_users::table
         .filter(room_users::user_id.eq(user_id))
         .filter(room_users::room_id.eq(room_id))
         .order_by(room_users::id.desc())
         .select(room_users::membership)
-        .first::<String>(&mut connect()?)
+        .first::<String>(&mut connect().await?)
+        .await
         .map(|m| m == MembershipState::Leave.to_string())
         .unwrap_or(true);
     Ok(left)
 }
 
 #[tracing::instrument]
-pub fn is_knocked(user_id: &UserId, room_id: &RoomId) -> AppResult<bool> {
+pub async fn is_knocked(user_id: &UserId, room_id: &RoomId) -> AppResult<bool> {
     let query = room_users::table
         .filter(room_users::user_id.eq(user_id))
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::membership.eq(MembershipState::Knock.to_string()));
-    diesel_exists!(query, &mut connect()?).map_err(Into::into)
+    diesel_exists!(query, &mut connect().await?).map_err(Into::into)
 }
 #[tracing::instrument]
-pub fn is_joined(user_id: &UserId, room_id: &RoomId) -> AppResult<bool> {
+pub async fn is_joined(user_id: &UserId, room_id: &RoomId) -> AppResult<bool> {
     let joined = room_users::table
         .filter(room_users::user_id.eq(user_id))
         .filter(room_users::room_id.eq(room_id))
         .order_by(room_users::id.desc())
         .select(room_users::membership)
-        .first::<String>(&mut connect()?)
+        .first::<String>(&mut connect().await?)
+        .await
         .map(|m| m == MembershipState::Join.to_string())
         .unwrap_or(false);
     Ok(joined)
 }
 
 #[tracing::instrument]
-pub fn left_sn(room_id: &RoomId, user_id: &UserId) -> AppResult<Seqnum> {
+pub async fn left_sn(room_id: &RoomId, user_id: &UserId) -> AppResult<Seqnum> {
     room_users::table
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::user_id.eq(user_id))
@@ -261,12 +274,13 @@ pub fn left_sn(room_id: &RoomId, user_id: &UserId) -> AppResult<Seqnum> {
                 .or(room_users::membership.eq("ban")),
         )
         .select(room_users::event_sn)
-        .first::<Seqnum>(&mut connect()?)
+        .first::<Seqnum>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
 #[tracing::instrument(level = "trace")]
-pub fn invite_state(
+pub async fn invite_state(
     user_id: &UserId,
     room_id: &RoomId,
 ) -> AppResult<Vec<RawJson<AnyStrippedStateEvent>>> {
@@ -275,7 +289,8 @@ pub fn invite_state(
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::membership.eq(MembershipState::Invite.to_string()))
         .select(room_users::state_data)
-        .first::<Option<JsonValue>>(&mut connect()?)
+        .first::<Option<JsonValue>>(&mut connect().await?)
+        .await
         .unwrap_or_default()
     {
         Ok(serde_json::from_value(state)?)
@@ -285,13 +300,14 @@ pub fn invite_state(
 }
 
 #[tracing::instrument(level = "trace")]
-pub fn membership(user_id: &UserId, room_id: &RoomId) -> AppResult<MembershipState> {
+pub async fn membership(user_id: &UserId, room_id: &RoomId) -> AppResult<MembershipState> {
     let membership = room_users::table
         .filter(room_users::user_id.eq(user_id))
         .filter(room_users::room_id.eq(room_id))
         .order_by(room_users::id.desc())
         .select(room_users::membership)
-        .first::<String>(&mut connect()?);
+        .first::<String>(&mut connect().await?)
+        .await;
     if let Ok(membership) = membership {
         Ok(membership.into())
     } else {
@@ -303,7 +319,7 @@ pub fn membership(user_id: &UserId, room_id: &RoomId) -> AppResult<MembershipSta
 }
 /// Returns an iterator over all rooms a user left.
 #[tracing::instrument]
-pub fn left_rooms(
+pub async fn left_rooms(
     user_id: &UserId,
     since_tk: Option<BatchToken>,
 ) -> AppResult<HashMap<OwnedRoomId, Vec<RawJson<AnySyncStateEvent>>>> {
@@ -321,7 +337,8 @@ pub fn left_rooms(
     };
     let room_event_ids = query
         .select((room_users::room_id, room_users::event_id))
-        .load::<(OwnedRoomId, OwnedEventId)>(&mut connect()?)
+        .load::<(OwnedRoomId, OwnedEventId)>(&mut connect().await?)
+        .await
         .map(|rows| {
             let mut map: HashMap<OwnedRoomId, Vec<OwnedEventId>> = HashMap::new();
             for (room_id, event_id) in rows {
@@ -334,7 +351,8 @@ pub fn left_rooms(
         let events = event_datas::table
             .filter(event_datas::event_id.eq_any(&event_ids))
             .select(event_datas::json_data)
-            .load::<JsonValue>(&mut connect()?)?
+            .load::<JsonValue>(&mut connect().await?)
+            .await?
             .into_iter()
             .filter_map(|value| RawJson::<AnySyncStateEvent>::from_value(&value).ok())
             .collect::<Vec<_>>();
@@ -343,20 +361,22 @@ pub fn left_rooms(
     Ok(room_events)
 }
 
-pub fn get_tags(user_id: &UserId, room_id: &RoomId) -> AppResult<Vec<DbRoomTag>> {
+pub async fn get_tags(user_id: &UserId, room_id: &RoomId) -> AppResult<Vec<DbRoomTag>> {
     let tags = room_tags::table
         .filter(room_tags::user_id.eq(user_id))
         .filter(room_tags::room_id.eq(room_id))
-        .load::<DbRoomTag>(&mut connect()?)?;
+        .load::<DbRoomTag>(&mut connect().await?)
+        .await?;
     Ok(tags)
 }
-pub fn local_users(room_id: &RoomId) -> AppResult<Vec<OwnedUserId>> {
+pub async fn local_users(room_id: &RoomId) -> AppResult<Vec<OwnedUserId>> {
     let users = room_users::table
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::membership.eq("join"))
         .select(room_users::user_id)
         .distinct()
-        .load::<OwnedUserId>(&mut connect()?)?;
+        .load::<OwnedUserId>(&mut connect().await?)
+        .await?;
     let users = users
         .into_iter()
         .filter(|user_id| user_id.server_name().is_local())
@@ -365,7 +385,7 @@ pub fn local_users(room_id: &RoomId) -> AppResult<Vec<OwnedUserId>> {
 }
 
 /// Copies the tags and direct room state from one room to another.
-pub fn copy_room_tags_and_direct_to_room(
+pub async fn copy_room_tags_and_direct_to_room(
     user_id: &UserId,
     old_room_id: &RoomId,
     new_room_id: &RoomId,
@@ -374,7 +394,9 @@ pub fn copy_room_tags_and_direct_to_room(
         user_id,
         None,
         &GlobalAccountDataEventType::Direct.to_string(),
-    ) else {
+    )
+    .await
+    else {
         return Ok(());
     };
 
@@ -394,9 +416,10 @@ pub fn copy_room_tags_and_direct_to_room(
         None,
         &GlobalAccountDataEventType::Direct.to_string(),
         serde_json::to_value(direct_rooms)?,
-    )?;
+    )
+    .await?;
 
-    let room_tags = get_tags(user_id, &old_room_id)?;
+    let room_tags = get_tags(user_id, &old_room_id).await?;
     for tag in room_tags {
         let DbRoomTag {
             user_id,
@@ -412,13 +435,14 @@ pub fn copy_room_tags_and_direct_to_room(
         };
         diesel::insert_into(room_tags::table)
             .values(&new_tag)
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     }
     Ok(())
 }
 
 /// Copy all of the push rules from one room to another for a specific user
-pub fn copy_push_rules_from_room_to_room(
+pub async fn copy_push_rules_from_room_to_room(
     user_id: &UserId,
     _old_room_id: &RoomId,
     new_room_id: &RoomId,
@@ -427,7 +451,9 @@ pub fn copy_push_rules_from_room_to_room(
         user_id,
         None,
         &GlobalAccountDataEventType::PushRules.to_string(),
-    ) else {
+    )
+    .await
+    else {
         return Ok(());
     };
 
@@ -462,6 +488,7 @@ pub fn copy_push_rules_from_room_to_room(
         None,
         &GlobalAccountDataEventType::PushRules.to_string(),
         serde_json::to_value(user_data_content)?,
-    )?;
+    )
+    .await?;
     Ok(())
 }

--- a/crates/server/src/routing/admin/appservice.rs
+++ b/crates/server/src/routing/admin/appservice.rs
@@ -100,8 +100,8 @@ pub fn router() -> Router {
 ///
 /// GET /_synapse/admin/v1/appservices
 #[endpoint(operation_id = "list_appservices")]
-pub fn list_appservices() -> JsonResult<ListAppservicesResponse> {
-    let rows = svc::list_all_registrations()?;
+pub async fn list_appservices() -> JsonResult<ListAppservicesResponse> {
+    let rows = svc::list_all_registrations().await?;
     let appservices = rows
         .into_iter()
         .map(|(r, disabled)| AppserviceSummary {
@@ -118,11 +118,13 @@ pub fn list_appservices() -> JsonResult<ListAppservicesResponse> {
 ///
 /// GET /_synapse/admin/v1/appservices/{id}
 #[endpoint(operation_id = "get_appservice")]
-pub fn get_appservice(id: PathParam<String>) -> JsonResult<AppserviceRegistrationBody> {
+pub async fn get_appservice(id: PathParam<String>) -> JsonResult<AppserviceRegistrationBody> {
     let id = id.into_inner();
-    let registration = svc::get_registration(&id)?
+    let registration = svc::get_registration(&id)
+        .await?
         .ok_or_else(|| MatrixError::not_found(format!("No such appservice: {}", id)))?;
-    let disabled = svc::list_all_registrations()?
+    let disabled = svc::list_all_registrations()
+        .await?
         .into_iter()
         .find(|(r, _)| r.id == id)
         .map(|(_, d)| d)
@@ -139,14 +141,14 @@ pub fn get_appservice(id: PathParam<String>) -> JsonResult<AppserviceRegistratio
 ///
 /// Request body: a full appservice `Registration` object.
 #[endpoint(operation_id = "register_appservice")]
-pub fn register_appservice(
+pub async fn register_appservice(
     body: JsonBody<AppserviceRegistrationBody>,
 ) -> JsonResult<AppserviceResponse> {
     let body = body.into_inner();
     if body.id.is_empty() {
         return Err(MatrixError::invalid_param("id must not be empty").into());
     }
-    if svc::get_registration(&body.id)?.is_some() {
+    if svc::get_registration(&body.id).await?.is_some() {
         return Err(MatrixError::invalid_param(format!(
             "Appservice with id {} already exists",
             body.id
@@ -156,7 +158,7 @@ pub fn register_appservice(
     let registration = body
         .into_registration()
         .map_err(|e| MatrixError::invalid_param(format!("invalid namespaces: {e}")))?;
-    let id = svc::register_appservice(registration)?;
+    let id = svc::register_appservice(registration).await?;
     json_ok(AppserviceResponse { id })
 }
 
@@ -164,12 +166,12 @@ pub fn register_appservice(
 ///
 /// DELETE /_synapse/admin/v1/appservices/{id}
 #[endpoint(operation_id = "delete_appservice")]
-pub fn delete_appservice(id: PathParam<String>) -> EmptyResult {
+pub async fn delete_appservice(id: PathParam<String>) -> EmptyResult {
     let id = id.into_inner();
-    if svc::get_registration(&id)?.is_none() {
+    if svc::get_registration(&id).await?.is_none() {
         return Err(MatrixError::not_found(format!("No such appservice: {}", id)).into());
     }
-    svc::unregister_appservice(&id)?;
+    svc::unregister_appservice(&id).await?;
     empty_ok()
 }
 
@@ -178,9 +180,9 @@ pub fn delete_appservice(id: PathParam<String>) -> EmptyResult {
 ///
 /// POST /_synapse/admin/v1/appservices/{id}/disable
 #[endpoint(operation_id = "disable_appservice")]
-pub fn disable_appservice(id: PathParam<String>) -> EmptyResult {
+pub async fn disable_appservice(id: PathParam<String>) -> EmptyResult {
     let id = id.into_inner();
-    if !svc::set_appservice_disabled(&id, true)? {
+    if !svc::set_appservice_disabled(&id, true).await? {
         return Err(MatrixError::not_found(format!("No such appservice: {}", id)).into());
     }
     empty_ok()
@@ -190,9 +192,9 @@ pub fn disable_appservice(id: PathParam<String>) -> EmptyResult {
 ///
 /// POST /_synapse/admin/v1/appservices/{id}/enable
 #[endpoint(operation_id = "enable_appservice")]
-pub fn enable_appservice(id: PathParam<String>) -> EmptyResult {
+pub async fn enable_appservice(id: PathParam<String>) -> EmptyResult {
     let id = id.into_inner();
-    if !svc::set_appservice_disabled(&id, false)? {
+    if !svc::set_appservice_disabled(&id, false).await? {
         return Err(MatrixError::not_found(format!("No such appservice: {}", id)).into());
     }
     empty_ok()

--- a/crates/server/src/routing/admin/event.rs
+++ b/crates/server/src/routing/admin/event.rs
@@ -23,11 +23,11 @@ pub struct FetchEventResponse {
 ///
 /// Fetch a single event by ID
 #[endpoint]
-pub fn fetch_event(event_id: PathParam<OwnedEventId>) -> JsonResult<FetchEventResponse> {
+pub async fn fetch_event(event_id: PathParam<OwnedEventId>) -> JsonResult<FetchEventResponse> {
     let event_id = event_id.into_inner();
 
     let pdu =
-        timeline::get_pdu(&event_id).map_err(|_| MatrixError::not_found("Event not found"))?;
+        timeline::get_pdu(&event_id).await.map_err(|_| MatrixError::not_found("Event not found"))?;
 
     let event = serde_json::to_value(&pdu).unwrap_or_default();
 

--- a/crates/server/src/routing/admin/event_report.rs
+++ b/crates/server/src/routing/admin/event_report.rs
@@ -122,7 +122,7 @@ fn normalize_event_report_status(status: &str) -> Option<&'static str> {
 ///
 /// List all reported events with pagination and filtering
 #[endpoint(operation_id = "list_event_reports")]
-pub fn list_event_reports(query: ListEventReportsQuery) -> JsonResult<EventReportsResponse> {
+pub async fn list_event_reports(query: ListEventReportsQuery) -> JsonResult<EventReportsResponse> {
     let from = query.from.unwrap_or(0);
     if from < 0 {
         return Err(MatrixError::invalid_param("from must be a non-negative integer").into());
@@ -160,7 +160,7 @@ pub fn list_event_reports(query: ListEventReportsQuery) -> JsonResult<EventRepor
         room_id,
     };
 
-    let (reports, total) = data::room::list_event_reports(&filter)?;
+    let (reports, total) = data::room::list_event_reports(&filter).await?;
 
     let event_reports: Vec<EventReport> = reports.into_iter().map(Into::into).collect();
     let next_token = if (from + limit) < total {
@@ -180,10 +180,11 @@ pub fn list_event_reports(query: ListEventReportsQuery) -> JsonResult<EventRepor
 ///
 /// Get details of a specific event report including the event JSON
 #[endpoint(operation_id = "get_event_report")]
-pub fn get_event_report(report_id: PathParam<i64>) -> JsonResult<EventReportDetailResponse> {
+pub async fn get_event_report(report_id: PathParam<i64>) -> JsonResult<EventReportDetailResponse> {
     let report_id = report_id.into_inner();
 
-    let report = data::room::get_event_report(report_id)?
+    let report = data::room::get_event_report(report_id)
+        .await?
         .ok_or_else(|| MatrixError::not_found(format!("Event report {} not found", report_id)))?;
 
     json_ok(report.into())
@@ -193,7 +194,7 @@ pub fn get_event_report(report_id: PathParam<i64>) -> JsonResult<EventReportDeta
 ///
 /// Update the moderation status of an event report
 #[endpoint(operation_id = "update_event_report_status")]
-pub fn update_event_report_status(
+pub async fn update_event_report_status(
     report_id: PathParam<i64>,
     body: JsonBody<UpdateEventReportReqBody>,
 ) -> JsonResult<EventReportDetailResponse> {
@@ -203,7 +204,8 @@ pub fn update_event_report_status(
         MatrixError::invalid_param("status must be one of: new, in_review, resolved")
     })?;
 
-    let report = data::room::update_event_report_status(report_id, status)?
+    let report = data::room::update_event_report_status(report_id, status)
+        .await?
         .ok_or_else(|| MatrixError::not_found(format!("Event report {} not found", report_id)))?;
 
     json_ok(report.into())
@@ -213,10 +215,10 @@ pub fn update_event_report_status(
 ///
 /// Delete an event report
 #[endpoint(operation_id = "delete_event_report")]
-pub fn delete_event_report(report_id: PathParam<i64>) -> EmptyResult {
+pub async fn delete_event_report(report_id: PathParam<i64>) -> EmptyResult {
     let report_id = report_id.into_inner();
 
-    let deleted = data::room::delete_event_report(report_id)?;
+    let deleted = data::room::delete_event_report(report_id).await?;
     if !deleted {
         return Err(MatrixError::not_found(format!("Event report {} not found", report_id)).into());
     }

--- a/crates/server/src/routing/admin/federation.rs
+++ b/crates/server/src/routing/admin/federation.rs
@@ -62,7 +62,7 @@ pub struct DestinationRoom {
 ///
 /// List all federation destinations
 #[endpoint]
-pub fn list_destinations(
+pub async fn list_destinations(
     from: QueryParam<i64, false>,
     limit: QueryParam<i64, false>,
     _destination: QueryParam<String, false>,
@@ -72,7 +72,7 @@ pub fn list_destinations(
     let offset = from.into_inner().unwrap_or(0);
     let limit = limit.into_inner().unwrap_or(100);
 
-    let servers = data::sending::get_all_destinations()?;
+    let servers = data::sending::get_all_destinations().await?;
     let total = servers.len() as i64;
 
     let destinations: Vec<DestinationInfo> = servers
@@ -105,11 +105,11 @@ pub fn list_destinations(
 ///
 /// Get details of a specific destination
 #[endpoint]
-pub fn get_destination(destination: PathParam<OwnedServerName>) -> JsonResult<DestinationInfo> {
+pub async fn get_destination(destination: PathParam<OwnedServerName>) -> JsonResult<DestinationInfo> {
     let destination = destination.into_inner();
 
     // Check if destination is known
-    if !data::sending::is_destination_known(&destination)? {
+    if !data::sending::is_destination_known(&destination).await? {
         return Err(MatrixError::not_found("Unknown destination").into());
     }
 
@@ -126,7 +126,7 @@ pub fn get_destination(destination: PathParam<OwnedServerName>) -> JsonResult<De
 ///
 /// Get rooms shared with a destination
 #[endpoint]
-pub fn destination_rooms(
+pub async fn destination_rooms(
     destination: PathParam<OwnedServerName>,
     from: QueryParam<i64, false>,
     limit: QueryParam<i64, false>,
@@ -136,11 +136,11 @@ pub fn destination_rooms(
     let limit = limit.into_inner().unwrap_or(100);
 
     // Check if destination is known
-    if !data::sending::is_destination_known(&destination)? {
+    if !data::sending::is_destination_known(&destination).await? {
         return Err(MatrixError::not_found("Unknown destination").into());
     }
 
-    let rooms = data::sending::get_destination_rooms(&destination)?;
+    let rooms = data::sending::get_destination_rooms(&destination).await?;
     let total = rooms.len() as i64;
 
     let rooms: Vec<DestinationRoom> = rooms
@@ -170,16 +170,18 @@ pub fn destination_rooms(
 ///
 /// Reset connection to a destination
 #[endpoint]
-pub fn reset_connection(destination: PathParam<OwnedServerName>) -> JsonResult<serde_json::Value> {
+pub async fn reset_connection(
+    destination: PathParam<OwnedServerName>,
+) -> JsonResult<serde_json::Value> {
     let destination = destination.into_inner();
 
     // Check if destination is known
-    if !data::sending::is_destination_known(&destination)? {
+    if !data::sending::is_destination_known(&destination).await? {
         return Err(MatrixError::not_found("Unknown destination").into());
     }
 
     // Reset retry timings
-    data::sending::reset_destination_retry(&destination)?;
+    data::sending::reset_destination_retry(&destination).await?;
 
     json_ok(serde_json::json!({}))
 }

--- a/crates/server/src/routing/admin/mas.rs
+++ b/crates/server/src/routing/admin/mas.rs
@@ -126,10 +126,11 @@ pub struct SetDisplaynameReqBody {
 #[endpoint]
 pub async fn query_user(localpart: QueryParam<String, true>) -> JsonResult<QueryUserResponse> {
     let user_id = localpart_to_user_id(&localpart.into_inner())?;
-    let db_user =
-        data::user::get_user(&user_id).map_err(|_| MatrixError::not_found("User not found"))?;
-    let display_name = data::user::display_name(&user_id).ok().flatten();
-    let avatar_url = data::user::avatar_url(&user_id).ok().flatten();
+    let db_user = data::user::get_user(&user_id)
+        .await
+        .map_err(|_| MatrixError::not_found("User not found"))?;
+    let display_name = data::user::display_name(&user_id).await.ok().flatten();
+    let avatar_url = data::user::avatar_url(&user_id).await.ok().flatten();
     json_ok(QueryUserResponse {
         user_id: user_id.to_string(),
         display_name,
@@ -147,35 +148,35 @@ pub async fn provision_user(
 ) -> EmptyResult {
     let body = body.into_inner();
     let user_id = localpart_to_user_id(&body.localpart)?;
-    let exists = data::user::user_exists(&user_id)?;
+    let exists = data::user::user_exists(&user_id).await?;
     if !exists {
-        user::create_user(user_id.clone(), None)?;
+        user::create_user(user_id.clone(), None).await?;
         res.status_code(salvo::http::StatusCode::CREATED);
     } else {
-        data::user::set_guest(&user_id, false)?;
+        data::user::set_guest(&user_id, false).await?;
     }
     if let Some(displayname) = &body.set_displayname {
-        data::user::set_display_name(&user_id, displayname)?;
+        data::user::set_display_name(&user_id, displayname).await?;
     } else if body.unset_displayname {
-        data::user::remove_display_name(&user_id)?;
+        data::user::remove_display_name(&user_id).await?;
     }
     if let Some(avatar_url) = &body.set_avatar_url {
         let mxc_uri: &MxcUri = avatar_url.as_str().into();
-        data::user::set_avatar_url(&user_id, mxc_uri)?;
+        data::user::set_avatar_url(&user_id, mxc_uri).await?;
     } else if body.unset_avatar_url {
-        data::user::remove_avatar_url(&user_id)?;
+        data::user::remove_avatar_url(&user_id).await?;
     }
     if let Some(emails) = body.set_emails {
         let entries: Vec<(String, String, Option<i64>, Option<i64>)> = emails
             .into_iter()
             .map(|email| ("email".to_string(), email, None, None))
             .collect();
-        data::user::replace_threepids(&user_id, &entries)?;
+        data::user::replace_threepids(&user_id, &entries).await?;
     } else if body.unset_emails {
-        data::user::replace_threepids(&user_id, &[])?;
+        data::user::replace_threepids(&user_id, &[]).await?;
     }
     if body.admin {
-        data::user::set_admin(&user_id, true)?;
+        data::user::set_admin(&user_id, true).await?;
     }
     empty_ok()
 }
@@ -188,7 +189,7 @@ pub async fn is_localpart_available(localpart: QueryParam<String, true>) -> Empt
         return Err(MatrixError::invalid_param("Invalid username").into());
     }
     let user_id = localpart_to_user_id(&localpart)?;
-    if data::user::user_exists(&user_id)? {
+    if data::user::user_exists(&user_id).await? {
         return Err(MatrixError::unknown("User ID already taken.").into());
     }
     empty_ok()
@@ -200,7 +201,7 @@ pub async fn upsert_device(body: JsonBody<UpsertDeviceReqBody>) -> EmptyResult {
     let body = body.into_inner();
     let user_id = localpart_to_user_id(&body.localpart)?;
     let device_id: OwnedDeviceId = body.device_id.into();
-    if data::user::device::is_device_exists(&user_id, &device_id)? {
+    if data::user::device::is_device_exists(&user_id, &device_id).await? {
         if let Some(display_name) = body.display_name {
             data::user::device::update_device(
                 &user_id,
@@ -211,11 +212,13 @@ pub async fn upsert_device(body: JsonBody<UpsertDeviceReqBody>) -> EmptyResult {
                     last_seen_ip: None,
                     last_seen_at: None,
                 },
-            )?;
+            )
+            .await?;
         }
     } else {
         let token = utils::random_string(64);
-        data::user::device::create_device(&user_id, &device_id, &token, body.display_name, None)?;
+        data::user::device::create_device(&user_id, &device_id, &token, body.display_name, None)
+            .await?;
     }
     empty_ok()
 }
@@ -237,7 +240,8 @@ pub async fn update_device_display_name(
             last_seen_ip: None,
             last_seen_at: None,
         },
-    )?;
+    )
+    .await?;
     empty_ok()
 }
 
@@ -247,7 +251,7 @@ pub async fn mas_delete_device(body: JsonBody<DeleteDeviceReqBody>) -> EmptyResu
     let body = body.into_inner();
     let user_id = localpart_to_user_id(&body.localpart)?;
     let device_id: OwnedDeviceId = body.device_id.into();
-    data::user::device::remove_device(&user_id, &device_id)?;
+    data::user::device::remove_device(&user_id, &device_id).await?;
     empty_ok()
 }
 
@@ -256,21 +260,21 @@ pub async fn mas_delete_device(body: JsonBody<DeleteDeviceReqBody>) -> EmptyResu
 pub async fn sync_devices(body: JsonBody<SyncDevicesReqBody>) -> EmptyResult {
     let body = body.into_inner();
     let user_id = localpart_to_user_id(&body.localpart)?;
-    let current_devices = data::user::device::get_devices(&user_id)?;
+    let current_devices = data::user::device::get_devices(&user_id).await?;
     let current_ids: HashSet<String> = current_devices
         .iter()
         .map(|d| d.device_id.to_string())
         .collect();
     for device in &current_devices {
         if !body.devices.contains(device.device_id.as_str()) {
-            let _ = data::user::device::remove_device(&user_id, &device.device_id);
+            let _ = data::user::device::remove_device(&user_id, &device.device_id).await;
         }
     }
     for device_id_str in &body.devices {
         if !current_ids.contains(device_id_str) {
             let device_id: OwnedDeviceId = device_id_str.as_str().into();
             let token = utils::random_string(64);
-            data::user::device::create_device(&user_id, &device_id, &token, None, None)?;
+            data::user::device::create_device(&user_id, &device_id, &token, None, None).await?;
         }
     }
     empty_ok()
@@ -281,10 +285,10 @@ pub async fn sync_devices(body: JsonBody<SyncDevicesReqBody>) -> EmptyResult {
 pub async fn delete_user(body: JsonBody<DeleteUserReqBody>) -> EmptyResult {
     let body = body.into_inner();
     let user_id = localpart_to_user_id(&body.localpart)?;
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
-    let joined_rooms = data::user::joined_rooms(&user_id)?;
+    let joined_rooms = data::user::joined_rooms(&user_id).await?;
     user::full_user_deactivate(&user_id, &joined_rooms).await?;
     if body.erase {
         user::delete_all_media(&user_id).await?;
@@ -296,10 +300,10 @@ pub async fn delete_user(body: JsonBody<DeleteUserReqBody>) -> EmptyResult {
 #[endpoint]
 pub async fn reactivate_user(body: JsonBody<LocalpartReqBody>) -> EmptyResult {
     let user_id = localpart_to_user_id(&body.into_inner().localpart)?;
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
-    data::user::reactivate(&user_id)?;
+    data::user::reactivate(&user_id).await?;
     empty_ok()
 }
 
@@ -308,7 +312,7 @@ pub async fn reactivate_user(body: JsonBody<LocalpartReqBody>) -> EmptyResult {
 pub async fn set_displayname(body: JsonBody<SetDisplaynameReqBody>) -> EmptyResult {
     let body = body.into_inner();
     let user_id = localpart_to_user_id(&body.localpart)?;
-    data::user::set_display_name(&user_id, &body.displayname)?;
+    data::user::set_display_name(&user_id, &body.displayname).await?;
     empty_ok()
 }
 
@@ -316,7 +320,7 @@ pub async fn set_displayname(body: JsonBody<SetDisplaynameReqBody>) -> EmptyResu
 #[endpoint]
 pub async fn unset_displayname(body: JsonBody<LocalpartReqBody>) -> EmptyResult {
     let user_id = localpart_to_user_id(&body.into_inner().localpart)?;
-    data::user::remove_display_name(&user_id)?;
+    data::user::remove_display_name(&user_id).await?;
     empty_ok()
 }
 
@@ -324,14 +328,14 @@ pub async fn unset_displayname(body: JsonBody<LocalpartReqBody>) -> EmptyResult 
 #[endpoint]
 pub async fn allow_cross_signing_reset(body: JsonBody<LocalpartReqBody>) -> EmptyResult {
     let user_id = localpart_to_user_id(&body.into_inner().localpart)?;
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
-    if !data::user::key::has_master_cross_signing_key(&user_id)? {
+    if !data::user::key::has_master_cross_signing_key(&user_id).await? {
         return Err(MatrixError::not_found("User has no master cross-signing key").into());
     }
     let now_ms = crate::core::UnixMillis::now().get() as i64;
     let expires_ts = now_ms + 10 * 60 * 1000;
-    data::user::key::set_cross_signing_replacement_allowed(&user_id, expires_ts)?;
+    data::user::key::set_cross_signing_replacement_allowed(&user_id, expires_ts).await?;
     empty_ok()
 }

--- a/crates/server/src/routing/admin/media.rs
+++ b/crates/server/src/routing/admin/media.rs
@@ -114,14 +114,15 @@ pub struct DeleteMediaByDateSizeQuery {
 
 /// GET /_synapse/admin/v1/media/{server_name}/{media_id}
 #[endpoint(operation_id = "get_media_info")]
-pub fn get_media_info(
+pub async fn get_media_info(
     server_name: PathParam<OwnedServerName>,
     media_id: PathParam<String>,
 ) -> JsonResult<MediaInfoResponse> {
     let server_name = server_name.into_inner();
     let media_id = media_id.into_inner();
 
-    let metadata = data::media::get_metadata(&server_name, &media_id)?
+    let metadata = data::media::get_metadata(&server_name, &media_id)
+        .await?
         .ok_or_else(|| MatrixError::not_found("Unknown media"))?;
 
     json_ok(MediaInfoResponse {
@@ -131,7 +132,7 @@ pub fn get_media_info(
 
 /// DELETE /_synapse/admin/v1/media/{server_name}/{media_id}
 #[endpoint(operation_id = "delete_media")]
-pub fn delete_media(
+pub async fn delete_media(
     server_name: PathParam<OwnedServerName>,
     media_id: PathParam<String>,
 ) -> JsonResult<DeleteMediaResponse> {
@@ -142,10 +143,11 @@ pub fn delete_media(
         return Err(MatrixError::invalid_param("Can only delete local media").into());
     }
 
-    let _ = data::media::get_metadata(&server_name, &media_id)?
+    let _ = data::media::get_metadata(&server_name, &media_id)
+        .await?
         .ok_or_else(|| MatrixError::not_found("Unknown media"))?;
 
-    let (deleted_media, total) = data::media::delete_media_by_ids(&server_name, &[media_id])?;
+    let (deleted_media, total) = data::media::delete_media_by_ids(&server_name, &[media_id]).await?;
 
     json_ok(DeleteMediaResponse {
         deleted_media,
@@ -155,7 +157,7 @@ pub fn delete_media(
 
 /// POST /_synapse/admin/v1/media/delete
 #[endpoint(operation_id = "delete_media_by_date_size")]
-pub fn delete_media_by_date_size(
+pub async fn delete_media_by_date_size(
     query: DeleteMediaByDateSizeQuery,
 ) -> JsonResult<DeleteMediaResponse> {
     let before_ts = query.before_ts;
@@ -171,7 +173,7 @@ pub fn delete_media_by_date_size(
 
     let local_server = &config::get().server_name;
     let (deleted_media, total) =
-        data::media::delete_old_local_media(local_server, before_ts, size_gt)?;
+        data::media::delete_old_local_media(local_server, before_ts, size_gt).await?;
 
     json_ok(DeleteMediaResponse {
         deleted_media,
@@ -195,7 +197,7 @@ pub fn list_media_in_room(room_id: PathParam<OwnedRoomId>) -> JsonResult<RoomMed
 
 /// GET /_synapse/admin/v1/users/{user_id}/media
 #[endpoint(operation_id = "list_user_media")]
-pub fn list_user_media(
+pub async fn list_user_media(
     user_id: PathParam<OwnedUserId>,
     query: ListUserMediaQuery,
 ) -> JsonResult<UserMediaResponse> {
@@ -209,12 +211,12 @@ pub fn list_user_media(
         return Err(MatrixError::invalid_param("Can only look up local users").into());
     }
 
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("Unknown user").into());
     }
 
     let (media_list, total) =
-        data::media::list_media_by_user(&user_id, from, limit, order_by, dir)?;
+        data::media::list_media_by_user(&user_id, from, limit, order_by, dir).await?;
 
     let media: Vec<MediaInfo> = media_list.into_iter().map(Into::into).collect();
     let next_token = if (from + limit) < total {
@@ -232,7 +234,7 @@ pub fn list_user_media(
 
 /// DELETE /_synapse/admin/v1/users/{user_id}/media
 #[endpoint(operation_id = "delete_user_media")]
-pub fn delete_user_media(
+pub async fn delete_user_media(
     user_id: PathParam<OwnedUserId>,
     query: ListUserMediaQuery,
 ) -> JsonResult<DeleteMediaResponse> {
@@ -246,15 +248,16 @@ pub fn delete_user_media(
         return Err(MatrixError::invalid_param("Can only look up local users").into());
     }
 
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("Unknown user").into());
     }
 
-    let (media_list, _) = data::media::list_media_by_user(&user_id, from, limit, order_by, dir)?;
+    let (media_list, _) =
+        data::media::list_media_by_user(&user_id, from, limit, order_by, dir).await?;
     let media_ids: Vec<String> = media_list.iter().map(|m| m.media_id.clone()).collect();
 
     let local_server = &config::get().server_name;
-    let (deleted_media, total) = data::media::delete_media_by_ids(local_server, &media_ids)?;
+    let (deleted_media, total) = data::media::delete_media_by_ids(local_server, &media_ids).await?;
 
     json_ok(DeleteMediaResponse {
         deleted_media,
@@ -264,7 +267,9 @@ pub fn delete_user_media(
 
 /// POST /_synapse/admin/v1/purge_media_cache
 #[endpoint(operation_id = "purge_media_cache")]
-pub fn purge_media_cache(before_ts: QueryParam<i64, true>) -> JsonResult<PurgeMediaCacheResponse> {
+pub async fn purge_media_cache(
+    before_ts: QueryParam<i64, true>,
+) -> JsonResult<PurgeMediaCacheResponse> {
     let before_ts = before_ts.into_inner();
 
     if before_ts < 0 {
@@ -282,7 +287,7 @@ pub fn purge_media_cache(before_ts: QueryParam<i64, true>) -> JsonResult<PurgeMe
     }
 
     let local_server = &config::get().server_name;
-    let deleted = data::media::purge_remote_media_cache(local_server, before_ts)?;
+    let deleted = data::media::purge_remote_media_cache(local_server, before_ts).await?;
 
     json_ok(PurgeMediaCacheResponse { deleted })
 }

--- a/crates/server/src/routing/admin/register.rs
+++ b/crates/server/src/routing/admin/register.rs
@@ -15,11 +15,11 @@ struct AvailableResBody {
 /// An admin API to check if a given username is available, regardless of whether registration is
 /// enabled.
 #[endpoint]
-fn check_username_available(
+async fn check_username_available(
     _aa: AuthArgs,
     username: QueryParam<String, true>,
 ) -> JsonResult<AvailableResBody> {
-    if !user::is_username_available(&username)? {
+    if !user::is_username_available(&username).await? {
         Err(MatrixError::user_in_use("desired user id is invalid or already taken").into())
     } else {
         json_ok(AvailableResBody { available: true })

--- a/crates/server/src/routing/admin/registration_token.rs
+++ b/crates/server/src/routing/admin/registration_token.rs
@@ -95,10 +95,10 @@ pub fn router() -> Router {
 /// Optional query parameter:
 /// - valid: Filter by validity (true/false)
 #[endpoint(operation_id = "list_registration_tokens")]
-pub fn list_registration_tokens(
+pub async fn list_registration_tokens(
     query: ListRegistrationTokensQuery,
 ) -> JsonResult<ListRegistrationTokensResponse> {
-    let tokens = data::user::list_registration_tokens(query.valid)?;
+    let tokens = data::user::list_registration_tokens(query.valid).await?;
     let registration_tokens = tokens.into_iter().map(Into::into).collect();
     json_ok(ListRegistrationTokensResponse {
         registration_tokens,
@@ -115,7 +115,7 @@ pub fn list_registration_tokens(
 /// - uses_allowed: Maximum number of uses (null for unlimited)
 /// - expiry_time: Expiry timestamp in milliseconds (null for no expiry)
 #[endpoint(operation_id = "create_registration_token")]
-pub fn create_registration_token(
+pub async fn create_registration_token(
     body: JsonBody<CreateRegistrationTokenReqBody>,
 ) -> AppResult<Json<RegistrationTokenResponse>> {
     let body = body.into_inner();
@@ -168,7 +168,7 @@ pub fn create_registration_token(
 
     // Create the token
     let created =
-        data::user::create_registration_token(&token, body.uses_allowed, body.expiry_time)?;
+        data::user::create_registration_token(&token, body.uses_allowed, body.expiry_time).await?;
     if !created {
         return Err(MatrixError::invalid_param(format!("Token already exists: {}", token)).into());
     }
@@ -186,9 +186,12 @@ pub fn create_registration_token(
 ///
 /// GET /_synapse/admin/v1/registration_tokens/{token}
 #[endpoint(operation_id = "get_registration_token")]
-pub fn get_registration_token(token: PathParam<String>) -> JsonResult<RegistrationTokenResponse> {
+pub async fn get_registration_token(
+    token: PathParam<String>,
+) -> JsonResult<RegistrationTokenResponse> {
     let token = token.into_inner();
-    let token_info = data::user::get_registration_token(&token)?
+    let token_info = data::user::get_registration_token(&token)
+        .await?
         .ok_or_else(|| MatrixError::not_found(format!("No such registration token: {}", token)))?;
     json_ok(token_info.into())
 }
@@ -201,7 +204,7 @@ pub fn get_registration_token(token: PathParam<String>) -> JsonResult<Registrati
 /// - uses_allowed: New maximum number of uses (null for unlimited)
 /// - expiry_time: New expiry timestamp in milliseconds (null for no expiry)
 #[endpoint(operation_id = "update_registration_token")]
-pub fn update_registration_token(
+pub async fn update_registration_token(
     token: PathParam<String>,
     body: JsonBody<UpdateRegistrationTokenReqBody>,
 ) -> JsonResult<RegistrationTokenResponse> {
@@ -228,9 +231,9 @@ pub fn update_registration_token(
 
     // If nothing to update, just get the token info
     let token_info = if body.uses_allowed.is_none() && body.expiry_time.is_none() {
-        data::user::get_registration_token(&token)?
+        data::user::get_registration_token(&token).await?
     } else {
-        data::user::update_registration_token(&token, body.uses_allowed, body.expiry_time)?
+        data::user::update_registration_token(&token, body.uses_allowed, body.expiry_time).await?
     };
 
     let token_info = token_info
@@ -243,9 +246,9 @@ pub fn update_registration_token(
 ///
 /// DELETE /_synapse/admin/v1/registration_tokens/{token}
 #[endpoint(operation_id = "delete_registration_token")]
-pub fn delete_registration_token(token: PathParam<String>) -> EmptyResult {
+pub async fn delete_registration_token(token: PathParam<String>) -> EmptyResult {
     let token = token.into_inner();
-    let deleted = data::user::delete_registration_token(&token)?;
+    let deleted = data::user::delete_registration_token(&token).await?;
     if !deleted {
         return Err(
             MatrixError::not_found(format!("No such registration token: {}", token)).into(),

--- a/crates/server/src/routing/admin/room.rs
+++ b/crates/server/src/routing/admin/room.rs
@@ -150,58 +150,67 @@ pub struct ForwardExtremity {
     pub received_ts: i64,
 }
 
-fn get_detailed_room_info(room_id: &RoomId) -> RoomInfoResponse {
-    let basic_info = admin::get_room_info(room_id);
+async fn get_detailed_room_info(room_id: &RoomId) -> RoomInfoResponse {
+    let basic_info = admin::get_room_info(room_id).await;
 
     let version = room::get_version(room_id)
+        .await
         .map(|v| v.to_string())
         .unwrap_or_else(|_| "unknown".to_string());
 
     let creator = room::get_create(room_id)
+        .await
         .ok()
         .and_then(|c| c.creator().ok().map(|u| u.to_string()));
 
     let canonical_alias = room::get_canonical_alias(room_id)
+        .await
         .ok()
         .flatten()
         .map(|a| a.to_string());
 
-    let encryption = room::get_encryption(room_id).ok().map(|e| e.to_string());
+    let encryption = room::get_encryption(room_id).await.ok().map(|e| e.to_string());
 
     let join_rules = room::get_join_rule(room_id)
+        .await
         .ok()
         .map(|r| format!("{:?}", r).to_lowercase());
 
     let history_visibility = room::get_history_visibility(room_id)
+        .await
         .ok()
         .map(|h| format!("{:?}", h).to_lowercase());
 
-    let topic = room::get_topic(room_id).ok();
+    let topic = room::get_topic(room_id).await.ok();
 
     let avatar = room::get_avatar_url(room_id)
+        .await
         .ok()
         .flatten()
         .map(|u| u.to_string());
 
     let room_type = room::get_room_type(room_id)
+        .await
         .ok()
         .flatten()
         .map(|t| t.to_string());
 
     let joined_local_members = room::local_users_in_room(room_id)
+        .await
         .map(|u| u.len() as u64)
         .unwrap_or(0);
 
-    let state_events = room::get_current_frame_id(room_id)
-        .ok()
-        .flatten()
-        .and_then(|frame_id| room::state::get_full_state_ids(frame_id).ok())
-        .map(|s| s.len() as u64)
-        .unwrap_or(0);
+    let state_events = match room::get_current_frame_id(room_id).await.ok().flatten() {
+        Some(frame_id) => room::state::get_full_state_ids(frame_id)
+            .await
+            .map(|s| s.len() as u64)
+            .unwrap_or(0),
+        None => 0,
+    };
 
-    let guest_access = room::guest_can_join(room_id);
+    let guest_access = room::guest_can_join(room_id).await;
 
-    let is_public = crate::data::room::is_public(room_id).unwrap_or(false);
+    let is_public = crate::data::room::is_public(room_id).await.unwrap_or(false);
 
     RoomInfoResponse {
         room_id: room_id.to_string(),
@@ -234,7 +243,7 @@ fn get_detailed_room_info(room_id: &RoomId) -> RoomInfoResponse {
 
 /// List all rooms
 #[endpoint]
-pub fn list_rooms(
+pub async fn list_rooms(
     from: QueryParam<i64, false>,
     limit: QueryParam<i64, false>,
     order_by: QueryParam<String, false>,
@@ -247,12 +256,12 @@ pub fn list_rooms(
     let dir = dir.into_inner().unwrap_or_else(|| "f".to_string());
     let order_by_field = order_by.into_inner().unwrap_or_else(|| "name".to_string());
 
-    let all_rooms = crate::room::all_room_ids()?;
+    let all_rooms = crate::room::all_room_ids().await?;
 
-    let mut rooms: Vec<RoomInfoResponse> = all_rooms
-        .iter()
-        .map(|room_id| get_detailed_room_info(room_id))
-        .collect();
+    let mut rooms: Vec<RoomInfoResponse> = Vec::with_capacity(all_rooms.len());
+    for room_id in &all_rooms {
+        rooms.push(get_detailed_room_info(room_id).await);
+    }
 
     // Filter by search term
     if let Some(ref term) = search_term {
@@ -315,14 +324,14 @@ pub fn list_rooms(
 
 /// Get room details
 #[endpoint]
-pub fn get_room(room_id: PathParam<OwnedRoomId>) -> JsonResult<RoomInfoResponse> {
+pub async fn get_room(room_id: PathParam<OwnedRoomId>) -> JsonResult<RoomInfoResponse> {
     let room_id = room_id.into_inner();
 
-    if !room::room_exists(&room_id)? {
+    if !room::room_exists(&room_id).await? {
         return Err(MatrixError::not_found("Room not found").into());
     }
 
-    json_ok(get_detailed_room_info(&room_id))
+    json_ok(get_detailed_room_info(&room_id).await)
 }
 
 /// Get room hierarchy
@@ -339,14 +348,14 @@ pub async fn get_hierarchy(
 
 /// Get room members
 #[endpoint]
-pub fn get_room_members(room_id: PathParam<OwnedRoomId>) -> JsonResult<RoomMembersResponse> {
+pub async fn get_room_members(room_id: PathParam<OwnedRoomId>) -> JsonResult<RoomMembersResponse> {
     let room_id = room_id.into_inner();
 
-    if !room::room_exists(&room_id)? {
+    if !room::room_exists(&room_id).await? {
         return Err(MatrixError::not_found("Room not found").into());
     }
 
-    let members = room::get_members(&room_id)?;
+    let members = room::get_members(&room_id).await?;
     let total = members.len() as u64;
     let members: Vec<String> = members.into_iter().map(|u| u.to_string()).collect();
 
@@ -355,17 +364,18 @@ pub fn get_room_members(room_id: PathParam<OwnedRoomId>) -> JsonResult<RoomMembe
 
 /// Get room state
 #[endpoint]
-pub fn get_room_state(room_id: PathParam<OwnedRoomId>) -> JsonResult<RoomStateResponse> {
+pub async fn get_room_state(room_id: PathParam<OwnedRoomId>) -> JsonResult<RoomStateResponse> {
     let room_id = room_id.into_inner();
 
-    if !room::room_exists(&room_id)? {
+    if !room::room_exists(&room_id).await? {
         return Err(MatrixError::not_found("Room not found").into());
     }
 
-    let frame_id = room::get_current_frame_id(&room_id)?
+    let frame_id = room::get_current_frame_id(&room_id)
+        .await?
         .ok_or_else(|| MatrixError::not_found("Room has no state"))?;
 
-    let state_map = room::state::get_full_state(frame_id)?;
+    let state_map = room::state::get_full_state(frame_id).await?;
 
     let state: Vec<JsonValue> = state_map
         .values()
@@ -377,7 +387,7 @@ pub fn get_room_state(room_id: PathParam<OwnedRoomId>) -> JsonResult<RoomStateRe
 
 /// Get room messages
 #[endpoint]
-pub fn get_room_messages(
+pub async fn get_room_messages(
     room_id: PathParam<OwnedRoomId>,
     from: QueryParam<String, false>,
     limit: QueryParam<i64, false>,
@@ -388,7 +398,7 @@ pub fn get_room_messages(
     let limit = limit.into_inner().unwrap_or(10).clamp(1, 1000);
     let dir = dir.into_inner().unwrap_or_else(|| "b".to_string()); // Default backward like Synapse
 
-    if !room::room_exists(&room_id)? {
+    if !room::room_exists(&room_id).await? {
         return Err(MatrixError::not_found("Room not found").into());
     }
 
@@ -401,17 +411,17 @@ pub fn get_room_messages(
         .and_then(|s| s.parse().ok());
 
     let db_events =
-        crate::data::room::timeline::get_pdus_by_room(&room_id, from_sn, limit, backward)?;
+        crate::data::room::timeline::get_pdus_by_room(&room_id, from_sn, limit, backward).await?;
 
     // Get actual PDU content from event_datas
-    let chunk: Vec<JsonValue> = db_events
-        .iter()
-        .filter_map(|e| {
-            room::timeline::get_pdu(&e.id)
-                .ok()
-                .and_then(|pdu| serde_json::to_value(&pdu.pdu).ok())
-        })
-        .collect();
+    let mut chunk: Vec<JsonValue> = Vec::new();
+    for e in &db_events {
+        if let Ok(pdu) = room::timeline::get_pdu(&e.id).await
+            && let Ok(value) = serde_json::to_value(&pdu.pdu)
+        {
+            chunk.push(value);
+        }
+    }
 
     let start = from_token.unwrap_or_else(|| {
         db_events
@@ -426,9 +436,9 @@ pub fn get_room_messages(
 
 /// Get room block status
 #[endpoint]
-pub fn get_room_block(room_id: PathParam<OwnedRoomId>) -> JsonResult<RoomBlockStatus> {
+pub async fn get_room_block(room_id: PathParam<OwnedRoomId>) -> JsonResult<RoomBlockStatus> {
     let room_id = room_id.into_inner();
-    let blocked = crate::data::room::is_banned(&room_id).unwrap_or(false);
+    let blocked = crate::data::room::is_banned(&room_id).await.unwrap_or(false);
 
     json_ok(RoomBlockStatus {
         block: blocked,
@@ -438,14 +448,14 @@ pub fn get_room_block(room_id: PathParam<OwnedRoomId>) -> JsonResult<RoomBlockSt
 
 /// Set room block status
 #[endpoint]
-pub fn set_room_block(
+pub async fn set_room_block(
     room_id: PathParam<OwnedRoomId>,
     body: JsonBody<RoomBlockStatus>,
 ) -> JsonResult<RoomBlockStatus> {
     let room_id = room_id.into_inner();
     let body = body.into_inner();
 
-    room::ban_room(&room_id, body.block)?;
+    room::ban_room(&room_id, body.block).await?;
 
     json_ok(RoomBlockStatus {
         block: body.block,
@@ -466,32 +476,33 @@ pub async fn delete_room(
     let room_id = room_id.into_inner();
     let body = body.into_inner();
 
-    if !room::room_exists(&room_id)? {
+    if !room::room_exists(&room_id).await? {
         return Err(MatrixError::not_found("Room not found").into());
     }
 
-    let members = room::get_members(&room_id)?;
+    let members = room::get_members(&room_id).await?;
     let kicked_users: Vec<String> = members
         .iter()
         .filter(|m| m.server_name().is_local())
         .map(|m| m.to_string())
         .collect();
 
-    let local_aliases: Vec<String> = room::local_aliases_for_room(&room_id)?
+    let local_aliases: Vec<String> = room::local_aliases_for_room(&room_id)
+        .await?
         .into_iter()
         .map(|a| a.to_string())
         .collect();
 
     if body.block {
-        room::ban_room(&room_id, true)?;
+        room::ban_room(&room_id, true).await?;
     }
 
     // Disable the room (prevents new joins/messages)
-    room::disable_room(&room_id, true)?;
+    room::disable_room(&room_id, true).await?;
 
     if body.purge {
         // Purge all non-state events by using a far-future timestamp
-        let _ = crate::data::room::timeline::purge_room_history(&room_id, i64::MAX);
+        let _ = crate::data::room::timeline::purge_room_history(&room_id, i64::MAX).await;
     }
 
     json_ok(DeleteRoomResponse {
@@ -520,14 +531,14 @@ pub struct PurgeHistoryResponse {
 
 /// Purge room history before a given timestamp or event
 #[endpoint]
-pub fn purge_history(
+pub async fn purge_history(
     room_id: PathParam<OwnedRoomId>,
     body: JsonBody<PurgeHistoryReqBody>,
 ) -> JsonResult<PurgeHistoryResponse> {
     let room_id = room_id.into_inner();
     let body = body.into_inner();
 
-    if !room::room_exists(&room_id)? {
+    if !room::room_exists(&room_id).await? {
         return Err(MatrixError::not_found("Room not found").into());
     }
 
@@ -537,6 +548,7 @@ pub fn purge_history(
         let event_id = <&EventId>::try_from(event_id.as_str())
             .map_err(|_| MatrixError::invalid_param("Invalid event_id"))?;
         let sn_pdu = room::timeline::get_pdu(event_id)
+            .await
             .map_err(|_| MatrixError::not_found("Event not found"))?;
         sn_pdu.pdu.origin_server_ts.get() as i64
     } else {
@@ -546,7 +558,8 @@ pub fn purge_history(
         .into());
     };
 
-    let deleted_events = crate::data::room::timeline::purge_room_history(&room_id, before_ts)?;
+    let deleted_events =
+        crate::data::room::timeline::purge_room_history(&room_id, before_ts).await?;
 
     let purge_id = format!("{}_{}", room_id, chrono::Utc::now().timestamp_millis());
 
@@ -558,30 +571,28 @@ pub fn purge_history(
 
 /// Get forward extremities
 #[endpoint]
-pub fn get_forward_extremities(
+pub async fn get_forward_extremities(
     room_id: PathParam<OwnedRoomId>,
 ) -> JsonResult<ForwardExtremitiesResponse> {
     let room_id = room_id.into_inner();
 
-    if !room::room_exists(&room_id)? {
+    if !room::room_exists(&room_id).await? {
         return Err(MatrixError::not_found("Room not found").into());
     }
 
-    let extremities = room::state::get_forward_extremities(&room_id)?;
+    let extremities = room::state::get_forward_extremities(&room_id).await?;
 
-    let results: Vec<ForwardExtremity> = extremities
-        .into_iter()
-        .filter_map(|event_id| {
-            room::timeline::get_pdu(&event_id)
-                .ok()
-                .map(|pdu| ForwardExtremity {
-                    event_id: event_id.to_string(),
-                    state_group: None,
-                    depth: pdu.depth as i64,
-                    received_ts: pdu.origin_server_ts.get() as i64,
-                })
-        })
-        .collect();
+    let mut results: Vec<ForwardExtremity> = Vec::new();
+    for event_id in extremities {
+        if let Ok(pdu) = room::timeline::get_pdu(&event_id).await {
+            results.push(ForwardExtremity {
+                event_id: event_id.to_string(),
+                state_group: None,
+                depth: pdu.depth as i64,
+                received_ts: pdu.origin_server_ts.get() as i64,
+            });
+        }
+    }
 
     json_ok(ForwardExtremitiesResponse {
         count: results.len() as u64,

--- a/crates/server/src/routing/admin/server_notice.rs
+++ b/crates/server/src/routing/admin/server_notice.rs
@@ -71,7 +71,7 @@ pub async fn send_server_notice(
         );
     }
 
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
 
@@ -80,10 +80,10 @@ pub async fn send_server_notice(
     // Find an existing shared room between the server user and the target,
     // or create one if none exists.
     let server_user = crate::config::server_user_id();
-    let rooms = crate::data::user::joined_rooms(&user_id)?;
+    let rooms = crate::data::user::joined_rooms(&user_id).await?;
     let mut notice_room = None;
     for room_id in &rooms {
-        if crate::room::user::is_joined(server_user, room_id)? {
+        if crate::room::user::is_joined(server_user, room_id).await? {
             notice_room = Some(room_id.clone());
             break;
         }
@@ -95,7 +95,7 @@ pub async fn send_server_notice(
     };
 
     let state_lock = crate::room::lock_state(&room_id).await;
-    let room_version = crate::room::get_version(&room_id)?;
+    let room_version = crate::room::get_version(&room_id).await?;
 
     let pdu = if event_type == "m.room.message" {
         let content: RoomMessageEventContent = serde_json::from_value(body.content)
@@ -152,7 +152,7 @@ async fn create_notice_room(
         RoomIdFormatVersion::V1 => {
             let room_id = RoomId::new_v1(&conf.server_name);
             let state_lock = room::lock_state(&room_id).await;
-            room::ensure_room(&room_id, &room_version)?;
+            room::ensure_room(&room_id, &room_version).await?;
 
             // 1. Room create event
             timeline::build_and_append_pdu(
@@ -175,7 +175,7 @@ async fn create_notice_room(
             let temp_room_id =
                 OwnedRoomId::try_from("!placehold").expect("placeholder room id is valid");
             let temp_lock = room::lock_state(&temp_room_id).await;
-            room::ensure_room(&temp_room_id, &room_version)?;
+            room::ensure_room(&temp_room_id, &room_version).await?;
 
             // 1. Room create event, using a placeholder room_id
             let create_event = timeline::build_and_append_pdu(
@@ -199,13 +199,15 @@ async fn create_notice_room(
     };
 
     // 2. Server user joins
+    let server_display_name = data::user::display_name(server_user).await.ok().flatten();
+    let server_avatar_url = data::user::avatar_url(server_user).await.ok().flatten();
     timeline::build_and_append_pdu(
         PduBuilder {
             event_type: TimelineEventType::RoomMember,
             content: to_raw_value(&RoomMemberEventContent {
                 membership: MembershipState::Join,
-                display_name: data::user::display_name(server_user).ok().flatten(),
-                avatar_url: data::user::avatar_url(server_user).ok().flatten(),
+                display_name: server_display_name,
+                avatar_url: server_avatar_url,
                 is_direct: Some(true),
                 third_party_invite: None,
                 blurhash: None,
@@ -334,13 +336,15 @@ async fn create_notice_room(
     .await?;
 
     // 9. Auto-join target user
+    let target_display_name = data::user::display_name(target_user).await.ok().flatten();
+    let target_avatar_url = data::user::avatar_url(target_user).await.ok().flatten();
     timeline::build_and_append_pdu(
         PduBuilder {
             event_type: TimelineEventType::RoomMember,
             content: to_raw_value(&RoomMemberEventContent {
                 membership: MembershipState::Join,
-                display_name: data::user::display_name(target_user).ok().flatten(),
-                avatar_url: data::user::avatar_url(target_user).ok().flatten(),
+                display_name: target_display_name,
+                avatar_url: target_avatar_url,
                 is_direct: Some(true),
                 third_party_invite: None,
                 blurhash: None,

--- a/crates/server/src/routing/admin/statistic.rs
+++ b/crates/server/src/routing/admin/statistic.rs
@@ -49,7 +49,7 @@ pub struct UserMediaStats {
 ///
 /// Get statistics about uploaded media by users
 #[endpoint]
-pub fn user_media_statistics(
+pub async fn user_media_statistics(
     from: QueryParam<i64, false>,
     limit: QueryParam<i64, false>,
     order_by: QueryParam<String, false>,
@@ -68,7 +68,8 @@ pub fn user_media_statistics(
         search_term.as_deref(),
         order_by.as_deref(),
         dir.as_deref(),
-    )?;
+    )
+    .await?;
 
     let next_token = if from + limit < total {
         Some((from + limit).to_string())

--- a/crates/server/src/routing/admin/user.rs
+++ b/crates/server/src/routing/admin/user.rs
@@ -75,10 +75,10 @@ fn to_admin_device_response(device: data::user::device::DbUserDevice) -> AdminDe
 }
 
 #[endpoint]
-pub fn list_devices(user_id: PathParam<OwnedUserId>) -> JsonResult<AdminDevicesListResponse> {
+pub async fn list_devices(user_id: PathParam<OwnedUserId>) -> JsonResult<AdminDevicesListResponse> {
     let user_id = user_id.into_inner();
 
-    let devices = data::user::device::get_devices(&user_id)?;
+    let devices = data::user::device::get_devices(&user_id).await?;
     let total = devices.len() as i64;
     let devices = devices.into_iter().map(to_admin_device_response).collect();
 
@@ -86,14 +86,14 @@ pub fn list_devices(user_id: PathParam<OwnedUserId>) -> JsonResult<AdminDevicesL
 }
 
 #[endpoint]
-pub fn create_device(
+pub async fn create_device(
     user_id: PathParam<OwnedUserId>,
     body: JsonBody<CreateDeviceReqBody>,
 ) -> EmptyResult {
     let user_id = user_id.into_inner();
     let body = body.into_inner();
 
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
 
@@ -103,30 +103,30 @@ pub fn create_device(
 
     let device_id = OwnedDeviceId::from(device_id_str.as_str());
 
-    if data::user::device::is_device_exists(&user_id, &device_id)? {
+    if data::user::device::is_device_exists(&user_id, &device_id).await? {
         return empty_ok();
     }
 
     let token = utils::random_string(64);
 
-    data::user::device::create_device(&user_id, &device_id, &token, body.display_name, None)?;
+    data::user::device::create_device(&user_id, &device_id, &token, body.display_name, None).await?;
 
     empty_ok()
 }
 
 #[endpoint]
-pub fn get_device(
+pub async fn get_device(
     user_id: PathParam<OwnedUserId>,
     device_id: PathParam<OwnedDeviceId>,
 ) -> JsonResult<AdminDeviceResponse> {
-    let Ok(device) = data::user::device::get_device(&user_id, &device_id) else {
+    let Ok(device) = data::user::device::get_device(&user_id, &device_id).await else {
         return Err(MatrixError::not_found("device is not found.").into());
     };
     json_ok(to_admin_device_response(device))
 }
 
 #[endpoint]
-pub fn put_device(
+pub async fn put_device(
     user_id: PathParam<OwnedUserId>,
     device_id: PathParam<OwnedDeviceId>,
     body: JsonBody<UpdateDeviceReqBody>,
@@ -138,36 +138,36 @@ pub fn put_device(
         last_seen_ip: None,
         last_seen_at: None,
     };
-    let Ok(device) = data::user::device::update_device(&user_id, &device_id, update) else {
+    let Ok(device) = data::user::device::update_device(&user_id, &device_id, update).await else {
         return Err(MatrixError::not_found("device is not found.").into());
     };
     json_ok(to_admin_device_response(device))
 }
 
 #[endpoint]
-pub fn delete_device(
+pub async fn delete_device(
     user_id: PathParam<OwnedUserId>,
     device_id: PathParam<OwnedDeviceId>,
 ) -> EmptyResult {
-    data::user::device::remove_device(&user_id, &device_id)?;
+    data::user::device::remove_device(&user_id, &device_id).await?;
     empty_ok()
 }
 
 #[endpoint]
-pub fn delete_devices(
+pub async fn delete_devices(
     user_id: PathParam<OwnedUserId>,
     body: JsonBody<DeleteDevicesReqBody>,
 ) -> EmptyResult {
     let user_id = user_id.into_inner();
     let body = body.into_inner();
 
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
 
     for device_id in body.devices {
         let device_id: OwnedDeviceId = device_id.into();
-        let _ = data::user::device::remove_device(&user_id, &device_id);
+        let _ = data::user::device::remove_device(&user_id, &device_id).await;
     }
 
     empty_ok()

--- a/crates/server/src/routing/admin/user_admin.rs
+++ b/crates/server/src/routing/admin/user_admin.rs
@@ -230,13 +230,14 @@ pub struct RateLimitResponse {
 // Helper functions
 // ============================================================================
 
-fn build_user_info(user_id: &UserId) -> crate::AppResult<UserInfoV2> {
-    let db_user =
-        data::user::get_user(user_id).map_err(|_| MatrixError::not_found("User not found"))?;
+async fn build_user_info(user_id: &UserId) -> crate::AppResult<UserInfoV2> {
+    let db_user = data::user::get_user(user_id)
+        .await
+        .map_err(|_| MatrixError::not_found("User not found"))?;
 
-    let display_name = data::user::display_name(user_id).ok().flatten();
-    let avatar_url = data::user::avatar_url(user_id).ok().flatten();
-    let threepids = data::user::get_threepids(user_id).ok().map(|tps| {
+    let display_name = data::user::display_name(user_id).await.ok().flatten();
+    let avatar_url = data::user::avatar_url(user_id).await.ok().flatten();
+    let threepids = data::user::get_threepids(user_id).await.ok().map(|tps| {
         tps.into_iter()
             .map(|tp| ThreepidInfo {
                 medium: tp.medium,
@@ -247,6 +248,7 @@ fn build_user_info(user_id: &UserId) -> crate::AppResult<UserInfoV2> {
             .collect()
     });
     let external_ids = data::user::get_external_ids_by_user(user_id)
+        .await
         .ok()
         .map(|eids| {
             eids.into_iter()
@@ -277,38 +279,38 @@ fn build_user_info(user_id: &UserId) -> crate::AppResult<UserInfoV2> {
     })
 }
 
-fn build_users_list(filter: &data::user::ListUsersFilter) -> crate::AppResult<UsersListResponse> {
-    let (users, total) = data::user::list_users(filter)?;
+async fn build_users_list(
+    filter: &data::user::ListUsersFilter,
+) -> crate::AppResult<UsersListResponse> {
+    let (users, total) = data::user::list_users(filter).await?;
     let limit = filter.limit.unwrap_or(100) as usize;
     let from = filter.from.unwrap_or(0) as usize;
 
-    let user_infos: Vec<UserInfoV2> = users
-        .into_iter()
-        .map(|db_user| {
-            let uid = &db_user.id;
-            let display_name = data::user::display_name(uid).ok().flatten();
-            let avatar_url = data::user::avatar_url(uid).ok().flatten();
+    let mut user_infos: Vec<UserInfoV2> = Vec::new();
+    for db_user in users.into_iter() {
+        let uid = &db_user.id;
+        let display_name = data::user::display_name(uid).await.ok().flatten();
+        let avatar_url = data::user::avatar_url(uid).await.ok().flatten();
 
-            UserInfoV2 {
-                name: uid.to_string(),
-                displayname: display_name,
-                threepids: None, // Not included in list response for performance
-                avatar_url: avatar_url.map(|u| u.to_string()),
-                is_guest: db_user.is_guest,
-                admin: db_user.is_admin,
-                deactivated: db_user.deactivated_at.is_some(),
-                shadow_banned: db_user.shadow_banned,
-                locked: db_user.locked_at.is_some(),
-                creation_ts: db_user.created_at.get() as i64,
-                appservice_id: db_user.appservice_id,
-                consent_version: db_user.consent_version,
-                consent_ts: db_user.consent_at.map(|t| t.get() as i64),
-                consent_server_notice_sent: db_user.consent_server_notice_sent,
-                user_type: db_user.ty,
-                external_ids: None,
-            }
-        })
-        .collect();
+        user_infos.push(UserInfoV2 {
+            name: uid.to_string(),
+            displayname: display_name,
+            threepids: None, // Not included in list response for performance
+            avatar_url: avatar_url.map(|u| u.to_string()),
+            is_guest: db_user.is_guest,
+            admin: db_user.is_admin,
+            deactivated: db_user.deactivated_at.is_some(),
+            shadow_banned: db_user.shadow_banned,
+            locked: db_user.locked_at.is_some(),
+            creation_ts: db_user.created_at.get() as i64,
+            appservice_id: db_user.appservice_id,
+            consent_version: db_user.consent_version,
+            consent_ts: db_user.consent_at.map(|t| t.get() as i64),
+            consent_server_notice_sent: db_user.consent_server_notice_sent,
+            user_type: db_user.ty,
+            external_ids: None,
+        });
+    }
 
     let next_token = if user_infos.len() >= limit {
         Some((from + user_infos.len()).to_string())
@@ -333,7 +335,7 @@ fn build_users_list(filter: &data::user::ListUsersFilter) -> crate::AppResult<Us
 #[endpoint]
 pub async fn get_user_v2(user_id: PathParam<OwnedUserId>) -> JsonResult<UserInfoV2> {
     let user_id = user_id.into_inner();
-    json_ok(build_user_info(&user_id)?)
+    json_ok(build_user_info(&user_id).await?)
 }
 
 /// PUT /_synapse/admin/v2/users/{user_id}
@@ -349,27 +351,27 @@ pub async fn put_user_v2(
     let body = body.into_inner();
 
     // Check if user exists
-    let user_exists = data::user::user_exists(&user_id).unwrap_or(false);
+    let user_exists = data::user::user_exists(&user_id).await.unwrap_or(false);
 
     if !user_exists {
         // Create new user
-        user::create_user(user_id.clone(), body.password.as_deref())?;
+        user::create_user(user_id.clone(), body.password.as_deref()).await?;
         res.status_code(salvo::http::StatusCode::CREATED);
     } else {
         // Update password if provided
         if let Some(password) = &body.password {
-            crate::user::set_password(&user_id, password)?;
+            crate::user::set_password(&user_id, password).await?;
 
             // Logout devices if requested
             if body.logout_devices.unwrap_or(true) {
-                data::user::remove_all_devices(&user_id)?;
+                data::user::remove_all_devices(&user_id).await?;
             }
         }
     }
 
     // Update display name
     if let Some(display_name) = &body.displayname {
-        data::user::set_display_name(&user_id, display_name)?;
+        data::user::set_display_name(&user_id, display_name).await?;
     }
 
     // Update threepids
@@ -378,37 +380,37 @@ pub async fn put_user_v2(
             .into_iter()
             .map(|tp| (tp.medium, tp.address, tp.added_at, tp.validated_at))
             .collect();
-        data::user::replace_threepids(&user_id, &entries)?;
+        data::user::replace_threepids(&user_id, &entries).await?;
     }
 
     // Update avatar
     if let Some(avatar_url) = &body.avatar_url {
         let mxc_uri: &MxcUri = avatar_url.as_str().into();
-        data::user::set_avatar_url(&user_id, mxc_uri)?;
+        data::user::set_avatar_url(&user_id, mxc_uri).await?;
     }
 
     // Update admin status
     if let Some(admin) = body.admin {
-        data::user::set_admin(&user_id, admin)?;
+        data::user::set_admin(&user_id, admin).await?;
     }
 
     // Update deactivated status
     if let Some(deactivated) = body.deactivated {
         if deactivated {
-            data::user::deactivate(&user_id)?;
+            data::user::deactivate(&user_id).await?;
         } else {
-            data::user::reactivate(&user_id)?;
+            data::user::reactivate(&user_id).await?;
         }
     }
 
     // Update locked status
     if let Some(locked) = body.locked {
-        data::user::set_locked(&user_id, locked, None)?;
+        data::user::set_locked(&user_id, locked, None).await?;
     }
 
     // Update user type
     if let Some(user_type) = body.user_type {
-        data::user::set_user_type(&user_id, Some(user_type.as_str()))?;
+        data::user::set_user_type(&user_id, Some(user_type.as_str())).await?;
     }
 
     // Update external IDs if provided
@@ -417,11 +419,11 @@ pub async fn put_user_v2(
             .into_iter()
             .map(|eid| (eid.auth_provider, eid.external_id))
             .collect();
-        data::user::replace_external_ids(&user_id, &ids)?;
+        data::user::replace_external_ids(&user_id, &ids).await?;
     }
 
     // Return updated user info
-    json_ok(build_user_info(&user_id)?)
+    json_ok(build_user_info(&user_id).await?)
 }
 
 /// GET /_synapse/admin/v2/users
@@ -452,7 +454,7 @@ pub async fn list_users_v2(
         dir: dir.into_inner(),
     };
 
-    json_ok(build_users_list(&filter)?)
+    json_ok(build_users_list(&filter).await?)
 }
 
 /// GET /_synapse/admin/v3/users
@@ -488,7 +490,7 @@ pub async fn list_users_v3(
         dir: dir.into_inner(),
     };
 
-    json_ok(build_users_list(&filter)?)
+    json_ok(build_users_list(&filter).await?)
 }
 
 /// POST /_synapse/admin/v1/users/{user_id}/_allow_cross_signing_replacement_without_uia
@@ -502,19 +504,19 @@ pub async fn allow_cross_signing_replacement(
     let user_id = user_id.into_inner();
 
     // Verify user exists
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
 
     // Check if user has a master cross-signing key
-    if !data::user::key::has_master_cross_signing_key(&user_id)? {
+    if !data::user::key::has_master_cross_signing_key(&user_id).await? {
         return Err(MatrixError::not_found("User has no master cross-signing key").into());
     }
 
     // Allow replacement for 10 minutes
     let now_ms = crate::core::UnixMillis::now().get() as i64;
     let expires_ts = now_ms + 10 * 60 * 1000;
-    data::user::key::set_cross_signing_replacement_allowed(&user_id, expires_ts)?;
+    data::user::key::set_cross_signing_replacement_allowed(&user_id, expires_ts).await?;
 
     json_ok(CrossSigningResponse {
         updatable_without_uia_before_ms: Some(expires_ts),
@@ -537,12 +539,12 @@ pub async fn deactivate_user(
     let body = body.into_inner();
 
     // Verify user exists
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
 
     // Get all joined rooms before deactivation
-    let joined_rooms = data::user::joined_rooms(&user_id)?;
+    let joined_rooms = data::user::joined_rooms(&user_id).await?;
 
     // Perform full deactivation
     user::full_user_deactivate(&user_id, &joined_rooms).await?;
@@ -568,16 +570,16 @@ pub async fn reset_password(
     let body = body.into_inner();
 
     // Verify user exists
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
 
     // Hash and set new password
-    crate::user::set_password(&user_id, &body.new_password)?;
+    crate::user::set_password(&user_id, &body.new_password).await?;
 
     // Logout all devices if requested (default true)
     if body.logout_devices.unwrap_or(true) {
-        data::user::remove_all_devices(&user_id)?;
+        data::user::remove_all_devices(&user_id).await?;
     }
 
     empty_ok()
@@ -590,8 +592,9 @@ pub async fn reset_password(
 pub async fn get_admin_status(user_id: PathParam<OwnedUserId>) -> JsonResult<AdminStatusResponse> {
     let user_id = user_id.into_inner();
 
-    let is_admin =
-        data::user::is_admin(&user_id).map_err(|_| MatrixError::not_found("User not found"))?;
+    let is_admin = data::user::is_admin(&user_id)
+        .await
+        .map_err(|_| MatrixError::not_found("User not found"))?;
 
     json_ok(AdminStatusResponse { admin: is_admin })
 }
@@ -608,11 +611,11 @@ pub async fn set_admin_status(
     let body = body.into_inner();
 
     // Verify user exists
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
 
-    data::user::set_admin(&user_id, body.admin)?;
+    data::user::set_admin(&user_id, body.admin).await?;
 
     empty_ok()
 }
@@ -625,11 +628,11 @@ pub async fn shadow_ban_user(user_id: PathParam<OwnedUserId>) -> EmptyResult {
     let user_id = user_id.into_inner();
 
     // Verify user exists
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
 
-    data::user::set_shadow_banned(&user_id, true)?;
+    data::user::set_shadow_banned(&user_id, true).await?;
 
     empty_ok()
 }
@@ -642,11 +645,11 @@ pub async fn unshadow_ban_user(user_id: PathParam<OwnedUserId>) -> EmptyResult {
     let user_id = user_id.into_inner();
 
     // Verify user exists
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
 
-    data::user::set_shadow_banned(&user_id, false)?;
+    data::user::set_shadow_banned(&user_id, false).await?;
 
     empty_ok()
 }
@@ -663,11 +666,11 @@ pub async fn suspend_user(
     let body = body.into_inner();
 
     // Verify user exists
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
 
-    data::user::set_suspended(&user_id, body.suspend)?;
+    data::user::set_suspended(&user_id, body.suspend).await?;
 
     json_ok(SuspendResponse {
         user_id: user_id.to_string(),
@@ -687,12 +690,12 @@ pub async fn whois_user(user_id: PathParam<OwnedUserId>) -> JsonResult<WhoisResp
     let user_id = user_id.into_inner();
 
     // Verify user exists
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
 
     // Get user's devices and session info
-    let devices = data::user::device::get_devices(&user_id)?;
+    let devices = data::user::device::get_devices(&user_id).await?;
     let mut device_map = std::collections::HashMap::new();
 
     for device in devices {
@@ -730,11 +733,11 @@ pub async fn user_joined_rooms(user_id: PathParam<OwnedUserId>) -> JsonResult<Jo
     let user_id = user_id.into_inner();
 
     // Verify user exists
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
 
-    let rooms = data::user::joined_rooms(&user_id)?;
+    let rooms = data::user::joined_rooms(&user_id).await?;
     let total = rooms.len() as i64;
 
     json_ok(JoinedRoomsResponse {
@@ -751,11 +754,11 @@ pub async fn user_pushers(user_id: PathParam<OwnedUserId>) -> JsonResult<Pushers
     let user_id = user_id.into_inner();
 
     // Verify user exists
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
 
-    let pushers = data::user::pusher::get_pushers(&user_id)?;
+    let pushers = data::user::pusher::get_pushers(&user_id).await?;
     let total = pushers.len() as i64;
 
     let pusher_list: Vec<serde_json::Value> = pushers
@@ -786,12 +789,12 @@ pub async fn user_account_data(user_id: PathParam<OwnedUserId>) -> JsonResult<Ac
     let user_id = user_id.into_inner();
 
     // Verify user exists
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
 
-    let global_data = data::user::get_global_account_data(&user_id)?;
-    let room_data = data::user::get_room_account_data(&user_id)?;
+    let global_data = data::user::get_global_account_data(&user_id).await?;
+    let room_data = data::user::get_room_account_data(&user_id).await?;
 
     json_ok(AccountDataResponse {
         account_data: AccountDataContent {
@@ -809,11 +812,11 @@ pub async fn get_user_ratelimit(user_id: PathParam<OwnedUserId>) -> JsonResult<R
     let user_id = user_id.into_inner();
 
     // Verify user exists
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
 
-    let ratelimit = data::user::get_ratelimit(&user_id)?;
+    let ratelimit = data::user::get_ratelimit(&user_id).await?;
 
     json_ok(RateLimitResponse {
         messages_per_second: ratelimit.as_ref().and_then(|r| r.messages_per_second),
@@ -833,11 +836,11 @@ pub async fn set_user_ratelimit(
     let body = body.into_inner();
 
     // Verify user exists
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
 
-    data::user::set_ratelimit(&user_id, body.messages_per_second, body.burst_count)?;
+    data::user::set_ratelimit(&user_id, body.messages_per_second, body.burst_count).await?;
 
     json_ok(RateLimitResponse {
         messages_per_second: body.messages_per_second,
@@ -853,11 +856,11 @@ pub async fn delete_user_ratelimit(user_id: PathParam<OwnedUserId>) -> EmptyResu
     let user_id = user_id.into_inner();
 
     // Verify user exists
-    if !data::user::user_exists(&user_id)? {
+    if !data::user::user_exists(&user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
 
-    data::user::delete_ratelimit(&user_id)?;
+    data::user::delete_ratelimit(&user_id).await?;
 
     empty_ok()
 }

--- a/crates/server/src/routing/admin/user_lookup.rs
+++ b/crates/server/src/routing/admin/user_lookup.rs
@@ -26,7 +26,8 @@ pub async fn get_user_by_external_id(
     let provider = provider.into_inner();
     let external_id = external_id.into_inner();
 
-    let user_id = crate::data::user::get_user_by_external_id(&provider, &external_id)?
+    let user_id = crate::data::user::get_user_by_external_id(&provider, &external_id)
+        .await?
         .ok_or_else(|| MatrixError::not_found("User not found"))?;
 
     json_ok(UserIdResponse {
@@ -45,7 +46,8 @@ pub async fn get_user_by_threepid(
     let medium = medium.into_inner();
     let address = address.into_inner();
 
-    let user_id = crate::data::user::get_user_by_threepid(&medium, &address)?
+    let user_id = crate::data::user::get_user_by_threepid(&medium, &address)
+        .await?
         .ok_or_else(|| MatrixError::not_found("User not found"))?;
 
     json_ok(UserIdResponse {

--- a/crates/server/src/routing/appservice.rs
+++ b/crates/server/src/routing/appservice.rs
@@ -22,12 +22,12 @@ pub fn router() -> Router {
     )
 }
 
-fn verify_hs_token(aa: &AuthArgs) -> Result<(), crate::AppError> {
+async fn verify_hs_token(aa: &AuthArgs) -> Result<(), crate::AppError> {
     let token = aa.require_access_token()?;
     let appservices = crate::appservices();
     // Use constant-time comparison to prevent timing attacks
     if appservices
-        .iter()
+        .await.iter()
         .any(|a| a.hs_token.as_bytes().ct_eq(token.as_bytes()).into())
     {
         Ok(())
@@ -41,7 +41,7 @@ fn verify_hs_token(aa: &AuthArgs) -> Result<(), crate::AppError> {
 /// Ping the application service to check it is alive.
 #[endpoint]
 async fn ping(aa: AuthArgs, body: JsonBody<SendPingReqBody>) -> EmptyResult {
-    verify_hs_token(&aa)?;
+    verify_hs_token(&aa).await?;
     let body = body.into_inner();
     debug!(
         "Appservice ping received, transaction_id: {:?}",
@@ -56,14 +56,14 @@ async fn ping(aa: AuthArgs, body: JsonBody<SendPingReqBody>) -> EmptyResult {
 /// Returns 200 if the alias is known, 404 otherwise.
 #[endpoint]
 async fn query_rooms(aa: AuthArgs, room_alias: PathParam<String>) -> EmptyResult {
-    verify_hs_token(&aa)?;
+    verify_hs_token(&aa).await?;
 
     let room_alias = room_alias.into_inner();
 
     // Check if any registered appservice has a namespace that matches this alias.
     // Use pre-compiled RegexSet from RegistrationInfo to prevent ReDoS attacks
     // and avoid re-compiling regex patterns on every request.
-    let appservices = appservice::all()?;
+    let appservices = appservice::all().await?;
     for (id, info) in appservices.iter() {
         if info.aliases.is_match(&room_alias) {
             debug!("Appservice '{}' claims room alias {}", id, room_alias);
@@ -80,14 +80,14 @@ async fn query_rooms(aa: AuthArgs, room_alias: PathParam<String>) -> EmptyResult
 /// Returns 200 if the user is known, 404 otherwise.
 #[endpoint]
 async fn query_users(aa: AuthArgs, user_id: PathParam<String>) -> EmptyResult {
-    verify_hs_token(&aa)?;
+    verify_hs_token(&aa).await?;
 
     let user_id = user_id.into_inner();
 
     // Check if any registered appservice has a namespace that matches this user ID.
     // Use pre-compiled RegexSet from RegistrationInfo to prevent ReDoS attacks
     // and avoid re-compiling regex patterns on every request.
-    let appservices = appservice::all()?;
+    let appservices = appservice::all().await?;
     for (id, info) in appservices.iter() {
         if info.users.is_match(&user_id) {
             debug!("Appservice '{}' claims user {}", id, user_id);

--- a/crates/server/src/routing/appservice/third_party.rs
+++ b/crates/server/src/routing/appservice/third_party.rs
@@ -21,12 +21,12 @@ pub fn router() -> Router {
         )
 }
 
-fn verify_hs_token(aa: &AuthArgs) -> Result<(), crate::AppError> {
+async fn verify_hs_token(aa: &AuthArgs) -> Result<(), crate::AppError> {
     let token = aa.require_access_token()?;
     let appservices = crate::appservices();
     // Constant-time comparison; mirrors `routing/appservice.rs::verify_hs_token`.
     if appservices
-        .iter()
+        .await.iter()
         .any(|a| a.hs_token.as_bytes().ct_eq(token.as_bytes()).into())
     {
         Ok(())
@@ -40,12 +40,12 @@ fn verify_hs_token(aa: &AuthArgs) -> Result<(), crate::AppError> {
 /// Retrieve metadata about a specific third party protocol.
 #[endpoint]
 async fn get_protocol(aa: AuthArgs, protocol: PathParam<String>) -> JsonResult<ProtocolResBody> {
-    verify_hs_token(&aa)?;
+    verify_hs_token(&aa).await?;
 
     let protocol_name = protocol.into_inner();
 
     // Look through registered appservices to find one that handles this protocol.
-    let appservices = crate::appservices();
+    let appservices = crate::appservices().await;
     for appservice in appservices {
         if let Some(protocols) = &appservice.protocols
             && protocols.iter().any(|p| p == &protocol_name)
@@ -70,7 +70,7 @@ async fn get_protocol(aa: AuthArgs, protocol: PathParam<String>) -> JsonResult<P
 /// Retrieve third party locations from a Matrix room alias.
 #[endpoint]
 async fn locations(aa: AuthArgs) -> JsonResult<LocationsResBody> {
-    verify_hs_token(&aa)?;
+    verify_hs_token(&aa).await?;
     json_ok(LocationsResBody::new(vec![]))
 }
 
@@ -82,7 +82,7 @@ async fn protocol_locations(
     aa: AuthArgs,
     _args: ForProtocolReqArgs,
 ) -> JsonResult<LocationsResBody> {
-    verify_hs_token(&aa)?;
+    verify_hs_token(&aa).await?;
     json_ok(LocationsResBody::new(vec![]))
 }
 
@@ -91,7 +91,7 @@ async fn protocol_locations(
 /// Retrieve third party users from a Matrix User ID.
 #[endpoint]
 async fn users(aa: AuthArgs) -> JsonResult<UsersResBody> {
-    verify_hs_token(&aa)?;
+    verify_hs_token(&aa).await?;
     json_ok(UsersResBody::new(vec![]))
 }
 
@@ -100,6 +100,6 @@ async fn users(aa: AuthArgs) -> JsonResult<UsersResBody> {
 /// Retrieve Matrix users bridged to the matched third party users.
 #[endpoint]
 async fn protocol_users(aa: AuthArgs, _args: ForProtocolReqArgs) -> JsonResult<UsersResBody> {
-    verify_hs_token(&aa)?;
+    verify_hs_token(&aa).await?;
     json_ok(UsersResBody::new(vec![]))
 }

--- a/crates/server/src/routing/appservice/transaction.rs
+++ b/crates/server/src/routing/appservice/transaction.rs
@@ -29,7 +29,7 @@ async fn send_event(
     // constant-time comparison to avoid leaking the token byte-by-byte
     // through response timing (mirrors the pattern in
     // `routing/appservice.rs::verify_hs_token`).
-    let appservices = crate::appservices();
+    let appservices = crate::appservices().await;
     let appservice = appservices
         .iter()
         .find(|a| a.hs_token.as_bytes().ct_eq(token.as_bytes()).into())

--- a/crates/server/src/routing/client.rs
+++ b/crates/server/src/routing/client.rs
@@ -128,7 +128,7 @@ pub fn router() -> Router {
 ///
 /// - Only works if the user is currently joined to the room (TODO: Respect history visibility)
 #[endpoint]
-fn search(
+async fn search(
     _aa: AuthArgs,
     args: SearchReqArgs,
     body: JsonBody<SearchReqBody>,
@@ -141,7 +141,8 @@ fn search(
         authed.user_id(),
         search_criteria,
         args.next_batch.as_deref(),
-    )?;
+    )
+    .await?;
     json_ok(SearchResBody::new(ResultCategories { room_events }))
 }
 

--- a/crates/server/src/routing/client/account.rs
+++ b/crates/server/src/routing/client/account.rs
@@ -121,13 +121,13 @@ async fn deactivate(
         uiaa_info.session = Some(utils::random_string(SESSION_ID_LENGTH));
         return Err(uiaa_info.into());
     };
-    if crate::uiaa::try_auth(authed.user_id(), authed.device_id(), auth, &uiaa_info).is_err() {
+    if crate::uiaa::try_auth(authed.user_id(), authed.device_id(), auth, &uiaa_info).await.is_err() {
         res.status_code(StatusCode::UNAUTHORIZED);
         return Err(MatrixError::forbidden("Authentication failed.", None).into());
     }
 
     // Remove devices and mark account as deactivated
-    data::user::deactivate(authed.user_id())?;
+    data::user::deactivate(authed.user_id()).await?;
 
     // info!("User {} deactivated their account.", authed.user_id());
     // crate::admin::send_message(RoomMessageEventContent::notice_plain(format!(

--- a/crates/server/src/routing/client/account/password.rs
+++ b/crates/server/src/routing/client/account/password.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use palpo_core::client::account::ChangePasswordReqBody;
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
@@ -50,19 +51,23 @@ async fn change_password(
         uiaa_info.session = Some(utils::random_string(SESSION_ID_LENGTH));
         return Err(uiaa_info.into());
     };
-    if crate::uiaa::try_auth(authed.user_id(), authed.device_id(), auth, &uiaa_info).is_err() {
+    if crate::uiaa::try_auth(authed.user_id(), authed.device_id(), auth, &uiaa_info)
+        .await
+        .is_err()
+    {
         uiaa_info.session = Some(utils::random_string(SESSION_ID_LENGTH));
         return Err(uiaa_info.into());
     }
 
-    crate::user::set_password(authed.user_id(), &body.new_password)?;
+    crate::user::set_password(authed.user_id(), &body.new_password).await?;
     if let Some(access_token_id) = authed.access_token_id() {
         diesel::delete(
             user_pushers::table
                 .filter(user_pushers::user_id.eq(authed.user_id()))
                 .filter(user_pushers::access_token_id.ne(access_token_id)),
         )
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     }
     if body.logout_devices {
         // Logout all devices except the current one
@@ -71,19 +76,22 @@ async fn change_password(
                 .filter(user_devices::user_id.eq(authed.user_id()))
                 .filter(user_devices::device_id.ne(authed.device_id())),
         )
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
         diesel::delete(
             user_access_tokens::table
                 .filter(user_access_tokens::user_id.eq(authed.user_id()))
                 .filter(user_access_tokens::device_id.ne(authed.device_id())),
         )
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
         diesel::delete(
             user_refresh_tokens::table
                 .filter(user_refresh_tokens::user_id.eq(authed.user_id()))
                 .filter(user_refresh_tokens::device_id.ne(authed.device_id())),
         )
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     }
 
     info!("User {} changed their password.", authed.user_id());

--- a/crates/server/src/routing/client/admin.rs
+++ b/crates/server/src/routing/client/admin.rs
@@ -41,7 +41,7 @@ async fn whois(
     let target_user_id = user_id.into_inner();
 
     // Check if the user is an admin or requesting their own info
-    let is_admin = data::user::is_admin(authed.user_id()).unwrap_or(false);
+    let is_admin = data::user::is_admin(authed.user_id()).await.unwrap_or(false);
     if !is_admin && authed.user_id() != target_user_id {
         return Err(MatrixError::forbidden(
             "Only admins can query other users' information.",
@@ -51,12 +51,12 @@ async fn whois(
     }
 
     // Verify user exists
-    if !data::user::user_exists(&target_user_id)? {
+    if !data::user::user_exists(&target_user_id).await? {
         return Err(MatrixError::not_found("User not found").into());
     }
 
     // Get user's devices and session info
-    let user_devices = data::user::device::get_devices(&target_user_id)?;
+    let user_devices = data::user::device::get_devices(&target_user_id).await?;
     let mut devices = BTreeMap::new();
 
     for device in user_devices {
@@ -93,12 +93,14 @@ fn require_admin(depot: &mut Depot) -> AppResult<OwnedUserId> {
     Ok(authed.user_id().to_owned())
 }
 
-fn get_local_user(user_id: &UserId) -> AppResult<data::user::DbUser> {
+async fn get_local_user(user_id: &UserId) -> AppResult<data::user::DbUser> {
     if user_id.server_name() != config::server_name() {
         return Err(MatrixError::not_found("User not found").into());
     }
 
-    data::user::get_user(user_id).map_err(|_| MatrixError::not_found("User not found").into())
+    data::user::get_user(user_id)
+        .await
+        .map_err(|_| MatrixError::not_found("User not found").into())
 }
 
 #[endpoint]
@@ -109,7 +111,7 @@ pub(super) async fn is_user_locked(
 ) -> JsonResult<IsUserLockedResBody> {
     require_admin(depot)?;
     let target_user_id = user_id.into_inner();
-    let user = get_local_user(&target_user_id)?;
+    let user = get_local_user(&target_user_id).await?;
 
     json_ok(IsUserLockedResBody::new(user.is_locked()))
 }
@@ -123,9 +125,9 @@ pub(super) async fn lock_user(
 ) -> JsonResult<LockUserResBody> {
     let admin_user_id = require_admin(depot)?;
     let target_user_id = user_id.into_inner();
-    get_local_user(&target_user_id)?;
+    get_local_user(&target_user_id).await?;
 
-    data::user::set_locked(&target_user_id, body.locked, Some(&admin_user_id))?;
+    data::user::set_locked(&target_user_id, body.locked, Some(&admin_user_id)).await?;
 
     json_ok(LockUserResBody::new(body.locked))
 }
@@ -138,7 +140,7 @@ pub(super) async fn is_user_suspended(
 ) -> JsonResult<IsUserSuspendedResBody> {
     require_admin(depot)?;
     let target_user_id = user_id.into_inner();
-    let user = get_local_user(&target_user_id)?;
+    let user = get_local_user(&target_user_id).await?;
 
     json_ok(IsUserSuspendedResBody::new(user.is_suspended()))
 }
@@ -152,9 +154,9 @@ pub(super) async fn suspend_user(
 ) -> JsonResult<SuspendUserResBody> {
     require_admin(depot)?;
     let target_user_id = user_id.into_inner();
-    get_local_user(&target_user_id)?;
+    get_local_user(&target_user_id).await?;
 
-    data::user::set_suspended(&target_user_id, body.suspended)?;
+    data::user::set_suspended(&target_user_id, body.suspended).await?;
 
     json_ok(SuspendUserResBody::new(body.suspended))
 }

--- a/crates/server/src/routing/client/auth.rs
+++ b/crates/server/src/routing/client/auth.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use salvo::oapi::extract::{PathParam, QueryParam};
 use salvo::prelude::*;
 
@@ -51,7 +52,7 @@ async fn uiaa_fallback(
     };
 
     if should_complete {
-        complete_uiaa_stage(&session_id, auth_type.clone())?;
+        complete_uiaa_stage(&session_id, auth_type.clone()).await?;
         let html = render_completion_html(server_name);
         res.add_header("Content-Type", "text/html; charset=utf-8", true)?;
         res.write_body(html)?;
@@ -76,7 +77,7 @@ async fn uiaa_fallback(
     Ok(())
 }
 
-fn load_uiaa_info_by_session(
+async fn load_uiaa_info_by_session(
     session: &str,
 ) -> Result<
     (
@@ -93,7 +94,8 @@ fn load_uiaa_info_by_session(
             user_uiaa_datas::device_id,
             user_uiaa_datas::uiaa_info,
         ))
-        .first::<(OwnedUserId, OwnedDeviceId, JsonValue)>(&mut connect()?)
+        .first::<(OwnedUserId, OwnedDeviceId, JsonValue)>(&mut connect().await?)
+        .await
         .optional()?;
     let Some((user_id, device_id, uiaa_info)) = record else {
         return Err(MatrixError::invalid_param("Invalid session").into());
@@ -102,8 +104,8 @@ fn load_uiaa_info_by_session(
     Ok((user_id, device_id, uiaa_info))
 }
 
-fn complete_uiaa_stage(session: &str, stage: AuthType) -> Result<(), crate::AppError> {
-    let (user_id, device_id, mut uiaa_info) = load_uiaa_info_by_session(session)?;
+async fn complete_uiaa_stage(session: &str, stage: AuthType) -> Result<(), crate::AppError> {
+    let (user_id, device_id, mut uiaa_info) = load_uiaa_info_by_session(session).await?;
 
     if !uiaa_info.completed.contains(&stage) {
         uiaa_info.completed.push(stage);
@@ -120,9 +122,9 @@ fn complete_uiaa_stage(session: &str, stage: AuthType) -> Result<(), crate::AppE
     }
 
     if completed {
-        crate::uiaa::update_session(&user_id, &device_id, session, None)?;
+        crate::uiaa::update_session(&user_id, &device_id, session, None).await?;
     } else {
-        crate::uiaa::update_session(&user_id, &device_id, session, Some(&uiaa_info))?;
+        crate::uiaa::update_session(&user_id, &device_id, session, Some(&uiaa_info)).await?;
     }
 
     Ok(())

--- a/crates/server/src/routing/client/device.rs
+++ b/crates/server/src/routing/client/device.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use palpo_core::UnixMillis;
 use salvo::oapi::extract::{JsonBody, PathParam};
 use salvo::prelude::*;
@@ -44,7 +45,7 @@ async fn get_device(
 ) -> JsonResult<DeviceResBody> {
     let authed = depot.authed_info()?;
 
-    let Ok(device) = data::user::device::get_device(authed.user_id(), &device_id) else {
+    let Ok(device) = data::user::device::get_device(authed.user_id(), &device_id).await else {
         return Err(MatrixError::not_found("Device is not found.").into());
     };
     json_ok(DeviceResBody(device.into_matrix_device()))
@@ -58,7 +59,8 @@ async fn list_devices(_aa: AuthArgs, depot: &mut Depot) -> JsonResult<DevicesRes
 
     let devices = user_devices::table
         .filter(user_devices::user_id.eq(authed.user_id()))
-        .load::<DbUserDevice>(&mut connect()?)?;
+        .load::<DbUserDevice>(&mut connect().await?)
+        .await?;
     json_ok(DevicesResBody {
         devices: devices
             .into_iter()
@@ -70,7 +72,7 @@ async fn list_devices(_aa: AuthArgs, depot: &mut Depot) -> JsonResult<DevicesRes
 /// #PUT /_matrix/client/r0/devices/{device_id}
 /// Updates the metadata on a given device of the sender user.
 #[endpoint]
-fn update_device(
+async fn update_device(
     _aa: AuthArgs,
     device_id: PathParam<OwnedDeviceId>,
     body: JsonBody<UpdatedDeviceReqBody>,
@@ -81,7 +83,8 @@ fn update_device(
     let device_id = device_id.into_inner();
     let device = user_devices::table
         .filter(user_devices::device_id.eq(&device_id))
-        .first::<DbUserDevice>(&mut connect()?)
+        .first::<DbUserDevice>(&mut connect().await?)
+        .await
         .optional()?;
 
     if let Some(device) = device {
@@ -91,8 +94,9 @@ fn update_device(
                 user_devices::last_seen_ip.eq(&req.remote_addr().to_string()),
                 user_devices::last_seen_at.eq(UnixMillis::now()),
             ))
-            .execute(&mut connect()?)?;
-        crate::user::key::send_device_key_update(&device.user_id, &device_id)?;
+            .execute(&mut connect().await?)
+            .await?;
+        crate::user::key::send_device_key_update(&device.user_id, &device_id).await?;
     } else {
         let Some(appservice) = authed.appservice() else {
             return Err(MatrixError::not_found("Device is not found.").into());
@@ -114,8 +118,9 @@ fn update_device(
             &appservice.registration.as_token,
             None,
             Some(req.remote_addr().to_string()),
-        )?;
-        crate::user::key::send_device_key_update(&device.user_id, &device_id)?;
+        )
+        .await?;
+        crate::user::key::send_device_key_update(&device.user_id, &device_id).await?;
     }
 
     empty_ok()
@@ -160,7 +165,7 @@ async fn delete_device(
         return Err(uiaa_info.into());
     };
 
-    if let Err(e) = crate::uiaa::try_auth(authed.user_id(), authed.device_id(), &auth, &uiaa_info) {
+    if let Err(e) = crate::uiaa::try_auth(authed.user_id(), authed.device_id(), &auth, &uiaa_info).await {
         if let AppError::Matrix(e) = e
             && let ErrorKind::Forbidden = e.kind
         {
@@ -174,7 +179,7 @@ async fn delete_device(
         res.status_code(StatusCode::UNAUTHORIZED); // TestDeviceManagement asks http code 401
         return Err(uiaa_info.into());
     }
-    data::user::device::remove_device(authed.user_id(), &device_id)?;
+    data::user::device::remove_device(authed.user_id(), &device_id).await?;
     empty_ok()
 }
 
@@ -211,13 +216,14 @@ async fn delete_devices(
         return Err(uiaa_info.into());
     };
 
-    crate::uiaa::try_auth(authed.user_id(), authed.device_id(), &auth, &uiaa_info)?;
+    crate::uiaa::try_auth(authed.user_id(), authed.device_id(), &auth, &uiaa_info).await?;
     diesel::delete(
         user_devices::table
             .filter(user_devices::user_id.eq(authed.device_id()))
             .filter(user_devices::device_id.eq_any(&devices)),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
 
     empty_ok()
 }
@@ -231,7 +237,7 @@ pub(super) async fn dehydrated(_aa: AuthArgs) -> EmptyResult {
 #[endpoint]
 pub(super) async fn delete_dehydrated(_aa: AuthArgs, depot: &mut Depot) -> EmptyResult {
     let authed = depot.authed_info()?;
-    data::user::delete_dehydrated_devices(authed.user_id())?;
+    data::user::delete_dehydrated_devices(authed.user_id()).await?;
     empty_ok()
 }
 

--- a/crates/server/src/routing/client/directory/alias.rs
+++ b/crates/server/src/routing/client/directory/alias.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use salvo::oapi::extract::{JsonBody, PathParam};
 use salvo::prelude::*;
 
@@ -42,20 +43,20 @@ pub(super) async fn upsert_alias(
         return Err(MatrixError::invalid_param("alias is from another server").into());
     }
 
-    if crate::room::resolve_local_alias(&alias_id).is_ok() {
+    if crate::room::resolve_local_alias(&alias_id).await.is_ok() {
         return Err(MatrixError::forbidden("alias already exists", None).into());
     }
 
     let query = room_aliases::table
         .filter(room_aliases::alias_id.eq(&alias_id))
         .filter(room_aliases::room_id.ne(&body.room_id));
-    if diesel_exists!(query, &mut connect()?)? {
+    if diesel_exists!(query, &mut connect().await?)? {
         return Err(StatusError::conflict()
             .brief("a room alias with that name already exists")
             .into());
     }
 
-    crate::room::set_alias(body.room_id.clone(), alias_id, authed.user_id())?;
+    crate::room::set_alias(body.room_id.clone(), alias_id, authed.user_id()).await?;
 
     empty_ok()
 }

--- a/crates/server/src/routing/client/directory/room.rs
+++ b/crates/server/src/routing/client/directory/room.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use salvo::oapi::extract::{JsonBody, PathParam};
 use salvo::prelude::*;
 
@@ -21,7 +22,7 @@ pub(super) async fn get_visibility(
     let query = rooms::table
         .filter(rooms::id.eq(&room_id))
         .filter(rooms::is_public.eq(true));
-    let visibility = if diesel_exists!(query, &mut connect()?)? {
+    let visibility = if diesel_exists!(query, &mut connect().await?)? {
         Visibility::Public
     } else {
         Visibility::Private
@@ -42,11 +43,13 @@ pub(super) async fn set_visibility(
     let room_id = room_id.into_inner();
     let room = rooms::table
         .find(&room_id)
-        .first::<DbRoom>(&mut connect()?)?;
+        .first::<DbRoom>(&mut connect().await?)
+        .await?;
 
     diesel::update(&room)
         .set(rooms::is_public.eq(body.visibility == Visibility::Public))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     empty_ok()
 }
 

--- a/crates/server/src/routing/client/key.rs
+++ b/crates/server/src/routing/client/key.rs
@@ -72,17 +72,19 @@ async fn upload_keys(
     let authed = depot.authed_info()?;
 
     for (key_id, one_time_key) in &body.one_time_keys {
-        crate::user::add_one_time_key(authed.user_id(), authed.device_id(), key_id, one_time_key)?;
+        crate::user::add_one_time_key(authed.user_id(), authed.device_id(), key_id, one_time_key)
+            .await?;
     }
 
     if let Some(device_keys) = &body.device_keys {
-        crate::user::add_device_keys(authed.user_id(), authed.device_id(), device_keys)?;
+        crate::user::add_device_keys(authed.user_id(), authed.device_id(), device_keys).await?;
     }
 
     // TODO: fallback keys. e2e_keys.py 848
 
     json_ok(UploadKeysResBody {
-        one_time_key_counts: data::user::count_one_time_keys(authed.user_id(), authed.device_id())?,
+        one_time_key_counts: data::user::count_one_time_keys(authed.user_id(), authed.device_id())
+            .await?,
     })
 }
 
@@ -102,18 +104,15 @@ async fn get_key_changes(
     let from_tk: BatchToken = args.from.parse()?;
     let to_tk: BatchToken = args.to.parse()?;
     let mut device_list_updates = HashSet::new();
-    device_list_updates.extend(data::user::keys_changed_users(
-        sender_id,
-        from_tk.event_sn(),
-        Some(to_tk.event_sn()),
-    )?);
+    device_list_updates.extend(
+        data::user::keys_changed_users(sender_id, from_tk.event_sn(), Some(to_tk.event_sn()))
+            .await?,
+    );
 
-    for room_id in data::user::joined_rooms(sender_id)? {
-        device_list_updates.extend(room::keys_changed_users(
-            &room_id,
-            from_tk.event_sn(),
-            Some(to_tk.event_sn()),
-        )?);
+    for room_id in data::user::joined_rooms(sender_id).await? {
+        device_list_updates.extend(
+            room::keys_changed_users(&room_id, from_tk.event_sn(), Some(to_tk.event_sn())).await?,
+        );
     }
     json_ok(KeyChangesResBody {
         changed: device_list_updates.into_iter().collect(),

--- a/crates/server/src/routing/client/key/device_signing.rs
+++ b/crates/server/src/routing/client/key/device_signing.rs
@@ -36,16 +36,16 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
     let uia_required = if config::get().enabled_delegated_auth().is_some() {
         false
     } else if none_auth {
-        let exist_master_key = crate::user::key::get_master_key(sender_id)?;
-        let exist_self_signing_key = crate::user::key::get_self_signing_key(sender_id)?;
-        let exist_user_signing_key = crate::user::key::get_user_signing_key(sender_id)?;
+        let exist_master_key = crate::user::key::get_master_key(sender_id).await?;
+        let exist_self_signing_key = crate::user::key::get_self_signing_key(sender_id).await?;
+        let exist_user_signing_key = crate::user::key::get_user_signing_key(sender_id).await?;
         if exist_master_key.is_none()
             && exist_self_signing_key.is_none()
             && exist_user_signing_key.is_none()
         {
             false
         } else if let Some(expires_ts) =
-            data::user::key::get_cross_signing_replacement_allowed(sender_id)?
+            data::user::key::get_cross_signing_replacement_allowed(sender_id).await?
         {
             let now_ms = crate::core::UnixMillis::now().get() as i64;
             // Bypass still valid — skip UIA
@@ -71,7 +71,7 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
     if body.is_err() || uia_required {
         if let Ok(json) = serde_json::from_slice::<CanonicalJsonValue>(payload) {
             uiaa_info.session = Some(utils::random_string(SESSION_ID_LENGTH));
-            crate::uiaa::create_session(sender_id, authed.device_id(), &uiaa_info, json)?;
+            crate::uiaa::create_session(sender_id, authed.device_id(), &uiaa_info, json).await?;
             return Err(uiaa_info.into());
         } else {
             return Err(MatrixError::not_json("no json body was sent when required").into());
@@ -83,7 +83,7 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
             return Err(MatrixError::not_json("auth is none should not happend").into());
         };
 
-        crate::uiaa::try_auth(sender_id, authed.device_id(), auth, &uiaa_info)?;
+        crate::uiaa::try_auth(sender_id, authed.device_id(), auth, &uiaa_info).await?;
     }
 
     if let Some(master_key) = &body.master_key {
@@ -93,7 +93,8 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
             &body.self_signing_key,
             &body.user_signing_key,
             true, // notify so that other users see the new keys
-        )?;
+        )
+        .await?;
     }
     empty_ok()
 }

--- a/crates/server/src/routing/client/key/signature.rs
+++ b/crates/server/src/routing/client/key/signature.rs
@@ -43,7 +43,7 @@ pub(super) async fn upload(
                         .ok_or(MatrixError::invalid_param("Invalid signature value."))?
                         .to_owned(),
                 );
-                crate::user::sign_key(user_id, key_id, signature, authed.user_id())?;
+                crate::user::sign_key(user_id, key_id, signature, authed.user_id()).await?;
             }
         }
     }

--- a/crates/server/src/routing/client/media.rs
+++ b/crates/server/src/routing/client/media.rs
@@ -2,6 +2,7 @@ use std::io::Cursor;
 use std::str::FromStr;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use image::imageops::FilterType;
 use mime::Mime;
 use reqwest::Url;
@@ -51,7 +52,7 @@ pub async fn get_content(
     _req: &mut Request,
     res: &mut Response,
 ) -> AppResult<()> {
-    if let Some(metadata) = crate::data::media::get_metadata(&args.server_name, &args.media_id)? {
+    if let Some(metadata) = crate::data::media::get_metadata(&args.server_name, &args.media_id).await? {
         let content_type = metadata
             .content_type
             .as_deref()
@@ -103,7 +104,7 @@ pub async fn get_content_with_filename(
     _req: &mut Request,
     res: &mut Response,
 ) -> AppResult<()> {
-    let Some(metadata) = crate::data::media::get_metadata(&args.server_name, &args.media_id)?
+    let Some(metadata) = crate::data::media::get_metadata(&args.server_name, &args.media_id).await?
     else {
         return Err(MatrixError::not_yet_uploaded("Media has not been uploaded yet").into());
     };
@@ -198,7 +199,7 @@ pub async fn create_content(
             created_at: UnixMillis::now(),
         };
 
-        crate::data::media::insert_metadata(&metadata)?;
+        crate::data::media::insert_metadata(&metadata).await?;
     } else {
         return Err(MatrixError::cannot_overwrite_media("Media ID already has content").into());
     }
@@ -248,7 +249,7 @@ pub async fn upload_content(
             created_at: UnixMillis::now(),
         };
 
-        crate::data::media::insert_metadata(&metadata)?;
+        crate::data::media::insert_metadata(&metadata).await?;
 
         empty_ok()
     } else {
@@ -349,7 +350,9 @@ pub async fn get_thumbnail(
         &args.media_id,
         args.width,
         args.height,
-    ) {
+    )
+    .await
+    {
         Ok(Some(DbThumbnail {
             id, content_type, ..
         })) => {
@@ -385,7 +388,9 @@ pub async fn get_thumbnail(
         &args.media_id,
         width,
         height,
-    )? {
+    )
+    .await?
+    {
         let key = thumbnail_storage_key(&args.server_name, &args.media_id, id);
         // Try presigned URL redirect for S3 storage
         if let Some(url) = storage::presign_read(&key).await? {
@@ -403,7 +408,7 @@ pub async fn get_thumbnail(
         disposition_type: _,
         content_type,
         ..
-    })) = crate::data::media::get_metadata(&args.server_name, &args.media_id)
+    })) = crate::data::media::get_metadata(&args.server_name, &args.media_id).await
     {
         // Generate a thumbnail: read original image from storage
         let image_key = media_storage_key(&args.server_name, &args.media_id);
@@ -477,7 +482,8 @@ pub async fn get_thumbnail(
                 })
                 .on_conflict_do_nothing()
                 .returning(media_thumbnails::id)
-                .get_result::<i64>(&mut connect()?)
+                .get_result::<i64>(&mut connect().await?)
+                .await
                 .optional()?;
             let thumbnail_id = if let Some(thumbnail_id) = thumbnail_id {
                 crate::media::save_thumbnail_file(
@@ -501,7 +507,8 @@ pub async fn get_thumbnail(
                             .to_string()),
                     )
                     .select(media_thumbnails::id)
-                    .first::<i64>(&mut connect()?)?
+                    .first::<i64>(&mut connect().await?)
+                    .await?
             };
 
             // Return the newly generated thumbnail

--- a/crates/server/src/routing/client/oidc.rs
+++ b/crates/server/src/routing/client/oidc.rs
@@ -1097,6 +1097,7 @@ async fn create_or_get_user(
     oidc_config: &crate::config::OidcConfig,
 ) -> AppResult<DbUser> {
     use diesel::prelude::*;
+    use diesel_async::RunQueryDsl;
 
     use crate::core::identifiers::UserId;
     use crate::data::connect;
@@ -1108,11 +1109,12 @@ async fn create_or_get_user(
     // Check if user already exists
     let exist_user = users::table
         .filter(users::id.eq(&parsed_user_id))
-        .first::<DbUser>(&mut connect()?);
+        .first::<DbUser>(&mut connect().await?)
+        .await;
     if let Ok(mut exist_user) = exist_user {
         tracing::debug!("Found existing user account: {}", user_id);
         if exist_user.is_guest {
-            data::user::set_guest(&exist_user.id, false)?;
+            data::user::set_guest(&exist_user.id, false).await?;
             exist_user.is_guest = false;
         }
 
@@ -1154,15 +1156,16 @@ async fn create_or_get_user(
 
     let user = diesel::insert_into(users::table)
         .values(&new_user)
-        .get_result::<DbUser>(&mut connect()?)
+        .get_result::<DbUser>(&mut connect().await?)
+        .await
         .map_err(|e| MatrixError::unknown(format!("Failed to create user account: {}", e)))?;
 
     // Set initial user profile
-    if let Err(e) = data::user::set_display_name(&user.id, display_name) {
+    if let Err(e) = data::user::set_display_name(&user.id, display_name).await {
         tracing::warn!("failed to set profile for new user (non-fatal): {}", e);
     }
     if let Some(picture) = user_info.picture.as_deref()
-        && let Err(e) = data::user::set_avatar_url(&user.id, picture.into())
+        && let Err(e) = data::user::set_avatar_url(&user.id, picture.into()).await
     {
         tracing::warn!("failed to set profile for new user (non-fatal): {}", e);
     }
@@ -1183,6 +1186,7 @@ async fn create_or_get_user(
 /// - Proper database transaction handling
 async fn create_access_token_for_user(user: &DbUser, device_id: &str) -> AppResult<String> {
     use diesel::prelude::*;
+    use diesel_async::RunQueryDsl;
 
     use crate::data::connect;
     use crate::data::schema::*;
@@ -1206,7 +1210,8 @@ async fn create_access_token_for_user(user: &DbUser, device_id: &str) -> AppResu
         .on_conflict((user_devices::user_id, user_devices::device_id))
         .do_update()
         .set(user_devices::last_seen_at.eq(Some(UnixMillis::now())))
-        .execute(&mut connect()?)
+        .execute(&mut connect().await?)
+        .await
         .map_err(|e| MatrixError::unknown(format!("Failed to create/update device: {}", e)))?;
 
     // Generate cryptographically secure access token
@@ -1226,7 +1231,8 @@ async fn create_access_token_for_user(user: &DbUser, device_id: &str) -> AppResu
 
     diesel::insert_into(user_access_tokens::table)
         .values(&new_access_token)
-        .execute(&mut connect()?)
+        .execute(&mut connect().await?)
+        .await
         .map_err(|e| MatrixError::unknown(format!("Failed to create access token: {}", e)))?;
 
     Ok(access_token)

--- a/crates/server/src/routing/client/presence.rs
+++ b/crates/server/src/routing/client/presence.rs
@@ -21,7 +21,10 @@ pub fn authed_router() -> Router {
 ///
 /// - Only works if you share a room with the user
 #[endpoint]
-fn get_status(user_id: PathParam<OwnedUserId>, depot: &mut Depot) -> JsonResult<PresenceResBody> {
+async fn get_status(
+    user_id: PathParam<OwnedUserId>,
+    depot: &mut Depot,
+) -> JsonResult<PresenceResBody> {
     if !crate::config::get().presence.allow_local {
         return Err(MatrixError::forbidden("presence is disabled on this server", None).into());
     }
@@ -30,13 +33,13 @@ fn get_status(user_id: PathParam<OwnedUserId>, depot: &mut Depot) -> JsonResult<
     let sender_id = authed.user_id();
     let user_id = user_id.into_inner();
 
-    if !state::user_can_see_user(sender_id, &user_id)? {
+    if !state::user_can_see_user(sender_id, &user_id).await? {
         return Err(
             MatrixError::unauthorized("you cannot get the presence state of this user").into(),
         );
     }
 
-    let content = crate::data::user::last_presence(&user_id)?.content;
+    let content = crate::data::user::last_presence(&user_id).await?.content;
 
     json_ok(PresenceResBody {
         // TODO: Should just use the presenceeventcontent type here?
@@ -83,7 +86,7 @@ async fn set_status(
         presence,
         status_msg,
     } = body.into_inner();
-    crate::user::set_presence(authed.user_id(), Some(presence), status_msg.clone(), true)?;
+    crate::user::set_presence(authed.user_id(), Some(presence), status_msg.clone(), true).await?;
 
     empty_ok()
 }

--- a/crates/server/src/routing/client/profile.rs
+++ b/crates/server/src/routing/client/profile.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use palpo_core::UnixMillis;
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
@@ -167,7 +168,8 @@ async fn get_profile(_aa: AuthArgs, user_id: PathParam<OwnedUserId>) -> JsonResu
     }) = user_profiles::table
         .filter(user_profiles::user_id.eq(&user_id))
         .filter(user_profiles::room_id.is_null())
-        .first::<DbProfile>(&mut connect()?)
+        .first::<DbProfile>(&mut connect().await?)
+        .await
     else {
         return json_ok(ProfileResBody {
             avatar_url: None,
@@ -221,7 +223,8 @@ async fn get_profile_field(
         return json_ok(ProfileFieldBody::single(field, value));
     }
 
-    let value = data::user::profile_field(&user_id, &field)?
+    let value = data::user::profile_field(&user_id, &field)
+        .await?
         .ok_or_else(|| MatrixError::not_found("Profile field not found."))?;
 
     json_ok(ProfileFieldBody::single(field, value))
@@ -262,7 +265,8 @@ async fn get_avatar_url(
         ..
     } = user_profiles::table
         .filter(user_profiles::user_id.eq(&user_id))
-        .first::<DbProfile>(&mut connect()?)?;
+        .first::<DbProfile>(&mut connect().await?)
+        .await?;
 
     json_ok(AvatarUrlResBody {
         avatar_url,
@@ -296,7 +300,7 @@ async fn set_avatar_url(
     let query = user_profiles::table
         .filter(user_profiles::user_id.eq(&user_id))
         .filter(user_profiles::room_id.is_null());
-    let profile_exists = diesel_exists!(query, &mut connect()?)?;
+    let profile_exists = diesel_exists!(query, &mut connect().await?)?;
     if profile_exists {
         #[derive(AsChangeset, Debug)]
         #[diesel(table_name = user_profiles, treat_none_as_null = true)]
@@ -310,16 +314,17 @@ async fn set_avatar_url(
         };
         diesel::update(query)
             .set(updata_params)
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     } else {
         return Err(StatusError::not_found().brief("Profile not found.").into());
     }
 
     // Send a new membership event and presence update into all joined rooms
-    let all_joined_rooms: Vec<_> = data::user::joined_rooms(&user_id)?
-        .into_iter()
-        .map(|room_id| {
-            Ok::<_, AppError>((
+    let mut all_joined_rooms: Vec<_> = Vec::new();
+    for room_id in data::user::joined_rooms(&user_id).await?.into_iter() {
+        let result: Result<_, AppError> = async {
+            Ok((
                 PduBuilder {
                     event_type: TimelineEventType::RoomMember,
                     content: to_raw_value(&RoomMemberEventContent {
@@ -329,7 +334,8 @@ async fn set_avatar_url(
                             &StateEventType::RoomMember,
                             user_id.as_str(),
                             None,
-                        )?
+                        )
+                        .await?
                     })
                     .expect("event is valid, we just created it"),
                     state_key: Some(user_id.to_string()),
@@ -337,9 +343,12 @@ async fn set_avatar_url(
                 },
                 room_id,
             ))
-        })
-        .filter_map(|r| r.ok())
-        .collect();
+        }
+        .await;
+        if let Ok(item) = result {
+            all_joined_rooms.push(item);
+        }
+    }
 
     // Presence update
     crate::data::user::set_presence(
@@ -355,13 +364,14 @@ async fn set_avatar_url(
             occur_sn: None,
         },
         true,
-    )?;
+    )
+    .await?;
     for (pdu_builder, room_id) in all_joined_rooms {
         let _ = timeline::build_and_append_pdu(
             pdu_builder,
             &user_id,
             &room_id,
-            &room::get_version(&room_id)?,
+            &room::get_version(&room_id).await?,
             &room::lock_state(&room_id).await,
         )
         .await?;
@@ -398,7 +408,7 @@ async fn get_display_name(
         return json_ok(body);
     }
     json_ok(DisplayNameResBody {
-        display_name: data::user::display_name(&user_id).ok().flatten(),
+        display_name: data::user::display_name(&user_id).await.ok().flatten(),
     })
 }
 
@@ -422,14 +432,14 @@ async fn set_display_name(
     let SetDisplayNameReqBody { display_name } = body.into_inner();
 
     if let Some(display_name) = display_name.as_deref() {
-        data::user::set_display_name(&user_id, display_name)?;
+        data::user::set_display_name(&user_id, display_name).await?;
     }
 
     // Send a new membership event and presence update into all joined rooms
-    let all_joined_rooms: Vec<_> = data::user::joined_rooms(&user_id)?
-        .into_iter()
-        .map(|room_id| {
-            Ok::<_, AppError>((
+    let mut all_joined_rooms: Vec<_> = Vec::new();
+    for room_id in data::user::joined_rooms(&user_id).await?.into_iter() {
+        let result: Result<_, AppError> = async {
+            Ok((
                 PduBuilder {
                     event_type: TimelineEventType::RoomMember,
                     content: to_raw_value(&RoomMemberEventContent {
@@ -439,7 +449,8 @@ async fn set_display_name(
                             &StateEventType::RoomMember,
                             user_id.as_str(),
                             None,
-                        )?
+                        )
+                        .await?
                     })
                     .expect("event is valid, we just created it"),
                     state_key: Some(user_id.to_string()),
@@ -447,16 +458,19 @@ async fn set_display_name(
                 },
                 room_id,
             ))
-        })
-        .filter_map(|r| r.ok())
-        .collect();
+        }
+        .await;
+        if let Ok(item) = result {
+            all_joined_rooms.push(item);
+        }
+    }
 
     for (pdu_builder, room_id) in all_joined_rooms {
         let _ = timeline::build_and_append_pdu(
             pdu_builder,
             &user_id,
             &room_id,
-            &crate::room::get_version(&room_id)?,
+            &crate::room::get_version(&room_id).await?,
             &room::lock_state(&room_id).await,
         )
         .await?;
@@ -475,7 +489,8 @@ async fn set_display_name(
                 occur_sn: None,
             },
             true,
-        )?;
+        )
+        .await?;
     }
 
     empty_ok()
@@ -504,7 +519,7 @@ async fn set_profile_field(
         .remove(&field)
         .ok_or_else(|| MatrixError::bad_json("Profile field body does not match path field."))?;
 
-    data::user::set_profile_field(&user_id, &field, value)?;
+    data::user::set_profile_field(&user_id, &field, value).await?;
 
     empty_ok()
 }
@@ -525,7 +540,7 @@ async fn delete_profile_field(
     let authed = depot.authed_info()?;
     ensure_profile_update_allowed(authed, &user_id)?;
 
-    data::user::delete_profile_field(&user_id, &field)?;
+    data::user::delete_profile_field(&user_id, &field).await?;
 
     empty_ok()
 }

--- a/crates/server/src/routing/client/push_rule.rs
+++ b/crates/server/src/routing/client/push_rule.rs
@@ -49,6 +49,7 @@ async fn global(depot: &mut Depot) -> JsonResult<RulesResBody> {
         None,
         &GlobalAccountDataEventType::PushRules.to_string(),
     )
+    .await
     .unwrap_or_default();
 
     json_ok(RulesResBody {
@@ -59,13 +60,14 @@ async fn global(depot: &mut Depot) -> JsonResult<RulesResBody> {
 /// #GET /_matrix/client/r0/pushrules/{scope}/{kind}/{rule_id}
 /// Retrieves a single specified push rule for this user.
 #[endpoint]
-fn get_rule(args: ScopeKindRuleReqArgs, depot: &mut Depot) -> JsonResult<RuleResBody> {
+async fn get_rule(args: ScopeKindRuleReqArgs, depot: &mut Depot) -> JsonResult<RuleResBody> {
     let authed = depot.authed_info()?;
 
     let user_data_content = crate::data::user::get_global_data::<PushRulesEventContent>(
         authed.user_id(),
         &GlobalAccountDataEventType::PushRules.to_string(),
-    )?
+    )
+    .await?
     .ok_or(MatrixError::not_found("push rule event not found."))?;
 
     let rule = user_data_content
@@ -143,6 +145,7 @@ async fn set_rule(args: SetRuleReqArgs, req: &mut Request, depot: &mut Depot) ->
         None,
         &GlobalAccountDataEventType::PushRules.to_string(),
     )
+    .await
     .unwrap_or_default();
 
     if let Err(error) =
@@ -177,7 +180,8 @@ async fn set_rule(args: SetRuleReqArgs, req: &mut Request, depot: &mut Depot) ->
         None,
         &GlobalAccountDataEventType::PushRules.to_string(),
         serde_json::to_value(user_data_content)?,
-    )?;
+    )
+    .await?;
 
     empty_ok()
 }
@@ -197,7 +201,8 @@ async fn delete_rule(args: ScopeKindRuleReqArgs, depot: &mut Depot) -> EmptyResu
     let mut user_data_content = crate::data::user::get_global_data::<PushRulesEventContent>(
         authed.user_id(),
         &GlobalAccountDataEventType::PushRules.to_string(),
-    )?
+    )
+    .await?
     .ok_or(MatrixError::not_found("PushRules event not found."))?;
 
     if let Err(error) = user_data_content
@@ -220,7 +225,8 @@ async fn delete_rule(args: ScopeKindRuleReqArgs, depot: &mut Depot) -> EmptyResu
         None,
         &GlobalAccountDataEventType::PushRules.to_string(),
         serde_json::to_value(user_data_content)?,
-    )?;
+    )
+    .await?;
     empty_ok()
 }
 
@@ -235,6 +241,7 @@ async fn list_rules(depot: &mut Depot) -> JsonResult<RulesResBody> {
         None,
         &GlobalAccountDataEventType::PushRules.to_string(),
     )
+    .await
     .unwrap_or_default();
 
     json_ok(RulesResBody {
@@ -262,6 +269,7 @@ async fn get_actions(
         None,
         &GlobalAccountDataEventType::PushRules.to_string(),
     )
+    .await
     .unwrap_or_default();
 
     let actions = user_data_content
@@ -276,7 +284,7 @@ async fn get_actions(
 /// #PUT /_matrix/client/r0/pushrules/{scope}/{kind}/{rule_id}/actions
 /// Sets the actions of a single specified push rule for this user.
 #[endpoint]
-fn set_actions(
+async fn set_actions(
     args: ScopeKindRuleReqArgs,
     body: JsonBody<SetRuleActionsReqBody>,
     depot: &mut Depot,
@@ -294,6 +302,7 @@ fn set_actions(
         None,
         &GlobalAccountDataEventType::PushRules.to_string(),
     )
+    .await
     .map_err(|_| MatrixError::not_found("push rules event not found"))?;
 
     if user_data_content
@@ -309,7 +318,8 @@ fn set_actions(
         None,
         &GlobalAccountDataEventType::PushRules.to_string(),
         serde_json::to_value(user_data_content).expect("to json value always works"),
-    )?;
+    )
+    .await?;
 
     empty_ok()
 }
@@ -317,7 +327,10 @@ fn set_actions(
 /// #GET /_matrix/client/r0/pushrules/{scope}/{kind}/{rule_id}/enabled
 /// Gets the enabled status of a single specified push rule for this user.
 #[endpoint]
-fn get_enabled(args: ScopeKindRuleReqArgs, depot: &mut Depot) -> JsonResult<RuleEnabledResBody> {
+async fn get_enabled(
+    args: ScopeKindRuleReqArgs,
+    depot: &mut Depot,
+) -> JsonResult<RuleEnabledResBody> {
     let authed = depot.authed_info()?;
 
     if args.scope != RuleScope::Global {
@@ -330,7 +343,8 @@ fn get_enabled(args: ScopeKindRuleReqArgs, depot: &mut Depot) -> JsonResult<Rule
         authed.user_id(),
         None,
         &GlobalAccountDataEventType::PushRules.to_string(),
-    )?;
+    )
+    .await?;
 
     let enabled = user_data_content
         .global
@@ -344,7 +358,7 @@ fn get_enabled(args: ScopeKindRuleReqArgs, depot: &mut Depot) -> JsonResult<Rule
 /// #PUT /_matrix/client/r0/pushrules/{scope}/{kind}/{rule_id}/enabled
 /// Sets the enabled status of a single specified push rule for this user.
 #[endpoint]
-fn set_enabled(
+async fn set_enabled(
     args: ScopeKindRuleReqArgs,
     body: JsonBody<SetRuleEnabledReqBody>,
     depot: &mut Depot,
@@ -361,7 +375,8 @@ fn set_enabled(
         authed.user_id(),
         None,
         &GlobalAccountDataEventType::PushRules.to_string(),
-    )?;
+    )
+    .await?;
 
     if user_data_content
         .global
@@ -376,7 +391,8 @@ fn set_enabled(
         None,
         &GlobalAccountDataEventType::PushRules.to_string(),
         serde_json::to_value(user_data_content)?,
-    )?;
+    )
+    .await?;
 
     empty_ok()
 }

--- a/crates/server/src/routing/client/pusher.rs
+++ b/crates/server/src/routing/client/pusher.rs
@@ -21,7 +21,8 @@ async fn pushers(depot: &mut Depot) -> JsonResult<PushersResBody> {
     let authed = depot.authed_info()?;
 
     json_ok(PushersResBody {
-        pushers: data::user::pusher::get_pushers(authed.user_id())?
+        pushers: data::user::pusher::get_pushers(authed.user_id())
+            .await?
             .into_iter()
             .map(TryInto::<Pusher>::try_into)
             .collect::<Result<Vec<_>, DataError>>()?,
@@ -47,6 +48,6 @@ async fn set_pusher(body: JsonBody<SetPusherReqBody>, depot: &mut Depot) -> Empt
         })?;
         url_guard::ensure_safe_outbound_url(&url)?;
     }
-    crate::user::pusher::set_pusher(authed, action)?;
+    crate::user::pusher::set_pusher(authed, action).await?;
     empty_ok()
 }

--- a/crates/server/src/routing/client/register.rs
+++ b/crates/server/src/routing/client/register.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use palpo_core::presence::PresenceState;
 use salvo::oapi::extract::{JsonBody, QueryParam};
 use salvo::prelude::*;
@@ -77,7 +78,7 @@ async fn register(
                     })
                     .ok_or(MatrixError::invalid_username("username is invalid"))?;
             proposed_user_id.validate_strict()?;
-            if data::user::user_exists(&proposed_user_id)? {
+            if data::user::user_exists(&proposed_user_id).await? {
                 return Err(MatrixError::user_in_use("desired user id is already taken").into());
             }
             proposed_user_id
@@ -88,7 +89,7 @@ async fn register(
                 &conf.server_name,
             )?;
             proposed_user_id.validate_strict()?;
-            if !data::user::user_exists(&proposed_user_id)? {
+            if !data::user::user_exists(&proposed_user_id).await? {
                 break proposed_user_id;
             }
         },
@@ -100,7 +101,7 @@ async fn register(
         // Constant-time comparison so we don't leak `as_token` bytes via
         // response timing. The same pattern is used in `hoops/auth.rs`.
         let matched = crate::appservices()
-            .iter()
+            .await.iter()
             .find(|appservice| {
                 appservice
                     .as_token
@@ -117,7 +118,7 @@ async fn register(
             return Err(MatrixError::exclusive("user is not in appservice namespace").into());
         }
         appservice = Some(matched);
-    } else if crate::appservice::is_exclusive_user_id(&user_id)? {
+    } else if crate::appservice::is_exclusive_user_id(&user_id).await? {
         return Err(MatrixError::exclusive("user id reserved by appservice").into());
     }
 
@@ -144,7 +145,8 @@ async fn register(
                 &body.device_id.clone().unwrap_or_else(|| "".into()),
                 auth,
                 &uiaa_info,
-            )?;
+            )
+            .await?;
             if !authed {
                 return Err(AppError::Uiaa(uiaa));
             }
@@ -156,16 +158,17 @@ async fn register(
                 &body.device_id.clone().unwrap_or_else(|| "".into()),
                 uiaa_info.session.as_ref().expect("session is always set"),
                 Some(&uiaa_info),
-            )?;
+            )
+            .await?;
             return Err(uiaa_info.into());
         }
     }
 
     // Create user
     let db_user = if is_guest {
-        crate::user::create_guest_user(user_id.clone())?
+        crate::user::create_guest_user(user_id.clone()).await?
     } else {
-        crate::user::create_user(user_id.clone(), body.password.as_deref())?
+        crate::user::create_user(user_id.clone(), body.password.as_deref()).await?
     };
 
     // Presence update
@@ -182,7 +185,8 @@ async fn register(
             occur_sn: None,
         },
         true,
-    )?;
+    )
+    .await?;
 
     // Initial account data
     crate::data::user::set_data(
@@ -193,7 +197,8 @@ async fn register(
             global: Ruleset::server_default(&user_id),
         })
         .expect("to json always works"),
-    )?;
+    )
+    .await?;
 
     // Inhibit login does not work for guests
     if !is_guest && body.inhibit_login {
@@ -224,7 +229,8 @@ async fn register(
         &token,
         body.initial_device_display_name.clone(),
         Some(req.remote_addr().to_string()),
-    )?;
+    )
+    .await?;
 
     // If this is the first real user, grant them admin privileges
     // Note: the server user, @palpo:servername, is generated first
@@ -257,7 +263,7 @@ async fn register(
                 continue;
             };
 
-            if !room::is_server_joined(&conf.server_name, &room_id)? {
+            if !room::is_server_joined(&conf.server_name, &room_id).await? {
                 warn!("skipping room {room} to automatically join as we have never joined before.");
                 continue;
             }
@@ -318,12 +324,12 @@ async fn available(username: QueryParam<String, true>) -> JsonResult<AvailableRe
 
     // Check if username is creative enough
     let query = users::table.find(&user_id);
-    if diesel_exists!(query, &mut connect()?)? {
+    if diesel_exists!(query, &mut connect().await?)? {
         return Err(MatrixError::user_in_use("Desired user ID is already taken.").into());
     }
 
     // Check if the username is reserved by an appservice exclusive namespace
-    if crate::appservice::is_exclusive_user_id(&user_id)? {
+    if crate::appservice::is_exclusive_user_id(&user_id).await? {
         return Err(
             MatrixError::exclusive("Username is reserved by an application service.").into(),
         );

--- a/crates/server/src/routing/client/room.rs
+++ b/crates/server/src/routing/client/room.rs
@@ -159,16 +159,18 @@ async fn initial_sync(
     let sender_id = authed.user_id();
     let room_id = &args.room_id;
 
-    if !room::state::user_can_see_events(sender_id, room_id)? {
+    if !room::state::user_can_see_events(sender_id, room_id).await? {
         return Err(MatrixError::forbidden("No room preview available.", None).into());
     }
 
     let limit = LIMIT_MAX;
     let events =
-        timeline::stream::load_pdus_backward(Some(sender_id), room_id, None, None, None, limit)?;
+        timeline::stream::load_pdus_backward(Some(sender_id), room_id, None, None, None, limit)
+            .await?;
 
-    let frame_id = room::get_frame_id(room_id, None).unwrap_or_default();
+    let frame_id = room::get_frame_id(room_id, None).await.unwrap_or_default();
     let state: Vec<_> = room::state::get_full_state(frame_id)
+        .await
         .unwrap_or_default()
         .into_values()
         .map(|event| event.to_state_event())
@@ -201,8 +203,8 @@ async fn initial_sync(
         } else {
             None
         },
-        visibility: room::directory::visibility(room_id).into(),
-        membership: room::user::membership(sender_id, room_id).ok(),
+        visibility: room::directory::visibility(room_id).await.into(),
+        membership: room::user::membership(sender_id, room_id).await.ok(),
     })
 }
 /// `#POST /_matrix/client/r0/rooms/{room_id}/read_markers`
@@ -211,7 +213,7 @@ async fn initial_sync(
 /// - Updates fully-read account data event to `fully_read`
 /// - If `read_receipt` is set: Update private marker and public read receipt EDU
 #[endpoint]
-fn set_read_markers(
+async fn set_read_markers(
     _aa: AuthArgs,
     room_id: PathParam<OwnedRoomId>,
     body: JsonBody<SetReadMarkerReqBody>,
@@ -231,15 +233,16 @@ fn set_read_markers(
             Some(room_id.clone()),
             &RoomAccountDataEventType::FullyRead.to_string(),
             serde_json::to_value(fully_read_event.content).expect("to json value always works"),
-        )?;
-        push_action::remove_actions_for_room(sender_id, &room_id)?;
+        )
+        .await?;
+        push_action::remove_actions_for_room(sender_id, &room_id).await?;
     }
 
     if let Some(event_id) = &body.private_read_receipt {
-        let (event_sn, _event_guard) = crate::event::ensure_event_sn(&room_id, event_id)?;
-        data::room::receipt::set_private_read(&room_id, sender_id, event_id, event_sn)?;
-        push_action::remove_actions_until(sender_id, &room_id, event_sn, None)?;
-        push_action::refresh_notify_summary(sender_id, &room_id)?;
+        let (event_sn, _event_guard) = crate::event::ensure_event_sn(&room_id, event_id).await?;
+        data::room::receipt::set_private_read(&room_id, sender_id, event_id, event_sn).await?;
+        push_action::remove_actions_until(sender_id, &room_id, event_sn, None).await?;
+        push_action::refresh_notify_summary(sender_id, &room_id).await?;
     }
 
     if let Some(event) = &body.read_receipt {
@@ -266,10 +269,11 @@ fn set_read_markers(
                 room_id: room_id.clone(),
             },
             true,
-        )?;
-        let event_sn = crate::event::get_event_sn(event)?;
-        push_action::remove_actions_until(sender_id, &room_id, event_sn, None)?;
-        push_action::refresh_notify_summary(sender_id, &room_id)?;
+        )
+        .await?;
+        let event_sn = crate::event::get_event_sn(event).await?;
+        push_action::remove_actions_until(sender_id, &room_id, event_sn, None).await?;
+        push_action::refresh_notify_summary(sender_id, &room_id).await?;
     }
     empty_ok()
 }
@@ -287,14 +291,14 @@ async fn get_aliases(
 ) -> JsonResult<AliasesResBody> {
     let authed = depot.authed_info()?;
 
-    if !room::user::is_joined(authed.user_id(), &room_id)? {
+    if !room::user::is_joined(authed.user_id(), &room_id).await? {
         return Err(
             MatrixError::forbidden("you don't have permission to view this room", None).into(),
         );
     }
 
     json_ok(AliasesResBody {
-        aliases: room::local_aliases_for_room(&room_id)?,
+        aliases: room::local_aliases_for_room(&room_id).await?,
     })
 }
 
@@ -337,7 +341,7 @@ async fn upgrade(
     };
 
     let state_lock = room::lock_state(&room_id).await;
-    room::ensure_room(&new_room_id, &body.new_version)?;
+    room::ensure_room(&new_room_id, &body.new_version).await?;
 
     // Use the m.room.tombstone event as the predecessor
     let predecessor = Some(events::room::create::PreviousRoom::new(room_id.clone()));
@@ -348,7 +352,8 @@ async fn upgrade(
         &StateEventType::RoomCreate,
         "",
         None,
-    )?;
+    )
+    .await?;
     if !version_rules.authorization.use_room_create_sender {
         create_event_content.insert(
             "creator".into(),
@@ -403,7 +408,7 @@ async fn upgrade(
         },
         sender_id,
         &new_room_id,
-        &crate::room::get_version(&new_room_id)?,
+        &crate::room::get_version(&new_room_id).await?,
         &state_lock,
     )
     .await?;
@@ -427,7 +432,7 @@ async fn upgrade(
         },
         sender_id,
         &room_id,
-        &crate::room::get_version(&room_id)?,
+        &crate::room::get_version(&room_id).await?,
         &state_lock,
     )
     .await?;
@@ -444,11 +449,11 @@ async fn upgrade(
             event_type: TimelineEventType::RoomMember,
             content: to_raw_value(&RoomMemberEventContent {
                 membership: MembershipState::Join,
-                display_name: crate::data::user::display_name(sender_id).ok().flatten(),
-                avatar_url: crate::data::user::avatar_url(sender_id).ok().flatten(),
+                display_name: crate::data::user::display_name(sender_id).await.ok().flatten(),
+                avatar_url: crate::data::user::avatar_url(sender_id).await.ok().flatten(),
                 is_direct: None,
                 third_party_invite: None,
-                blurhash: crate::data::user::blurhash(sender_id).ok().flatten(),
+                blurhash: crate::data::user::blurhash(sender_id).await.ok().flatten(),
                 reason: None,
                 join_authorized_via_users_server: None,
                 #[cfg(feature = "unstable-msc4293")]
@@ -484,7 +489,7 @@ async fn upgrade(
         if event_ty == StateEventType::RoomPowerLevels {
             continue; // Handled later
         }
-        let event_content = match room::get_state(&room_id, &event_ty, "", None) {
+        let event_content = match room::get_state(&room_id, &event_ty, "", None).await {
             Ok(v) => v.content.clone(),
             _ => continue, // Skipping missing events.
         };
@@ -505,8 +510,8 @@ async fn upgrade(
     }
 
     // Moves any local aliases to the new room
-    for alias in room::local_aliases_for_room(&room_id)? {
-        room::set_alias(&new_room_id, &alias, sender_id)?;
+    for alias in room::local_aliases_for_room(&room_id).await? {
+        room::set_alias(&new_room_id, &alias, sender_id).await?;
     }
 
     // Get the old room power levels
@@ -515,7 +520,8 @@ async fn upgrade(
         &StateEventType::RoomPowerLevels,
         "",
         None,
-    )?;
+    )
+    .await?;
 
     // Setting events_default and invite to the greater of 50 and users_default + 1
     let restricted_level = max(50, power_levels_event_content.users_default + 1);
@@ -536,7 +542,7 @@ async fn upgrade(
         },
         sender_id,
         &room_id,
-        &crate::room::get_version(&room_id)?,
+        &crate::room::get_version(&room_id).await?,
         &state_lock,
     )
     .await?;
@@ -662,7 +668,7 @@ pub(super) async fn create_room(
         let alias = RoomAliasId::parse(format!("#{}:{}", localpart, &conf.server_name))
             .map_err(|_| MatrixError::invalid_param("Invalid alias."))?;
 
-        if room::resolve_local_alias(&alias).is_ok() {
+        if room::resolve_local_alias(&alias).await.is_ok() {
             return Err(MatrixError::room_in_use("room alias already exists").into());
         } else {
             Some(alias)
@@ -693,11 +699,11 @@ pub(super) async fn create_room(
             event_type: TimelineEventType::RoomMember,
             content: to_raw_value(&RoomMemberEventContent {
                 membership: MembershipState::Join,
-                display_name: crate::data::user::display_name(sender_id).ok().flatten(),
-                avatar_url: crate::data::user::avatar_url(sender_id).ok().flatten(),
+                display_name: crate::data::user::display_name(sender_id).await.ok().flatten(),
+                avatar_url: crate::data::user::avatar_url(sender_id).await.ok().flatten(),
                 is_direct: Some(body.is_direct),
                 third_party_invite: None,
-                blurhash: crate::data::user::blurhash(sender_id).ok().flatten(),
+                blurhash: crate::data::user::blurhash(sender_id).await.ok().flatten(),
                 reason: None,
                 join_authorized_via_users_server: None,
                 #[cfg(feature = "unstable-msc4293")]
@@ -724,7 +730,8 @@ pub(super) async fn create_room(
         users.insert(sender_id.to_owned(), 100);
         if preset == RoomPreset::TrustedPrivateChat {
             for invitee_id in &body.invite {
-                if user_is_ignored(sender_id, invitee_id) || user_is_ignored(invitee_id, sender_id)
+                if user_is_ignored(sender_id, invitee_id).await
+                    || user_is_ignored(invitee_id, sender_id).await
                 {
                     continue;
                 }
@@ -921,11 +928,11 @@ pub(super) async fn create_room(
 
     // Homeserver specific stuff
     if let Some(alias) = alias {
-        room::set_alias(&room_id, &alias, sender_id)?;
+        room::set_alias(&room_id, &alias, sender_id).await?;
     }
 
     if body.visibility == Visibility::Public {
-        room::directory::set_public(&room_id, true)?;
+        room::directory::set_public(&room_id, true).await?;
     }
 
     info!("{} created a room", sender_id);
@@ -944,7 +951,7 @@ async fn create_create_event_legacy(
     // };
     let room_id = RoomId::new_v1(&config::get().server_name);
     let state_lock = room::lock_state(&room_id).await;
-    room::ensure_room(&room_id, room_version)?;
+    room::ensure_room(&room_id, room_version).await?;
 
     let content = match &body.creation_content {
         Some(content) => {
@@ -1070,7 +1077,7 @@ async fn create_create_event(
     // 1. The room create event, using a placeholder room_id
     let temp_room_id = OwnedRoomId::try_from("!placehold").expect("invalid room id");
     let state_lock = room::lock_state(&temp_room_id).await;
-    room::ensure_room(&temp_room_id, room_version)?;
+    room::ensure_room(&temp_room_id, room_version).await?;
     let create_event = timeline::build_and_append_pdu(
         PduBuilder {
             event_type: TimelineEventType::RoomCreate,

--- a/crates/server/src/routing/client/room/event.rs
+++ b/crates/server/src/routing/client/room/event.rs
@@ -441,6 +441,19 @@ pub(super) async fn timestamp_to_event(
         )
         .await?;
 
+        // Per the spec, after finding the event the server "should try to
+        // backfill this event". Fetching the single event above leaves it as an
+        // outlier whenever its prev_events aren't local yet, which keeps it out
+        // of `/messages` pagination (the timeline page stops at the gap). Pull
+        // the surrounding history so the event becomes a connected, non-outlier
+        // timeline event that subsequent backward pagination can return.
+        if let Err(e) =
+            timeline::backfill_from_extremities(&args.room_id, std::slice::from_ref(&event_id), 100)
+                .await
+        {
+            warn!("failed to backfill history around timestamp_to_event result: {e}");
+        }
+
         return json_ok(TimestampToEventResBody {
             event_id,
             origin_server_ts,

--- a/crates/server/src/routing/client/room/event.rs
+++ b/crates/server/src/routing/client/room/event.rs
@@ -32,14 +32,14 @@ use crate::{
 ///
 /// - You have to currently be joined to the room (TODO: Respect history visibility)
 #[endpoint]
-pub(super) fn get_room_event(
+pub(super) async fn get_room_event(
     _aa: AuthArgs,
     args: RoomEventReqArgs,
     depot: &mut Depot,
 ) -> JsonResult<RoomEventResBody> {
     let authed = depot.authed_info()?;
 
-    let event = DbEvent::get_by_id(&args.event_id)?;
+    let event = DbEvent::get_by_id(&args.event_id).await?;
     if event.rejection_reason.is_some() {
         warn!("event {} is rejected", &args.event_id);
         return Err(MatrixError::not_found("event not found").into());
@@ -49,19 +49,19 @@ pub(super) fn get_room_event(
         return Err(MatrixError::not_found("event not found").into());
     }
 
-    let event = timeline::get_pdu(&args.event_id)?;
+    let event = timeline::get_pdu(&args.event_id).await?;
 
-    if !state::user_can_see_event(authed.user_id(), &args.event_id)? {
+    if !state::user_can_see_event(authed.user_id(), &args.event_id).await? {
         return Err(MatrixError::not_found("event not found").into());
     }
-    if crate::event::is_ignored_sender_pdu(&event, authed.user_id()) {
+    if crate::event::is_ignored_sender_pdu(&event, authed.user_id()).await {
         return Err(MatrixError::sender_ignored(
             "the sender of the requested event is ignored",
             Some(event.sender.clone()),
         )
         .into());
     }
-    if crate::event::is_ignored_pdu(&event, authed.user_id()) {
+    if crate::event::is_ignored_pdu(&event, authed.user_id()).await {
         return Err(MatrixError::not_found("event not found").into());
     }
 
@@ -81,7 +81,7 @@ pub(super) async fn report(
     depot: &mut Depot,
 ) -> EmptyResult {
     let authed = depot.authed_info()?;
-    let pdu = timeline::get_pdu(&args.event_id)?;
+    let pdu = timeline::get_pdu(&args.event_id).await?;
     let body = body.into_inner();
 
     if let Some(true) = body.score.map(|s| !(-100..=0).contains(&s)) {
@@ -107,7 +107,8 @@ pub(super) async fn report(
             "score": report_score,
         })),
         report_score,
-    ))?;
+    ))
+    .await?;
 
     let _ = crate::admin::send_message(RoomMessageEventContent::text_html(
         format!(
@@ -148,7 +149,7 @@ pub(super) async fn report(
 /// - Only works if the user is joined (TODO: always allow, but only show events if the user was
 /// joined, depending on history_visibility)
 #[endpoint]
-pub(super) fn get_context(
+pub(super) async fn get_context(
     _aa: AuthArgs,
     args: ContextReqArgs,
     depot: &mut Depot,
@@ -165,16 +166,17 @@ pub(super) fn get_context(
 
     let mut lazy_loaded = HashSet::new();
     let base_token = crate::event::get_live_token(&args.event_id)
+        .await
         .map_err(|_| MatrixError::not_found("base event id not found"))?;
-    let base_event = timeline::get_pdu(&args.event_id)?;
+    let base_event = timeline::get_pdu(&args.event_id).await?;
     let room_id = base_event.room_id.clone();
 
-    if !state::user_can_see_event(sender_id, &args.event_id)? {
+    if !state::user_can_see_event(sender_id, &args.event_id).await? {
         return Err(
             MatrixError::forbidden("you don't have permission to view this event", None).into(),
         );
     }
-    if crate::event::is_ignored_sender_pdu(&base_event, sender_id) {
+    if crate::event::is_ignored_sender_pdu(&base_event, sender_id).await {
         return Err(MatrixError::sender_ignored(
             "the sender of the requested event is ignored",
             Some(base_event.sender.clone()),
@@ -187,7 +189,9 @@ pub(super) fn get_context(
         authed.device_id(),
         &room_id,
         &base_event.sender,
-    )? || lazy_load_send_redundant
+    )
+    .await?
+        || lazy_load_send_redundant
     {
         lazy_loaded.insert(base_event.sender.as_str().to_owned());
     }
@@ -195,17 +199,24 @@ pub(super) fn get_context(
     // Use limit with maximum 100
     let limit = args.limit.min(100);
     let base_event = base_event.to_room_event();
-    let events_before = timeline::stream::load_pdus_backward(
+    let events_before_loaded = timeline::stream::load_pdus_backward(
         Some(sender_id),
         &room_id,
         Some(base_token),
         None,
         None,
         limit / 2,
-    )?
-    .into_iter()
-    .filter(|(_, pdu)| state::user_can_see_event(sender_id, &pdu.event_id).unwrap_or(false))
-    .collect::<Vec<_>>();
+    )
+    .await?;
+    let mut events_before = Vec::new();
+    for (sn, pdu) in events_before_loaded {
+        if state::user_can_see_event(sender_id, &pdu.event_id)
+            .await
+            .unwrap_or(false)
+        {
+            events_before.push((sn, pdu));
+        }
+    }
 
     for (_, event) in &events_before {
         if !crate::room::lazy_loading::lazy_load_was_sent_before(
@@ -213,7 +224,9 @@ pub(super) fn get_context(
             authed.device_id(),
             &room_id,
             &event.sender,
-        )? || lazy_load_send_redundant
+        )
+        .await?
+            || lazy_load_send_redundant
         {
             lazy_loaded.insert(event.sender.as_str().to_owned());
         }
@@ -234,7 +247,8 @@ pub(super) fn get_context(
         None,
         None,
         limit / 2,
-    )?;
+    )
+    .await?;
 
     for (_, event) in &events_after {
         if !crate::room::lazy_loading::lazy_load_was_sent_before(
@@ -242,7 +256,9 @@ pub(super) fn get_context(
             authed.device_id(),
             &room_id,
             &event.sender,
-        )? || lazy_load_send_redundant
+        )
+        .await?
+            || lazy_load_send_redundant
         {
             lazy_loaded.insert(event.sender.as_str().to_owned());
         }
@@ -252,11 +268,15 @@ pub(super) fn get_context(
         events_after
             .last()
             .map_or(&*args.event_id, |(_, e)| &*e.event_id),
-    ) {
+    )
+    .await
+    {
         Ok(s) => s,
-        Err(_) => crate::room::get_frame_id(&room_id, None).unwrap_or_default(),
+        Err(_) => crate::room::get_frame_id(&room_id, None)
+            .await
+            .unwrap_or_default(),
     };
-    let state_ids = state::get_full_state_ids(frame_id).unwrap_or_default();
+    let state_ids = state::get_full_state_ids(frame_id).await.unwrap_or_default();
     let end_token = events_after
         .last()
         .map(|(_, e)| e.live_token())
@@ -272,10 +292,10 @@ pub(super) fn get_context(
             event_ty,
             state_key,
             ..
-        } = state::get_field(field_id)?;
+        } = state::get_field(field_id).await?;
 
         if event_ty != StateEventType::RoomMember {
-            let pdu = match timeline::get_pdu(&event_id) {
+            let pdu = match timeline::get_pdu(&event_id).await {
                 Ok(pdu) => pdu,
                 Err(_) => {
                     error!("pdu in state not found: {}", event_id);
@@ -284,7 +304,7 @@ pub(super) fn get_context(
             };
             state.push(pdu.to_state_event());
         } else if !lazy_load_enabled || lazy_loaded.contains(&state_key) {
-            let pdu = match timeline::get_pdu(&event_id) {
+            let pdu = match timeline::get_pdu(&event_id).await {
                 Ok(pdu) => pdu,
                 Err(_) => {
                     error!("pdu in state not found: {}", event_id);
@@ -332,7 +352,7 @@ pub(super) async fn send_redact(
         },
         authed.user_id(),
         &args.room_id,
-        &crate::room::get_version(&args.room_id)?,
+        &crate::room::get_version(&args.room_id).await?,
         &state_lock,
     )
     .await?
@@ -351,28 +371,30 @@ pub(super) async fn timestamp_to_event(
     depot: &mut Depot,
 ) -> JsonResult<TimestampToEventResBody> {
     let authed = depot.authed_info()?;
-    if !room::user::is_joined(authed.user_id(), &args.room_id)? {
+    if !room::user::is_joined(authed.user_id(), &args.room_id).await? {
         return Err(MatrixError::forbidden("You are not joined to this room.", None).into());
     }
-    let local_event =
-        crate::event::get_event_for_timestamp(&args.room_id, args.ts, args.dir).optional()?;
+    let local_event = crate::event::get_event_for_timestamp(&args.room_id, args.ts, args.dir)
+        .await
+        .optional()?;
 
     let mut is_event_next_to_backward_gap = false;
     let mut is_event_next_to_forward_gap = false;
     if let Some(local_event) = &local_event {
-        let local_event = timeline::get_pdu(&local_event.0)?;
+        let local_event = timeline::get_pdu(&local_event.0).await?;
         match args.dir {
             Direction::Backward => {
-                is_event_next_to_forward_gap = timeline::is_event_next_to_forward_gap(&local_event)?
+                is_event_next_to_forward_gap =
+                    timeline::is_event_next_to_forward_gap(&local_event).await?
             }
             Direction::Forward => {
                 is_event_next_to_backward_gap =
-                    timeline::is_event_next_to_backward_gap(&local_event)?
+                    timeline::is_event_next_to_backward_gap(&local_event).await?
             }
         }
     }
     if local_event.is_none() || is_event_next_to_backward_gap || is_event_next_to_forward_gap {
-        let remote_servers = room::admin_servers(&args.room_id, false)?;
+        let remote_servers = room::admin_servers(&args.room_id, false).await?;
         let Ok((
             remote_server,
             TimestampToEventResBody {
@@ -397,7 +419,7 @@ pub(super) async fn timestamp_to_event(
                 Err(StatusError::not_found().brief("no event found").into())
             };
         };
-        let room_version = crate::room::get_version(&args.room_id)?;
+        let room_version = crate::room::get_version(&args.room_id).await?;
         let Ok((event_id, event_value)) = parse_fetched_pdu(
             &args.room_id,
             &room_version,

--- a/crates/server/src/routing/client/room/membership.rs
+++ b/crates/server/src/routing/client/room/membership.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use palpo_core::Seqnum;
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
@@ -37,7 +38,7 @@ use crate::{
 ///
 /// - Only works if the user is currently joined
 #[endpoint]
-pub(super) fn get_members(
+pub(super) async fn get_members(
     _aa: AuthArgs,
     args: MembersReqArgs,
     depot: &mut Depot,
@@ -47,8 +48,8 @@ pub(super) fn get_members(
     let membership = args.membership.as_ref();
     let not_membership = args.not_membership.as_ref();
 
-    let mut until_sn = if !state::user_can_see_events(sender_id, &args.room_id)? {
-        if let Ok(leave_sn) = crate::room::user::leave_sn(sender_id, &args.room_id) {
+    let mut until_sn = if !state::user_can_see_events(sender_id, &args.room_id).await? {
+        if let Ok(leave_sn) = crate::room::user::leave_sn(sender_id, &args.room_id).await {
             Some(leave_sn)
         } else {
             return Err(MatrixError::forbidden(
@@ -74,15 +75,19 @@ pub(super) fn get_members(
                 .filter(event_points::frame_id.is_not_null())
                 .order(event_points::frame_id.desc())
                 .select(event_points::frame_id)
-                .first::<Option<i64>>(&mut connect()?)?
+                .first::<Option<i64>>(&mut connect().await?)
+                .await?
                 .unwrap_or_default()
         } else {
             return Err(MatrixError::bad_state("invalid at parameter").into());
         }
     } else {
-        crate::room::get_frame_id(&args.room_id, until_sn).unwrap_or_default()
+        crate::room::get_frame_id(&args.room_id, until_sn)
+            .await
+            .unwrap_or_default()
     };
-    let states: Vec<_> = state::get_full_state(frame_id)?
+    let states: Vec<_> = state::get_full_state(frame_id)
+        .await?
         .into_iter()
         .filter(|(key, _)| key.0 == StateEventType::RoomMember)
         .filter_map(|(_, pdu)| membership_filter(pdu, membership, not_membership, until_sn))
@@ -153,7 +158,7 @@ fn membership_filter(
 /// - TODO: An appservice just needs a puppet joined
 /// https://spec.matrix.org/latest/client-server-api/#knocking-on-rooms
 #[endpoint]
-pub(super) fn joined_members(
+pub(super) async fn joined_members(
     _aa: AuthArgs,
     room_id: PathParam<OwnedRoomId>,
     depot: &mut Depot,
@@ -172,19 +177,19 @@ pub(super) fn joined_members(
     //     None
     // };
     // the sender user must be in the room
-    if !state::user_can_see_events(sender_id, &room_id)? {
+    if !state::user_can_see_events(sender_id, &room_id).await? {
         return Err(
             MatrixError::forbidden("you don't have permission to view this room", None).into(),
         );
     }
 
     let mut joined = BTreeMap::new();
-    for user_id in crate::room::joined_users(&room_id, None)? {
+    for user_id in crate::room::joined_users(&room_id, None).await? {
         if let Some(DbProfile {
             display_name,
             avatar_url,
             ..
-        }) = data::user::get_profile(&user_id, None)?
+        }) = data::user::get_profile(&user_id, None).await?
         {
             joined.insert(user_id, RoomMember::new(display_name, avatar_url));
         }
@@ -203,7 +208,7 @@ pub(crate) async fn joined_rooms(
     let authed = depot.authed_info()?;
 
     json_ok(JoinedRoomsResBody {
-        joined_rooms: data::user::joined_rooms(authed.user_id())?,
+        joined_rooms: data::user::joined_rooms(authed.user_id()).await?,
     })
 }
 
@@ -224,7 +229,7 @@ pub(super) async fn forget_room(
     let authed = depot.authed_info()?;
     let room_id = room_id.into_inner();
 
-    crate::membership::forget_room(authed.user_id(), &room_id)?;
+    crate::membership::forget_room(authed.user_id(), &room_id).await?;
 
     empty_ok()
 }
@@ -264,7 +269,8 @@ pub(super) async fn join_room_by_id(
 
     let mut servers = Vec::new(); // There is no body.server_name for /roomId/join
     servers.extend(
-        state::get_user_state(authed.user_id(), &room_id)?
+        state::get_user_state(authed.user_id(), &room_id)
+            .await?
             .unwrap_or_default()
             .iter()
             .filter_map(|event| serde_json::from_str(event.inner().get()).ok())
@@ -280,7 +286,7 @@ pub(super) async fn join_room_by_id(
     if let Ok(server) = room_id.server_name() {
         servers.push(server.to_owned());
     } else {
-        servers.extend(crate::room::lookup_servers(&room_id).unwrap_or_default());
+        servers.extend(crate::room::lookup_servers(&room_id).await.unwrap_or_default());
     }
     servers.sort_unstable();
     servers.dedup();
@@ -375,12 +381,14 @@ pub(crate) async fn join_room_by_id_or_alias(
             )
             .await?;
             let mut servers = if via.is_empty() {
-                crate::room::lookup_servers(&room_id)?
+                crate::room::lookup_servers(&room_id).await?
             } else {
                 via.clone()
             };
 
-            let state_servers = state::get_user_state(sender_id, &room_id)?.unwrap_or_default();
+            let state_servers = state::get_user_state(sender_id, &room_id)
+                .await?
+                .unwrap_or_default();
             let state_servers = state_servers
                 .iter()
                 .filter_map(|event| serde_json::from_str(event.inner().get()).ok())
@@ -413,13 +421,14 @@ pub(crate) async fn join_room_by_id_or_alias(
             .await?;
 
             let addl_via_servers = if via.is_empty() {
-                crate::room::lookup_servers(&room_id)?
+                crate::room::lookup_servers(&room_id).await?
             } else {
                 via
             };
 
-            let addl_state_servers =
-                state::get_user_state(sender_id, &room_id)?.unwrap_or_default();
+            let addl_state_servers = state::get_user_state(sender_id, &room_id)
+                .await?
+                .unwrap_or_default();
 
             let mut addl_servers: Vec<_> = addl_state_servers
                 .iter()
@@ -481,7 +490,7 @@ pub(super) async fn ban_user(
         body.user_id.as_ref(),
         None,
     )
-    .ok();
+    .await.ok();
 
     let event = if let Some(room_state) = room_state {
         let event = room_state
@@ -542,7 +551,8 @@ pub(super) async fn ban_user(
             avatar_url,
             blurhash,
             ..
-        } = data::user::get_profile(&body.user_id, None)?
+        } = data::user::get_profile(&body.user_id, None)
+            .await?
             .ok_or(MatrixError::not_found("User profile not found."))?;
         RoomMemberEventContent {
             membership: MembershipState::Ban,
@@ -568,7 +578,7 @@ pub(super) async fn ban_user(
         },
         authed.user_id(),
         &room_id,
-        &crate::room::get_version(&room_id)?,
+        &crate::room::get_version(&room_id).await?,
         &state_lock,
     )
     .await?;
@@ -577,7 +587,9 @@ pub(super) async fn ban_user(
         &pdu.event_id,
         &[body.user_id.server_name().to_owned()],
         &[],
-    ) {
+    )
+    .await
+    {
         error!("failed to notify banned user server: {e}");
     }
 
@@ -602,7 +614,7 @@ pub(super) async fn unban_user(
         &StateEventType::RoomMember,
         body.user_id.as_ref(),
         None,
-    )?;
+    ).await?;
 
     if event.membership != MembershipState::Ban {
         return Err(MatrixError::bad_state(format!(
@@ -623,7 +635,7 @@ pub(super) async fn unban_user(
         },
         authed.user_id(),
         &room_id,
-        &crate::room::get_version(&room_id)?,
+        &crate::room::get_version(&room_id).await?,
         &state_lock,
     )
     .await?;
@@ -633,7 +645,9 @@ pub(super) async fn unban_user(
         &pdu.event_id,
         &[body.user_id.server_name().to_owned()],
         &[],
-    ) {
+    )
+    .await
+    {
         error!("failed to notify banned user server: {e}");
     }
 
@@ -658,7 +672,7 @@ pub(super) async fn kick_user(
         &StateEventType::RoomMember,
         body.user_id.as_str(),
         None,
-    ) else {
+    ).await else {
         return Err(MatrixError::forbidden(
             "users cannot kick users from a room they are not in",
             None,
@@ -699,7 +713,7 @@ pub(super) async fn kick_user(
         ),
         authed.user_id(),
         &room_id,
-        &crate::room::get_version(&room_id)?,
+        &crate::room::get_version(&room_id).await?,
         &state_lock,
     )
     .await?;
@@ -709,7 +723,9 @@ pub(super) async fn kick_user(
         &pdu.event_id,
         &[body.user_id.server_name().to_owned()],
         &[],
-    ) {
+    )
+    .await
+    {
         error!("failed to notify banned user server: {e}");
     }
 
@@ -738,9 +754,10 @@ pub(crate) async fn knock_room(
             .await?;
 
             let mut servers = body.via.clone();
-            servers.extend(crate::room::lookup_servers(&room_id).unwrap_or_default());
+            servers.extend(crate::room::lookup_servers(&room_id).await.unwrap_or_default());
             servers.extend(
                 state::get_user_state(sender_id, &room_id)
+                    .await
                     .unwrap_or_default()
                     .unwrap_or_default()
                     .iter()
@@ -769,9 +786,10 @@ pub(crate) async fn knock_room(
             )
             .await?;
 
-            let addl_via_servers = crate::room::lookup_servers(&room_id)?;
-            let addl_state_servers =
-                state::get_user_state(sender_id, &room_id)?.unwrap_or_default();
+            let addl_via_servers = crate::room::lookup_servers(&room_id).await?;
+            let addl_state_servers = state::get_user_state(sender_id, &room_id)
+                .await?
+                .unwrap_or_default();
 
             let mut addl_servers: Vec<_> = addl_state_servers
                 .iter()

--- a/crates/server/src/routing/client/room/message.rs
+++ b/crates/server/src/routing/client/room/message.rs
@@ -180,6 +180,7 @@ pub(super) async fn get_messages(
                     limit,
                 )
                 .await?;
+                events = timeline::trim_pdus_until_backfill_gap(events).await?;
             }
 
             for (_, event) in &events {

--- a/crates/server/src/routing/client/room/message.rs
+++ b/crates/server/src/routing/client/room/message.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use serde_json::value::to_raw_value;
 
 use crate::core::Direction;
@@ -45,7 +46,7 @@ pub(super) async fn get_messages(
             .filter(room_users::room_id.eq(&args.room_id))
             .filter(room_users::user_id.eq(sender_id))
             .filter(room_users::membership.eq("join")),
-        &mut connect()?
+        &mut connect().await?
     )?;
     if !is_joined {
         let forgotten_row = room_users::table
@@ -53,7 +54,8 @@ pub(super) async fn get_messages(
             .filter(room_users::user_id.eq(sender_id))
             .filter(room_users::membership.eq("leave"))
             .select((room_users::event_sn, room_users::forgotten))
-            .first::<(i64, bool)>(&mut connect()?);
+            .first::<(i64, bool)>(&mut connect().await?)
+            .await;
         let Some((_event_sn, forgotten)) = diesel::OptionalExtension::optional(forgotten_row)?
         else {
             return Err(MatrixError::forbidden("you aren't a member of the room", None).into());
@@ -121,7 +123,8 @@ pub(super) async fn get_messages(
                 until_tk,
                 Some(&args.filter),
                 limit,
-            )?;
+            )
+            .await?;
 
             for (_, event) in &events {
                 // TODO: Remove this when these are resolved:
@@ -158,7 +161,8 @@ pub(super) async fn get_messages(
                     until_tk,
                     Some(&args.filter),
                     limit,
-                )?;
+                )
+                .await?;
             // Backfill if the local page is short on history. Backfilled events
             // may have higher depth than what we already loaded (e.g. on a fresh
             // join, locally we only have low-depth state events while the
@@ -174,7 +178,8 @@ pub(super) async fn get_messages(
                     until_tk,
                     Some(&args.filter),
                     limit,
-                )?;
+                )
+                .await?;
             }
 
             for (_, event) in &events {
@@ -205,7 +210,7 @@ pub(super) async fn get_messages(
             &StateEventType::RoomMember,
             ll_id.as_str(),
             None,
-        ) {
+        ).await {
             resp.state.push(member_event.to_state_event());
         }
     }
@@ -257,7 +262,9 @@ pub(super) async fn send_message(
         authed.user_id(),
         Some(authed.device_id()),
         Some(&args.room_id),
-    )? {
+    )
+    .await?
+    {
         return json_ok(SendMessageResBody::new(event_id));
     }
 
@@ -281,7 +288,7 @@ pub(super) async fn send_message(
         },
         authed.user_id(),
         &args.room_id,
-        &crate::room::get_version(&args.room_id)?,
+        &crate::room::get_version(&args.room_id).await?,
         &state_lock,
     )
     .await?
@@ -294,7 +301,8 @@ pub(super) async fn send_message(
         Some(authed.device_id()),
         Some(&args.room_id),
         Some(&event_id),
-    )?;
+    )
+    .await?;
 
     json_ok(SendMessageResBody::new((*event_id).to_owned()))
 }
@@ -335,7 +343,7 @@ pub(super) async fn post_message(
         },
         authed.user_id(),
         &args.room_id,
-        &crate::room::get_version(&args.room_id)?,
+        &crate::room::get_version(&args.room_id).await?,
         &state_lock,
     )
     .await?

--- a/crates/server/src/routing/client/room/receipt.rs
+++ b/crates/server/src/routing/client/room/receipt.rs
@@ -17,7 +17,7 @@ use crate::{AppError, AuthArgs, DepotExt, EmptyResult, empty_ok, room};
 /// #POST /_matrix/client/r0/rooms/{room_id}/receipt/{receipt_type}/{event_id}
 /// Sets private read marker and public read receipt EDU.
 #[endpoint]
-pub(super) fn send_receipt(
+pub(super) async fn send_receipt(
     _aa: AuthArgs,
     args: SendReceiptReqArgs,
     body: JsonBody<CreateReceiptReqBody>,
@@ -31,8 +31,8 @@ pub(super) fn send_receipt(
         _ => None,
     };
 
-    crate::user::ping_presence(sender_id, &PresenceState::Online)?;
-    let event_sn = crate::event::get_event_sn(&args.event_id)?;
+    crate::user::ping_presence(sender_id, &PresenceState::Online).await?;
+    let event_sn = crate::event::get_event_sn(&args.event_id).await?;
     match args.receipt_type {
         ReceiptType::FullyRead => {
             let fully_read_event = FullyReadEvent {
@@ -45,8 +45,9 @@ pub(super) fn send_receipt(
                 Some(args.room_id.clone()),
                 &RoomAccountDataEventType::FullyRead.to_string(),
                 serde_json::to_value(fully_read_event.content).expect("to json value always works"),
-            )?;
-            push_action::remove_actions_for_room(sender_id, &args.room_id)?;
+            )
+            .await?;
+            push_action::remove_actions_for_room(sender_id, &args.room_id).await?;
         }
         ReceiptType::Read => {
             let mut user_receipts = BTreeMap::new();
@@ -71,8 +72,10 @@ pub(super) fn send_receipt(
                     room_id: args.room_id.clone(),
                 },
                 true,
-            )?;
-            push_action::remove_actions_until(sender_id, &args.room_id, event_sn, thread_id)?;
+            )
+            .await?;
+            push_action::remove_actions_until(sender_id, &args.room_id, event_sn, thread_id)
+                .await?;
         }
         ReceiptType::ReadPrivate => {
             // let count = timeline::get_event_sn(&args.event_id)?
@@ -82,8 +85,10 @@ pub(super) fn send_receipt(
                 sender_id,
                 &args.event_id,
                 event_sn,
-            )?;
-            push_action::remove_actions_until(sender_id, &args.room_id, event_sn, thread_id)?;
+            )
+            .await?;
+            push_action::remove_actions_until(sender_id, &args.room_id, event_sn, thread_id)
+                .await?;
         }
         _ => return Err(AppError::internal("unsupported receipt type")),
     }
@@ -91,7 +96,7 @@ pub(super) fn send_receipt(
         &args.receipt_type,
         ReceiptType::Read | ReceiptType::ReadPrivate
     ) {
-        push_action::refresh_notify_summary(sender_id, &args.room_id)?;
+        push_action::refresh_notify_summary(sender_id, &args.room_id).await?;
     }
     empty_ok()
 }

--- a/crates/server/src/routing/client/room/relation.rs
+++ b/crates/server/src/routing/client/room/relation.rs
@@ -8,7 +8,7 @@ use crate::{AuthArgs, DepotExt, JsonResult, json_ok};
 
 /// #GET /_matrix/client/r0/rooms/{room_id}/relations/{event_id}
 #[endpoint]
-pub(super) fn get_relation(
+pub(super) async fn get_relation(
     _aa: AuthArgs,
     args: RelatingEventsReqArgs,
     depot: &mut Depot,
@@ -26,7 +26,8 @@ pub(super) fn get_relation(
         args.limit,
         args.recurse,
         args.dir,
-    )?;
+    )
+    .await?;
     json_ok(body)
 }
 
@@ -50,7 +51,7 @@ pub(super) async fn get_relation_by_rel_type(
         args.limit,
         args.recurse,
         args.dir,
-    )?;
+    ).await?;
 
     json_ok(body)
 }
@@ -75,7 +76,7 @@ pub(super) async fn get_relation_by_rel_type_and_event_type(
         args.limit,
         args.recurse,
         args.dir,
-    )?;
+    ).await?;
 
     json_ok(body)
 }

--- a/crates/server/src/routing/client/room/state.rs
+++ b/crates/server/src/routing/client/room/state.rs
@@ -21,7 +21,7 @@ use crate::{AuthArgs, DepotExt, EmptyResult, JsonResult, MatrixError, empty_ok, 
 ///
 /// - If not joined: Only works if current room history visibility is world readable
 #[endpoint]
-pub(super) fn get_state(
+pub(super) async fn get_state(
     _aa: AuthArgs,
     room_id: PathParam<OwnedRoomId>,
     depot: &mut Depot,
@@ -30,8 +30,8 @@ pub(super) fn get_state(
     let sender_id = authed.user_id();
     let room_id = room_id.into_inner();
 
-    let _until_sn = if !state::user_can_see_events(sender_id, &room_id)? {
-        if let Ok(leave_sn) = room::user::leave_sn(sender_id, &room_id) {
+    let _until_sn = if !state::user_can_see_events(sender_id, &room_id).await? {
+        if let Ok(leave_sn) = room::user::leave_sn(sender_id, &room_id).await {
             Some(leave_sn)
         } else {
             return Err(MatrixError::forbidden(
@@ -44,9 +44,10 @@ pub(super) fn get_state(
         None
     };
 
-    let frame_id = room::get_frame_id(&room_id, None).unwrap_or_default();
+    let frame_id = room::get_frame_id(&room_id, None).await.unwrap_or_default();
 
     let room_state = state::get_full_state(frame_id)
+        .await
         .unwrap_or_default()
         .values()
         .map(|pdu| pdu.to_state_event())
@@ -66,7 +67,7 @@ pub async fn report(
     let authed = depot.authed_info()?;
     let body = body.into_inner();
 
-    let pdu = match timeline::get_pdu(&args.event_id) {
+    let pdu = match timeline::get_pdu(&args.event_id).await {
         Ok(pdu) => pdu,
         _ => return Err(MatrixError::invalid_param("Invalid Event ID").into()),
     };
@@ -94,7 +95,8 @@ pub async fn report(
             "score": report_score,
         })),
         report_score,
-    ))?;
+    ))
+    .await?;
 
     let _ = crate::admin::send_message(RoomMessageEventContent::text_html(
         format!(
@@ -134,7 +136,7 @@ pub async fn report(
 ///
 /// - If not joined: Only works if current room history visibility is world readable
 #[endpoint]
-pub(super) fn state_for_key(
+pub(super) async fn state_for_key(
     _aa: AuthArgs,
     args: StateEventsForKeyReqArgs,
     depot: &mut Depot,
@@ -142,8 +144,8 @@ pub(super) fn state_for_key(
     let authed = depot.authed_info()?;
     let sender_id = authed.user_id();
 
-    let until_sn = if !state::user_can_see_events(sender_id, &args.room_id)? {
-        if let Ok(leave_sn) = room::user::leave_sn(sender_id, &args.room_id) {
+    let until_sn = if !state::user_can_see_events(sender_id, &args.room_id).await? {
+        if let Ok(leave_sn) = room::user::leave_sn(sender_id, &args.room_id).await {
             Some(leave_sn)
         } else {
             return Err(MatrixError::forbidden(
@@ -156,7 +158,7 @@ pub(super) fn state_for_key(
         None
     };
 
-    let event = room::get_state(&args.room_id, &args.event_type, &args.state_key, until_sn)?;
+    let event = room::get_state(&args.room_id, &args.event_type, &args.state_key, until_sn).await?;
     let event_format = args
         .format
         .as_ref()
@@ -183,8 +185,8 @@ pub(super) async fn state_for_empty_key(
 ) -> JsonResult<StateEventsForKeyResBody> {
     let authed = depot.authed_info()?;
     let sender_id = authed.user_id();
-    let until_sn = if !state::user_can_see_events(sender_id, &args.room_id)? {
-        if let Ok(leave_sn) = room::user::leave_sn(sender_id, &args.room_id) {
+    let until_sn = if !state::user_can_see_events(sender_id, &args.room_id).await? {
+        if let Ok(leave_sn) = room::user::leave_sn(sender_id, &args.room_id).await {
             Some(leave_sn)
         } else {
             return Err(MatrixError::forbidden(
@@ -197,7 +199,7 @@ pub(super) async fn state_for_empty_key(
         None
     };
 
-    let event = room::get_state(&args.room_id, &args.event_type, "", until_sn)?;
+    let event = room::get_state(&args.room_id, &args.event_type, "", until_sn).await?;
     let event_format = args
         .format
         .as_ref()
@@ -231,7 +233,7 @@ pub(super) async fn send_state_for_key(
     let event_id = crate::state::send_state_event_for_key(
         authed.user_id(),
         &args.room_id,
-        &crate::room::get_version(&args.room_id)?,
+        &crate::room::get_version(&args.room_id).await?,
         &args.event_type,
         body.0,
         args.state_key.to_owned(),
@@ -261,7 +263,7 @@ pub(super) async fn send_state_for_empty_key(
     let event_id = crate::state::send_state_event_for_key(
         authed.user_id(),
         &args.room_id,
-        &crate::room::get_version(&args.room_id)?,
+        &crate::room::get_version(&args.room_id).await?,
         &args.event_type.to_string().into(),
         body.0,
         "".into(),
@@ -284,7 +286,7 @@ pub async fn send_typing(
 ) -> EmptyResult {
     let authed = depot.authed_info()?;
 
-    if !room::user::is_joined(authed.user_id(), &args.room_id)? {
+    if !room::user::is_joined(authed.user_id(), &args.room_id).await? {
         return Err(MatrixError::forbidden("You are not in this room.", None).into());
     }
 

--- a/crates/server/src/routing/client/room/summary.rs
+++ b/crates/server/src/routing/client/room/summary.rs
@@ -29,11 +29,11 @@ pub async fn get_summary_msc_3266(
     let (room_id, servers) =
         room::alias::resolve_with_servers(&args.room_id_or_alias, Some(args.via.clone())).await?;
 
-    if data::room::is_disabled(&room_id)? {
+    if data::room::is_disabled(&room_id).await? {
         return Err(MatrixError::forbidden("This room is banned on this homeserver.", None).into());
     }
 
-    if room::is_server_joined(&config::get().server_name, &room_id)? {
+    if room::is_server_joined(&config::get().server_name, &room_id).await? {
         let res_body = local_room_summary(&room_id, sender_id).await?;
         json_ok(res_body)
     } else {
@@ -66,9 +66,9 @@ async fn local_room_summary(
         ?sender_id,
         "Sending local room summary response for {room_id:?}"
     );
-    let join_rule = room::get_join_rule(room_id)?;
-    let world_readable = room::is_world_readable(room_id);
-    let guest_can_join = room::guest_can_join(room_id);
+    let join_rule = room::get_join_rule(room_id).await?;
+    let world_readable = room::is_world_readable(room_id).await;
+    let guest_can_join = room::guest_can_join(room_id).await;
 
     trace!("{join_rule:?}, {world_readable:?}, {guest_can_join:?}");
 
@@ -82,18 +82,22 @@ async fn local_room_summary(
     )
     .await?;
 
-    let canonical_alias = room::get_canonical_alias(room_id).ok().flatten();
-    let name = room::get_name(room_id).ok();
-    let topic = room::get_topic(room_id).ok();
-    let room_type = room::get_room_type(room_id).ok().flatten();
-    let avatar_url = room::get_avatar_url(room_id).ok().flatten();
-    let room_version = room::get_version(room_id).ok();
-    let encryption = room::get_encryption(room_id).ok();
-    let num_joined_members = room::joined_member_count(room_id).unwrap_or(0);
-    let membership = sender_id.map(|sender_id| {
-        room::get_member(room_id, sender_id, None)
-            .map_or(MembershipState::Leave, |content| content.membership)
-    });
+    let canonical_alias = room::get_canonical_alias(room_id).await.ok().flatten();
+    let name = room::get_name(room_id).await.ok();
+    let topic = room::get_topic(room_id).await.ok();
+    let room_type = room::get_room_type(room_id).await.ok().flatten();
+    let avatar_url = room::get_avatar_url(room_id).await.ok().flatten();
+    let room_version = room::get_version(room_id).await.ok();
+    let encryption = room::get_encryption(room_id).await.ok();
+    let num_joined_members = room::joined_member_count(room_id).await.unwrap_or(0);
+    let membership = match sender_id {
+        Some(sender_id) => Some(
+            room::get_member(room_id, sender_id, None)
+                .await
+                .map_or(MembershipState::Leave, |content| content.membership),
+        ),
+        None => None,
+    };
 
     Ok(SummaryMsc3266ResBody {
         room_id: room_id.to_owned(),
@@ -129,7 +133,7 @@ async fn remote_room_summary_hierarchy(
         return Err(MatrixError::forbidden("Federation is disabled.", None).into());
     }
 
-    if room::is_disabled(room_id)? {
+    if room::is_disabled(room_id).await? {
         return Err(MatrixError::forbidden(
             "Federaton of room {room_id} is currently disabled on this server.",
             None,
@@ -193,7 +197,7 @@ async fn require_user_can_see_summary<'a, I>(
     join_rule: &SpaceRoomJoinRule,
     guest_can_join: bool,
     world_readable: bool,
-    mut allowed_room_ids: I,
+    allowed_room_ids: I,
     sender_id: Option<&UserId>,
 ) -> AppResult<()>
 where
@@ -205,10 +209,15 @@ where
     );
     match sender_id {
         Some(sender_id) => {
-            let user_can_see_events = state::user_can_see_events(sender_id, room_id)?;
-            let is_guest = data::user::is_guest(sender_id).unwrap_or(false);
-            let user_in_allowed_restricted_room = allowed_room_ids
-                .any(|room| room::user::is_joined(sender_id, room).unwrap_or(false));
+            let user_can_see_events = state::user_can_see_events(sender_id, room_id).await?;
+            let is_guest = data::user::is_guest(sender_id).await.unwrap_or(false);
+            let mut user_in_allowed_restricted_room = false;
+            for room in allowed_room_ids {
+                if room::user::is_joined(sender_id, room).await.unwrap_or(false) {
+                    user_in_allowed_restricted_room = true;
+                    break;
+                }
+            }
 
             if user_can_see_events
                 || (is_guest && guest_can_join)

--- a/crates/server/src/routing/client/room/tag.rs
+++ b/crates/server/src/routing/client/room/tag.rs
@@ -24,6 +24,7 @@ pub(super) async fn list_tags(
         Some(&args.room_id),
         &RoomAccountDataEventType::Tag.to_string(),
     )
+    .await
     .unwrap_or_default();
 
     json_ok(TagsResBody {
@@ -49,6 +50,7 @@ pub(super) async fn upsert_tag(
         Some(&args.room_id),
         &RoomAccountDataEventType::Tag.to_string(),
     )
+    .await
     .unwrap_or_default();
 
     user_data_content
@@ -60,7 +62,8 @@ pub(super) async fn upsert_tag(
         Some(args.room_id.clone()),
         &RoomAccountDataEventType::Tag.to_string(),
         serde_json::to_value(user_data_content).expect("to json value always works"),
-    )?;
+    )
+    .await?;
     empty_ok()
 }
 
@@ -81,6 +84,7 @@ pub(super) async fn delete_tag(
         Some(&args.room_id),
         &RoomAccountDataEventType::Tag.to_string(),
     )
+    .await
     .unwrap_or_default();
 
     user_data_content.tags.remove(&args.tag.clone().into());
@@ -90,6 +94,7 @@ pub(super) async fn delete_tag(
         Some(args.room_id.clone()),
         &RoomAccountDataEventType::Tag.to_string(),
         serde_json::to_value(user_data_content).expect("to json value always works"),
-    )?;
+    )
+    .await?;
     empty_ok()
 }

--- a/crates/server/src/routing/client/room/thread.rs
+++ b/crates/server/src/routing/client/room/thread.rs
@@ -27,14 +27,17 @@ pub(super) async fn list_threads(
     };
 
     let (events, next_batch) =
-        crate::room::thread::get_threads(&args.room_id, &args.include, limit, from)?;
+        crate::room::thread::get_threads(&args.room_id, &args.include, limit, from).await?;
 
-    let threads = events
-        .into_iter()
-        .filter(|(_, pdu)| {
-            state::user_can_see_event(authed.user_id(), &pdu.event_id).unwrap_or(false)
-        })
-        .collect::<Vec<_>>();
+    let mut threads = Vec::new();
+    for (sn, pdu) in events.into_iter() {
+        if state::user_can_see_event(authed.user_id(), &pdu.event_id)
+            .await
+            .unwrap_or(false)
+        {
+            threads.push((sn, pdu));
+        }
+    }
 
     json_ok(ThreadsResBody {
         chunk: threads

--- a/crates/server/src/routing/client/room_key.rs
+++ b/crates/server/src/routing/client/room_key.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
 
@@ -58,7 +59,8 @@ async fn get_keys(
     let rooms = e2e_room_keys::table
         .filter(e2e_room_keys::user_id.eq(authed.user_id()))
         .filter(e2e_room_keys::version.eq(version))
-        .load::<DbRoomKey>(&mut connect()?)?
+        .load::<DbRoomKey>(&mut connect().await?)
+        .await?
         .into_iter()
         .map(|rk| {
             let DbRoomKey {
@@ -78,7 +80,7 @@ async fn get_keys(
 /// #GET /_matrix/client/r0/room_keys/keys/{room_id}
 /// Retrieves all keys from the backup for a given room.
 #[endpoint]
-fn get_keys_for_room(
+async fn get_keys_for_room(
     _aa: AuthArgs,
     args: KeysForRoomReqArgs,
     depot: &mut Depot,
@@ -88,9 +90,11 @@ fn get_keys_for_room(
         room_id,
         session_data,
         ..
-    } = key_backup::get_room_key(authed.user_id(), &args.room_id, args.version)?.ok_or(
-        MatrixError::not_found("Backup key not found for this user's room."),
-    )?;
+    } = key_backup::get_room_key(authed.user_id(), &args.room_id, args.version)
+        .await?
+        .ok_or(MatrixError::not_found(
+            "Backup key not found for this user's room.",
+        ))?;
     json_ok(KeysForRoomResBody::new(BTreeMap::from_iter(
         [(
             room_id,
@@ -114,7 +118,8 @@ async fn get_session_keys(
         .filter(e2e_room_keys::room_id.eq(&args.room_id))
         .filter(e2e_room_keys::session_id.eq(&args.session_id))
         // .select(e2e_room_keys::session_data)
-        .first::<DbRoomKey>(&mut connect()?)
+        .first::<DbRoomKey>(&mut connect().await?)
+        .await
         .optional()?
         .ok_or(MatrixError::not_found(
             "Backup key not found for this user's session.",
@@ -131,7 +136,7 @@ async fn get_session_keys(
 /// - Adds the keys to the backup
 /// - Returns the new number of keys in this backup and the etag
 #[endpoint]
-fn add_keys(
+async fn add_keys(
     _aa: AuthArgs,
     version: QueryParam<i64, true>,
     body: JsonBody<AddKeysReqBody>,
@@ -140,7 +145,8 @@ fn add_keys(
     let authed = depot.authed_info()?;
     let version = version.into_inner();
 
-    let keys_version = key_backup::get_latest_room_keys_version(authed.user_id())?
+    let keys_version = key_backup::get_latest_room_keys_version(authed.user_id())
+        .await?
         .ok_or(MatrixError::not_found("Key backup does not exist."))?;
     if version != keys_version.version {
         return Err(MatrixError::invalid_param(
@@ -151,13 +157,13 @@ fn add_keys(
 
     for (room_id, room) in &body.rooms {
         for (session_id, key_data) in &room.sessions {
-            key_backup::add_key(authed.user_id(), version, room_id, session_id, key_data)?
+            key_backup::add_key(authed.user_id(), version, room_id, session_id, key_data).await?
         }
     }
 
     json_ok(ModifyKeysResBody {
-        count: (key_backup::count_keys(authed.user_id(), version)? as u32).into(),
-        etag: key_backup::get_etag(authed.user_id(), version)?,
+        count: (key_backup::count_keys(authed.user_id(), version).await? as u32).into(),
+        etag: key_backup::get_etag(authed.user_id(), version).await?,
     })
 }
 
@@ -168,7 +174,7 @@ fn add_keys(
 /// - Adds the keys to the backup
 /// - Returns the new number of keys in this backup and the etag
 #[endpoint]
-fn add_keys_for_room(
+async fn add_keys_for_room(
     _aa: AuthArgs,
     args: KeysForRoomReqArgs,
     body: JsonBody<AddKeysForRoomReqBody>,
@@ -176,7 +182,8 @@ fn add_keys_for_room(
 ) -> JsonResult<ModifyKeysResBody> {
     let authed = depot.authed_info()?;
 
-    let keys_version = key_backup::get_latest_room_keys_version(authed.user_id())?
+    let keys_version = key_backup::get_latest_room_keys_version(authed.user_id())
+        .await?
         .ok_or(MatrixError::not_found("Key backup does not exist."))?;
     if args.version != keys_version.version {
         return Err(MatrixError::invalid_param(
@@ -192,12 +199,13 @@ fn add_keys_for_room(
             &args.room_id,
             session_id,
             key_data,
-        )?
+        )
+        .await?
     }
 
     json_ok(ModifyKeysResBody {
-        count: (key_backup::count_keys(authed.user_id(), args.version)? as u32).into(),
-        etag: key_backup::get_etag(authed.user_id(), args.version)?,
+        count: (key_backup::count_keys(authed.user_id(), args.version).await? as u32).into(),
+        etag: key_backup::get_etag(authed.user_id(), args.version).await?,
     })
 }
 /// #PUT /_matrix/client/r0/room_keys/keys/{room_d}/{session_id}
@@ -207,7 +215,7 @@ fn add_keys_for_room(
 /// - Adds the keys to the backup
 /// - Returns the new number of keys in this backup and the etag
 #[endpoint]
-fn add_keys_for_session(
+async fn add_keys_for_session(
     _aa: AuthArgs,
     args: KeysForSessionReqArgs,
     body: JsonBody<AddKeysForSessionReqBody>,
@@ -216,7 +224,8 @@ fn add_keys_for_session(
     let authed = depot.authed_info()?;
     let body = body.into_inner();
 
-    let keys_version = key_backup::get_latest_room_keys_version(authed.user_id())?
+    let keys_version = key_backup::get_latest_room_keys_version(authed.user_id())
+        .await?
         .ok_or(MatrixError::not_found("Key backup does not exist."))?;
     if args.version != keys_version.version {
         return Err(MatrixError::invalid_param(
@@ -231,7 +240,8 @@ fn add_keys_for_session(
         &args.room_id,
         &args.session_id,
         &body.0,
-    )?;
+    )
+    .await?;
 
     // json_ok(ModifyKeysResBody {
     //     count: (key_backup::count_keys(authed.user_id(), args.version)? as u32).into(),
@@ -243,21 +253,22 @@ fn add_keys_for_session(
 /// #GET /_matrix/client/r0/room_keys/version/{version}
 /// Get information about an existing backup.
 #[endpoint]
-fn get_version(
+async fn get_version(
     _aa: AuthArgs,
     version: PathParam<i64>,
     depot: &mut Depot,
 ) -> JsonResult<VersionResBody> {
     let authed = depot.authed_info()?;
     let version = version.into_inner();
-    let algorithm = key_backup::get_room_keys_version(authed.user_id(), version)?
+    let algorithm = key_backup::get_room_keys_version(authed.user_id(), version)
+        .await?
         .ok_or(MatrixError::not_found("Key backup does not exist."))?
         .algorithm;
 
     json_ok(VersionResBody {
         algorithm: serde_json::from_value(algorithm)?,
-        count: (key_backup::count_keys(authed.user_id(), version)? as u32).into(),
-        etag: key_backup::get_etag(authed.user_id(), version)?,
+        count: (key_backup::count_keys(authed.user_id(), version).await? as u32).into(),
+        etag: key_backup::get_etag(authed.user_id(), version).await?,
         version: version.to_string(),
     })
 }
@@ -265,14 +276,15 @@ fn get_version(
 /// #POST /_matrix/client/r0/room_keys/version
 /// Creates a new backup.
 #[endpoint]
-fn create_version(
+async fn create_version(
     _aa: AuthArgs,
     body: JsonBody<CreateVersionReqBody>,
     depot: &mut Depot,
 ) -> JsonResult<CreateVersionResBody> {
     let authed = depot.authed_info()?;
     let algorithm = body.into_inner().0;
-    let version = key_backup::create_backup(authed.user_id(), &algorithm)?
+    let version = key_backup::create_backup(authed.user_id(), &algorithm)
+        .await?
         .version
         .to_string();
 
@@ -282,14 +294,14 @@ fn create_version(
 /// #PUT /_matrix/client/r0/room_keys/version/{version}
 /// Update information about an existing backup. Only `auth_data` can be modified.
 #[endpoint]
-fn update_version(
+async fn update_version(
     _aa: AuthArgs,
     body: JsonBody<CreateVersionReqBody>,
     depot: &mut Depot,
 ) -> EmptyResult {
     let authed = depot.authed_info()?;
     let algorithm = body.into_inner().0;
-    key_backup::create_backup(authed.user_id(), &algorithm)?;
+    key_backup::create_backup(authed.user_id(), &algorithm).await?;
 
     empty_ok()
 }
@@ -297,18 +309,19 @@ fn update_version(
 /// #GET /_matrix/client/r0/room_keys/version
 /// Get information about the latest backup version.
 #[endpoint]
-fn latest_version(_aa: AuthArgs, depot: &mut Depot) -> JsonResult<VersionResBody> {
+async fn latest_version(_aa: AuthArgs, depot: &mut Depot) -> JsonResult<VersionResBody> {
     let authed = depot.authed_info()?;
 
     let DbRoomKeysVersion {
         version, algorithm, ..
-    } = key_backup::get_latest_room_keys_version(authed.user_id())?
+    } = key_backup::get_latest_room_keys_version(authed.user_id())
+        .await?
         .ok_or(MatrixError::not_found("Key backup does not exist."))?;
 
     json_ok(VersionResBody {
         algorithm: serde_json::from_value(algorithm)?,
-        count: (key_backup::count_keys(authed.user_id(), version)? as u32).into(),
-        etag: key_backup::get_etag(authed.user_id(), version)?,
+        count: (key_backup::count_keys(authed.user_id(), version).await? as u32).into(),
+        etag: key_backup::get_etag(authed.user_id(), version).await?,
         version: version.to_string(),
     })
 }
@@ -317,11 +330,11 @@ fn latest_version(_aa: AuthArgs, depot: &mut Depot) -> JsonResult<VersionResBody
 ///
 /// - Deletes both information about the backup, as well as all key data related to the backup
 #[endpoint]
-fn delete_version(_aa: AuthArgs, version: PathParam<i64>, depot: &mut Depot) -> EmptyResult {
+async fn delete_version(_aa: AuthArgs, version: PathParam<i64>, depot: &mut Depot) -> EmptyResult {
     let authed = depot.authed_info()?;
     let version = version.into_inner();
 
-    key_backup::delete_backup(authed.user_id(), version)?;
+    key_backup::delete_backup(authed.user_id(), version).await?;
 
     empty_ok()
 }
@@ -329,41 +342,41 @@ fn delete_version(_aa: AuthArgs, version: PathParam<i64>, depot: &mut Depot) -> 
 /// #DELETE /_matrix/client/r0/room_keys/keys
 /// Delete the keys from the backup.
 #[endpoint]
-fn delete_keys(
+async fn delete_keys(
     _aa: AuthArgs,
     version: QueryParam<i64, true>,
     depot: &mut Depot,
 ) -> JsonResult<ModifyKeysResBody> {
     let authed = depot.authed_info()?;
     let version = version.into_inner();
-    key_backup::delete_all_keys(authed.user_id(), version)?;
+    key_backup::delete_all_keys(authed.user_id(), version).await?;
 
     json_ok(ModifyKeysResBody {
-        count: (key_backup::count_keys(authed.user_id(), version)? as u32).into(),
-        etag: key_backup::get_etag(authed.user_id(), version)?,
+        count: (key_backup::count_keys(authed.user_id(), version).await? as u32).into(),
+        etag: key_backup::get_etag(authed.user_id(), version).await?,
     })
 }
 /// #DELETE /_matrix/client/r0/room_keys/keys/{room_id}
 /// Delete the keys from the backup for a given room.
 #[endpoint]
-fn delete_room_keys(
+async fn delete_room_keys(
     _aa: AuthArgs,
     args: KeysForRoomReqArgs,
     depot: &mut Depot,
 ) -> JsonResult<ModifyKeysResBody> {
     let authed = depot.authed_info()?;
 
-    key_backup::delete_room_keys(authed.user_id(), args.version, &args.room_id)?;
+    key_backup::delete_room_keys(authed.user_id(), args.version, &args.room_id).await?;
 
     json_ok(ModifyKeysResBody {
-        count: (key_backup::count_keys(authed.user_id(), args.version)? as u32).into(),
-        etag: key_backup::get_etag(authed.user_id(), args.version)?,
+        count: (key_backup::count_keys(authed.user_id(), args.version).await? as u32).into(),
+        etag: key_backup::get_etag(authed.user_id(), args.version).await?,
     })
 }
 /// #DELETE /_matrix/client/r0/room_keys/keys/{room_id}/{session_id}
 /// Delete a key from the backup.
 #[endpoint]
-fn delete_session_keys(
+async fn delete_session_keys(
     _aa: AuthArgs,
     args: KeysForSessionReqArgs,
     depot: &mut Depot,
@@ -375,10 +388,11 @@ fn delete_session_keys(
         args.version,
         &args.room_id,
         &args.session_id,
-    )?;
+    )
+    .await?;
 
     json_ok(ModifyKeysResBody {
-        count: (key_backup::count_keys(authed.user_id(), args.version)? as u32).into(),
-        etag: key_backup::get_etag(authed.user_id(), args.version)?,
+        count: (key_backup::count_keys(authed.user_id(), args.version).await? as u32).into(),
+        etag: key_backup::get_etag(authed.user_id(), args.version).await?,
     })
 }

--- a/crates/server/src/routing/client/session.rs
+++ b/crates/server/src/routing/client/session.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use palpo_data::user::set_display_name;
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
@@ -167,10 +167,10 @@ async fn login(
             //         admin::revoke_admin(&user_id).await?;
             //     }
             // } else {
-            let Ok(user) = data::user::get_user(&user_id) else {
+            let Ok(user) = data::user::get_user(&user_id).await else {
                 return Err(MatrixError::forbidden("User not found.", None).into());
             };
-            if let Err(e) = user::verify_password(&user, password) {
+            if let Err(e) = user::verify_password(&user, password).await {
                 res.status_code(StatusCode::FORBIDDEN); //for complement testing: TestLogin/parallel/POST_/login_wrong_password_is_rejected
                 if let AppError::Matrix(matrix) = e {
                     if matches!(
@@ -192,7 +192,7 @@ async fn login(
             if !crate::config::get().login_via_existing_session {
                 return Err(MatrixError::unknown("Token login is not enabled.").into());
             }
-            user::take_login_token(token)?
+            user::take_login_token(token).await?
         }
         LoginInfo::Jwt(info) => {
             let conf = config::get();
@@ -209,7 +209,7 @@ async fn login(
                     ))
                 })?;
 
-            if !data::user::user_exists(&user_id)? {
+            if !data::user::user_exists(&user_id).await? {
                 if !jwt_conf.register_user {
                     return Err(
                         MatrixError::not_found("user is not registered on this server.").into(),
@@ -232,10 +232,11 @@ async fn login(
                     .on_conflict(users::id)
                     .do_update()
                     .set(&new_user)
-                    .get_result::<DbUser>(&mut connect()?)?;
+                    .get_result::<DbUser>(&mut connect().await?)
+                    .await?;
 
                 // Set initial user profile
-                if let Err(e) = set_display_name(&user.id, user.id.localpart()) {
+                if let Err(e) = set_display_name(&user.id, user.id.localpart()).await {
                     tracing::warn!("failed to set profile for new user (non-fatal): {}", e);
                 }
             }
@@ -257,6 +258,7 @@ async fn login(
     };
 
     let user = data::user::get_user(&user_id)
+        .await
         .map_err(|_| MatrixError::forbidden("User not found.", None))?;
     user::ensure_account_usable(&user)?;
 
@@ -280,20 +282,22 @@ async fn login(
             &refresh_token,
             expires_at,
             ultimate_session_expires_at,
-        )?;
+        )
+        .await?;
         (Some(refresh_token), Some(refresh_token_id))
     } else {
         (None, None)
     };
 
     // Determine if device_id was provided and exists in the db for this user
-    if data::user::device::is_device_exists(&user_id, &device_id)? {
+    if data::user::device::is_device_exists(&user_id, &device_id).await? {
         data::user::device::set_access_token(
             &user_id,
             &device_id,
             &access_token,
             refresh_token_id,
-        )?;
+        )
+        .await?;
     } else {
         data::user::device::create_device(
             &user_id,
@@ -301,7 +305,8 @@ async fn login(
             &access_token,
             body.initial_device_display_name.clone(),
             Some(req.remote_addr().to_string()),
-        )?;
+        )
+        .await?;
     }
 
     tracing::info!("{} logged in", user_id);
@@ -354,21 +359,22 @@ async fn get_access_token(
     let payload = req.payload().await?;
     let body = serde_json::from_slice::<TokenReqBody>(payload);
     if let Ok(Some(auth)) = body.as_ref().map(|b| &b.auth) {
-        let (worked, uiaa_info) = crate::uiaa::try_auth(sender_id, device_id, auth, &uiaa_info)?;
+        let (worked, uiaa_info) =
+            crate::uiaa::try_auth(sender_id, device_id, auth, &uiaa_info).await?;
 
         if !worked {
             return Err(AppError::Uiaa(uiaa_info));
         }
     } else if let Ok(json) = serde_json::from_slice::<CanonicalJsonValue>(payload) {
         uiaa_info.session = Some(utils::random_string(SESSION_ID_LENGTH));
-        let _ = crate::uiaa::create_session(sender_id, device_id, &uiaa_info, json);
+        let _ = crate::uiaa::create_session(sender_id, device_id, &uiaa_info, json).await;
         return Err(AppError::Uiaa(uiaa_info));
     } else {
         return Err(MatrixError::not_json("No JSON body was sent when required.").into());
     }
 
     let login_token = utils::random_string(TOKEN_LENGTH);
-    let expires_in = crate::user::create_login_token(sender_id, &login_token)?;
+    let expires_in = crate::user::create_login_token(sender_id, &login_token).await?;
 
     json_ok(TokenResBody {
         expires_in: Duration::from_millis(expires_in),
@@ -403,7 +409,7 @@ async fn logout(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) -> EmptyRes
         tracing::warn!("Failed to revoke delegated auth token: {e}");
     }
 
-    data::user::device::remove_device(authed.user_id(), authed.device_id())?;
+    data::user::device::remove_device(authed.user_id(), authed.device_id()).await?;
     empty_ok()
 }
 
@@ -455,7 +461,7 @@ async fn logout_all(_aa: AuthArgs, depot: &mut Depot) -> EmptyResult {
         return empty_ok();
     };
 
-    data::user::remove_all_devices(authed.user_id())?;
+    data::user::remove_all_devices(authed.user_id()).await?;
 
     empty_ok()
 }
@@ -469,7 +475,7 @@ async fn refresh_access_token(
     let authed = depot.authed_info()?;
     let user_id = authed.user_id();
     let device_id = authed.device_id();
-    crate::user::valid_refresh_token(user_id, device_id, &body.refresh_token)?;
+    crate::user::valid_refresh_token(user_id, device_id, &body.refresh_token).await?;
 
     let access_token = utils::random_string(TOKEN_LENGTH);
     let refresh_token = utils::random_string(TOKEN_LENGTH);
@@ -481,14 +487,16 @@ async fn refresh_access_token(
         &refresh_token,
         expires_at,
         ultimate_session_expires_at,
-    )?;
-    if data::user::device::is_device_exists(user_id, device_id)? {
+    )
+    .await?;
+    if data::user::device::is_device_exists(user_id, device_id).await? {
         data::user::device::set_access_token(
             user_id,
             device_id,
             &access_token,
             Some(refresh_token_id),
-        )?;
+        )
+        .await?;
     } else {
         return Err(MatrixError::not_found("Device not found.").into());
     }

--- a/crates/server/src/routing/client/sync_msc4186.rs
+++ b/crates/server/src/routing/client/sync_msc4186.rs
@@ -60,6 +60,7 @@ pub(super) async fn sync_events_v5(
             device_id.to_owned(),
             req_body.conn_id.to_owned(),
         )
+        .await
     }
 
     // Get sticky parameters from cache
@@ -67,13 +68,14 @@ pub(super) async fn sync_events_v5(
         sender_id.to_owned(),
         device_id.to_owned(),
         &mut req_body,
-    );
+    )
+    .await;
 
     let mut res_body =
         crate::sync_v5::sync_events(sender_id, device_id, since_sn, &req_body, &known_rooms)
             .await?;
 
-    if since_sn > data::curr_sn()?
+    if since_sn > data::curr_sn().await?
         || (args.pos.is_some()
             && res_body.is_empty_for_long_poll()
             && !has_list_count_changes(&res_body, &previous_list_counts))
@@ -95,7 +97,8 @@ pub(super) async fn sync_events_v5(
             .iter()
             .map(|(list_id, list)| (list_id.clone(), list.count))
             .collect(),
-    );
+    )
+    .await;
 
     trace!(
         rooms=?res_body.rooms.len(),

--- a/crates/server/src/routing/client/sync_v3.rs
+++ b/crates/server/src/routing/client/sync_v3.rs
@@ -51,7 +51,7 @@ pub(super) async fn sync_events_v3(
     let sender_id = authed.user_id();
     let device_id = authed.device_id();
 
-    crate::user::ping_presence(sender_id, &args.set_presence)?;
+    crate::user::ping_presence(sender_id, &args.set_presence).await?;
     let mut body = crate::sync_v3::sync_events(sender_id, device_id, &args).await?;
 
     if !args.full_state

--- a/crates/server/src/routing/client/third_party.rs
+++ b/crates/server/src/routing/client/third_party.rs
@@ -42,7 +42,7 @@ fn encode_query_value(value: &str) -> String {
 async fn protocols(_aa: AuthArgs) -> JsonResult<ProtocolsResBody> {
     let mut result = BTreeMap::new();
 
-    for appservice in crate::appservice::all()?.values() {
+    for appservice in crate::appservice::all().await?.values() {
         let Some(proto_list) = &appservice.registration.protocols else {
             continue;
         };
@@ -84,7 +84,7 @@ async fn protocols(_aa: AuthArgs) -> JsonResult<ProtocolsResBody> {
 async fn get_protocol(_aa: AuthArgs, protocol: PathParam<String>) -> JsonResult<ProtocolResBody> {
     let protocol_id = protocol.into_inner();
 
-    for appservice in crate::appservice::all()?.values() {
+    for appservice in crate::appservice::all().await?.values() {
         let Some(proto_list) = &appservice.registration.protocols else {
             continue;
         };
@@ -115,7 +115,7 @@ async fn locations(_aa: AuthArgs, req: &mut Request) -> JsonResult<LocationsResB
     let alias = req.query::<String>("alias");
     let mut result = Vec::new();
 
-    for appservice in crate::appservice::all()?.values() {
+    for appservice in crate::appservice::all().await?.values() {
         if appservice.registration.protocols.is_none() {
             continue;
         }
@@ -160,7 +160,7 @@ async fn protocol_locations(
     let protocol_id = protocol.into_inner();
     let mut result = Vec::new();
 
-    for appservice in crate::appservice::all()?.values() {
+    for appservice in crate::appservice::all().await?.values() {
         let Some(proto_list) = &appservice.registration.protocols else {
             continue;
         };
@@ -202,7 +202,7 @@ async fn users(_aa: AuthArgs, req: &mut Request) -> JsonResult<UsersResBody> {
     let userid = req.query::<String>("userid");
     let mut result = Vec::new();
 
-    for appservice in crate::appservice::all()?.values() {
+    for appservice in crate::appservice::all().await?.values() {
         if appservice.registration.protocols.is_none() {
             continue;
         }
@@ -244,7 +244,7 @@ async fn protocol_users(_aa: AuthArgs, protocol: PathParam<String>) -> JsonResul
     let protocol_id = protocol.into_inner();
     let mut result = Vec::new();
 
-    for appservice in crate::appservice::all()?.values() {
+    for appservice in crate::appservice::all().await?.values() {
         let Some(proto_list) = &appservice.registration.protocols else {
             continue;
         };

--- a/crates/server/src/routing/client/to_device.rs
+++ b/crates/server/src/routing/client/to_device.rs
@@ -18,7 +18,7 @@ pub fn authed_router() -> Router {
 /// #PUT /_matrix/client/r0/sendToDevice/{event_type}/{txn_id}
 /// Send a to-device event to a set of client devices.
 #[endpoint]
-fn send_to_device(
+async fn send_to_device(
     _aa: AuthArgs,
     args: SendEventToDeviceReqArgs,
     body: JsonBody<SendEventToDeviceReqBody>,
@@ -30,7 +30,9 @@ fn send_to_device(
         &args.txn_id,
         authed.user_id(),
         Some(authed.device_id()),
-    )? {
+    )
+    .await?
+    {
         return empty_ok();
     }
 
@@ -52,7 +54,8 @@ fn send_to_device(
                         messages,
                     }),
                     &message_id.to_string(),
-                )?;
+                )
+                .await?;
 
                 continue;
             }
@@ -67,11 +70,12 @@ fn send_to_device(
                         event
                             .deserialize_as()
                             .map_err(|_| MatrixError::invalid_param("Event is invalid"))?,
-                    )?
+                    )
+                    .await?
                 }
 
                 DeviceIdOrAllDevices::AllDevices => {
-                    for target_device_id in data::user::all_device_ids(target_user_id)? {
+                    for target_device_id in data::user::all_device_ids(target_user_id).await? {
                         data::user::device::add_to_device_event(
                             authed.user_id(),
                             target_user_id,
@@ -80,7 +84,8 @@ fn send_to_device(
                             event
                                 .deserialize_as()
                                 .map_err(|_| MatrixError::invalid_param("Event is invalid"))?,
-                        )?;
+                        )
+                        .await?;
                     }
                 }
             }
@@ -94,7 +99,8 @@ fn send_to_device(
         Some(authed.device_id()),
         None,
         None,
-    )?;
+    )
+    .await?;
 
     empty_ok()
 }

--- a/crates/server/src/routing/client/user/account.rs
+++ b/crates/server/src/routing/client/user/account.rs
@@ -26,6 +26,7 @@ pub(super) async fn get_global_data(
 
     let content =
         data::user::get_data::<JsonValue>(authed.user_id(), None, &args.event_type.to_string())
+            .await
             .map_err(|_| MatrixError::not_found("user data not found"))?;
 
     json_ok(GlobalAccountDataResBody(RawJson::from_value(&content)?))
@@ -53,10 +54,10 @@ pub(super) async fn set_global_data(
             .filter_map(|(id, _)| OwnedUserId::try_from(id).ok())
             .collect();
 
-        data::user::set_ignored_users(authed.user_id(), &ignored_ids)?;
+        data::user::set_ignored_users(authed.user_id(), &ignored_ids).await?;
     }
 
-    data::user::set_data(authed.user_id(), None, &event_type, body)?;
+    data::user::set_data(authed.user_id(), None, &event_type, body).await?;
     empty_ok()
 }
 
@@ -75,6 +76,7 @@ pub(super) async fn get_room_data(
         Some(&*args.room_id),
         &args.event_type.to_string(),
     )
+    .await
     .map_err(|_| MatrixError::not_found("user data not found"))?;
 
     json_ok(RoomAccountDataResBody(RawJson::from_value(&content)?))
@@ -98,6 +100,7 @@ pub(super) async fn set_room_data(
         Some(args.room_id),
         &event_type,
         body.into_inner(),
-    )?;
+    )
+    .await?;
     empty_ok()
 }

--- a/crates/server/src/routing/client/user/filter.rs
+++ b/crates/server/src/routing/client/user/filter.rs
@@ -9,25 +9,25 @@ use crate::{AuthArgs, DepotExt, JsonResult, data, json_ok};
 ///
 /// - A user can only access their own filters
 #[endpoint]
-pub(super) fn get_filter(
+pub(super) async fn get_filter(
     _aa: AuthArgs,
     filter_id: PathParam<i64>,
     depot: &mut Depot,
 ) -> JsonResult<FilterResBody> {
     let authed = depot.authed_info()?;
-    let filter = crate::data::user::get_filter(authed.user_id(), filter_id.into_inner())?;
+    let filter = crate::data::user::get_filter(authed.user_id(), filter_id.into_inner()).await?;
     json_ok(FilterResBody::new(filter))
 }
 
 /// #POST /_matrix/client/r0/user/{user_id}/filter
 /// Creates a new filter to be used by other endpoints.
 #[endpoint]
-pub(super) fn create_filter(
+pub(super) async fn create_filter(
     _aa: AuthArgs,
     body: JsonBody<CreateFilterReqBody>,
     depot: &mut Depot,
 ) -> JsonResult<CreateFilterResBody> {
     let authed = depot.authed_info()?;
-    let filter_id = data::user::create_filter(authed.user_id(), &body.filter)?;
+    let filter_id = data::user::create_filter(authed.user_id(), &body.filter).await?;
     json_ok(CreateFilterResBody::new(filter_id.to_string()))
 }

--- a/crates/server/src/routing/client/user/openid.rs
+++ b/crates/server/src/routing/client/user/openid.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use salvo::oapi::extract::PathParam;
 use salvo::prelude::*;
 
@@ -47,7 +48,8 @@ pub(super) async fn request_token(
             user_openid_tokens::token.eq(&access_token),
             user_openid_tokens::expires_at.eq(expires_at),
         ))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
 
     json_ok(RequstOpenidTokenResBody::new(
         access_token,

--- a/crates/server/src/routing/client/user/room.rs
+++ b/crates/server/src/routing/client/user/room.rs
@@ -18,12 +18,12 @@ pub(super) async fn get_mutual_rooms(
     let authed = depot.authed_info()?;
 
     // Get the authenticated user's joined rooms
-    let our_rooms: HashSet<_> = data::user::joined_rooms(authed.user_id())?
+    let our_rooms: HashSet<_> = data::user::joined_rooms(authed.user_id()).await?
         .into_iter()
         .collect();
 
     // Get the target user's joined rooms
-    let their_rooms = data::user::joined_rooms(&args.user_id)?;
+    let their_rooms = data::user::joined_rooms(&args.user_id).await?;
 
     // Find the intersection (mutual rooms)
     let joined: Vec<_> = their_rooms

--- a/crates/server/src/routing/client/user_directory.rs
+++ b/crates/server/src/routing/client/user_directory.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
 
@@ -26,7 +27,7 @@ pub fn authed_router() -> Router {
 ///   to public)
 /// and don't share a room with the sender
 #[endpoint]
-fn search(
+async fn search(
     _aa: AuthArgs,
     _args: SearchUsersReqArgs,
     body: JsonBody<SearchUsersReqBody>,
@@ -42,47 +43,64 @@ fn search(
         )
         .filter(user_profiles::user_id.ne(authed.user_id()))
         .select(user_profiles::user_id)
-        .load::<OwnedUserId>(&mut connect()?)?;
+        .load::<OwnedUserId>(&mut connect().await?)
+        .await?;
 
-    let mut users = user_ids.into_iter().filter_map(|user_id| {
+    let mut results = Vec::new();
+    let mut limited = false;
+    for user_id in user_ids {
         let user = SearchedUser {
             user_id: user_id.clone(),
-            display_name: data::user::display_name(&user_id).ok().flatten(),
-            avatar_url: data::user::avatar_url(&user_id).ok().flatten(),
+            display_name: data::user::display_name(&user_id).await.ok().flatten(),
+            avatar_url: data::user::avatar_url(&user_id).await.ok().flatten(),
         };
 
-        let user_is_in_public_rooms =
-            data::user::joined_rooms(&user_id)
-                .ok()?
-                .into_iter()
-                .any(|room_id| {
-                    room::get_state_content::<RoomJoinRulesEventContent>(
-                        &room_id,
-                        &StateEventType::RoomJoinRules,
-                        "",
-                        None,
-                    )
-                    .map(|r| r.join_rule == JoinRule::Public)
-                    .unwrap_or(false)
-                });
+        let matched = 'matched: {
+            let Some(joined_rooms) = data::user::joined_rooms(&user_id).await.ok() else {
+                break 'matched false;
+            };
+            let mut user_is_in_public_rooms = false;
+            for room_id in joined_rooms.into_iter() {
+                if room::get_state_content::<RoomJoinRulesEventContent>(
+                    &room_id,
+                    &StateEventType::RoomJoinRules,
+                    "",
+                    None,
+                )
+                .await
+                .map(|r| r.join_rule == JoinRule::Public)
+                .unwrap_or(false)
+                {
+                    user_is_in_public_rooms = true;
+                    break;
+                }
+            }
 
-        if user_is_in_public_rooms {
-            return Some(user);
+            if user_is_in_public_rooms {
+                break 'matched true;
+            }
+
+            let Some(shared_rooms) =
+                room::user::shared_rooms(vec![authed.user_id().to_owned(), user_id.clone()])
+                    .await
+                    .ok()
+            else {
+                break 'matched false;
+            };
+
+            !shared_rooms.is_empty()
+        };
+
+        if !matched {
+            continue;
         }
 
-        let user_is_in_shared_rooms =
-            !room::user::shared_rooms(vec![authed.user_id().to_owned(), user_id])
-                .ok()?
-                .is_empty();
-
-        if user_is_in_shared_rooms {
-            return Some(user);
+        if results.len() >= body.limit {
+            limited = true;
+            break;
         }
+        results.push(user);
+    }
 
-        None
-    });
-
-    let results = users.by_ref().take(body.limit).collect();
-    let limited = users.next().is_some();
     json_ok(SearchUsersResBody { results, limited })
 }

--- a/crates/server/src/routing/federation/backfill.rs
+++ b/crates/server/src/routing/federation/backfill.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use indexmap::IndexMap;
 use salvo::prelude::*;
 
@@ -30,7 +31,8 @@ async fn get_backfill(
     let seeds = events::table
         .filter(events::id.eq_any(&args.v))
         .select((events::id, events::depth))
-        .load::<(OwnedEventId, i64)>(&mut connect()?)?;
+        .load::<(OwnedEventId, i64)>(&mut connect().await?)
+        .await?;
 
     let mut queue = BTreeMap::new();
     for (seed_id, seed_depth) in seeds {
@@ -47,21 +49,23 @@ async fn get_backfill(
         let mut prev_ids = event_edges::table
             .filter(event_edges::event_id.eq(&event_id))
             .select(event_edges::prev_id)
-            .load::<OwnedEventId>(&mut connect()?)?;
+            .load::<OwnedEventId>(&mut connect().await?)
+            .await?;
         prev_ids.retain(|p| !events.contains_key(p));
         if !events.contains_key(&event_id)
-            && let Ok((pdu, data)) = timeline::get_pdu_and_data(&event_id)
-            && state::server_can_see_event(origin, &args.room_id, &pdu.event_id)?
+            && let Ok((pdu, data)) = timeline::get_pdu_and_data(&event_id).await
+            && state::server_can_see_event(origin, &args.room_id, &pdu.event_id).await?
         {
             events.insert(
                 event_id.clone(),
-                crate::sending::convert_to_outgoing_federation_event(data),
+                crate::sending::convert_to_outgoing_federation_event(data).await,
             );
         }
         let prevs = events::table
             .filter(events::id.eq_any(&prev_ids))
             .select((events::id, events::depth))
-            .load::<(OwnedEventId, i64)>(&mut connect()?)?;
+            .load::<(OwnedEventId, i64)>(&mut connect().await?)
+            .await?;
         for (prev_id, prev_depth) in prevs {
             queue.insert(prev_depth, prev_id);
         }

--- a/crates/server/src/routing/federation/backfill.rs
+++ b/crates/server/src/routing/federation/backfill.rs
@@ -6,6 +6,7 @@ use indexmap::IndexMap;
 use salvo::prelude::*;
 
 use crate::core::UnixMillis;
+use crate::core::events::room::history_visibility::HistoryVisibility;
 use crate::core::federation::backfill::{BackfillReqArgs, BackfillResBody};
 use crate::data::connect;
 use crate::data::schema::*;
@@ -40,6 +41,14 @@ async fn get_backfill(
     }
 
     let limit = args.limit;
+    let can_see_all_events = crate::room::get_history_visibility(&args.room_id)
+        .await
+        .is_ok_and(|visibility| {
+            matches!(
+                visibility,
+                HistoryVisibility::WorldReadable | HistoryVisibility::Shared
+            )
+        });
 
     let mut events = IndexMap::with_capacity(limit);
     while !queue.is_empty() && events.len() < limit {
@@ -54,7 +63,8 @@ async fn get_backfill(
         prev_ids.retain(|p| !events.contains_key(p));
         if !events.contains_key(&event_id)
             && let Ok((pdu, data)) = timeline::get_pdu_and_data(&event_id).await
-            && state::server_can_see_event(origin, &args.room_id, &pdu.event_id).await?
+            && (can_see_all_events
+                || state::server_can_see_event(origin, &args.room_id, &pdu.event_id).await?)
         {
             events.insert(
                 event_id.clone(),

--- a/crates/server/src/routing/federation/backfill.rs
+++ b/crates/server/src/routing/federation/backfill.rs
@@ -29,15 +29,21 @@ async fn get_backfill(
     let origin = depot.origin()?;
     debug!("got backfill request from: {}", origin);
 
+    let seed_prev_ids = event_edges::table
+        .filter(event_edges::event_id.eq_any(&args.v))
+        .select(event_edges::prev_id)
+        .load::<OwnedEventId>(&mut connect().await?)
+        .await?;
+
     let seeds = events::table
-        .filter(events::id.eq_any(&args.v))
+        .filter(events::id.eq_any(seed_prev_ids))
         .select((events::id, events::depth))
         .load::<(OwnedEventId, i64)>(&mut connect().await?)
         .await?;
 
     let mut queue = BTreeMap::new();
     for (seed_id, seed_depth) in seeds {
-        queue.insert(seed_depth, seed_id);
+        queue.insert((seed_depth, seed_id.clone()), seed_id);
     }
 
     let limit = args.limit;
@@ -77,7 +83,7 @@ async fn get_backfill(
             .load::<(OwnedEventId, i64)>(&mut connect().await?)
             .await?;
         for (prev_id, prev_depth) in prevs {
-            queue.insert(prev_depth, prev_id);
+            queue.insert((prev_depth, prev_id.clone()), prev_id);
         }
     }
     json_ok(BackfillResBody {

--- a/crates/server/src/routing/federation/event.rs
+++ b/crates/server/src/routing/federation/event.rs
@@ -31,15 +31,19 @@ pub fn router() -> Router {
 ///
 /// - Only works if a user of this server is currently invited or joined the room
 #[endpoint]
-fn get_event(_aa: AuthArgs, args: EventReqArgs, depot: &mut Depot) -> JsonResult<EventResBody> {
+async fn get_event(
+    _aa: AuthArgs,
+    args: EventReqArgs,
+    depot: &mut Depot,
+) -> JsonResult<EventResBody> {
     let origin = depot.origin()?;
-    let event = DbEvent::get_by_id(&args.event_id)?;
+    let event = DbEvent::get_by_id(&args.event_id).await?;
     if event.rejection_reason.is_some() {
         warn!("event {} is rejected, returning 404", &args.event_id);
         return Err(MatrixError::not_found("event not found").into());
     }
 
-    let event_json = timeline::get_pdu_json(&args.event_id)?.ok_or_else(|| {
+    let event_json = timeline::get_pdu_json(&args.event_id).await?.ok_or_else(|| {
         warn!("event not found, event id: {:?}", &args.event_id);
         MatrixError::not_found("event not found")
     })?;
@@ -48,11 +52,11 @@ fn get_event(_aa: AuthArgs, args: EventReqArgs, depot: &mut Depot) -> JsonResult
     // event JSON. v12 events do not include `room_id` in their JSON content
     // (it's derived from the create event id), so reading it from JSON would
     // fail for those rooms.
-    crate::federation::access_check(origin, &event.room_id, Some(&args.event_id))?;
+    crate::federation::access_check(origin, &event.room_id, Some(&args.event_id)).await?;
     json_ok(EventResBody {
         origin: config::get().server_name.to_owned(),
         origin_server_ts: UnixMillis::now(),
-        pdu: crate::sending::convert_to_outgoing_federation_event(event_json),
+        pdu: crate::sending::convert_to_outgoing_federation_event(event_json).await,
     })
 }
 
@@ -61,15 +65,15 @@ fn get_event(_aa: AuthArgs, args: EventReqArgs, depot: &mut Depot) -> JsonResult
 ///
 /// - This does not include the event itself
 #[endpoint]
-fn auth_chain(
+async fn auth_chain(
     _aa: AuthArgs,
     args: EventAuthReqArgs,
     depot: &mut Depot,
 ) -> JsonResult<EventAuthResBody> {
     let origin = depot.origin()?;
-    crate::federation::access_check(origin, &args.room_id, None)?;
+    crate::federation::access_check(origin, &args.room_id, None).await?;
 
-    let event = timeline::get_pdu_json(&args.event_id)?.ok_or_else(|| {
+    let event = timeline::get_pdu_json(&args.event_id).await?.ok_or_else(|| {
         warn!("event not found, event id: {:?}", &args.event_id);
         MatrixError::not_found("event not found")
     })?;
@@ -80,18 +84,23 @@ fn auth_chain(
         Some(s) => s
             .try_into()
             .map_err(|_| AppError::internal("invalid room id field in event in database"))?,
-        None => DbEvent::get_by_id(&args.event_id)?.room_id,
+        None => DbEvent::get_by_id(&args.event_id).await?.room_id,
     };
 
     let auth_chain_ids =
-        crate::room::auth_chain::get_auth_chain_ids(&room_id_owned, [&*args.event_id].into_iter())?;
+        crate::room::auth_chain::get_auth_chain_ids(&room_id_owned, [&*args.event_id].into_iter())
+            .await?;
+
+    let mut auth_chain_events = Vec::new();
+    for id in auth_chain_ids.into_iter() {
+        if let Some(json) = timeline::get_pdu_json(&id).await.ok().flatten() {
+            auth_chain_events
+                .push(crate::sending::convert_to_outgoing_federation_event(json).await);
+        }
+    }
 
     json_ok(EventAuthResBody {
-        auth_chain: auth_chain_ids
-            .into_iter()
-            .filter_map(|id| timeline::get_pdu_json(&id).ok()?)
-            .map(crate::sending::convert_to_outgoing_federation_event)
-            .collect(),
+        auth_chain: auth_chain_events,
     })
 }
 
@@ -102,10 +111,10 @@ async fn timestamp_to_event(
     depot: &mut Depot,
 ) -> JsonResult<TimestampToEventResBody> {
     let origin = depot.origin()?;
-    crate::federation::access_check(origin, &args.room_id, None)?;
+    crate::federation::access_check(origin, &args.room_id, None).await?;
 
     let (event_id, origin_server_ts) =
-        crate::event::get_event_for_timestamp(&args.room_id, args.ts, args.dir)?;
+        crate::event::get_event_for_timestamp(&args.room_id, args.ts, args.dir).await?;
     json_ok(TimestampToEventResBody {
         event_id,
         origin_server_ts,
@@ -115,7 +124,7 @@ async fn timestamp_to_event(
 /// #POST /_matrix/federation/v1/get_missing_events/{room_id}
 /// Retrieves events that the sender is missing.
 #[endpoint]
-fn missing_events(
+async fn missing_events(
     _aa: AuthArgs,
     room_id: PathParam<OwnedRoomId>,
     body: JsonBody<MissingEventsReqBody>,
@@ -124,7 +133,7 @@ fn missing_events(
     let origin = depot.origin()?;
 
     let room_id = room_id.into_inner();
-    crate::federation::access_check(origin, &room_id, None)?;
+    crate::federation::access_check(origin, &room_id, None).await?;
 
     let mut queued_events = body.latest_events.clone();
     let mut events = Vec::new();
@@ -132,7 +141,7 @@ fn missing_events(
     let mut i = 0;
     while i < queued_events.len() && events.len() < body.limit {
         let event_id = queued_events[i].clone();
-        if let Some(pdu) = timeline::get_pdu_json(&event_id)? {
+        if let Some(pdu) = timeline::get_pdu_json(&event_id).await? {
             // For v12 rooms, the event JSON does not contain `room_id` (it is
             // derived from the create event id). Look it up from the events
             // table instead and only use the JSON room_id if present.
@@ -142,7 +151,7 @@ fn missing_events(
                         AppError::internal("invalid room id field in event in database")
                     })?,
                     None => {
-                        let db_event = DbEvent::get_by_id(&event_id)?;
+                        let db_event = DbEvent::get_by_id(&event_id).await?;
                         db_event.room_id
                     }
                 };
@@ -172,7 +181,7 @@ fn missing_events(
             if i >= body.latest_events.len() {
                 events.push((
                     event_id,
-                    crate::sending::convert_to_outgoing_federation_event(pdu),
+                    crate::sending::convert_to_outgoing_federation_event(pdu).await,
                 ));
             }
         } else {
@@ -180,17 +189,16 @@ fn missing_events(
         }
         i += 1;
     }
-    let events = events
-        .into_iter()
-        .rev()
-        .filter_map(|(event_id, event)| {
-            if state::server_can_see_event(origin, &room_id, &event_id).unwrap_or(false) {
-                Some(event)
-            } else {
-                None
-            }
-        })
-        .collect();
+    let mut filtered_events = Vec::new();
+    for (event_id, event) in events.into_iter().rev() {
+        if state::server_can_see_event(origin, &room_id, &event_id)
+            .await
+            .unwrap_or(false)
+        {
+            filtered_events.push(event);
+        }
+    }
+    let events = filtered_events;
     json_ok(MissingEventsResBody { events })
 }
 

--- a/crates/server/src/routing/federation/key.rs
+++ b/crates/server/src/routing/federation/key.rs
@@ -42,7 +42,7 @@ async fn fetch_signing_keys(
     minimum_valid_until_ts: UnixMillis,
 ) -> Option<ServerSigningKeys> {
     // Try local cache first
-    if let Ok(cached) = crate::server_key::signing_keys_for(server)
+    if let Ok(cached) = crate::server_key::signing_keys_for(server).await
         && cached.valid_until_ts >= minimum_valid_until_ts
     {
         return Some(cached);
@@ -51,7 +51,7 @@ async fn fetch_signing_keys(
     // Cache miss or expired — fetch from origin server
     match crate::server_key::server_request(server).await {
         Ok(keys) => {
-            if let Err(e) = crate::server_key::add_signing_keys(keys.clone()) {
+            if let Err(e) = crate::server_key::add_signing_keys(keys.clone()).await {
                 warn!("failed to cache signing keys for {server}: {e}");
             }
             Some(keys)
@@ -59,7 +59,7 @@ async fn fetch_signing_keys(
         Err(e) => {
             warn!("failed to fetch signing keys from {server}: {e}");
             // Fall back to whatever we have cached, even if expired
-            crate::server_key::signing_keys_for(server).ok()
+            crate::server_key::signing_keys_for(server).await.ok()
         }
     }
 }

--- a/crates/server/src/routing/federation/media.rs
+++ b/crates/server/src/routing/federation/media.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 use std::str::FromStr;
 
-use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use image::imageops::FilterType;
 use mime::Mime;
 use palpo_core::http_headers::ContentDispositionType;
@@ -34,7 +34,7 @@ pub async fn get_content(
     res: &mut Response,
 ) -> AppResult<()> {
     let server_name = &config::get().server_name;
-    if let Some(metadata) = crate::data::media::get_metadata(server_name, &args.media_id)? {
+    if let Some(metadata) = crate::data::media::get_metadata(server_name, &args.media_id).await? {
         let content_type = metadata
             .content_type
             .as_deref()
@@ -83,7 +83,9 @@ pub async fn get_thumbnail(
         &args.media_id,
         args.width,
         args.height,
-    )? {
+    )
+    .await?
+    {
         let key = thumbnail_storage_key(server_name, &args.media_id, id);
         // Try presigned URL redirect for S3 storage
         if let Some(url) = storage::presign_read(&key).await? {
@@ -118,8 +120,8 @@ pub async fn get_thumbnail(
 
     if let Some(DbThumbnail {
         id, content_type, ..
-    }) =
-        crate::data::media::get_thumbnail_by_dimension(server_name, &args.media_id, width, height)?
+    }) = crate::data::media::get_thumbnail_by_dimension(server_name, &args.media_id, width, height)
+        .await?
     {
         // Using saved thumbnail
         let key = thumbnail_storage_key(server_name, &args.media_id, id);
@@ -152,7 +154,7 @@ pub async fn get_thumbnail(
         disposition_type: _,
         content_type,
         ..
-    })) = crate::data::media::get_metadata(server_name, &args.media_id)
+    })) = crate::data::media::get_metadata(server_name, &args.media_id).await
     {
         // Generate a thumbnail: read original from storage
         let image_key = media_storage_key(server_name, &args.media_id);
@@ -234,7 +236,8 @@ pub async fn get_thumbnail(
                     resize_method: args.method.clone().unwrap_or_default().to_string(),
                     created_at: UnixMillis::now(),
                 })
-                .execute(&mut connect()?)?;
+                .execute(&mut connect().await?)
+                .await?;
 
             // Save to storage backend
             let thumb_key =

--- a/crates/server/src/routing/federation/membership.rs
+++ b/crates/server/src/routing/federation/membership.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
 use serde_json::json;
@@ -45,7 +46,7 @@ pub fn router_v2() -> Router {
 /// Creates a join template.
 #[endpoint]
 async fn make_join(args: MakeJoinReqArgs, depot: &mut Depot) -> JsonResult<MakeJoinResBody> {
-    if !room::room_exists(&args.room_id)? {
+    if !room::room_exists(&args.room_id).await? {
         return Err(MatrixError::not_found("Room is unknown to this server.").into());
     }
 
@@ -56,9 +57,9 @@ async fn make_join(args: MakeJoinReqArgs, depot: &mut Depot) -> JsonResult<MakeJ
         );
     }
 
-    handler::acl_check(args.user_id.server_name(), &args.room_id)?;
+    handler::acl_check(args.user_id.server_name(), &args.room_id).await?;
 
-    let room_version_id = room::get_version(&args.room_id)?;
+    let room_version_id = room::get_version(&args.room_id).await?;
     if !args.ver.contains(&room_version_id) {
         return Err(MatrixError::incompatible_room_version(
             "Room version not supported.",
@@ -71,7 +72,7 @@ async fn make_join(args: MakeJoinReqArgs, depot: &mut Depot) -> JsonResult<MakeJ
 
     if args.user_id.is_remote()
         && args.room_id.is_remote()
-        && !room::is_server_joined(&config::get().server_name, &args.room_id)?
+        && !room::is_server_joined(&config::get().server_name, &args.room_id).await?
     {
         return Err(MatrixError::bad_json("Not allowed to join on unkonwn remote server.").into());
     }
@@ -81,8 +82,8 @@ async fn make_join(args: MakeJoinReqArgs, depot: &mut Depot) -> JsonResult<MakeJ
             // room version does not support restricted join rules
             None
         } else {
-            let join_rule = room::get_join_rule(&args.room_id)?;
-            let guest_can_join = room::guest_can_join(&args.room_id);
+            let join_rule = room::get_join_rule(&args.room_id).await?;
+            let guest_can_join = room::guest_can_join(&args.room_id).await;
             if join_rule == JoinRule::Public || guest_can_join {
                 None
             } else if crate::federation::user_can_perform_restricted_join(
@@ -151,7 +152,7 @@ async fn invite_user(
     let body = body.into_inner();
     let origin = depot.origin()?;
     let conf = config::get();
-    handler::acl_check(origin, &args.room_id)?;
+    handler::acl_check(origin, &args.room_id).await?;
 
     if !config::supported_room_versions().contains(&body.room_version) {
         return Err(MatrixError::incompatible_room_version(
@@ -175,8 +176,9 @@ async fn invite_user(
         return Err(MatrixError::invalid_param("cannot invite remote users").into());
     }
     let invitee = data::user::get_user(&invitee_id)
+        .await
         .map_err(|_| MatrixError::not_found("invitee user not found"))?;
-    handler::acl_check(invitee_id.server_name(), &args.room_id)?;
+    handler::acl_check(invitee_id.server_name(), &args.room_id).await?;
 
     crate::server_key::hash_and_sign_event(&mut signed_event, &body.room_version)
         .map_err(|e| MatrixError::invalid_param(format!("failed to sign event: {e}")))?;
@@ -191,8 +193,8 @@ async fn invite_user(
     );
 
     let state_lock = room::lock_state(&args.room_id).await;
-    ensure_room(&args.room_id, &body.room_version)?;
-    if data::room::is_banned(&args.room_id)? {
+    ensure_room(&args.room_id, &body.room_version).await?;
+    if data::room::is_banned(&args.room_id).await? {
         return Err(MatrixError::forbidden("this room is banned on this homeserver", None).into());
     }
 
@@ -213,7 +215,7 @@ async fn invite_user(
     // let event_id: OwnedEventId = format!("$dummy_{}", Ulid::new().to_string()).try_into()?;
     event.insert("event_id".to_owned(), event_id.to_string().into());
 
-    let (event_sn, event_guard) = crate::event::ensure_event_sn(&args.room_id, &event_id)?;
+    let (event_sn, event_guard) = crate::event::ensure_event_sn(&args.room_id, &event_id).await?;
     let pdu = SnPduEvent::from_canonical_object(
         &args.room_id,
         &event_id,
@@ -227,7 +229,7 @@ async fn invite_user(
         warn!("invalid invite event: {}", e);
         MatrixError::invalid_param("invalid invite event")
     })?;
-    invite_state.push(pdu.to_stripped_state_event());
+    invite_state.push(pdu.to_stripped_state_event().await);
 
     NewDbEvent {
         id: pdu.event_id.to_owned(),
@@ -249,7 +251,8 @@ async fn invite_user(
         is_rejected: false,
         rejection_reason: None,
     }
-    .save()?;
+    .save()
+    .await?;
     timeline::append_pdu(&pdu, event, &state_lock).await?;
 
     // let sender_id: OwnedUserId = serde_json::from_value(
@@ -270,7 +273,8 @@ async fn invite_user(
         ),
     )
     .set(room_users::state_data.eq(json!(invite_state)))
-    .execute(&mut connect()?)
+    .execute(&mut connect().await?)
+    .await
     .ok();
 
     drop(event_guard);
@@ -278,7 +282,7 @@ async fn invite_user(
     drop(state_lock);
 
     json_ok(InviteUserResBodyV2 {
-        event: crate::sending::convert_to_outgoing_federation_event(signed_event),
+        event: crate::sending::convert_to_outgoing_federation_event(signed_event).await,
     })
 }
 
@@ -291,14 +295,14 @@ async fn make_leave(args: MakeLeaveReqArgs, depot: &mut Depot) -> JsonResult<Mak
             MatrixError::bad_json("not allowed to leave on behalf of another server").into(),
         );
     }
-    if !room::is_room_exists(&args.room_id)? {
+    if !room::is_room_exists(&args.room_id).await? {
         return Err(MatrixError::forbidden("room is unknown to this server", None).into());
     }
 
     // ACL check origin
-    handler::acl_check(origin, &args.room_id)?;
+    handler::acl_check(origin, &args.room_id).await?;
 
-    let room_version_id = room::get_version(&args.room_id)?;
+    let room_version_id = room::get_version(&args.room_id).await?;
     let state_lock = crate::room::lock_state(&args.room_id).await;
 
     let (_pdu, mut pdu_json) = PduBuilder::state(
@@ -364,13 +368,13 @@ async fn send_leave(
     let origin = depot.origin()?;
     let body = body.into_inner();
 
-    if !room::is_room_exists(&args.room_id)? {
+    if !room::is_room_exists(&args.room_id).await? {
         return Err(MatrixError::forbidden("Room is unknown to this server.", None).into());
     }
-    handler::acl_check(origin, &args.room_id)?;
+    handler::acl_check(origin, &args.room_id).await?;
 
     // We do not add the event_id field to the pdu here because of signature and hashes checks
-    let room_version_id = room::get_version(&args.room_id)?;
+    let room_version_id = room::get_version(&args.room_id).await?;
 
     let Ok((event_id, value)) =
         crate::event::gen_event_id_canonical_json(&body.0, &room_version_id)
@@ -439,7 +443,7 @@ async fn send_leave(
     )
     .map_err(|_| MatrixError::bad_json("user in sender is invalid"))?;
 
-    handler::acl_check(sender.server_name(), &args.room_id)?;
+    handler::acl_check(sender.server_name(), &args.room_id).await?;
 
     if sender.server_name() != origin {
         return Err(
@@ -470,7 +474,7 @@ async fn send_leave(
         false,
     )
     .await?;
-    if let Err(e) = crate::sending::send_pdu_room(&args.room_id, &event_id, &[], &[]) {
+    if let Err(e) = crate::sending::send_pdu_room(&args.room_id, &event_id, &[], &[]).await {
         error!("failed to notify leave event: {e}");
     }
     empty_ok()

--- a/crates/server/src/routing/federation/query.rs
+++ b/crates/server/src/routing/federation/query.rs
@@ -50,7 +50,8 @@ async fn get_profile(_aa: AuthArgs, args: ProfileReqArgs) -> JsonResult<ProfileR
 
     let mut response = ProfileResBody::new();
 
-    let profile = data::user::get_profile(&args.user_id, None)?
+    let profile = data::user::get_profile(&args.user_id, None)
+        .await?
         .ok_or(MatrixError::not_found("Profile not found."))?;
     let custom_fields = profile.fields.as_object().cloned().unwrap_or_default();
 
@@ -102,8 +103,8 @@ async fn get_directory(
     _aa: AuthArgs,
     room_alias: QueryParam<OwnedRoomAliasId, true>,
 ) -> JsonResult<RoomInfoResBody> {
-    let room_id = crate::room::resolve_local_alias(&room_alias)?;
-    let mut servers = crate::room::lookup_servers(&room_id)?;
+    let room_id = crate::room::resolve_local_alias(&room_alias).await?;
+    let mut servers = crate::room::lookup_servers(&room_id).await?;
     servers.insert(0, config::get().server_name.to_owned());
     servers.dedup();
     json_ok(RoomInfoResBody { room_id, servers })

--- a/crates/server/src/routing/federation/room.rs
+++ b/crates/server/src/routing/federation/room.rs
@@ -43,41 +43,43 @@ async fn get_state(
     depot: &mut Depot,
 ) -> JsonResult<RoomStateResBody> {
     let origin = depot.origin()?;
-    crate::federation::access_check(origin, &args.room_id, None)?;
+    crate::federation::access_check(origin, &args.room_id, None).await?;
 
-    let state_hash = state::get_pdu_frame_id(&args.event_id)?;
+    let state_hash = state::get_pdu_frame_id(&args.event_id).await?;
 
-    let pdus = state::get_full_state_ids(state_hash)?
-        .into_values()
-        .filter_map(|id| match timeline::get_pdu_json(&id) {
-            Ok(Some(json)) => Some(sending::convert_to_outgoing_federation_event(json)),
+    let mut pdus = Vec::new();
+    for id in state::get_full_state_ids(state_hash).await?.into_values() {
+        match timeline::get_pdu_json(&id).await {
+            Ok(Some(json)) => {
+                pdus.push(sending::convert_to_outgoing_federation_event(json).await);
+            }
             Ok(None) => {
                 error!("Could not find event json for state event {id} in db");
-                None
             }
             Err(e) => {
                 error!("Failed to load state event {id} from db: {e}");
-                None
             }
-        })
-        .collect();
+        }
+    }
 
     let auth_chain_ids =
-        room::auth_chain::get_auth_chain_ids(&args.room_id, [&*args.event_id].into_iter())?;
+        room::auth_chain::get_auth_chain_ids(&args.room_id, [&*args.event_id].into_iter()).await?;
 
-    json_ok(RoomStateResBody {
-        auth_chain: auth_chain_ids
-            .into_iter()
-            .filter_map(|id| match timeline::get_pdu_json(&id).ok()? {
-                Some(json) => Some(crate::sending::convert_to_outgoing_federation_event(json)),
-                None => {
-                    error!("Could not find event json for {id} in db::");
-                    None
-                }
-            })
-            .collect(),
-        pdus,
-    })
+    let mut auth_chain = Vec::new();
+    for id in auth_chain_ids.into_iter() {
+        match timeline::get_pdu_json(&id).await {
+            Ok(Some(json)) => {
+                auth_chain
+                    .push(crate::sending::convert_to_outgoing_federation_event(json).await);
+            }
+            Ok(None) => {
+                error!("Could not find event json for {id} in db::");
+            }
+            Err(_) => {}
+        }
+    }
+
+    json_ok(RoomStateResBody { auth_chain, pdus })
 }
 
 /// #GET /_matrix/federation/v1/publicRooms
@@ -137,9 +139,9 @@ async fn send_knock(
     }
 
     // ACL check origin server
-    handler::acl_check(origin, &args.room_id)?;
+    handler::acl_check(origin, &args.room_id).await?;
 
-    let room_version = crate::room::get_version(&args.room_id)?;
+    let room_version = crate::room::get_version(&args.room_id).await?;
 
     if matches!(room_version, V1 | V2 | V3 | V4 | V5 | V6) {
         return Err(MatrixError::forbidden("room version does not support knocking", None).into());
@@ -194,7 +196,7 @@ async fn send_knock(
     )
     .map_err(|e| MatrixError::invalid_param(format!("event sender is not a valid user id: {e}")))?;
 
-    handler::acl_check(sender.server_name(), &args.room_id)?;
+    handler::acl_check(sender.server_name(), &args.room_id).await?;
 
     // check if origin server is trying to send for another server
     if sender.server_name() != origin {
@@ -252,10 +254,10 @@ async fn send_knock(
         MatrixError::invalid_param("could not accept as timeline event".to_string())
     })?;
 
-    data::room::add_joined_server(&args.room_id, &origin)?;
+    data::room::add_joined_server(&args.room_id, &origin).await?;
 
-    let knock_room_state = state::summary_stripped(&pdu)?;
-    if let Err(e) = crate::sending::send_pdu_room(&args.room_id, &event_id, &[], &[]) {
+    let knock_room_state = state::summary_stripped(&pdu).await?;
+    if let Err(e) = crate::sending::send_pdu_room(&args.room_id, &event_id, &[], &[]).await {
         error!("failed to notify knock event: {e}");
     }
     json_ok(SendKnockResBody { knock_room_state })
@@ -273,7 +275,7 @@ async fn make_knock(
     use crate::core::RoomVersionId::*;
 
     let origin = depot.origin()?;
-    if !crate::room::room_exists(&args.room_id)? {
+    if !crate::room::room_exists(&args.room_id).await? {
         return Err(MatrixError::not_found("room is unknown to this server").into());
     }
 
@@ -284,9 +286,9 @@ async fn make_knock(
     }
 
     // ACL check origin server
-    handler::acl_check(origin, &args.room_id)?;
+    handler::acl_check(origin, &args.room_id).await?;
 
-    let room_version_id = crate::room::get_version(&args.room_id)?;
+    let room_version_id = crate::room::get_version(&args.room_id).await?;
 
     if matches!(room_version_id, V1 | V2 | V3 | V4 | V5 | V6) {
         return Err(MatrixError::incompatible_room_version(
@@ -304,7 +306,7 @@ async fn make_knock(
     // }
 
     let state_lock = room::lock_state(&args.room_id).await;
-    if let Ok(member) = room::get_member(&args.room_id, &args.user_id, None)
+    if let Ok(member) = room::get_member(&args.room_id, &args.user_id, None).await
         && member.membership == MembershipState::Ban
     {
         warn!(
@@ -335,23 +337,25 @@ async fn make_knock(
 /// #GET /_matrix/federation/v1/state_ids/{room_id}
 /// Retrieves the current state of the room.
 #[endpoint]
-fn get_state_at_event(
+async fn get_state_at_event(
     depot: &mut Depot,
     args: RoomStateAtEventReqArgs,
 ) -> JsonResult<RoomStateIdsResBody> {
     let origin = depot.origin()?;
 
-    crate::federation::access_check(origin, &args.room_id, Some(&args.event_id))?;
+    crate::federation::access_check(origin, &args.room_id, Some(&args.event_id)).await?;
 
-    let frame_id = state::get_pdu_frame_id(&args.event_id)?;
+    let frame_id = state::get_pdu_frame_id(&args.event_id).await?;
 
-    let pdu_ids = state::get_full_state_ids(frame_id)?
+    let pdu_ids = state::get_full_state_ids(frame_id)
+        .await?
         .into_values()
         .map(|id| (*id).to_owned())
         .collect();
 
     let auth_chain_ids =
-        crate::room::auth_chain::get_auth_chain_ids(&args.room_id, [&*args.event_id].into_iter())?;
+        crate::room::auth_chain::get_auth_chain_ids(&args.room_id, [&*args.event_id].into_iter())
+            .await?;
 
     json_ok(RoomStateIdsResBody {
         auth_chain_ids: auth_chain_ids

--- a/crates/server/src/routing/federation/space.rs
+++ b/crates/server/src/routing/federation/space.rs
@@ -20,7 +20,7 @@ async fn get_hierarchy(
     args: HierarchyReqArgs,
     depot: &mut Depot,
 ) -> JsonResult<HierarchyResBody> {
-    if !crate::room::room_exists(&args.room_id)? {
+    if !crate::room::room_exists(&args.room_id).await? {
         return Err(MatrixError::not_found("Room does not exist.").into());
     }
 

--- a/crates/server/src/routing/federation/transaction.rs
+++ b/crates/server/src/routing/federation/transaction.rs
@@ -79,7 +79,7 @@ async fn process_pdus(
 ) -> AppResult<BTreeMap<OwnedEventId, AppResult<()>>> {
     let mut parsed_pdus = Vec::with_capacity(pdus.len());
     for pdu in pdus {
-        parsed_pdus.push(match parse_incoming_pdu(pdu) {
+        parsed_pdus.push(match parse_incoming_pdu(pdu).await {
             Ok(t) => t,
             Err(e) => {
                 warn!("could not parse pdu: {e}");
@@ -165,6 +165,7 @@ async fn process_edu_presence(origin: &ServerName, presence: PresenceContent) {
             },
             true,
         )
+        .await
         .ok();
     }
 }
@@ -175,7 +176,7 @@ async fn process_edu_receipt(origin: &ServerName, receipt: ReceiptContent) {
     }
 
     for (room_id, room_updates) in receipt {
-        if handler::acl_check(origin, &room_id).is_err() {
+        if handler::acl_check(origin, &room_id).await.is_err() {
             warn!(
                 %origin, %room_id,
                 "received read receipt edu from ACL'd server"
@@ -193,6 +194,7 @@ async fn process_edu_receipt(origin: &ServerName, receipt: ReceiptContent) {
             // }
 
             if room::joined_users(&room_id, None)
+                .await
                 .unwrap_or_default()
                 .iter()
                 .any(|member| member.server_name() == user_id.server_name())
@@ -207,7 +209,7 @@ async fn process_edu_receipt(origin: &ServerName, receipt: ReceiptContent) {
                         room_id: room_id.clone(),
                     };
 
-                    let _ = room::receipt::update_read(&user_id, &room_id, &event, false);
+                    let _ = room::receipt::update_read(&user_id, &room_id, &event, false).await;
                 }
             } else {
                 warn!(
@@ -233,7 +235,10 @@ async fn process_edu_typing(origin: &ServerName, typing: TypingContent) {
         return;
     }
 
-    if handler::acl_check(typing.user_id.server_name(), &typing.room_id).is_err() {
+    if handler::acl_check(typing.user_id.server_name(), &typing.room_id)
+        .await
+        .is_err()
+    {
         warn!(
             %typing.user_id, %typing.room_id, %origin,
             "received typing edu for ACL'd user's server"
@@ -241,7 +246,10 @@ async fn process_edu_typing(origin: &ServerName, typing: TypingContent) {
         return;
     }
 
-    if room::user::is_joined(&typing.user_id, &typing.room_id).unwrap_or(false) {
+    if room::user::is_joined(&typing.user_id, &typing.room_id)
+        .await
+        .unwrap_or(false)
+    {
         if typing.typing {
             let timeout = UnixMillis::now().get().saturating_add(
                 crate::config::get()
@@ -275,7 +283,7 @@ async fn process_edu_device_list_update(origin: &ServerName, content: DeviceList
         return;
     }
 
-    let _ = crate::user::mark_device_key_update(&user_id, &device_id);
+    let _ = crate::user::mark_device_key_update(&user_id, &device_id).await;
 }
 
 async fn process_edu_direct_to_device(origin: &ServerName, content: DirectDeviceContent) {
@@ -295,7 +303,10 @@ async fn process_edu_direct_to_device(origin: &ServerName, content: DirectDevice
     }
 
     // Check if this is a new transaction id
-    if crate::transaction_id::txn_id_exists(&message_id, &sender, None).unwrap_or_default() {
+    if crate::transaction_id::txn_id_exists(&message_id, &sender, None)
+        .await
+        .unwrap_or_default()
+    {
         return;
     }
 
@@ -317,30 +328,33 @@ async fn process_edu_direct_to_device(origin: &ServerName, content: DirectDevice
                         target_device_id,
                         &ev_type,
                         event,
-                    );
+                    )
+                    .await;
                 }
 
                 DeviceIdOrAllDevices::AllDevices => {
                     let (sender, ev_type, event) = (&sender, &ev_type, &event);
-                    data::user::all_device_ids(target_user_id)
+                    for target_device_id in data::user::all_device_ids(target_user_id)
+                        .await
                         .unwrap_or_default()
                         .iter()
-                        .for_each(|target_device_id| {
-                            let _ = data::user::device::add_to_device_event(
-                                sender,
-                                target_user_id,
-                                target_device_id,
-                                ev_type,
-                                event.clone(),
-                            );
-                        });
+                    {
+                        let _ = data::user::device::add_to_device_event(
+                            sender,
+                            target_user_id,
+                            target_device_id,
+                            ev_type,
+                            event.clone(),
+                        )
+                        .await;
+                    }
                 }
             }
         }
     }
 
     // Save transaction id with empty data
-    let _ = crate::transaction_id::add_txn_id(&message_id, &sender, None, None, None);
+    let _ = crate::transaction_id::add_txn_id(&message_id, &sender, None, None, None).await;
 }
 
 async fn process_edu_signing_key_update(origin: &ServerName, content: SigningKeyUpdateContent) {
@@ -365,6 +379,7 @@ async fn process_edu_signing_key_update(origin: &ServerName, content: SigningKey
             &self_signing_key,
             &None,
             true,
-        );
+        )
+        .await;
     }
 }

--- a/crates/server/src/routing/federation/user.rs
+++ b/crates/server/src/routing/federation/user.rs
@@ -1,6 +1,7 @@
 //! Endpoints for handling keys for end-to-end encryption
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
 
@@ -63,7 +64,7 @@ async fn query_keys(
 /// #GET /_matrix/federation/v1/user/devices/{user_id}
 /// Gets information on all devices of the user.
 #[endpoint]
-fn get_devices(
+async fn get_devices(
     _aa: AuthArgs,
     user_id: PathParam<OwnedUserId>,
     depot: &mut Depot,
@@ -74,7 +75,8 @@ fn get_devices(
         .filter(device_streams::user_id.eq(&user_id))
         .select(device_streams::id)
         .order_by(device_streams::id.desc())
-        .first::<i64>(&mut connect()?)
+        .first::<i64>(&mut connect().await?)
+        .await
         .optional()?
         .unwrap_or_default();
 
@@ -82,10 +84,12 @@ fn get_devices(
     let devices_and_names = user_devices::table
         .filter(user_devices::user_id.eq(&user_id))
         .select((user_devices::device_id, user_devices::display_name))
-        .load::<(OwnedDeviceId, Option<String>)>(&mut connect()?)?;
+        .load::<(OwnedDeviceId, Option<String>)>(&mut connect().await?)
+        .await?;
     for (device_id, display_name) in devices_and_names {
         devices.push(Device {
-            keys: data::user::get_device_keys_and_sigs(&user_id, &device_id)?
+            keys: data::user::get_device_keys_and_sigs(&user_id, &device_id)
+                .await?
                 .ok_or_else(|| AppError::public("server keys not found"))?,
             device_id,
             device_display_name: display_name,
@@ -96,12 +100,14 @@ fn get_devices(
         devices,
         master_key: crate::user::get_allowed_master_key(Some(&user_id), &user_id, &|u| {
             u.server_name() == origin
-        })?,
+        })
+        .await?,
         self_signing_key: crate::user::get_allowed_self_signing_key(
             Some(&user_id),
             &user_id,
             &|u| u.server_name() == origin,
-        )?,
+        )
+        .await?,
         user_id: user_id.to_owned(),
     })
 }

--- a/crates/server/src/sending.rs
+++ b/crates/server/src/sending.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 use base64::Engine as _;
 use base64::engine::general_purpose;
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::RetryTransientMiddleware;
 use reqwest_retry::policies::ExponentialBackoff;
@@ -184,10 +185,10 @@ pub fn push_gateway_client() -> reqwest::Client {
 }
 
 #[tracing::instrument(skip(pdu_id, user, pushkey))]
-pub fn send_push_pdu(pdu_id: &EventId, user: &UserId, pushkey: String) -> AppResult<()> {
+pub async fn send_push_pdu(pdu_id: &EventId, user: &UserId, pushkey: String) -> AppResult<()> {
     let outgoing_kind = OutgoingKind::Push(user.to_owned(), pushkey);
     let event = SendingEventType::Pdu(pdu_id.to_owned());
-    let keys = queue_requests(&[(&outgoing_kind, event.clone())])?;
+    let keys = queue_requests(&[(&outgoing_kind, event.clone())]).await?;
     if let Some(key) = keys.into_iter().next() {
         sender()
             .send((outgoing_kind, event, key))
@@ -198,7 +199,7 @@ pub fn send_push_pdu(pdu_id: &EventId, user: &UserId, pushkey: String) -> AppRes
 }
 
 #[tracing::instrument(level = "debug")]
-pub fn send_pdu_room(
+pub async fn send_pdu_room(
     room_id: &RoomId,
     pdu_id: &EventId,
     extra_servers: &[OwnedServerName],
@@ -209,7 +210,8 @@ pub fn send_pdu_room(
         .filter(room_joined_servers::server_id.ne(&config::get().server_name))
         // .filter(room_joined_servers::server_id.ne_all(skip_servers))
         .select(room_joined_servers::server_id)
-        .load::<OwnedServerName>(&mut connect()?)?;
+        .load::<OwnedServerName>(&mut connect().await?)
+        .await?;
     let mut servers = servers
         .into_iter()
         .chain(extra_servers.iter().cloned())
@@ -217,11 +219,11 @@ pub fn send_pdu_room(
     servers.sort_unstable();
     servers.dedup();
     let servers = servers.into_iter().filter(|s| !ignore_servers.contains(s));
-    send_pdu_servers(servers, pdu_id)
+    send_pdu_servers(servers, pdu_id).await
 }
 
 #[tracing::instrument(skip(servers, pdu_id), level = "debug")]
-pub fn send_pdu_servers<S: Iterator<Item = OwnedServerName>>(
+pub async fn send_pdu_servers<S: Iterator<Item = OwnedServerName>>(
     servers: S,
     pdu_id: &EventId,
 ) -> AppResult<()> {
@@ -249,7 +251,8 @@ pub fn send_pdu_servers<S: Iterator<Item = OwnedServerName>>(
             .iter()
             .map(|(o, e)| (o, e.clone()))
             .collect::<Vec<_>>(),
-    )?;
+    )
+    .await?;
     for ((outgoing_kind, event_type), key) in requests.into_iter().zip(keys) {
         if let Err(e) = sender().send((outgoing_kind.to_owned(), event_type, key)) {
             error!("failed to send pdu: {}", e);
@@ -260,17 +263,18 @@ pub fn send_pdu_servers<S: Iterator<Item = OwnedServerName>>(
 }
 
 #[tracing::instrument(skip(room_id, edu), level = "debug")]
-pub fn send_edu_room(room_id: &RoomId, edu: &Edu) -> AppResult<()> {
+pub async fn send_edu_room(room_id: &RoomId, edu: &Edu) -> AppResult<()> {
     let servers = room_joined_servers::table
         .filter(room_joined_servers::room_id.eq(room_id))
         .filter(room_joined_servers::server_id.ne(&config::get().server_name))
         .select(room_joined_servers::server_id)
-        .load::<OwnedServerName>(&mut connect()?)?;
-    send_edu_servers(servers.into_iter(), edu)
+        .load::<OwnedServerName>(&mut connect().await?)
+        .await?;
+    send_edu_servers(servers.into_iter(), edu).await
 }
 
 #[tracing::instrument(skip(servers, edu), level = "debug")]
-pub fn send_edu_servers<S: Iterator<Item = OwnedServerName>>(
+pub async fn send_edu_servers<S: Iterator<Item = OwnedServerName>>(
     servers: S,
     edu: &Edu,
 ) -> AppResult<()> {
@@ -300,7 +304,8 @@ pub fn send_edu_servers<S: Iterator<Item = OwnedServerName>>(
             .iter()
             .map(|(o, e)| (o, e.clone()))
             .collect::<Vec<_>>(),
-    )?;
+    )
+    .await?;
     for ((outgoing_kind, event), key) in requests.into_iter().zip(keys) {
         sender()
             .send((outgoing_kind.to_owned(), event, key))
@@ -310,7 +315,7 @@ pub fn send_edu_servers<S: Iterator<Item = OwnedServerName>>(
     Ok(())
 }
 #[tracing::instrument(skip(server, edu), level = "debug")]
-pub fn send_edu_server(server: &ServerName, edu: &Edu) -> AppResult<()> {
+pub async fn send_edu_server(server: &ServerName, edu: &Edu) -> AppResult<()> {
     let mut serialized = EduBuf::new();
     serde_json::to_writer(&mut serialized, &edu)
         .map_err(|e| AppError::internal(format!("failed to serialize edu: {e}")))?;
@@ -329,7 +334,7 @@ pub fn send_edu_server(server: &ServerName, edu: &Edu) -> AppResult<()> {
 
     let outgoing_kind = OutgoingKind::Normal(server.to_owned());
     let event = SendingEventType::Edu(serialized.to_owned());
-    let key = queue_request(&outgoing_kind, &event)?;
+    let key = queue_request(&outgoing_kind, &event).await?;
     sender()
         .send((outgoing_kind, event, key))
         .map_err(|e| AppError::internal(e.to_string()))?;
@@ -338,7 +343,7 @@ pub fn send_edu_server(server: &ServerName, edu: &Edu) -> AppResult<()> {
 }
 
 #[tracing::instrument(skip(server, edu))]
-pub fn send_reliable_edu(server: &ServerName, edu: &Edu, id: &str) -> AppResult<()> {
+pub async fn send_reliable_edu(server: &ServerName, edu: &Edu, id: &str) -> AppResult<()> {
     let mut serialized = EduBuf::new();
     serde_json::to_writer(&mut serialized, &edu)
         .map_err(|e| AppError::internal(format!("failed to serialize edu: {e}")))?;
@@ -357,7 +362,7 @@ pub fn send_reliable_edu(server: &ServerName, edu: &Edu, id: &str) -> AppResult<
 
     let outgoing_kind = OutgoingKind::Normal(server.to_owned());
     let event = SendingEventType::Edu(serialized);
-    let keys = queue_requests(&[(&outgoing_kind, event.clone())])?;
+    let keys = queue_requests(&[(&outgoing_kind, event.clone())]).await?;
     if let Some(key) = keys.into_iter().next() {
         sender()
             .send((outgoing_kind, event, key))
@@ -368,10 +373,10 @@ pub fn send_reliable_edu(server: &ServerName, edu: &Edu, id: &str) -> AppResult<
 }
 
 #[tracing::instrument]
-pub fn send_pdu_appservice(appservice_id: String, pdu_id: &EventId) -> AppResult<()> {
+pub async fn send_pdu_appservice(appservice_id: String, pdu_id: &EventId) -> AppResult<()> {
     let outgoing_kind = OutgoingKind::Appservice(appservice_id);
     let event = SendingEventType::Pdu(pdu_id.to_owned());
-    let keys = queue_requests(&[(&outgoing_kind, event.clone())])?;
+    let keys = queue_requests(&[(&outgoing_kind, event.clone())]).await?;
     if let Some(key) = keys.into_iter().next() {
         sender()
             .send((outgoing_kind, event, key))
@@ -394,6 +399,7 @@ async fn send_events(
                     SendingEventType::Pdu(event_id) => {
                         pdu_jsons.push(
                             timeline::get_pdu(event_id)
+                                .await
                                 .map_err(|e| (kind.clone(), e))?
                                 .to_room_event(),
                         );
@@ -409,6 +415,7 @@ async fn send_events(
             let permit = max_request.acquire().await;
 
             let registration = crate::appservice::get_registration(id)
+                .await
                 .map_err(|e| (kind.clone(), e))?
                 .ok_or_else(|| {
                     (
@@ -452,7 +459,11 @@ async fn send_events(
             for event in &events {
                 match event {
                     SendingEventType::Pdu(event_id) => {
-                        pdus.push(timeline::get_pdu(event_id).map_err(|e| (kind.clone(), e))?);
+                        pdus.push(
+                            timeline::get_pdu(event_id)
+                                .await
+                                .map_err(|e| (kind.clone(), e))?,
+                        );
                     }
                     SendingEventType::Edu(_) => {
                         // Push gateways don't need EDUs (?)
@@ -467,7 +478,7 @@ async fn send_events(
                     continue;
                 }
                 let pusher =
-                    match data::user::pusher::get_pusher(user_id, pushkey).map_err(|e| {
+                    match data::user::pusher::get_pusher(user_id, pushkey).await.map_err(|e| {
                         (
                             OutgoingKind::Push(user_id.clone(), pushkey.clone()),
                             e.into(),
@@ -481,11 +492,13 @@ async fn send_events(
                     user_id,
                     &GlobalAccountDataEventType::PushRules.to_string(),
                 )
+                .await
                 .unwrap_or_default()
                 .map(|content: PushRulesEventContent| content.global)
                 .unwrap_or_else(|| push::Ruleset::server_default(user_id));
 
                 let notify_summary = crate::room::user::notify_summary(user_id, &pdu.room_id)
+                    .await
                     .map_err(|e| (kind.clone(), e))?;
 
                 let max_request = crate::sending::max_request();
@@ -515,6 +528,7 @@ async fn send_events(
                     SendingEventType::Pdu(pdu_id) => {
                         let raw = crate::sending::convert_to_outgoing_federation_event(
                             timeline::get_pdu_json(pdu_id)
+                                .await
                                 .map_err(|e| (OutgoingKind::Normal(server.clone()), e))?
                                 .ok_or_else(|| {
                                     error!("event not found: {server} {pdu_id:?}");
@@ -525,7 +539,8 @@ async fn send_events(
                                         )),
                                     )
                                 })?,
-                        );
+                        )
+                        .await;
                         pdu_jsons.push(raw);
                     }
                     SendingEventType::Edu(edu) => {
@@ -630,10 +645,11 @@ where
     Ok(response.json().await?)
 }
 
-fn active_requests() -> AppResult<Vec<(i64, OutgoingKind, SendingEventType)>> {
+async fn active_requests() -> AppResult<Vec<(i64, OutgoingKind, SendingEventType)>> {
     let outgoing_requests = outgoing_requests::table
         .filter(outgoing_requests::state.eq("pending"))
-        .load::<DbOutgoingRequest>(&mut connect()?)?;
+        .load::<DbOutgoingRequest>(&mut connect().await?)
+        .await?;
     Ok(outgoing_requests
         .into_iter()
         .filter_map(|item| {
@@ -675,12 +691,14 @@ fn active_requests() -> AppResult<Vec<(i64, OutgoingKind, SendingEventType)>> {
         .collect())
 }
 
-fn delete_request(id: i64) -> AppResult<()> {
-    diesel::delete(outgoing_requests::table.find(id)).execute(&mut connect()?)?;
+async fn delete_request(id: i64) -> AppResult<()> {
+    diesel::delete(outgoing_requests::table.find(id))
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
-fn delete_all_active_requests_for(outgoing_kind: &OutgoingKind) -> AppResult<()> {
+async fn delete_all_active_requests_for(outgoing_kind: &OutgoingKind) -> AppResult<()> {
     match outgoing_kind {
         OutgoingKind::Appservice(appservice_id) => {
             diesel::delete(
@@ -689,7 +707,8 @@ fn delete_all_active_requests_for(outgoing_kind: &OutgoingKind) -> AppResult<()>
                     .filter(outgoing_requests::state.eq("pending"))
                     .filter(outgoing_requests::appservice_id.eq(appservice_id)),
             )
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         }
         OutgoingKind::Normal(server_id) => {
             diesel::delete(
@@ -698,7 +717,8 @@ fn delete_all_active_requests_for(outgoing_kind: &OutgoingKind) -> AppResult<()>
                     .filter(outgoing_requests::state.eq("pending"))
                     .filter(outgoing_requests::server_id.eq(server_id.as_str())),
             )
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         }
         OutgoingKind::Push(user_id, pushkey) => {
             diesel::delete(
@@ -708,14 +728,15 @@ fn delete_all_active_requests_for(outgoing_kind: &OutgoingKind) -> AppResult<()>
                     .filter(outgoing_requests::user_id.eq(user_id.as_str()))
                     .filter(outgoing_requests::pushkey.eq(pushkey)),
             )
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         }
     }
 
     Ok(())
 }
 
-fn delete_all_requests_for(outgoing_kind: &OutgoingKind) -> AppResult<()> {
+async fn delete_all_requests_for(outgoing_kind: &OutgoingKind) -> AppResult<()> {
     match outgoing_kind {
         OutgoingKind::Appservice(appservice_id) => {
             diesel::delete(
@@ -723,7 +744,8 @@ fn delete_all_requests_for(outgoing_kind: &OutgoingKind) -> AppResult<()> {
                     .filter(outgoing_requests::kind.eq(outgoing_kind.name()))
                     .filter(outgoing_requests::appservice_id.eq(appservice_id)),
             )
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         }
         OutgoingKind::Normal(server_id) => {
             diesel::delete(
@@ -731,7 +753,8 @@ fn delete_all_requests_for(outgoing_kind: &OutgoingKind) -> AppResult<()> {
                     .filter(outgoing_requests::kind.eq(outgoing_kind.name()))
                     .filter(outgoing_requests::server_id.eq(server_id.as_str())),
             )
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         }
         OutgoingKind::Push(user_id, pushkey) => {
             diesel::delete(
@@ -740,21 +763,22 @@ fn delete_all_requests_for(outgoing_kind: &OutgoingKind) -> AppResult<()> {
                     .filter(outgoing_requests::user_id.eq(user_id.as_str()))
                     .filter(outgoing_requests::pushkey.eq(pushkey)),
             )
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         }
     }
 
     Ok(())
 }
 
-fn queue_requests(requests: &[(&OutgoingKind, SendingEventType)]) -> AppResult<Vec<i64>> {
+async fn queue_requests(requests: &[(&OutgoingKind, SendingEventType)]) -> AppResult<Vec<i64>> {
     let mut ids = Vec::new();
     for (outgoing_kind, event) in requests {
-        ids.push(queue_request(outgoing_kind, event)?);
+        ids.push(queue_request(outgoing_kind, event).await?);
     }
     Ok(ids)
 }
-fn queue_request(outgoing_kind: &OutgoingKind, event: &SendingEventType) -> AppResult<i64> {
+async fn queue_request(outgoing_kind: &OutgoingKind, event: &SendingEventType) -> AppResult<i64> {
     let appservice_id = if let OutgoingKind::Appservice(service_id) = outgoing_kind {
         Some(service_id.clone())
     } else {
@@ -786,11 +810,14 @@ fn queue_request(outgoing_kind: &OutgoingKind, event: &SendingEventType) -> AppR
             edu_json,
         })
         .returning(outgoing_requests::id)
-        .get_result::<i64>(&mut connect()?)?;
+        .get_result::<i64>(&mut connect().await?)
+        .await?;
     Ok(id)
 }
 
-fn active_requests_for(outgoing_kind: &OutgoingKind) -> AppResult<Vec<(i64, SendingEventType)>> {
+async fn active_requests_for(
+    outgoing_kind: &OutgoingKind,
+) -> AppResult<Vec<(i64, SendingEventType)>> {
     let mut query = outgoing_requests::table
         .filter(outgoing_requests::kind.eq(outgoing_kind.name()))
         .filter(outgoing_requests::state.eq("pending"))
@@ -812,7 +839,8 @@ fn active_requests_for(outgoing_kind: &OutgoingKind) -> AppResult<Vec<(i64, Send
     }
 
     let list = query
-        .load::<DbOutgoingRequest>(&mut connect()?)?
+        .load::<DbOutgoingRequest>(&mut connect().await?)
+        .await?
         .into_iter()
         .filter_map(|r| {
             if let Some(value) = r.edu_json {
@@ -828,7 +856,7 @@ fn active_requests_for(outgoing_kind: &OutgoingKind) -> AppResult<Vec<(i64, Send
     Ok(list)
 }
 
-fn queued_requests(outgoing_kind: &OutgoingKind) -> AppResult<Vec<(i64, SendingEventType)>> {
+async fn queued_requests(outgoing_kind: &OutgoingKind) -> AppResult<Vec<(i64, SendingEventType)>> {
     let mut query = outgoing_requests::table
         .filter(outgoing_requests::kind.eq(outgoing_kind.name()))
         // Exclude already active requests (state="pending" means being processed)
@@ -851,7 +879,8 @@ fn queued_requests(outgoing_kind: &OutgoingKind) -> AppResult<Vec<(i64, SendingE
     }
 
     Ok(query
-        .load::<DbOutgoingRequest>(&mut connect()?)?
+        .load::<DbOutgoingRequest>(&mut connect().await?)
+        .await?
         .into_iter()
         .filter_map(|r| {
             if let Some(value) = r.edu_json {
@@ -864,7 +893,7 @@ fn queued_requests(outgoing_kind: &OutgoingKind) -> AppResult<Vec<(i64, SendingE
         })
         .collect())
 }
-fn mark_as_active(events: &[(i64, SendingEventType)]) -> AppResult<()> {
+async fn mark_as_active(events: &[(i64, SendingEventType)]) -> AppResult<()> {
     for (id, e) in events {
         let value = if let SendingEventType::Edu(value) = &e {
             &**value
@@ -876,7 +905,8 @@ fn mark_as_active(events: &[(i64, SendingEventType)]) -> AppResult<()> {
                 outgoing_requests::data.eq(value),
                 outgoing_requests::state.eq("pending"),
             ))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     }
 
     Ok(())
@@ -888,7 +918,7 @@ fn mark_as_active(events: &[(i64, SendingEventType)]) -> AppResult<()> {
 /// `event_id` based on the room version. Room versions V1/V2 require `event_id` in
 /// the federation format; V3+ derive it from the event hash.
 #[tracing::instrument]
-pub fn convert_to_outgoing_federation_event(
+pub async fn convert_to_outgoing_federation_event(
     mut pdu_json: CanonicalJsonObject,
 ) -> Box<RawJsonValue> {
     if let Some(unsigned) = pdu_json
@@ -904,18 +934,24 @@ pub fn convert_to_outgoing_federation_event(
     // intentionally has no room_id and other events are looked up via the
     // event_id stored elsewhere), so fall back to looking up room_id from the
     // events table by event_id when the JSON doesn't have one.
-    let room_version = pdu_json
+    let mut room_version = None;
+    if let Some(r) = pdu_json
         .get("room_id")
         .and_then(|v| v.as_str())
         .and_then(|r| <&RoomId>::try_from(r).ok())
-        .and_then(|r| crate::room::get_version(r).ok())
-        .or_else(|| {
-            // Fall back: look up room_id by the event's id from the DB.
+    {
+        room_version = crate::room::get_version(r).await.ok();
+    }
+    if room_version.is_none() {
+        // Fall back: look up room_id by the event's id from the DB.
+        room_version = async {
             let event_id_str = pdu_json.get("event_id").and_then(|v| v.as_str())?;
             let event_id = <&crate::core::identifiers::EventId>::try_from(event_id_str).ok()?;
-            let db_event = crate::data::room::DbEvent::get_by_id(event_id).ok()?;
-            crate::room::get_version(&db_event.room_id).ok()
-        });
+            let db_event = crate::data::room::DbEvent::get_by_id(event_id).await.ok()?;
+            crate::room::get_version(&db_event.room_id).await.ok()
+        }
+        .await;
+    }
 
     match room_version {
         Some(room_version) => {

--- a/crates/server/src/sending/guard.rs
+++ b/crates/server/src/sending/guard.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::{Mutex, mpsc};
 
@@ -44,7 +45,7 @@ async fn process() -> AppResult<()> {
     // Retry requests we could not finish yet
     let mut initial_transactions = HashMap::<OutgoingKind, Vec<SendingEventType>>::new();
 
-    for (id, outgoing_kind, event) in super::active_requests()? {
+    for (id, outgoing_kind, event) in super::active_requests().await? {
         let entry = initial_transactions
             .entry(outgoing_kind.clone())
             .or_default();
@@ -56,7 +57,7 @@ async fn process() -> AppResult<()> {
                 outgoing_kind,
                 id
             );
-            super::delete_request(id)?;
+            super::delete_request(id).await?;
             continue;
         }
 
@@ -75,14 +76,14 @@ async fn process() -> AppResult<()> {
             Some(response) = futures.next() => {
                 match response {
                     Ok(outgoing_kind) => {
-                        super::delete_all_active_requests_for(&outgoing_kind)?;
+                        super::delete_all_active_requests_for(&outgoing_kind).await?;
 
                         // Find events that have been added since starting the last request
-                        let new_events = super::queued_requests(&outgoing_kind).unwrap_or_default().into_iter().take(30).collect::<Vec<_>>();
+                        let new_events = super::queued_requests(&outgoing_kind).await.unwrap_or_default().into_iter().take(30).collect::<Vec<_>>();
 
                         if !new_events.is_empty() {
                             // Insert pdus we found
-                            super::mark_as_active(&new_events)?;
+                            super::mark_as_active(&new_events).await?;
 
                             futures.push(
                                 super::send_events(
@@ -110,7 +111,7 @@ async fn process() -> AppResult<()> {
                         });
                         // Persist retry state to DB for cross-instance coordination
                         if let Some(TransactionStatus::Failed(tries, _)) = current_transaction_status.get(&outgoing_kind) {
-                            let _ = persist_retry_state(&outgoing_kind, *tries);
+                            let _ = persist_retry_state(&outgoing_kind, *tries).await;
                         }
                     }
                 };
@@ -120,7 +121,7 @@ async fn process() -> AppResult<()> {
                     &outgoing_kind,
                     vec![(id, event)],
                     &mut current_transaction_status,
-                ) {
+                ).await {
                     futures.push(super::send_events(outgoing_kind, events));
                 }
             }
@@ -144,7 +145,7 @@ async fn process() -> AppResult<()> {
                     .collect::<Vec<_>>();
 
                 for (outgoing_kind, tries) in retry_ready {
-                    let active_events = match super::active_requests_for(&outgoing_kind) {
+                    let active_events = match super::active_requests_for(&outgoing_kind).await {
                         Ok(events) => events,
                         Err(e) => {
                             error!(
@@ -200,7 +201,7 @@ fn next_retry_delay(
 }
 
 #[tracing::instrument(skip_all)]
-fn select_events(
+async fn select_events(
     outgoing_kind: &OutgoingKind,
     new_events: Vec<(i64, SendingEventType)>, // Events we want to send: event and full key
     current_transaction_status: &mut HashMap<OutgoingKind, TransactionStatus>,
@@ -237,17 +238,17 @@ fn select_events(
 
     if retry {
         // We retry the previous transaction
-        for (_, e) in super::active_requests_for(outgoing_kind)? {
+        for (_, e) in super::active_requests_for(outgoing_kind).await? {
             events.push(e);
         }
     } else {
-        super::mark_as_active(&new_events)?;
+        super::mark_as_active(&new_events).await?;
         for (_, e) in new_events {
             events.push(e);
         }
 
         if let OutgoingKind::Normal(server_name) = outgoing_kind
-            && let Ok((select_edus, _last_count)) = select_edus(server_name)
+            && let Ok((select_edus, _last_count)) = select_edus(server_name).await
         {
             events.extend(select_edus.into_iter().map(SendingEventType::Edu));
         }
@@ -257,7 +258,7 @@ fn select_events(
 }
 
 /// Persist retry state to the database so other instances can respect backoff.
-fn persist_retry_state(outgoing_kind: &OutgoingKind, tries: u32) -> AppResult<()> {
+async fn persist_retry_state(outgoing_kind: &OutgoingKind, tries: u32) -> AppResult<()> {
     let now = UnixMillis::now().get() as i64;
     match outgoing_kind {
         OutgoingKind::Normal(server_name) => {
@@ -271,7 +272,8 @@ fn persist_retry_state(outgoing_kind: &OutgoingKind, tries: u32) -> AppResult<()
                 outgoing_requests::retry_count.eq(tries as i32),
                 outgoing_requests::last_failed_at.eq(Some(now)),
             ))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         }
         OutgoingKind::Appservice(id) => {
             diesel::update(
@@ -284,7 +286,8 @@ fn persist_retry_state(outgoing_kind: &OutgoingKind, tries: u32) -> AppResult<()
                 outgoing_requests::retry_count.eq(tries as i32),
                 outgoing_requests::last_failed_at.eq(Some(now)),
             ))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         }
         OutgoingKind::Push(user_id, pushkey) => {
             diesel::update(
@@ -298,7 +301,8 @@ fn persist_retry_state(outgoing_kind: &OutgoingKind, tries: u32) -> AppResult<()
                 outgoing_requests::retry_count.eq(tries as i32),
                 outgoing_requests::last_failed_at.eq(Some(now)),
             ))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         }
     }
     Ok(())
@@ -306,18 +310,19 @@ fn persist_retry_state(outgoing_kind: &OutgoingKind, tries: u32) -> AppResult<()
 
 /// Look for device changes
 #[tracing::instrument(level = "trace", skip(server_name))]
-fn select_edus_device_changes(
+async fn select_edus_device_changes(
     server_name: &ServerName,
     since_sn: Seqnum,
     _max_edu_sn: &Seqnum,
     events_len: &AtomicUsize,
 ) -> AppResult<EduVec> {
     let mut events = EduVec::new();
-    let server_rooms = state::server_joined_rooms(server_name)?;
+    let server_rooms = state::server_joined_rooms(server_name).await?;
 
     let mut device_list_changes = HashSet::<OwnedUserId>::new();
     for room_id in server_rooms {
-        let keys_changed = room::keys_changed_users(&room_id, since_sn, None)?
+        let keys_changed = room::keys_changed_users(&room_id, since_sn, None)
+            .await?
             .into_iter()
             .filter(|user_id| user_id.is_local());
 
@@ -357,25 +362,24 @@ fn select_edus_device_changes(
 
 /// Look for read receipts in this room
 #[tracing::instrument(level = "trace", skip(server_name, max_edu_sn))]
-fn select_edus_receipts(
+async fn select_edus_receipts(
     server_name: &ServerName,
     since_sn: Seqnum,
     max_edu_sn: &Seqnum,
 ) -> AppResult<Option<EduBuf>> {
     let mut num = 0;
-    let receipts: BTreeMap<OwnedRoomId, ReceiptMap> = state::server_joined_rooms(server_name)?
-        .into_iter()
-        .filter_map(|room_id| {
-            let receipt_map =
-                select_edus_receipts_room(&room_id, since_sn, max_edu_sn, &mut num).ok()?;
+    let mut receipts: BTreeMap<OwnedRoomId, ReceiptMap> = BTreeMap::new();
+    for room_id in state::server_joined_rooms(server_name).await? {
+        let Ok(receipt_map) =
+            select_edus_receipts_room(&room_id, since_sn, max_edu_sn, &mut num).await
+        else {
+            continue;
+        };
 
-            receipt_map
-                .read
-                .is_empty()
-                .eq(&false)
-                .then_some((room_id, receipt_map))
-        })
-        .collect();
+        if !receipt_map.read.is_empty() {
+            receipts.insert(room_id, receipt_map);
+        }
+    }
 
     if receipts.is_empty() {
         return Ok(None);
@@ -393,13 +397,13 @@ fn select_edus_receipts(
 }
 /// Look for read receipts in this room
 #[tracing::instrument(level = "trace", skip(since_sn))]
-fn select_edus_receipts_room(
+async fn select_edus_receipts_room(
     room_id: &RoomId,
     since_sn: Seqnum,
     _max_edu_sn: &Seqnum,
     num: &mut usize,
 ) -> AppResult<ReceiptMap> {
-    let receipts = data::room::receipt::read_receipts(room_id, since_sn)?;
+    let receipts = data::room::receipt::read_receipts(room_id, since_sn).await?;
 
     let mut read = BTreeMap::<OwnedUserId, ReceiptData>::new();
     for (user_id, read_receipt) in receipts {
@@ -456,12 +460,12 @@ fn select_edus_receipts_room(
 
 /// Look for presence
 #[tracing::instrument(level = "trace", skip(server_name))]
-fn select_edus_presence(
+async fn select_edus_presence(
     server_name: &ServerName,
     since_sn: Seqnum,
     _max_edu_sn: &Seqnum,
 ) -> AppResult<Option<EduBuf>> {
-    let presences_since = crate::data::user::presences_since(since_sn)?;
+    let presences_since = crate::data::user::presences_since(since_sn).await?;
 
     let mut presence_updates = HashMap::<OwnedUserId, PresenceUpdate>::new();
     for (user_id, presence_event) in presences_since {
@@ -470,7 +474,7 @@ fn select_edus_presence(
             continue;
         }
 
-        if !state::server_can_see_user(server_name, &user_id)? {
+        if !state::server_can_see_user(server_name, &user_id).await? {
             continue;
         }
 
@@ -506,25 +510,25 @@ fn select_edus_presence(
 }
 
 #[tracing::instrument(skip(server_name))]
-pub fn select_edus(server_name: &ServerName) -> AppResult<(EduVec, i64)> {
-    let max_edu_sn = data::curr_sn()?;
+pub async fn select_edus(server_name: &ServerName) -> AppResult<(EduVec, i64)> {
+    let max_edu_sn = data::curr_sn().await?;
     let conf = crate::config::get();
 
-    let since_sn = data::curr_sn()?;
+    let since_sn = data::curr_sn().await?;
 
     let events_len = AtomicUsize::default();
     let device_changes =
-        select_edus_device_changes(server_name, since_sn, &max_edu_sn, &events_len)?;
+        select_edus_device_changes(server_name, since_sn, &max_edu_sn, &events_len).await?;
 
     let mut events = device_changes;
     if conf.read_receipt.allow_outgoing
-        && let Some(receipts) = select_edus_receipts(server_name, since_sn, &max_edu_sn)?
+        && let Some(receipts) = select_edus_receipts(server_name, since_sn, &max_edu_sn).await?
     {
         events.push(receipts);
     }
 
     if conf.presence.allow_outgoing
-        && let Some(presence) = select_edus_presence(server_name, since_sn, &max_edu_sn)?
+        && let Some(presence) = select_edus_presence(server_name, since_sn, &max_edu_sn).await?
     {
         events.push(presence);
     }

--- a/crates/server/src/server_key.rs
+++ b/crates/server/src/server_key.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 pub use acquire::*;
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 pub use request::*;
 use serde_json::value::RawValue as RawJsonValue;
 pub use verify::*;
@@ -47,14 +48,15 @@ fn merge_signing_keys_for_storage(
     keys
 }
 
-pub(crate) fn add_signing_keys(new_keys: ServerSigningKeys) -> AppResult<()> {
+pub(crate) async fn add_signing_keys(new_keys: ServerSigningKeys) -> AppResult<()> {
     let server = new_keys.server_name.clone();
 
     // (timo) Not atomic, but this is not critical
     let existing = server_signing_keys::table
         .find(&server)
         .select(server_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect()?)
+        .first::<JsonValue>(&mut connect().await?)
+        .await
         .optional()?;
     let existing = existing
         .map(serde_json::from_value::<ServerSigningKeys>)
@@ -74,17 +76,22 @@ pub(crate) fn add_signing_keys(new_keys: ServerSigningKeys) -> AppResult<()> {
             server_signing_keys::key_data.eq(serde_json::to_value(&keys)?),
             server_signing_keys::updated_at.eq(UnixMillis::now()),
         ))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
-pub fn verify_key_exists(server: &ServerName, key_id: &ServerSigningKeyId) -> AppResult<bool> {
+pub async fn verify_key_exists(
+    server: &ServerName,
+    key_id: &ServerSigningKeyId,
+) -> AppResult<bool> {
     type KeysMap<'a> = BTreeMap<&'a str, &'a RawJsonValue>;
 
     let key_data = server_signing_keys::table
         .filter(server_signing_keys::server_id.eq(server))
         .select(server_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect()?)
+        .first::<JsonValue>(&mut connect().await?)
+        .await
         .optional()?;
 
     let Some(keys) = key_data else {
@@ -107,8 +114,9 @@ pub fn verify_key_exists(server: &ServerName, key_id: &ServerSigningKeyId) -> Ap
     Ok(false)
 }
 
-pub fn verify_keys_for(server: &ServerName) -> VerifyKeys {
+pub async fn verify_keys_for(server: &ServerName) -> VerifyKeys {
     let mut keys = signing_keys_for(server)
+        .await
         .map(|keys| merge_old_keys(keys).verify_keys)
         .unwrap_or_default();
 
@@ -127,11 +135,12 @@ pub fn verify_keys_for(server: &ServerName) -> VerifyKeys {
     keys
 }
 
-pub fn signing_keys_for(server: &ServerName) -> AppResult<ServerSigningKeys> {
+pub async fn signing_keys_for(server: &ServerName) -> AppResult<ServerSigningKeys> {
     let key_data = server_signing_keys::table
         .filter(server_signing_keys::server_id.eq(server))
         .select(server_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect()?)?;
+        .first::<JsonValue>(&mut connect().await?)
+        .await?;
     Ok(serde_json::from_value(key_data)?)
 }
 
@@ -219,7 +228,7 @@ pub async fn get_verify_key(
     let notary_first = crate::config::get().query_trusted_key_servers_first;
     let notary_only = crate::config::get().only_query_trusted_key_servers;
 
-    if let Some(result) = verify_keys_for(origin).remove(key_id) {
+    if let Some(result) = verify_keys_for(origin).await.remove(key_id) {
         return Ok(result);
     }
 
@@ -246,7 +255,7 @@ async fn get_verify_key_from_notaries(
     for notary in &crate::config::get().trusted_servers {
         if let Ok(server_keys) = notary_request(notary, origin).await {
             for server_key in server_keys.clone() {
-                add_signing_keys(server_key)?;
+                add_signing_keys(server_key).await?;
             }
 
             for server_key in server_keys {
@@ -267,7 +276,7 @@ async fn get_verify_key_from_origin(
     key_id: &ServerSigningKeyId,
 ) -> AppResult<VerifyKey> {
     if let Ok(server_key) = server_request(origin).await {
-        add_signing_keys(server_key.clone())?;
+        add_signing_keys(server_key.clone()).await?;
         if let Some(result) = extract_key(server_key, key_id) {
             return Ok(result);
         }

--- a/crates/server/src/server_key/acquire.rs
+++ b/crates/server/src/server_key/acquire.rs
@@ -116,7 +116,7 @@ where
 {
     let mut missing = Batch::new();
     for (server, key_ids) in batch {
-        let available_keys = verify_keys_for(server);
+        let available_keys = verify_keys_for(server).await;
         let missing_key_ids = missing_local_key_ids(&available_keys, key_ids);
         if !missing_key_ids.is_empty() {
             missing.insert(server.into(), missing_key_ids);

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -21,7 +21,7 @@ pub async fn send_state_event_for_key(
     json: RawJson<AnyStateEventContent>,
     state_key: String,
 ) -> AppResult<OwnedEventId> {
-    allowed_to_send_state_event(room_id, event_type, &state_key, &json)?;
+    allowed_to_send_state_event(room_id, event_type, &state_key, &json).await?;
     let pdu = timeline::build_and_append_pdu(
         PduBuilder {
             event_type: event_type.to_string().into(),
@@ -40,7 +40,7 @@ pub async fn send_state_event_for_key(
     Ok(pdu.event_id)
 }
 
-fn allowed_to_send_state_event(
+async fn allowed_to_send_state_event(
     room_id: &RoomId,
     event_type: &StateEventType,
     state_key: &str,
@@ -66,7 +66,7 @@ fn allowed_to_send_state_event(
         }
         // admin room is a sensitive room, it should not ever be made public
         StateEventType::RoomJoinRules => {
-            if crate::room::is_admin_room(room_id)?
+            if crate::room::is_admin_room(room_id).await?
                 && let Ok(join_rule) =
                     serde_json::from_str::<RoomJoinRulesEventContent>(json.inner().get())
                 && join_rule.join_rule == JoinRule::Public
@@ -82,7 +82,7 @@ fn allowed_to_send_state_event(
         StateEventType::RoomHistoryVisibility => {
             if let Ok(visibility_content) =
                 serde_json::from_str::<RoomHistoryVisibilityEventContent>(json.inner().get())
-                && crate::room::is_admin_room(room_id)?
+                && crate::room::is_admin_room(room_id).await?
                 && visibility_content.history_visibility == HistoryVisibility::WorldReadable
             {
                 return Err(MatrixError::forbidden(
@@ -112,7 +112,7 @@ fn allowed_to_send_state_event(
                         .into());
                     }
 
-                    if !crate::room::resolve_local_alias(&alias).is_ok_and(|room| room == room_id)
+                    if !crate::room::resolve_local_alias(&alias).await.is_ok_and(|room| room == room_id)
                     // Make sure it's the right room
                     {
                         return Err(MatrixError::bad_alias(
@@ -152,7 +152,7 @@ fn allowed_to_send_state_event(
                     .into());
                 }
 
-                if crate::room::user::is_joined(&state_key, room_id)? {
+                if crate::room::user::is_joined(&state_key, room_id).await? {
                     return Err(MatrixError::invalid_param(
                         "{state_key} is already joined, an authorising user is not required.",
                     )
@@ -166,7 +166,7 @@ fn allowed_to_send_state_event(
                     .into());
                 }
 
-                if !crate::room::user::is_joined(&authorising_user, room_id)? {
+                if !crate::room::user::is_joined(&authorising_user, room_id).await? {
                     return Err(MatrixError::invalid_param(
                         "Authorising user {authorising_user} is not in the room, they cannot \
 						 authorise the join.",
@@ -176,7 +176,7 @@ fn allowed_to_send_state_event(
             }
         }
         StateEventType::RoomPowerLevels => {
-            let room_version = room::get_version(room_id)?;
+            let room_version = room::get_version(room_id).await?;
             let version_rules = crate::room::get_version_rules(&room_version)?;
             if version_rules
                 .authorization
@@ -192,7 +192,7 @@ fn allowed_to_send_state_event(
                     .into());
                 };
 
-                let create_event = crate::room::get_create(room_id)?;
+                let create_event = crate::room::get_create(room_id).await?;
                 for crator in create_event.creators()? {
                     if power_level_content.users.contains_key(&crator) {
                         return Err(MatrixError::bad_json(

--- a/crates/server/src/sync_v3.rs
+++ b/crates/server/src/sync_v3.rs
@@ -39,7 +39,7 @@ pub async fn sync_events(
     device_id: &DeviceId,
     args: &SyncEventsReqArgs,
 ) -> AppResult<SyncEventsResBody> {
-    let curr_sn = data::curr_sn()?;
+    let curr_sn = data::curr_sn().await?;
     crate::seqnum_reach(curr_sn).await;
     let since_tk = if let Some(since_str) = args.since.as_ref() {
         let since_tk: BatchToken = since_str.parse()?;
@@ -60,7 +60,7 @@ pub async fn sync_events(
             let filter_id: i64 = filter_id
                 .parse()
                 .map_err(|_| MatrixError::invalid_param("Invalid filter ID"))?;
-            data::user::get_filter(sender_id, filter_id)?
+            data::user::get_filter(sender_id, filter_id).await?
         }
     };
     let _lazy_load_enabled = filter.room.state.lazy_load_options.is_enabled()
@@ -78,13 +78,16 @@ pub async fn sync_events(
     let mut device_list_left = HashSet::new();
 
     // Look for device list updates of this account
-    device_list_updates.extend(data::user::keys_changed_users(
-        sender_id,
-        since_tk.unwrap_or(BatchToken::LIVE_MIN).event_sn(),
-        None,
-    )?);
+    device_list_updates.extend(
+        data::user::keys_changed_users(
+            sender_id,
+            since_tk.unwrap_or(BatchToken::LIVE_MIN).event_sn(),
+            None,
+        )
+        .await?,
+    );
 
-    let all_joined_rooms = data::user::joined_rooms(sender_id)?;
+    let all_joined_rooms = data::user::joined_rooms(sender_id).await?;
     for room_id in &all_joined_rooms {
         let joined_room = match load_joined_room(
             sender_id,
@@ -121,10 +124,10 @@ pub async fn sync_events(
     }
 
     let mut left_rooms = BTreeMap::new();
-    let all_left_rooms = room::user::left_rooms(sender_id, since_tk)?;
+    let all_left_rooms = room::user::left_rooms(sender_id, since_tk).await?;
 
     for room_id in all_left_rooms.keys() {
-        let Ok(left_sn) = room::user::left_sn(room_id, sender_id) else {
+        let Ok(left_sn) = room::user::left_sn(room_id, sender_id).await else {
             tracing::warn!("left room {} without a left_sn, skipping", room_id);
             continue;
         };
@@ -160,7 +163,8 @@ pub async fn sync_events(
     let invited_rooms: BTreeMap<_, _> = data::user::invited_rooms(
         sender_id,
         since_tk.unwrap_or(BatchToken::LIVE_MIN).stream_ordering(),
-    )?
+    )
+    .await?
     .into_iter()
     .map(|(room_id, invite_state_events)| {
         (
@@ -171,15 +175,24 @@ pub async fn sync_events(
     .collect();
 
     for left_room in left_rooms.keys() {
-        for user_id in room::joined_users(left_room, None)? {
-            let dont_share_encrypted_room =
-                room::user::shared_rooms(vec![sender_id.to_owned(), user_id.clone()])?
-                    .into_iter()
-                    .map(|other_room_id| {
-                        room::get_state(&other_room_id, &StateEventType::RoomEncryption, "", None)
-                            .is_ok()
-                    })
-                    .all(|encrypted| !encrypted);
+        for user_id in room::joined_users(left_room, None).await? {
+            let mut dont_share_encrypted_room = true;
+            for other_room_id in
+                room::user::shared_rooms(vec![sender_id.to_owned(), user_id.clone()]).await?
+            {
+                let encrypted = room::get_state(
+                    &other_room_id,
+                    &StateEventType::RoomEncryption,
+                    "",
+                    None,
+                )
+                .await
+                .is_ok();
+                if encrypted {
+                    dont_share_encrypted_room = false;
+                    break;
+                }
+            }
             // If the user doesn't share an encrypted room with the target anymore, we need to tell
             // them.
             if dont_share_encrypted_room {
@@ -188,14 +201,23 @@ pub async fn sync_events(
         }
     }
     for user_id in left_users {
-        let dont_share_encrypted_room =
-            room::user::shared_rooms(vec![sender_id.to_owned(), user_id.clone()])?
-                .into_iter()
-                .map(|other_room_id| {
-                    room::get_state(&other_room_id, &StateEventType::RoomEncryption, "", None)
-                        .is_ok()
-                })
-                .all(|encrypted| !encrypted);
+        let mut dont_share_encrypted_room = true;
+        for other_room_id in
+            room::user::shared_rooms(vec![sender_id.to_owned(), user_id.clone()]).await?
+        {
+            let encrypted = room::get_state(
+                &other_room_id,
+                &StateEventType::RoomEncryption,
+                "",
+                None,
+            )
+            .await
+            .is_ok();
+            if encrypted {
+                dont_share_encrypted_room = false;
+                break;
+            }
+        }
         // If the user doesn't share an encrypted room with the target anymore, we need to tell
         // them.
         if dont_share_encrypted_room {
@@ -203,33 +225,31 @@ pub async fn sync_events(
         }
     }
 
-    let knocked_rooms = data::user::knocked_rooms(sender_id, 0)?.into_iter().fold(
-        BTreeMap::default(),
-        |mut knocked_rooms: BTreeMap<_, _>, (room_id, knock_state)| {
-            let knock_sn = room::user::knock_sn(sender_id, &room_id).ok();
+    let mut knocked_rooms: BTreeMap<_, _> = BTreeMap::default();
+    for (room_id, knock_state) in data::user::knocked_rooms(sender_id, 0).await?.into_iter() {
+        let knock_sn = room::user::knock_sn(sender_id, &room_id).await.ok();
 
-            // Knocked before last sync
-            if since_tk.map(|t| t.event_sn()) > knock_sn {
-                return knocked_rooms;
-            }
+        // Knocked before last sync
+        if since_tk.map(|t| t.event_sn()) > knock_sn {
+            continue;
+        }
 
-            let knocked_room = KnockedRoom {
-                knock_state: KnockState {
-                    events: knock_state,
-                },
-            };
+        let knocked_room = KnockedRoom {
+            knock_state: KnockState {
+                events: knock_state,
+            },
+        };
 
-            knocked_rooms.insert(room_id, knocked_room);
-            knocked_rooms
-        },
-    );
+        knocked_rooms.insert(room_id, knocked_room);
+    }
 
     if config::get().presence.allow_local {
         // Take presence updates from this room
         for (user_id, presence_event) in
-            crate::data::user::presences_since(since_tk.unwrap_or(BatchToken::LIVE_MIN).event_sn())?
+            crate::data::user::presences_since(since_tk.unwrap_or(BatchToken::LIVE_MIN).event_sn())
+                .await?
         {
-            if user_id == sender_id || !state::user_can_see_user(sender_id, &user_id)? {
+            if user_id == sender_id || !state::user_can_see_user(sender_id, &user_id).await? {
                 continue;
             }
 
@@ -261,7 +281,7 @@ pub async fn sync_events(
         }
         for joined_user in &joined_users {
             if !presence_updates.contains_key(joined_user)
-                && let Ok(presence) = data::user::last_presence(joined_user)
+                && let Ok(presence) = data::user::last_presence(joined_user).await
             {
                 presence_updates.insert(joined_user.to_owned(), presence);
             }
@@ -273,7 +293,8 @@ pub async fn sync_events(
         sender_id,
         device_id,
         since_tk.unwrap_or(BatchToken::LIVE_MIN).event_sn() - 1,
-    )?;
+    )
+    .await?;
 
     let account_data = GlobalAccountData {
         events: data::user::data_changes(
@@ -281,7 +302,8 @@ pub async fn sync_events(
             sender_id,
             since_tk.unwrap_or(BatchToken::LIVE_MIN).event_sn(),
             None,
-        )?
+        )
+        .await?
         .into_iter()
         .filter_map(|e| extract_variant!(e, AnyRawAccountDataEvent::Global))
         .collect(),
@@ -310,7 +332,8 @@ pub async fn sync_events(
             device_id,
             since_tk.map(|s| s.event_sn()),
             Some(next_batch.event_sn()),
-        )?,
+        )
+        .await?,
     };
 
     let res_body = SyncEventsResBody {
@@ -320,7 +343,9 @@ pub async fn sync_events(
         account_data,
         device_lists,
         device_one_time_keys_count: {
-            data::user::count_one_time_keys(sender_id, device_id).unwrap_or_default()
+            data::user::count_one_time_keys(sender_id, device_id)
+                .await
+                .unwrap_or_default()
         },
         to_device,
         // Fallback keys are not yet supported
@@ -344,7 +369,7 @@ async fn load_joined_room(
     joined_users: &mut HashSet<OwnedUserId>,
     left_users: &mut HashSet<OwnedUserId>,
 ) -> AppResult<(JoinedRoom, Option<BatchToken>)> {
-    if since_tk.map(|s| s.event_sn()) > Some(data::curr_sn()?) {
+    if since_tk.map(|s| s.event_sn()) > Some(data::curr_sn().await?) {
         return Ok((JoinedRoom::default(), None));
     }
     let lazy_load_enabled = filter.room.state.lazy_load_options.is_enabled()
@@ -357,11 +382,11 @@ async fn load_joined_room(
         _ => false,
     };
 
-    let Ok(current_frame_id) = room::get_frame_id(room_id, None) else {
+    let Ok(current_frame_id) = room::get_frame_id(room_id, None).await else {
         return Ok((JoinedRoom::default(), None));
     };
     let since_frame_id =
-        crate::event::get_last_frame_id(room_id, since_tk.map(|t| t.event_sn())).ok();
+        crate::event::get_last_frame_id(room_id, since_tk.map(|t| t.event_sn())).await.ok();
 
     let mut timeline = load_timeline(
         sender_id,
@@ -369,9 +394,10 @@ async fn load_joined_room(
         since_tk,
         Some(next_batch),
         Some(&filter.room.timeline),
-    )?;
+    )
+    .await?;
 
-    let join_sn = crate::room::user::join_sn(sender_id, room_id).unwrap_or_default();
+    let join_sn = crate::room::user::join_sn(sender_id, room_id).await.unwrap_or_default();
     let joined_since_incremental = since_tk
         .map(|since_tk| join_sn >= since_tk.event_sn())
         .unwrap_or(false);
@@ -393,7 +419,8 @@ async fn load_joined_room(
                     room_id,
                     BatchToken::new_live(join_sn),
                     Some(&filter.room.timeline),
-                )?;
+                )
+                .await?;
             }
             Ok(_) => {}
             Err(e) => {
@@ -409,7 +436,7 @@ async fn load_joined_room(
     };
 
     let send_notification_counts = !timeline.events.is_empty()
-        || room::user::last_read_notification(sender_id, room_id)? >= since_tk.event_sn();
+        || room::user::last_read_notification(sender_id, room_id).await? >= since_tk.event_sn();
     let mut timeline_users = HashSet::new();
     let mut timeline_pdu_ids = HashSet::new();
     for (_, event) in &timeline.events {
@@ -430,9 +457,9 @@ async fn load_joined_room(
             (Vec::new(), None, None, false, Vec::new())
         } else {
             // Calculates joined_member_count, invited_member_count and heroes
-            let calculate_counts = || {
-                let joined_member_count = room::joined_member_count(room_id).unwrap_or(0);
-                let invited_member_count = room::invited_member_count(room_id).unwrap_or(0);
+            let calculate_counts = || async {
+                let joined_member_count = room::joined_member_count(room_id).await.unwrap_or(0);
+                let invited_member_count = room::invited_member_count(room_id).await.unwrap_or(0);
 
                 // Recalculate heroes (first 5 members)
                 let mut heroes = Vec::new();
@@ -440,10 +467,12 @@ async fn load_joined_room(
                 if joined_member_count + invited_member_count <= 5 {
                     // Go through all PDUs and for each member event, check if the user is still
                     // joined or invited until we have 5 or we reach the end
-                    for hero in timeline::stream::load_all_pdus(Some(sender_id), room_id, until_tk)?
+                    for (_, pdu) in timeline::stream::load_all_pdus(Some(sender_id), room_id, until_tk)
+                        .await?
                         .into_iter() // Ignore all broken pdus
                         .filter(|(_, pdu)| pdu.event_ty == TimelineEventType::RoomMember)
-                        .map(|(_, pdu)| {
+                    {
+                        let hero = {
                             let content = pdu.get_content::<RoomMemberEventContent>()?;
 
                             if let Some(state_key) = &pdu.state_key {
@@ -455,8 +484,8 @@ async fn load_joined_room(
                                 if matches!(
                                     content.membership,
                                     MembershipState::Join | MembershipState::Invite
-                                ) && (room::user::is_joined(&user_id, room_id)?
-                                    || room::user::is_invited(&user_id, room_id)?)
+                                ) && (room::user::is_joined(&user_id, room_id).await?
+                                    || room::user::is_invited(&user_id, room_id).await?)
                                 {
                                     Ok::<_, AppError>(Some(state_key.clone()))
                                 } else {
@@ -465,12 +494,12 @@ async fn load_joined_room(
                             } else {
                                 Ok(None)
                             }
-                        })
-                        // Filter out buggy users
-                        .filter_map(|u| u.ok())
-                        // Filter for possible heroes
-                        .flatten()
-                    {
+                        };
+                        // Filter out buggy users and filter for possible heroes
+                        let Some(hero) = hero.ok().flatten() else {
+                            continue;
+                        };
+
                         if heroes.contains(&hero) || hero == sender_id.as_str() {
                             continue;
                         }
@@ -488,9 +517,9 @@ async fn load_joined_room(
             let joined_since_last_sync = join_sn >= since_tk.event_sn();
             if since_tk.event_sn() == 0 || joined_since_last_sync {
                 // Probably since = 0, we will do an initial sync
-                let (joined_member_count, invited_member_count, heroes) = calculate_counts()?;
+                let (joined_member_count, invited_member_count, heroes) = calculate_counts().await?;
                 let current_state_ids =
-                    state::get_full_state_ids(since_frame_id.unwrap_or(current_frame_id))?;
+                    state::get_full_state_ids(since_frame_id.unwrap_or(current_frame_id)).await?;
                 let mut state_events = Vec::new();
                 let mut lazy_loaded = HashSet::new();
 
@@ -504,7 +533,7 @@ async fn load_joined_room(
                         event_ty,
                         state_key,
                         ..
-                    } = state::get_field(state_key_id)?;
+                    } = state::get_field(state_key_id).await?;
 
                     // skip room name type is just for pass TestSyncOmitsStateChangeOnFilteredEvents
                     // test
@@ -513,7 +542,7 @@ async fn load_joined_room(
                         continue;
                     }
                     if event_ty != StateEventType::RoomMember {
-                        let Ok(pdu) = timeline::get_pdu(&event_id) else {
+                        let Ok(pdu) = timeline::get_pdu(&event_id).await else {
                             warn!(
                                 "pdu in state not found: {} event_type: {}",
                                 event_id, event_ty
@@ -529,7 +558,7 @@ async fn load_joined_room(
                     // TODO: Delete the following line when this is resolved: https://github.com/vector-im/element-web/issues/22565
                     || *sender_id == state_key
                     {
-                        let Ok(pdu) = timeline::get_pdu(&event_id) else {
+                        let Ok(pdu) = timeline::get_pdu(&event_id).await else {
                             warn!(
                                 "pdu in state not found: {} state_key: {}",
                                 event_id, state_key
@@ -548,7 +577,7 @@ async fn load_joined_room(
                 }
 
                 // Reset lazy loading because this is an initial sync
-                room::lazy_loading::lazy_load_reset(sender_id, device_id, room_id)?;
+                room::lazy_loading::lazy_load_reset(sender_id, device_id, room_id).await?;
                 // The state_events above should contain all timeline_users, let's mark them as lazy
                 // loaded.
                 room::lazy_loading::lazy_load_mark_sent(
@@ -557,11 +586,12 @@ async fn load_joined_room(
                     room_id,
                     lazy_loaded,
                     next_batch.event_sn(),
-                );
+                )
+                .await;
 
                 // && encrypted_room || new_encrypted_room {
                 // If the user is in a new encrypted room, give them all joined users
-                *joined_users = room::joined_users(room_id, None)?.into_iter().collect();
+                *joined_users = room::joined_users(room_id, None).await?.into_iter().collect();
                 // .into_iter()
                 // .filter(|user_id| {
                 //     // Don't send key updates from the sender to the sender
@@ -590,8 +620,8 @@ async fn load_joined_room(
                 let mut lazy_loaded = HashSet::new();
 
                 if since_frame_id != current_frame_id {
-                    let current_state_ids = state::get_full_state_ids(current_frame_id)?;
-                    let since_state_ids = state::get_full_state_ids(since_frame_id)?;
+                    let current_state_ids = state::get_full_state_ids(current_frame_id).await?;
+                    let since_state_ids = state::get_full_state_ids(since_frame_id).await?;
 
                     for (key, id) in current_state_ids {
                         if let Some(state_limit) = filter.room.state.limit
@@ -600,7 +630,7 @@ async fn load_joined_room(
                             break;
                         }
                         if full_state || since_state_ids.get(&key) != Some(&id) {
-                            let pdu = match timeline::get_pdu(&id) {
+                            let pdu = match timeline::get_pdu(&id).await {
                                 Ok(pdu) => pdu,
                                 Err(_) => {
                                     warn!("pdu in state not found: {}", id);
@@ -641,13 +671,13 @@ async fn load_joined_room(
                         device_id,
                         room_id,
                         &event.sender,
-                    )? || lazy_load_send_redundant)
+                    ).await? || lazy_load_send_redundant)
                         && let Ok(member_event) = room::get_state(
                             room_id,
                             &StateEventType::RoomMember,
                             event.sender.as_str(),
                             None,
-                        )
+                        ).await
                     {
                         lazy_loaded.insert(event.sender.clone());
                         if member_event.can_pass_filter(&filter.room.state) {
@@ -661,12 +691,13 @@ async fn load_joined_room(
                     room_id,
                     lazy_loaded,
                     next_batch.event_sn(),
-                );
+                )
+                .await;
 
                 let encrypted_room =
-                    state::get_state(current_frame_id, &StateEventType::RoomEncryption, "").is_ok();
+                    state::get_state(current_frame_id, &StateEventType::RoomEncryption, "").await.is_ok();
                 let since_encryption =
-                    state::get_state(since_frame_id, &StateEventType::RoomEncryption, "").ok();
+                    state::get_state(since_frame_id, &StateEventType::RoomEncryption, "").await.ok();
                 // Calculations:
                 let _new_encrypted_room = encrypted_room && since_encryption.is_none();
                 let send_member_count = state_events
@@ -700,7 +731,7 @@ async fn load_joined_room(
                                     && !room::user::shared_rooms(vec![
                                         sender_id.to_owned(),
                                         user_id.to_owned(),
-                                    ])?
+                                    ]).await?
                                     .is_empty()
                                 {
                                     // if user_id.is_local() {
@@ -724,7 +755,7 @@ async fn load_joined_room(
                     // && encrypted_room || new_encrypted_room {
                     // If the user is in a new encrypted room, give them all joined users
                     device_list_updates.extend(
-                        room::joined_users(room_id, None)?
+                        room::joined_users(room_id, None).await?
                             .into_iter()
                             .filter(|user_id| {
                                 // Don't send key updates from the sender to the sender
@@ -739,7 +770,7 @@ async fn load_joined_room(
                 }
 
                 let (joined_member_count, invited_member_count, heroes) = if send_member_count {
-                    calculate_counts()?
+                    calculate_counts().await?
                 } else {
                     (None, None, Vec::new())
                 };
@@ -761,7 +792,7 @@ async fn load_joined_room(
         room_id,
         since_tk.event_sn(),
         None,
-    )?);
+    ).await?);
 
     let mut limited = timeline.limited || joined_since_last_sync;
     if let Some((_, first_event)) = timeline.events.first()
@@ -771,7 +802,7 @@ async fn load_joined_room(
     }
 
     let mut edus: Vec<RawJson<AnySyncEphemeralRoomEvent>> = Vec::new();
-    for (_, content) in data::room::receipt::read_receipts(room_id, since_tk.event_sn())? {
+    for (_, content) in data::room::receipt::read_receipts(room_id, since_tk.event_sn()).await? {
         let receipt = SyncReceiptEvent { content };
         edus.push(RawJson::new(&receipt)?.cast());
     }
@@ -785,11 +816,12 @@ async fn load_joined_room(
     }
 
     let account_events =
-        data::user::data_changes(Some(room_id), sender_id, since_tk.event_sn(), None)?
+        data::user::data_changes(Some(room_id), sender_id, since_tk.event_sn(), None)
+            .await?
             .into_iter()
             .filter_map(|e| extract_variant!(e, AnyRawAccountDataEvent::Room))
             .collect();
-    let notify_summary = room::user::notify_summary(sender_id, room_id)?;
+    let notify_summary = room::user::notify_summary(sender_id, room_id).await?;
     let mut notification_count = None;
     let mut highlight_count = None;
     let mut unread_count = None;
@@ -872,7 +904,7 @@ async fn load_left_room(
     _left_users: &mut HashSet<OwnedUserId>,
 ) -> AppResult<LeftRoom> {
     let conf = crate::config::get();
-    if !room::room_exists(room_id)? {
+    if !room::room_exists(room_id).await? {
         let event = PduEvent {
             event_id: EventId::new_v1(&conf.server_name),
             sender: sender_id.to_owned(),
@@ -905,27 +937,28 @@ async fn load_left_room(
         });
     }
 
-    let Ok(curr_frame_id) = room::get_frame_id(room_id, None) else {
+    let Ok(curr_frame_id) = room::get_frame_id(room_id, None).await else {
         return Ok(LeftRoom::default());
     };
     let left_event_id = state::get_state_event_id(
         curr_frame_id,
         &StateEventType::RoomMember,
         sender_id.as_str(),
-    )?;
-    let left_frame_id = state::get_pdu_frame_id(&left_event_id)?;
+    ).await?;
+    let left_frame_id = state::get_pdu_frame_id(&left_event_id).await?;
     let timeline = load_timeline(
         sender_id,
         room_id,
         since_tk,
         None,
         Some(&filter.room.timeline),
-    )?;
+    )
+    .await?;
     let mut limited = timeline.limited;
     let since_tk = since_tk.unwrap_or(BatchToken::LIVE_MIN);
 
     let _send_notification_counts = !timeline.events.is_empty()
-        || room::user::last_read_notification(sender_id, room_id)? >= since_tk.event_sn();
+        || room::user::last_read_notification(sender_id, room_id).await? >= since_tk.event_sn();
     let mut timeline_users = HashSet::new();
     let mut timeline_pdu_ids = HashSet::new();
     for (_, event) in &timeline.events {
@@ -934,9 +967,9 @@ async fn load_left_room(
     }
 
     let mut state_events = Vec::new();
-    let mut left_state_ids = state::get_full_state_ids(left_frame_id).unwrap_or_default();
+    let mut left_state_ids = state::get_full_state_ids(left_frame_id).await.unwrap_or_default();
     let leave_state_key_id =
-        state::ensure_field_id(&StateEventType::RoomMember, sender_id.as_str())?;
+        state::ensure_field_id(&StateEventType::RoomMember, sender_id.as_str()).await?;
     left_state_ids.insert(leave_state_key_id, left_event_id.clone());
 
     for (key, event_id) in left_state_ids {
@@ -948,10 +981,10 @@ async fn load_left_room(
         if timeline_pdu_ids.contains(&event_id) {
             continue;
         }
-        let DbRoomStateField { state_key, .. } = state::get_field(key)?;
+        let DbRoomStateField { state_key, .. } = state::get_field(key).await?;
 
         if *sender_id == state_key {
-            let pdu = match timeline::get_pdu(&event_id) {
+            let pdu = match timeline::get_pdu(&event_id).await {
                 Ok(pdu) => pdu,
                 _ => {
                     warn!(
@@ -1024,7 +1057,7 @@ fn timeline_contains_own_join(timeline: &TimelineData, user_id: &UserId) -> bool
     })
 }
 
-fn load_timeline_around_join(
+async fn load_timeline_around_join(
     user_id: &UserId,
     room_id: &RoomId,
     join_tk: BatchToken,
@@ -1038,7 +1071,8 @@ fn load_timeline_around_join(
         None,
         filter,
         limit + 1,
-    )?;
+    )
+    .await?;
 
     let mut limited = false;
     if timeline_pdus.len() > limit {
@@ -1060,7 +1094,7 @@ fn load_timeline_around_join(
 }
 
 #[tracing::instrument]
-pub(crate) fn load_timeline(
+pub(crate) async fn load_timeline(
     user_id: &UserId,
     room_id: &RoomId,
     since_tk: Option<BatchToken>,
@@ -1085,7 +1119,7 @@ pub(crate) fn load_timeline(
                 Some(min),
                 filter,
                 limit + 1,
-            )?
+            ).await?
         } else {
             timeline::stream::load_pdus_backward(
                 Some(user_id),
@@ -1094,10 +1128,10 @@ pub(crate) fn load_timeline(
                 Some(since_tk),
                 filter,
                 limit + 1,
-            )?
+            ).await?
         }
     } else {
-        timeline::stream::load_pdus_backward(Some(user_id), room_id, None, None, filter, limit + 1)?
+        timeline::stream::load_pdus_backward(Some(user_id), room_id, None, None, filter, limit + 1).await?
     };
 
     let mut limited = false;
@@ -1124,7 +1158,7 @@ pub(crate) fn load_timeline(
         }
         let min_sn = pdu_sns.iter().min().cloned().unwrap_or_default();
         let max_sn = pdu_sns.iter().max().cloned().unwrap_or_default();
-        if let Ok(mut gap_sns) = data::room::get_timeline_gaps(room_id, min_sn, max_sn)
+        if let Ok(mut gap_sns) = data::room::get_timeline_gaps(room_id, min_sn, max_sn).await
             && !gap_sns.is_empty()
         {
             let mut filtered_pdus = vec![];
@@ -1175,7 +1209,7 @@ pub(crate) fn load_timeline(
         }
         let min_sn = pdu_sns.iter().min().cloned().unwrap_or_default();
         let max_sn = pdu_sns.iter().max().cloned().unwrap_or_default();
-        if let Ok(gap_sns) = data::room::get_timeline_gaps(room_id, min_sn, max_sn)
+        if let Ok(gap_sns) = data::room::get_timeline_gaps(room_id, min_sn, max_sn).await
             && !gap_sns.is_empty()
         {
             // Pick the LARGEST gap_sn (the most recent gap). Events with sn
@@ -1215,17 +1249,25 @@ pub(crate) fn load_timeline(
 }
 
 #[tracing::instrument]
-pub(crate) fn share_encrypted_room(
+pub(crate) async fn share_encrypted_room(
     sender_id: &UserId,
     user_id: &UserId,
     ignore_room: Option<&RoomId>,
 ) -> AppResult<bool> {
-    let shared_rooms = room::user::shared_rooms(vec![sender_id.to_owned(), user_id.to_owned()])?
-        .into_iter()
-        .filter(|room_id| Some(&**room_id) != ignore_room)
-        .any(|other_room_id| {
-            room::get_state(&other_room_id, &StateEventType::RoomEncryption, "", None).is_ok()
-        });
+    let mut shared_rooms = false;
+    for other_room_id in
+        room::user::shared_rooms(vec![sender_id.to_owned(), user_id.to_owned()]).await?
+            .into_iter()
+            .filter(|room_id| Some(&**room_id) != ignore_room)
+    {
+        if room::get_state(&other_room_id, &StateEventType::RoomEncryption, "", None)
+            .await
+            .is_ok()
+        {
+            shared_rooms = true;
+            break;
+        }
+    }
 
     Ok(shared_rooms)
 }

--- a/crates/server/src/sync_v3.rs
+++ b/crates/server/src/sync_v3.rs
@@ -50,7 +50,7 @@ pub async fn sync_events(
     } else {
         None
     };
-    let mut next_batch = BatchToken::new_live(curr_sn + 1);
+    let next_batch = BatchToken::new_live(curr_sn + 1);
 
     // Load filter
     let filter = match &args.filter {
@@ -105,14 +105,7 @@ pub async fn sync_events(
         )
         .await
         {
-            Ok((joined_room, nb)) => {
-                if let Some(nb) = nb
-                    && nb.stream_ordering() < next_batch.stream_ordering()
-                {
-                    next_batch = nb;
-                }
-                joined_room
-            }
+            Ok((joined_room, _)) => joined_room,
             Err(e) => {
                 tracing::error!(error = ?e, "load joined room failed");
                 continue;

--- a/crates/server/src/sync_v3.rs
+++ b/crates/server/src/sync_v3.rs
@@ -82,7 +82,7 @@ pub async fn sync_events(
         data::user::keys_changed_users(
             sender_id,
             since_tk.unwrap_or(BatchToken::LIVE_MIN).event_sn(),
-            None,
+            Some(curr_sn),
         )
         .await?,
     );
@@ -784,7 +784,7 @@ async fn load_joined_room(
     device_list_updates.extend(room::keys_changed_users(
         room_id,
         since_tk.event_sn(),
-        None,
+        until_tk.map(|t| t.event_sn()),
     ).await?);
 
     let mut limited = timeline.limited || joined_since_last_sync;

--- a/crates/server/src/sync_v5.rs
+++ b/crates/server/src/sync_v5.rs
@@ -161,10 +161,17 @@ async fn load_or_create_connection(
         .and_then(|json| serde_json::from_value::<SlidingSyncCache>(json).ok())
         .unwrap_or_default();
 
+    // Re-check under the lock: another task may have loaded/created (and possibly
+    // already mutated and persisted) the entry for this key while we were awaiting
+    // the DB load above. Keep the existing entry if so; only insert our freshly
+    // loaded default when the key is still vacant. Without this, the last writer
+    // would clobber a concurrent task's cache, losing sticky list/subscription/
+    // required-state updates on startup or after expiry.
     let mut cache = CONNECTIONS.lock().unwrap();
-    let entry = Arc::new(Mutex::new(db_cache));
-    cache.insert(key, Arc::clone(&entry));
-    entry
+    let entry = cache
+        .entry(key)
+        .or_insert_with(|| Arc::new(Mutex::new(db_cache)));
+    Arc::clone(entry)
 }
 
 /// Maximum age for sliding sync connections before they are expired (7 days).

--- a/crates/server/src/sync_v5.rs
+++ b/crates/server/src/sync_v5.rs
@@ -411,7 +411,7 @@ pub async fn sync_events(
         rooms: BTreeMap::new(),
         extensions: Extensions {
             account_data: collect_account_data(sync_info).await?,
-            e2ee: collect_e2ee(sync_info, &all_joined_rooms).await?,
+            e2ee: collect_e2ee(sync_info, &all_joined_rooms, curr_sn).await?,
             to_device: collect_to_device(sync_info, next_batch).await,
             receipts: collect_receipts(sync_info),
             typing: collect_typing(sync_info, next_batch, all_rooms.iter().cloned()).await?,
@@ -1029,6 +1029,7 @@ async fn collect_e2ee(
         req_body,
     }: SyncInfo<'_>,
     all_joined_rooms: &Vec<&RoomId>,
+    until_sn: Seqnum,
 ) -> AppResult<sync_events::v5::E2ee> {
     if !req_body.extensions.e2ee.enabled.unwrap_or(false) {
         return Ok(sync_events::v5::E2ee::default());
@@ -1038,7 +1039,7 @@ async fn collect_e2ee(
     let mut device_list_left = HashSet::new();
     // Look for device list updates of this account
     device_list_changes
-        .extend(data::user::keys_changed_users(sender_id, since_sn, None).await?);
+        .extend(data::user::keys_changed_users(sender_id, since_sn, Some(until_sn)).await?);
 
     for room_id in all_joined_rooms {
         let Ok(current_frame_id) = crate::room::get_frame_id(room_id, None).await else {
@@ -1123,7 +1124,8 @@ async fn collect_e2ee(
             }
         }
         // Look for device list updates in this room
-        device_list_changes.extend(crate::room::keys_changed_users(room_id, since_sn, None).await?);
+        device_list_changes
+            .extend(crate::room::keys_changed_users(room_id, since_sn, Some(until_sn)).await?);
     }
 
     for user_id in left_encrypted_users {

--- a/crates/server/src/sync_v5.rs
+++ b/crates/server/src/sync_v5.rs
@@ -4,6 +4,8 @@ use std::sync::atomic::{AtomicI64, Ordering as AtomicOrdering};
 use std::sync::{Arc, LazyLock, Mutex};
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use crate::core::client::filter::RoomEventFilter;
@@ -32,7 +34,7 @@ use crate::{AppResult, data, extract_variant};
 /// the request. Used by both `process_lists` (which sorts and slices the
 /// result for ops) and the `since_sn > curr_sn` fast path (which only needs
 /// the count).
-fn compute_active_rooms<'a>(
+async fn compute_active_rooms<'a>(
     list: &sync_events::v5::ReqList,
     all_invited_rooms: &[&'a RoomId],
     all_joined_rooms: &[&'a RoomId],
@@ -49,7 +51,7 @@ fn compute_active_rooms<'a>(
     if let Some(filter) = list.filters.as_ref().map(|f| &f.not_room_types)
         && !filter.is_empty()
     {
-        active_rooms = filter_rooms(&active_rooms, filter, true);
+        active_rooms = filter_rooms(&active_rooms, filter, true).await;
     }
 
     // Apply room_types filter
@@ -60,7 +62,7 @@ fn compute_active_rooms<'a>(
             Some(&f.room_types)
         }
     }) {
-        active_rooms = filter_rooms(&active_rooms, filter, false);
+        active_rooms = filter_rooms(&active_rooms, filter, false).await;
     }
 
     // Apply is_dm filter
@@ -72,8 +74,15 @@ fn compute_active_rooms<'a>(
 
     // Apply is_encrypted filter
     match list.filters.as_ref().and_then(|f| f.is_encrypted) {
-        Some(true) => active_rooms.retain(|r| room::is_encrypted(r)),
-        Some(false) => active_rooms.retain(|r| !room::is_encrypted(r)),
+        Some(want_encrypted) => {
+            let mut retained: Vec<&'a RoomId> = Vec::with_capacity(active_rooms.len());
+            for r in active_rooms {
+                if room::is_encrypted(r).await == want_encrypted {
+                    retained.push(r);
+                }
+            }
+            active_rooms = retained;
+        }
         None => {}
     }
 
@@ -81,7 +90,7 @@ fn compute_active_rooms<'a>(
 }
 
 /// Sort rooms by last activity (most recent first) using event sequence numbers.
-fn sort_rooms_by_activity(rooms: &mut [&RoomId]) -> AppResult<()> {
+async fn sort_rooms_by_activity(rooms: &mut [&RoomId]) -> AppResult<()> {
     if rooms.is_empty() {
         return Ok(());
     }
@@ -93,7 +102,8 @@ fn sort_rooms_by_activity(rooms: &mut [&RoomId]) -> AppResult<()> {
         .distinct_on(event_points::room_id)
         .order_by((event_points::room_id.asc(), event_points::event_sn.desc()))
         .select((event_points::room_id, event_points::event_sn))
-        .load(&mut connect()?)?;
+        .load(&mut connect().await?)
+        .await?;
 
     let last_sn: BTreeMap<&str, i64> = results.iter().map(|(r, sn)| (r.as_str(), *sn)).collect();
 
@@ -106,7 +116,7 @@ fn sort_rooms_by_activity(rooms: &mut [&RoomId]) -> AppResult<()> {
     Ok(())
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 struct SlidingSyncCache {
     lists: BTreeMap<String, sync_events::v5::ReqList>,
     #[serde(default)]
@@ -124,33 +134,34 @@ static CONNECTIONS: LazyLock<
 > = LazyLock::new(Default::default);
 
 /// Load a connection cache from the database if not present in memory.
-fn load_or_create_connection(
+async fn load_or_create_connection(
     user_id: &OwnedUserId,
     device_id: &OwnedDeviceId,
     conn_id: &Option<String>,
 ) -> Arc<Mutex<SlidingSyncCache>> {
-    let mut cache = CONNECTIONS.lock().unwrap();
     let key = (user_id.clone(), device_id.clone(), conn_id.clone());
-    if let Some(entry) = cache.get(&key) {
+    if let Some(entry) = CONNECTIONS.lock().unwrap().get(&key) {
         return Arc::clone(entry);
     }
 
     // Try to load from database
     let conn_id_str = conn_id.as_deref().unwrap_or("");
-    let db_cache = connect()
-        .ok()
-        .and_then(|mut conn| {
-            sliding_sync_connections::table
-                .filter(sliding_sync_connections::user_id.eq(user_id.as_str()))
-                .filter(sliding_sync_connections::device_id.eq(device_id.as_str()))
-                .filter(sliding_sync_connections::conn_id.eq(conn_id_str))
-                .select(sliding_sync_connections::cache_data)
-                .first::<serde_json::Value>(&mut conn)
-                .ok()
-        })
+    let db_json = match connect().await {
+        Ok(mut conn) => sliding_sync_connections::table
+            .filter(sliding_sync_connections::user_id.eq(user_id.as_str()))
+            .filter(sliding_sync_connections::device_id.eq(device_id.as_str()))
+            .filter(sliding_sync_connections::conn_id.eq(conn_id_str))
+            .select(sliding_sync_connections::cache_data)
+            .first::<serde_json::Value>(&mut conn)
+            .await
+            .ok(),
+        Err(_) => None,
+    };
+    let db_cache = db_json
         .and_then(|json| serde_json::from_value::<SlidingSyncCache>(json).ok())
         .unwrap_or_default();
 
+    let mut cache = CONNECTIONS.lock().unwrap();
     let entry = Arc::new(Mutex::new(db_cache));
     cache.insert(key, Arc::clone(&entry));
     entry
@@ -167,24 +178,26 @@ const NUM_ROOMS_THRESHOLD: usize = 100;
 const STALE_SYNC_THRESHOLD_MS: i64 = 60 * 60 * 1000;
 
 /// Delete expired sliding sync connections from both memory and database.
-pub fn cleanup_expired_connections() {
+pub async fn cleanup_expired_connections() {
     let now = UnixMillis::now().get() as i64;
     let cutoff = now - CONNECTION_EXPIRY_MS;
 
-    let expired_keys: HashSet<(OwnedUserId, OwnedDeviceId, Option<String>)> = connect()
-        .ok()
-        .and_then(|mut conn| {
-            sliding_sync_connections::table
-                .filter(sliding_sync_connections::updated_at.lt(cutoff))
-                .select((
-                    sliding_sync_connections::user_id,
-                    sliding_sync_connections::device_id,
-                    sliding_sync_connections::conn_id,
-                ))
-                .load::<(String, String, String)>(&mut conn)
-                .ok()
-        })
-        .unwrap_or_default()
+    let expired_rows: Vec<(String, String, String)> = match connect().await {
+        Ok(mut conn) => sliding_sync_connections::table
+            .filter(sliding_sync_connections::updated_at.lt(cutoff))
+            .select((
+                sliding_sync_connections::user_id,
+                sliding_sync_connections::device_id,
+                sliding_sync_connections::conn_id,
+            ))
+            .load::<(String, String, String)>(&mut conn)
+            .await
+            .ok(),
+        Err(_) => None,
+    }
+    .unwrap_or_default();
+
+    let expired_keys: HashSet<(OwnedUserId, OwnedDeviceId, Option<String>)> = expired_rows
         .into_iter()
         .filter_map(|(user_id, device_id, conn_id)| {
             Some((
@@ -201,11 +214,12 @@ pub fn cleanup_expired_connections() {
         .retain(|key, _entry| !expired_keys.contains(key));
 
     // Clean up database
-    if let Ok(mut conn) = connect() {
+    if let Ok(mut conn) = connect().await {
         let _ = diesel::delete(
             sliding_sync_connections::table.filter(sliding_sync_connections::updated_at.lt(cutoff)),
         )
-        .execute(&mut conn);
+        .execute(&mut conn)
+        .await;
     }
 }
 
@@ -227,28 +241,28 @@ fn check_connection_staleness(
 }
 
 /// Get the last update timestamp for a connection.
-fn get_connection_updated_at(
+async fn get_connection_updated_at(
     user_id: &UserId,
     device_id: &DeviceId,
     conn_id: &Option<String>,
 ) -> i64 {
     let conn_id_str = conn_id.as_deref().unwrap_or("");
-    connect()
-        .ok()
-        .and_then(|mut conn| {
-            sliding_sync_connections::table
-                .filter(sliding_sync_connections::user_id.eq(user_id.as_str()))
-                .filter(sliding_sync_connections::device_id.eq(device_id.as_str()))
-                .filter(sliding_sync_connections::conn_id.eq(conn_id_str))
-                .select(sliding_sync_connections::updated_at)
-                .first::<i64>(&mut conn)
-                .ok()
-        })
-        .unwrap_or(0)
+    let updated_at = match connect().await {
+        Ok(mut conn) => sliding_sync_connections::table
+            .filter(sliding_sync_connections::user_id.eq(user_id.as_str()))
+            .filter(sliding_sync_connections::device_id.eq(device_id.as_str()))
+            .filter(sliding_sync_connections::conn_id.eq(conn_id_str))
+            .select(sliding_sync_connections::updated_at)
+            .first::<i64>(&mut conn)
+            .await
+            .ok(),
+        Err(_) => None,
+    };
+    updated_at.unwrap_or(0)
 }
 
 /// Persist the connection cache to the database for cross-instance access.
-fn persist_connection(
+async fn persist_connection(
     user_id: &OwnedUserId,
     device_id: &OwnedDeviceId,
     conn_id: &Option<String>,
@@ -259,7 +273,7 @@ fn persist_connection(
         return;
     };
     let now = UnixMillis::now();
-    if let Ok(mut conn) = connect() {
+    if let Ok(mut conn) = connect().await {
         let _ = diesel::insert_into(sliding_sync_connections::table)
             .values((
                 sliding_sync_connections::user_id.eq(user_id.as_str()),
@@ -278,7 +292,8 @@ fn persist_connection(
                 sliding_sync_connections::cache_data.eq(&cache_data),
                 sliding_sync_connections::updated_at.eq(now),
             ))
-            .execute(&mut conn);
+            .execute(&mut conn)
+            .await;
     }
 }
 
@@ -288,15 +303,15 @@ static LAST_CLEANUP: AtomicI64 = AtomicI64::new(0);
 /// Frequency of connection cleanup (1 hour in milliseconds).
 const CLEANUP_FREQUENCY_MS: i64 = 60 * 60 * 1000;
 
-fn maybe_cleanup_connections() {
+async fn maybe_cleanup_connections() {
     let now = UnixMillis::now().get() as i64;
-    let last = LAST_CLEANUP.load(AtomicOrdering::Relaxed);
+    let last = AtomicI64::load(&LAST_CLEANUP, AtomicOrdering::Relaxed);
     if now - last > CLEANUP_FREQUENCY_MS
         && LAST_CLEANUP
             .compare_exchange(last, now, AtomicOrdering::Relaxed, AtomicOrdering::Relaxed)
             .is_ok()
     {
-        cleanup_expired_connections();
+        cleanup_expired_connections().await;
     }
 }
 
@@ -309,19 +324,19 @@ pub async fn sync_events(
     known_rooms: &KnownRooms,
 ) -> AppResult<SyncEventsResBody> {
     // Periodically clean up expired connections
-    maybe_cleanup_connections();
+    maybe_cleanup_connections().await;
 
-    let curr_sn = data::curr_sn()?;
+    let curr_sn = data::curr_sn().await?;
     crate::seqnum_reach(curr_sn).await;
     let next_batch = curr_sn + 1;
 
-    let all_joined_rooms = data::user::joined_rooms(sender_id)?;
-    let ignored_users = crate::user::ignored_users(sender_id);
+    let all_joined_rooms = data::user::joined_rooms(sender_id).await?;
+    let ignored_users = crate::user::ignored_users(sender_id).await;
 
-    let all_invited_rooms = data::user::invited_rooms(sender_id, 0)?;
+    let all_invited_rooms = data::user::invited_rooms(sender_id, 0).await?;
     let all_invited_rooms: Vec<&RoomId> = all_invited_rooms.iter().map(|r| r.0.as_ref()).collect();
 
-    let all_knocked_rooms = data::user::knocked_rooms(sender_id, 0)?;
+    let all_knocked_rooms = data::user::knocked_rooms(sender_id, 0).await?;
     let all_knocked_rooms: Vec<&RoomId> = all_knocked_rooms.iter().map(|r| r.0.as_ref()).collect();
 
     let all_rooms: Vec<&RoomId> = all_joined_rooms
@@ -340,6 +355,7 @@ pub async fn sync_events(
         None,
         &GlobalAccountDataEventType::Direct.to_string(),
     )
+    .await
     .map(|direct| direct.0.values().flatten().cloned().collect())
     .unwrap_or_default();
 
@@ -360,7 +376,8 @@ pub async fn sync_events(
                 &all_joined_rooms,
                 &all_rooms,
                 &dm_rooms,
-            );
+            )
+            .await;
             res.lists.insert(
                 list_id.clone(),
                 sync_events::v5::SyncList {
@@ -386,9 +403,9 @@ pub async fn sync_events(
         lists: BTreeMap::new(),
         rooms: BTreeMap::new(),
         extensions: Extensions {
-            account_data: collect_account_data(sync_info)?,
-            e2ee: collect_e2ee(sync_info, &all_joined_rooms)?,
-            to_device: collect_to_device(sync_info, next_batch),
+            account_data: collect_account_data(sync_info).await?,
+            e2ee: collect_e2ee(sync_info, &all_joined_rooms).await?,
+            to_device: collect_to_device(sync_info, next_batch).await,
             receipts: collect_receipts(sync_info),
             typing: collect_typing(sync_info, next_batch, all_rooms.iter().cloned()).await?,
         },
@@ -406,7 +423,7 @@ pub async fn sync_events(
     )
     .await?;
 
-    fetch_subscriptions(sync_info, &mut todo_rooms, known_rooms)?;
+    fetch_subscriptions(sync_info, &mut todo_rooms, known_rooms).await?;
 
     res_body.rooms = process_rooms(
         sync_info,
@@ -444,11 +461,12 @@ async fn process_lists(
             all_joined_rooms,
             all_rooms,
             dm_rooms,
-        );
+        )
+        .await;
 
         // Sort rooms by last activity (most recent first)
         let mut sorted_rooms = active_rooms;
-        sort_rooms_by_activity(&mut sorted_rooms)?;
+        sort_rooms_by_activity(&mut sorted_rooms).await?;
         let count = sorted_rooms.len();
 
         let mut new_known_rooms: BTreeSet<OwnedRoomId> = BTreeSet::new();
@@ -519,12 +537,13 @@ async fn process_lists(
             list_id.clone(),
             new_known_rooms,
             since_sn,
-        );
+        )
+        .await;
     }
     Ok(())
 }
 
-fn fetch_subscriptions(
+async fn fetch_subscriptions(
     SyncInfo {
         sender_id,
         device_id,
@@ -536,7 +555,7 @@ fn fetch_subscriptions(
 ) -> AppResult<()> {
     let mut known_subscription_rooms = BTreeSet::new();
     for (room_id, room) in &req_body.room_subscriptions {
-        if !crate::room::room_exists(room_id)? {
+        if !crate::room::room_exists(room_id).await? {
             continue;
         }
         let todo_room = todo_rooms.entry(room_id.clone()).or_insert(TodoRoom::new(
@@ -575,7 +594,8 @@ fn fetch_subscriptions(
         "subscriptions".to_owned(),
         known_subscription_rooms,
         since_sn,
-    );
+    )
+    .await;
     Ok(())
 }
 
@@ -616,7 +636,7 @@ async fn process_rooms(
 
         let timeline = if all_invited_rooms.contains(&new_room_id) {
             // Invited rooms have empty timeline, only stripped state
-            invite_state = crate::room::user::invite_state(sender_id, room_id).ok();
+            invite_state = crate::room::user::invite_state(sender_id, room_id).await.ok();
             TimelineData {
                 events: Default::default(),
                 limited: false,
@@ -631,7 +651,8 @@ async fn process_rooms(
                 None,
                 Some(BatchToken::LIVE_MAX),
                 Some(&RoomEventFilter::with_limit(*timeline_limit)),
-            )?
+            )
+            .await?
         } else {
             // Incremental sync: use stream ordering to catch late-arriving events
             crate::sync_v3::load_timeline(
@@ -640,12 +661,14 @@ async fn process_rooms(
                 Some(BatchToken::new_live(*room_since_sn)),
                 Some(BatchToken::LIVE_MAX),
                 Some(&RoomEventFilter::with_limit(*timeline_limit)),
-            )?
+            )
+            .await?
         };
 
         if req_body.extensions.account_data.enabled == Some(true) {
             let room_account_data =
-                data::user::data_changes(Some(room_id), sender_id, *room_since_sn, None)?
+                data::user::data_changes(Some(room_id), sender_id, *room_since_sn, None)
+                    .await?
                     .into_iter()
                     .filter_map(|e| extract_variant!(e, AnyRawAccountDataEvent::Room))
                     .collect::<Vec<_>>();
@@ -661,16 +684,18 @@ async fn process_rooms(
         let receipt_size = if receipts_enabled {
             let last_private_read_update =
                 data::room::receipt::last_private_read_update_sn(sender_id, room_id)
+                    .await
                     .unwrap_or_default()
                     > *room_since_sn;
 
             let private_read_event = if last_private_read_update {
-                crate::room::receipt::last_private_read(sender_id, room_id).ok()
+                crate::room::receipt::last_private_read(sender_id, room_id).await.ok()
             } else {
                 None
             };
 
-            let mut receipts = data::room::receipt::read_receipts(room_id, *room_since_sn)?
+            let mut receipts = data::room::receipt::read_receipts(room_id, *room_since_sn)
+                .await?
                 .into_iter()
                 .filter_map(|(read_user, content)| {
                     if !ignored_users.contains(&read_user) {
@@ -708,7 +733,7 @@ async fn process_rooms(
             continue;
         }
 
-        let prev_batch = timeline.events.first().and_then(|(sn, _)| {
+        let prev_batch = IndexMap::first(&timeline.events).and_then(|(sn, _)| {
             if *sn == 0 {
                 None
             } else {
@@ -756,26 +781,29 @@ async fn process_rooms(
                             &StateEventType::RoomMember,
                             sender.as_str(),
                             None,
-                        ) && !is_required_state_send(
+                        ).await && !is_required_state_send(
                             sender_id.to_owned(),
                             device_id.to_owned(),
                             req_body.conn_id.clone(),
                             pdu.event_sn,
-                        ) {
+                        )
+                        .await
+                        {
                             mark_required_state_sent(
                                 sender_id.to_owned(),
                                 device_id.to_owned(),
                                 req_body.conn_id.clone(),
                                 pdu.event_sn,
-                            );
+                            )
+                            .await;
                             required_state_events.push(pdu.to_sync_state_event());
                         }
                     }
                 }
                 // * state key: return all state events of this type
                 (ref event_type, "*") => {
-                    if let Ok(frame_id) = room::get_frame_id(room_id, None)
-                        && let Ok(full_state) = state::get_full_state(frame_id)
+                    if let Ok(frame_id) = room::get_frame_id(room_id, None).await
+                        && let Ok(full_state) = state::get_full_state(frame_id).await
                     {
                         for ((ty, _sk), pdu) in &full_state {
                             if ty == event_type
@@ -785,13 +813,15 @@ async fn process_rooms(
                                     req_body.conn_id.clone(),
                                     pdu.event_sn,
                                 )
+                                .await
                             {
                                 mark_required_state_sent(
                                     sender_id.to_owned(),
                                     device_id.to_owned(),
                                     req_body.conn_id.clone(),
                                     pdu.event_sn,
-                                );
+                                )
+                                .await;
                                 required_state_events.push(pdu.to_sync_state_event());
                             }
                         }
@@ -799,39 +829,43 @@ async fn process_rooms(
                 }
                 // $ME: substitute with the requester's user_id
                 (ref event_type, "$ME") => {
-                    if let Ok(pdu) = room::get_state(room_id, event_type, sender_id.as_str(), None)
+                    if let Ok(pdu) = room::get_state(room_id, event_type, sender_id.as_str(), None).await
                         && !is_required_state_send(
                             sender_id.to_owned(),
                             device_id.to_owned(),
                             req_body.conn_id.clone(),
                             pdu.event_sn,
                         )
+                        .await
                     {
                         mark_required_state_sent(
                             sender_id.to_owned(),
                             device_id.to_owned(),
                             req_body.conn_id.clone(),
                             pdu.event_sn,
-                        );
+                        )
+                        .await;
                         required_state_events.push(pdu.to_sync_state_event());
                     }
                 }
                 // Specific state key
                 (ref event_type, state_key) => {
-                    if let Ok(pdu) = room::get_state(room_id, event_type, state_key, None)
+                    if let Ok(pdu) = room::get_state(room_id, event_type, state_key, None).await
                         && !is_required_state_send(
                             sender_id.to_owned(),
                             device_id.to_owned(),
                             req_body.conn_id.clone(),
                             pdu.event_sn,
                         )
+                        .await
                     {
                         mark_required_state_sent(
                             sender_id.to_owned(),
                             device_id.to_owned(),
                             req_body.conn_id.clone(),
                             pdu.event_sn,
-                        );
+                        )
+                        .await;
                         required_state_events.push(pdu.to_sync_state_event());
                     }
                 }
@@ -841,22 +875,22 @@ async fn process_rooms(
         let required_state = required_state_events;
 
         // Heroes - only compute when requested or when room name isn't set
-        let room_name = room::get_name(room_id).ok();
+        let room_name = room::get_name(room_id).await.ok();
         let (heroes, hero_name, heroes_avatar) = if *include_heroes || room_name.is_none() {
-            let heroes: Vec<_> = room::get_members_limit(room_id, 6)?
+            let mut heroes: Vec<sync_events::v5::SyncRoomHero> = Vec::new();
+            for user_id in room::get_members_limit(room_id, 6).await?
                 .into_iter()
                 .filter(|member| *member != sender_id)
                 .take(5)
-                .filter_map(|user_id| {
-                    room::get_member(room_id, &user_id, None)
-                        .ok()
-                        .map(|member| sync_events::v5::SyncRoomHero {
-                            user_id,
-                            name: member.display_name,
-                            avatar: member.avatar_url,
-                        })
-                })
-                .collect();
+            {
+                if let Ok(member) = room::get_member(room_id, &user_id, None).await {
+                    heroes.push(sync_events::v5::SyncRoomHero {
+                        user_id,
+                        name: member.display_name,
+                        avatar: member.avatar_url,
+                    });
+                }
+            }
 
             let name = match heroes.len().cmp(&(1_usize)) {
                 Ordering::Greater => {
@@ -895,14 +929,14 @@ async fn process_rooms(
             (None, None, None)
         };
 
-        let notify_summary = room::user::notify_summary(sender_id, room_id)?;
+        let notify_summary = room::user::notify_summary(sender_id, room_id).await?;
         rooms.insert(
             room_id.clone(),
             SyncRoom {
                 name: room_name.or(hero_name),
                 avatar: match heroes_avatar {
                     Some(ref heroes_avatar) => Some(heroes_avatar.clone()),
-                    _ => room::get_avatar_url(room_id).ok().flatten(),
+                    _ => room::get_avatar_url(room_id).await.ok().flatten(),
                 },
                 initial: Some(is_initial),
                 is_dm: Some(dm_rooms.contains(room_id)),
@@ -917,13 +951,13 @@ async fn process_rooms(
                 limited: timeline.limited,
                 joined_count: Some(
                     crate::room::joined_member_count(room_id)
-                        .unwrap_or(0)
+                        .await.unwrap_or(0)
                         .try_into()
                         .unwrap_or(0),
                 ),
                 invited_count: Some(
                     crate::room::invited_member_count(room_id)
-                        .unwrap_or(0)
+                        .await.unwrap_or(0)
                         .try_into()
                         .unwrap_or(0),
                 ),
@@ -941,7 +975,7 @@ async fn process_rooms(
     }
     Ok(rooms)
 }
-fn collect_account_data(
+async fn collect_account_data(
     SyncInfo {
         sender_id,
         since_sn,
@@ -958,7 +992,8 @@ fn collect_account_data(
         return Ok(sync_events::v5::AccountData::default());
     }
 
-    account_data.global = data::user::data_changes(None, sender_id, since_sn, None)?
+    account_data.global = data::user::data_changes(None, sender_id, since_sn, None)
+        .await?
         .into_iter()
         .filter_map(|e| extract_variant!(e, AnyRawAccountDataEvent::Global))
         .collect();
@@ -967,7 +1002,8 @@ fn collect_account_data(
         for room in rooms {
             account_data.rooms.insert(
                 room.clone(),
-                data::user::data_changes(Some(room), sender_id, since_sn, None)?
+                data::user::data_changes(Some(room), sender_id, since_sn, None)
+                    .await?
                     .into_iter()
                     .filter_map(|e| extract_variant!(e, AnyRawAccountDataEvent::Room))
                     .collect(),
@@ -978,7 +1014,7 @@ fn collect_account_data(
     Ok(account_data)
 }
 
-fn collect_e2ee(
+async fn collect_e2ee(
     SyncInfo {
         sender_id,
         device_id,
@@ -994,17 +1030,18 @@ fn collect_e2ee(
     let mut device_list_changes = HashSet::new();
     let mut device_list_left = HashSet::new();
     // Look for device list updates of this account
-    device_list_changes.extend(data::user::keys_changed_users(sender_id, since_sn, None)?);
+    device_list_changes
+        .extend(data::user::keys_changed_users(sender_id, since_sn, None).await?);
 
     for room_id in all_joined_rooms {
-        let Ok(current_frame_id) = crate::room::get_frame_id(room_id, None) else {
+        let Ok(current_frame_id) = crate::room::get_frame_id(room_id, None).await else {
             error!("Room {room_id} has no state");
             continue;
         };
-        let since_frame_id = crate::event::get_last_frame_id(room_id, Some(since_sn)).ok();
+        let since_frame_id = crate::event::get_last_frame_id(room_id, Some(since_sn)).await.ok();
 
         let encrypted_room =
-            state::get_state(current_frame_id, &StateEventType::RoomEncryption, "").is_ok();
+            state::get_state(current_frame_id, &StateEventType::RoomEncryption, "").await.is_ok();
 
         if let Some(since_frame_id) = since_frame_id {
             // // Skip if there are only timeline changes
@@ -1013,20 +1050,20 @@ fn collect_e2ee(
             // }
 
             let since_encryption =
-                state::get_state(since_frame_id, &StateEventType::RoomEncryption, "").ok();
+                state::get_state(since_frame_id, &StateEventType::RoomEncryption, "").await.ok();
 
-            let joined_since_last_sync = room::user::join_sn(sender_id, room_id)? >= since_sn;
+            let joined_since_last_sync = room::user::join_sn(sender_id, room_id).await? >= since_sn;
 
             let new_encrypted_room = encrypted_room && since_encryption.is_none();
 
             if encrypted_room {
-                let current_state_ids = state::get_full_state_ids(current_frame_id)?;
+                let current_state_ids = state::get_full_state_ids(current_frame_id).await?;
 
-                let since_state_ids = state::get_full_state_ids(since_frame_id)?;
+                let since_state_ids = state::get_full_state_ids(since_frame_id).await?;
 
                 for (key, id) in current_state_ids {
                     if since_state_ids.get(&key) != Some(&id) {
-                        let Ok(pdu) = timeline::get_pdu(&id) else {
+                        let Ok(pdu) = timeline::get_pdu(&id).await else {
                             error!("pdu in state not found: {id}");
                             continue;
                         };
@@ -1041,7 +1078,9 @@ fn collect_e2ee(
                             match content.membership {
                                 MembershipState::Join => {
                                     // A new user joined an encrypted room
-                                    if !share_encrypted_room(sender_id, &user_id, Some(room_id))? {
+                                    if !share_encrypted_room(sender_id, &user_id, Some(room_id))
+                                        .await?
+                                    {
                                         device_list_changes.insert(user_id.to_owned());
                                     }
                                 }
@@ -1057,33 +1096,31 @@ fn collect_e2ee(
                 }
                 if joined_since_last_sync || new_encrypted_room {
                     // If the user is in a new encrypted room, give them all joined users
-                    device_list_changes.extend(
-                        room::get_members(room_id)?
-                            .into_iter()
-                            // Don't send key updates from the sender to the sender
-                            .filter(|user_id| sender_id != *user_id)
-                            // Only send keys if the sender doesn't share an encrypted room with the target
-                            // already
-                            .filter_map(|user_id| {
-                                if !share_encrypted_room(sender_id, &user_id, Some(room_id))
-                                    .unwrap_or(false)
-                                {
-                                    Some(user_id.to_owned())
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect::<Vec<_>>(),
-                    );
+                    let mut new_changes: Vec<OwnedUserId> = Vec::new();
+                    for user_id in room::get_members(room_id).await?
+                        .into_iter()
+                        // Don't send key updates from the sender to the sender
+                        .filter(|user_id| sender_id != *user_id)
+                    {
+                        // Only send keys if the sender doesn't share an encrypted room with the
+                        // target already
+                        if !share_encrypted_room(sender_id, &user_id, Some(room_id))
+                            .await
+                            .unwrap_or(false)
+                        {
+                            new_changes.push(user_id.to_owned());
+                        }
+                    }
+                    device_list_changes.extend(new_changes);
                 }
             }
         }
         // Look for device list updates in this room
-        device_list_changes.extend(crate::room::keys_changed_users(room_id, since_sn, None)?);
+        device_list_changes.extend(crate::room::keys_changed_users(room_id, since_sn, None).await?);
     }
 
     for user_id in left_encrypted_users {
-        let Ok(share_encrypted_room) = share_encrypted_room(sender_id, &user_id, None) else {
+        let Ok(share_encrypted_room) = share_encrypted_room(sender_id, &user_id, None).await else {
             continue;
         };
 
@@ -1099,31 +1136,34 @@ fn collect_e2ee(
             changed: device_list_changes.into_iter().collect(),
             left: device_list_left.into_iter().collect(),
         },
-        device_one_time_keys_count: data::user::count_one_time_keys(sender_id, device_id)?,
-        device_unused_fallback_key_types: Some(get_unused_fallback_key_types(sender_id, device_id)),
+        device_one_time_keys_count: data::user::count_one_time_keys(sender_id, device_id).await?,
+        device_unused_fallback_key_types: Some(
+            get_unused_fallback_key_types(sender_id, device_id).await,
+        ),
     })
 }
 
-fn get_unused_fallback_key_types(
+async fn get_unused_fallback_key_types(
     user_id: &UserId,
     device_id: &DeviceId,
 ) -> Vec<DeviceKeyAlgorithm> {
-    connect()
-        .ok()
-        .and_then(|mut conn| {
-            e2e_fallback_keys::table
-                .filter(e2e_fallback_keys::user_id.eq(user_id.as_str()))
-                .filter(e2e_fallback_keys::device_id.eq(device_id.as_str()))
-                .filter(e2e_fallback_keys::used_at.is_null())
-                .select(e2e_fallback_keys::algorithm)
-                .load::<String>(&mut conn)
-                .ok()
-        })
+    let algos = match connect().await {
+        Ok(mut conn) => e2e_fallback_keys::table
+            .filter(e2e_fallback_keys::user_id.eq(user_id.as_str()))
+            .filter(e2e_fallback_keys::device_id.eq(device_id.as_str()))
+            .filter(e2e_fallback_keys::used_at.is_null())
+            .select(e2e_fallback_keys::algorithm)
+            .load::<String>(&mut conn)
+            .await
+            .ok(),
+        Err(_) => None,
+    };
+    algos
         .map(|algos| algos.into_iter().map(|a| a.into()).collect())
         .unwrap_or_default()
 }
 
-fn collect_to_device(
+async fn collect_to_device(
     SyncInfo {
         sender_id,
         device_id,
@@ -1136,10 +1176,13 @@ fn collect_to_device(
         return None;
     }
 
-    data::user::device::remove_to_device_events(sender_id, device_id, since_sn - 1).ok()?;
+    data::user::device::remove_to_device_events(sender_id, device_id, since_sn - 1)
+        .await
+        .ok()?;
 
     let events =
         data::user::device::get_to_device_events(sender_id, device_id, None, Some(next_batch))
+            .await
             .ok()?;
 
     Some(sync_events::v5::ToDevice {
@@ -1194,7 +1237,7 @@ where
     Ok(typing)
 }
 
-pub fn forget_sync_request_connection(
+pub async fn forget_sync_request_connection(
     user_id: OwnedUserId,
     device_id: OwnedDeviceId,
     conn_id: Option<String>,
@@ -1206,14 +1249,15 @@ pub fn forget_sync_request_connection(
 
     // Also remove from database
     let conn_id_str = conn_id.as_deref().unwrap_or("");
-    if let Ok(mut db_conn) = connect() {
+    if let Ok(mut db_conn) = connect().await {
         let _ = diesel::delete(
             sliding_sync_connections::table
                 .filter(sliding_sync_connections::user_id.eq(user_id.as_str()))
                 .filter(sliding_sync_connections::device_id.eq(device_id.as_str()))
                 .filter(sliding_sync_connections::conn_id.eq(conn_id_str)),
         )
-        .execute(&mut db_conn);
+        .execute(&mut db_conn)
+        .await;
     }
 }
 /// load params from cache if body doesn't contain it, as long as it's allowed
@@ -1228,7 +1272,7 @@ fn some_or_sticky<T>(target: &mut Option<T>, cached: Option<T>) {
         *target = cached;
     }
 }
-pub fn update_sync_request_with_cache(
+pub async fn update_sync_request_with_cache(
     user_id: OwnedUserId,
     device_id: OwnedDeviceId,
     req_body: &mut sync_events::v5::SyncEventsReqBody,
@@ -1236,8 +1280,10 @@ pub fn update_sync_request_with_cache(
     BTreeMap<String, BTreeMap<OwnedRoomId, i64>>,
     BTreeMap<String, usize>,
 ) {
-    let cached = load_or_create_connection(&user_id, &device_id, &req_body.conn_id);
-    let cached = &mut cached.lock().unwrap();
+    let entry = load_or_create_connection(&user_id, &device_id, &req_body.conn_id).await;
+    let (known, list_counts, cache_snapshot) = {
+        let mut guard = entry.lock().unwrap();
+        let cached = &mut *guard;
 
     for (list_id, list) in &mut req_body.lists {
         if let Some(cached_list) = cached.lists.get(list_id) {
@@ -1334,35 +1380,44 @@ pub fn update_sync_request_with_cache(
     let known = cached.known_rooms.clone();
     let list_counts = cached.list_counts.clone();
     // Persist to DB for cross-instance availability
-    persist_connection(&user_id, &device_id, &req_body.conn_id, cached);
+    let cache_snapshot = cached.clone();
+        (known, list_counts, cache_snapshot)
+    };
+    persist_connection(&user_id, &device_id, &req_body.conn_id, &cache_snapshot).await;
     (known, list_counts)
 }
 
-pub fn update_sync_list_counts(
+pub async fn update_sync_list_counts(
     user_id: OwnedUserId,
     device_id: OwnedDeviceId,
     conn_id: Option<String>,
     list_counts: BTreeMap<String, usize>,
 ) {
-    let entry = load_or_create_connection(&user_id, &device_id, &conn_id);
-    let cached = &mut entry.lock().unwrap();
-    cached.list_counts = list_counts;
-    persist_connection(&user_id, &device_id, &conn_id, cached);
+    let entry = load_or_create_connection(&user_id, &device_id, &conn_id).await;
+    let cache_snapshot = {
+        let cached = &mut entry.lock().unwrap();
+        cached.list_counts = list_counts;
+        (*cached).clone()
+    };
+    persist_connection(&user_id, &device_id, &conn_id, &cache_snapshot).await;
 }
 
-pub fn update_sync_subscriptions(
+pub async fn update_sync_subscriptions(
     user_id: OwnedUserId,
     device_id: OwnedDeviceId,
     conn_id: Option<String>,
     subscriptions: BTreeMap<OwnedRoomId, sync_events::v5::RoomSubscription>,
 ) {
-    let entry = load_or_create_connection(&user_id, &device_id, &conn_id);
-    let cached = &mut entry.lock().unwrap();
-    cached.subscriptions = subscriptions;
-    persist_connection(&user_id, &device_id, &conn_id, cached);
+    let entry = load_or_create_connection(&user_id, &device_id, &conn_id).await;
+    let cache_snapshot = {
+        let cached = &mut entry.lock().unwrap();
+        cached.subscriptions = subscriptions;
+        (*cached).clone()
+    };
+    persist_connection(&user_id, &device_id, &conn_id, &cache_snapshot).await;
 }
 
-pub fn update_sync_known_rooms(
+pub async fn update_sync_known_rooms(
     user_id: OwnedUserId,
     device_id: OwnedDeviceId,
     conn_id: Option<String>,
@@ -1370,44 +1425,50 @@ pub fn update_sync_known_rooms(
     new_cached_rooms: BTreeSet<OwnedRoomId>,
     since_sn: i64,
 ) {
-    let entry = load_or_create_connection(&user_id, &device_id, &conn_id);
-    let cached = &mut entry.lock().unwrap();
+    let entry = load_or_create_connection(&user_id, &device_id, &conn_id).await;
+    let cache_snapshot = {
+        let cached = &mut entry.lock().unwrap();
 
-    for (roomid, last_since) in cached
-        .known_rooms
-        .entry(list_id.clone())
-        .or_default()
-        .iter_mut()
-    {
-        if !new_cached_rooms.contains(roomid) {
-            *last_since = 0;
+        for (roomid, last_since) in cached
+            .known_rooms
+            .entry(list_id.clone())
+            .or_default()
+            .iter_mut()
+        {
+            if !new_cached_rooms.contains(roomid) {
+                *last_since = 0;
+            }
         }
-    }
-    let list = cached.known_rooms.entry(list_id).or_default();
-    for room_id in new_cached_rooms {
-        list.insert(room_id, since_sn);
-    }
-    persist_connection(&user_id, &device_id, &conn_id, cached);
+        let list = cached.known_rooms.entry(list_id).or_default();
+        for room_id in new_cached_rooms {
+            list.insert(room_id, since_sn);
+        }
+        (*cached).clone()
+    };
+    persist_connection(&user_id, &device_id, &conn_id, &cache_snapshot).await;
 }
 
-pub fn mark_required_state_sent(
+pub async fn mark_required_state_sent(
     user_id: OwnedUserId,
     device_id: OwnedDeviceId,
     conn_id: Option<String>,
     event_sn: Seqnum,
 ) {
-    let entry = load_or_create_connection(&user_id, &device_id, &conn_id);
-    let cached = &mut entry.lock().unwrap();
-    cached.required_state.insert(event_sn);
-    persist_connection(&user_id, &device_id, &conn_id, cached);
+    let entry = load_or_create_connection(&user_id, &device_id, &conn_id).await;
+    let cache_snapshot = {
+        let cached = &mut entry.lock().unwrap();
+        cached.required_state.insert(event_sn);
+        (*cached).clone()
+    };
+    persist_connection(&user_id, &device_id, &conn_id, &cache_snapshot).await;
 }
-pub fn is_required_state_send(
+pub async fn is_required_state_send(
     user_id: OwnedUserId,
     device_id: OwnedDeviceId,
     conn_id: Option<String>,
     event_sn: Seqnum,
 ) -> bool {
-    let entry = load_or_create_connection(&user_id, &device_id, &conn_id);
+    let entry = load_or_create_connection(&user_id, &device_id, &conn_id).await;
     let cached = entry.lock().unwrap();
     cached.required_state.contains(&event_sn)
 }
@@ -1434,8 +1495,8 @@ mod tests {
     /// Default filter pipeline (no filters set) returns all rooms — this is
     /// what the typical `lists.all_rooms` config hits, and it's the count
     /// path exercised by the bug repro.
-    #[test]
-    fn no_filters_returns_all_rooms() {
+    #[tokio::test]
+    async fn no_filters_returns_all_rooms() {
         let r1 = rid("!one:example.org");
         let r2 = rid("!two:example.org");
         let r3 = rid("!three:example.org");
@@ -1448,7 +1509,8 @@ mod tests {
             .collect();
         let dms = HashSet::new();
 
-        let active = compute_active_rooms(&ReqList::default(), &invited, &joined, &all, &dms);
+        let active =
+            compute_active_rooms(&ReqList::default(), &invited, &joined, &all, &dms).await;
 
         assert_eq!(active.len(), 3);
     }
@@ -1456,8 +1518,8 @@ mod tests {
     /// `is_invite=true` selects only the invited subset — this is how an EX
     /// client renders the invite shelf, and `count` here drives whether the
     /// client knows there's an invite badge to show.
-    #[test]
-    fn is_invite_true_returns_invited_only() {
+    #[tokio::test]
+    async fn is_invite_true_returns_invited_only() {
         let joined1 = rid("!j1:example.org");
         let joined2 = rid("!j2:example.org");
         let invited1 = rid("!i1:example.org");
@@ -1474,13 +1536,13 @@ mod tests {
             is_invite: Some(true),
             ..Default::default()
         });
-        let active = compute_active_rooms(&list, &invited, &joined, &all, &dms);
+        let active = compute_active_rooms(&list, &invited, &joined, &all, &dms).await;
 
         assert_eq!(active.len(), 1);
     }
 
-    #[test]
-    fn is_invite_false_returns_joined_only() {
+    #[tokio::test]
+    async fn is_invite_false_returns_joined_only() {
         let joined1 = rid("!j1:example.org");
         let joined2 = rid("!j2:example.org");
         let invited1 = rid("!i1:example.org");
@@ -1497,15 +1559,15 @@ mod tests {
             is_invite: Some(false),
             ..Default::default()
         });
-        let active = compute_active_rooms(&list, &invited, &joined, &all, &dms);
+        let active = compute_active_rooms(&list, &invited, &joined, &all, &dms).await;
 
         assert_eq!(active.len(), 2);
     }
 
     /// `is_dm=true` retains only rooms that are tagged in `m.direct`.
     /// This filter doesn't touch the database, so we can exercise it in-process.
-    #[test]
-    fn is_dm_true_keeps_dm_rooms_only() {
+    #[tokio::test]
+    async fn is_dm_true_keeps_dm_rooms_only() {
         let r_dm = rid("!dm:example.org");
         let r_other = rid("!other:example.org");
         let joined: Vec<&RoomId> = vec![r_dm.as_ref(), r_other.as_ref()];
@@ -1518,14 +1580,14 @@ mod tests {
             is_dm: Some(true),
             ..Default::default()
         });
-        let active = compute_active_rooms(&list, &invited, &joined, &all, &dms);
+        let active = compute_active_rooms(&list, &invited, &joined, &all, &dms).await;
 
         assert_eq!(active.len(), 1);
         assert_eq!(active[0], &*r_dm);
     }
 
-    #[test]
-    fn is_dm_false_excludes_dm_rooms() {
+    #[tokio::test]
+    async fn is_dm_false_excludes_dm_rooms() {
         let r_dm = rid("!dm:example.org");
         let r_other = rid("!other:example.org");
         let joined: Vec<&RoomId> = vec![r_dm.as_ref(), r_other.as_ref()];
@@ -1538,7 +1600,7 @@ mod tests {
             is_dm: Some(false),
             ..Default::default()
         });
-        let active = compute_active_rooms(&list, &invited, &joined, &all, &dms);
+        let active = compute_active_rooms(&list, &invited, &joined, &all, &dms).await;
 
         assert_eq!(active.len(), 1);
         assert_eq!(active[0], &*r_other);

--- a/crates/server/src/transaction_id.rs
+++ b/crates/server/src/transaction_id.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use palpo_core::UnixMillis;
 
 use crate::AppResult;
@@ -8,7 +9,7 @@ use crate::data::room::NewDbEventIdempotent;
 use crate::data::schema::*;
 use crate::data::{connect, diesel_exists};
 
-pub fn add_txn_id(
+pub async fn add_txn_id(
     txn_id: &TransactionId,
     user_id: &UserId,
     device_id: Option<&DeviceId>,
@@ -24,11 +25,12 @@ pub fn add_txn_id(
             event_id: event_id.map(|e| e.to_owned()),
             created_at: UnixMillis::now(),
         })
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
-pub fn txn_id_exists(
+pub async fn txn_id_exists(
     txn_id: &TransactionId,
     user_id: &UserId,
     device_id: Option<&DeviceId>,
@@ -39,18 +41,18 @@ pub fn txn_id_exists(
             .filter(event_idempotents::device_id.eq(device_id))
             .filter(event_idempotents::txn_id.eq(txn_id))
             .select(event_idempotents::event_id);
-        diesel_exists!(query, &mut connect()?).map_err(Into::into)
+        diesel_exists!(query, &mut connect().await?).map_err(Into::into)
     } else {
         let query = event_idempotents::table
             .filter(event_idempotents::user_id.eq(user_id))
             .filter(event_idempotents::device_id.is_null())
             .filter(event_idempotents::txn_id.eq(txn_id))
             .select(event_idempotents::event_id);
-        diesel_exists!(query, &mut connect()?).map_err(Into::into)
+        diesel_exists!(query, &mut connect().await?).map_err(Into::into)
     }
 }
 
-pub fn get_event_id(
+pub async fn get_event_id(
     txn_id: &TransactionId,
     user_id: &UserId,
     device_id: Option<&DeviceId>,
@@ -72,7 +74,8 @@ pub fn get_event_id(
     }
     query
         .select(event_idempotents::event_id)
-        .first::<Option<OwnedEventId>>(&mut connect()?)
+        .first::<Option<OwnedEventId>>(&mut connect().await?)
+        .await
         .optional()
         .map(|v| v.flatten())
         .map_err(Into::into)

--- a/crates/server/src/uiaa.rs
+++ b/crates/server/src/uiaa.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use subtle::ConstantTimeEq;
 
 use crate::core::client::uiaa::{
@@ -11,7 +12,7 @@ use crate::data::schema::*;
 use crate::{AppResult, MatrixError, SESSION_ID_LENGTH, data, utils};
 
 /// Creates a new Uiaa session. Make sure the session token is unique.
-pub fn create_session(
+pub async fn create_session(
     user_id: &UserId,
     device_id: &DeviceId,
     uiaa_info: &UiaaInfo,
@@ -19,13 +20,13 @@ pub fn create_session(
 ) -> AppResult<()> {
     let session = uiaa_info.session.as_ref().expect("session should be set");
     // First create/update the DB row with uiaa_info
-    update_session(user_id, device_id, session, Some(uiaa_info))?;
+    update_session(user_id, device_id, session, Some(uiaa_info)).await?;
     // Then store the request body (now the row exists)
-    set_uiaa_request(user_id, device_id, session, json_body)?;
+    set_uiaa_request(user_id, device_id, session, json_body).await?;
     Ok(())
 }
 
-pub fn update_session(
+pub async fn update_session(
     user_id: &UserId,
     device_id: &DeviceId,
     session: &str,
@@ -47,7 +48,8 @@ pub fn update_session(
             ))
             .do_update()
             .set(user_uiaa_datas::uiaa_info.eq(&uiaa_info))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     } else {
         diesel::delete(
             user_uiaa_datas::table
@@ -55,29 +57,35 @@ pub fn update_session(
                 .filter(user_uiaa_datas::device_id.eq(device_id))
                 .filter(user_uiaa_datas::session.eq(session)),
         )
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     };
     Ok(())
 }
-pub fn get_session(user_id: &UserId, device_id: &DeviceId, session: &str) -> AppResult<UiaaInfo> {
+pub async fn get_session(
+    user_id: &UserId,
+    device_id: &DeviceId,
+    session: &str,
+) -> AppResult<UiaaInfo> {
     let uiaa_info = user_uiaa_datas::table
         .filter(user_uiaa_datas::user_id.eq(user_id))
         .filter(user_uiaa_datas::device_id.eq(device_id))
         .filter(user_uiaa_datas::session.eq(session))
         .select(user_uiaa_datas::uiaa_info)
-        .first::<JsonValue>(&mut connect()?)?;
+        .first::<JsonValue>(&mut connect().await?)
+        .await?;
     Ok(serde_json::from_value(uiaa_info)?)
 }
-pub fn try_auth(
+pub async fn try_auth(
     user_id: &UserId,
     device_id: &DeviceId,
     auth: &AuthData,
     uiaa_info: &UiaaInfo,
 ) -> AppResult<(bool, UiaaInfo)> {
-    let mut uiaa_info = auth
-        .session()
-        .map(|session| get_session(user_id, device_id, session))
-        .unwrap_or_else(|| Ok(uiaa_info.clone()))?;
+    let mut uiaa_info = match auth.session() {
+        Some(session) => get_session(user_id, device_id, session).await?,
+        None => uiaa_info.clone(),
+    };
 
     if uiaa_info.session.is_none() {
         uiaa_info.session = Some(utils::random_string(SESSION_ID_LENGTH));
@@ -104,10 +112,10 @@ pub fn try_auth(
                 return Err(MatrixError::forbidden("User ID does not match.", None).into());
             }
 
-            let Ok(user) = data::user::get_user(&auth_user_id) else {
+            let Ok(user) = data::user::get_user(&auth_user_id).await else {
                 return Err(MatrixError::unauthorized("user not found.").into());
             };
-            crate::user::verify_password(&user, password)?;
+            crate::user::verify_password(&user, password).await?;
         }
         AuthData::RegistrationToken(t) => {
             let token_valid = conf
@@ -154,7 +162,8 @@ pub fn try_auth(
             device_id,
             uiaa_info.session.as_ref().expect("session is always set"),
             Some(&uiaa_info),
-        )?;
+        )
+        .await?;
         return Ok((false, uiaa_info));
     }
 
@@ -164,12 +173,13 @@ pub fn try_auth(
         device_id,
         uiaa_info.session.as_ref().expect("session is always set"),
         None,
-    )?;
+    )
+    .await?;
     Ok((true, uiaa_info))
 }
 
 /// Store the UIAA request body in the database for cross-instance access.
-pub fn set_uiaa_request(
+pub async fn set_uiaa_request(
     user_id: &UserId,
     device_id: &DeviceId,
     session: &str,
@@ -183,12 +193,13 @@ pub fn set_uiaa_request(
             .filter(user_uiaa_datas::session.eq(session)),
     )
     .set(user_uiaa_datas::request_body.eq(Some(&request_body)))
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }
 
 /// Get the UIAA request body from the database.
-pub fn get_uiaa_request(
+pub async fn get_uiaa_request(
     user_id: &UserId,
     device_id: &DeviceId,
     session: &str,
@@ -198,7 +209,8 @@ pub fn get_uiaa_request(
         .filter(user_uiaa_datas::device_id.eq(device_id))
         .filter(user_uiaa_datas::session.eq(session))
         .select(user_uiaa_datas::request_body)
-        .first::<Option<JsonValue>>(&mut connect().ok()?)
+        .first::<Option<JsonValue>>(&mut connect().await.ok()?)
+        .await
         .ok()
         .flatten()?;
 

--- a/crates/server/src/user.rs
+++ b/crates/server/src/user.rs
@@ -11,6 +11,7 @@ pub mod session;
 use std::{collections::BTreeSet, mem};
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 pub use presence::*;
 use serde::de::DeserializeOwned;
 
@@ -26,23 +27,26 @@ use crate::data::{DataResult, connect};
 use crate::room::timeline;
 use crate::{AppError, AppResult, IsRemoteOrLocal, MatrixError, PduBuilder, config, data, room};
 
-pub fn is_username_available(username: &str) -> AppResult<bool> {
+pub async fn is_username_available(username: &str) -> AppResult<bool> {
     let user_id = UserId::parse(format!("@{}:{}", username, config::server_name()))
         .map_err(|_| AppError::internal("invalid username format"))?;
     user_id.validate_strict()?;
-    let available = !data::user::user_exists(&user_id)?;
+    let available = !data::user::user_exists(&user_id).await?;
     Ok(available)
 }
 
-pub fn create_user(user_id: impl Into<OwnedUserId>, password: Option<&str>) -> AppResult<DbUser> {
-    create_user_inner(user_id, password, false)
+pub async fn create_user(
+    user_id: impl Into<OwnedUserId>,
+    password: Option<&str>,
+) -> AppResult<DbUser> {
+    create_user_inner(user_id, password, false).await
 }
 
-pub fn create_guest_user(user_id: impl Into<OwnedUserId>) -> AppResult<DbUser> {
-    create_user_inner(user_id, None, true)
+pub async fn create_guest_user(user_id: impl Into<OwnedUserId>) -> AppResult<DbUser> {
+    create_user_inner(user_id, None, true).await
 }
 
-fn create_user_inner(
+async fn create_user_inner(
     user_id: impl Into<OwnedUserId>,
     password: Option<&str>,
     is_guest: bool,
@@ -64,7 +68,8 @@ fn create_user_inner(
         .on_conflict(users::id)
         .do_update()
         .set(&new_user)
-        .get_result::<DbUser>(&mut connect()?)?;
+        .get_result::<DbUser>(&mut connect().await?)
+        .await?;
     // Default to pretty display_name
     let display_name = user_id.localpart().to_owned();
     // // If enabled append lightning bolt to display name (default true)
@@ -79,20 +84,22 @@ fn create_user_inner(
             avatar_url: None,
             blurhash: None,
         })
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     if let Some(password) = password {
-        crate::user::set_password(&user.id, password)?;
+        crate::user::set_password(&user.id, password).await?;
     }
-    if let Err(e) = set_display_name(&user.id, &display_name) {
+    if let Err(e) = set_display_name(&user.id, &display_name).await {
         tracing::warn!("failed to set profile for new user (non-fatal): {}", e);
     }
     Ok(user)
 }
 
-pub fn list_local_users() -> AppResult<Vec<OwnedUserId>> {
+pub async fn list_local_users() -> AppResult<Vec<OwnedUserId>> {
     let users = user_passwords::table
         .select(user_passwords::user_id)
-        .load::<OwnedUserId>(&mut connect()?)?;
+        .load::<OwnedUserId>(&mut connect().await?)
+        .await?;
     Ok(users)
 }
 /// Ensure that a user only sees signatures from themselves and the target user
@@ -125,14 +132,17 @@ pub fn clean_signatures<F: Fn(&UserId) -> bool>(
 
 /// Returns true/false based on whether the recipient/receiving user has
 /// blocked the sender
-pub fn user_is_ignored(sender_id: &UserId, recipient_id: &UserId) -> bool {
+pub async fn user_is_ignored(sender_id: &UserId, recipient_id: &UserId) -> bool {
     ignored_users(recipient_id)
+        .await
         .iter()
         .any(|blocked_user| blocked_user == sender_id)
 }
 
-pub fn ignored_users(recipient_id: &UserId) -> BTreeSet<OwnedUserId> {
-    let ignored_user_ids = data::user::ignored_users(recipient_id).unwrap_or_default();
+pub async fn ignored_users(recipient_id: &UserId) -> BTreeSet<OwnedUserId> {
+    let ignored_user_ids = data::user::ignored_users(recipient_id)
+        .await
+        .unwrap_or_default();
     if !ignored_user_ids.is_empty() {
         return ignored_user_ids.into_iter().collect();
     }
@@ -140,7 +150,9 @@ pub fn ignored_users(recipient_id: &UserId) -> BTreeSet<OwnedUserId> {
     if let Ok(Some(ignored)) = data::user::get_global_data::<IgnoredUserListEvent>(
         recipient_id,
         &GlobalAccountDataEventType::IgnoredUserList.to_string(),
-    ) {
+    )
+    .await
+    {
         ignored.content.ignored_users.keys().cloned().collect()
     } else {
         BTreeSet::new()
@@ -158,8 +170,8 @@ pub async fn full_user_deactivate(
     user_id: &UserId,
     all_joined_rooms: &[OwnedRoomId],
 ) -> AppResult<()> {
-    data::user::deactivate(user_id).ok();
-    data::user::delete_profile(user_id).ok();
+    data::user::deactivate(user_id).await.ok();
+    data::user::delete_profile(user_id).await.ok();
 
     // TODO: remove all user data
     // for profile_key in data::user::all_profile_keys(user_id) {
@@ -169,7 +181,7 @@ pub async fn full_user_deactivate(
     for room_id in all_joined_rooms {
         let state_lock = room::lock_state(room_id).await;
 
-        let room_version = room::get_version(room_id)?;
+        let room_version = room::get_version(room_id).await?;
         let version_rules = room::get_version_rules(&room_version)?;
         let room_power_levels = room::get_power_levels(room_id).await.ok();
 
@@ -178,7 +190,7 @@ pub async fn full_user_deactivate(
         });
 
         let user_can_demote_self = user_can_change_self
-            || room::get_create(room_id).is_ok_and(|event| event.sender == user_id);
+            || room::get_create(room_id).await.is_ok_and(|event| event.sender == user_id);
 
         if user_can_demote_self {
             let mut power_levels_content: RoomPowerLevelsEventContent = room_power_levels
@@ -219,14 +231,16 @@ pub async fn find_from_openid_token(token: &str) -> AppResult<OwnedUserId> {
     let Ok((user_id, expires_at)) = user_openid_tokens::table
         .filter(user_openid_tokens::token.eq(token))
         .select((user_openid_tokens::user_id, user_openid_tokens::expires_at))
-        .first::<(OwnedUserId, UnixMillis)>(&mut connect()?)
+        .first::<(OwnedUserId, UnixMillis)>(&mut connect().await?)
+        .await
     else {
         return Err(MatrixError::unauthorized("OpenID token is unrecognised").into());
     };
     if expires_at < UnixMillis::now() {
         tracing::warn!("OpenID token is expired, removing");
         diesel::delete(user_openid_tokens::table.filter(user_openid_tokens::token.eq(token)))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
 
         return Err(MatrixError::unauthorized("OpenID token is expired").into());
     }
@@ -236,7 +250,7 @@ pub async fn find_from_openid_token(token: &str) -> AppResult<OwnedUserId> {
 
 /// Creates a short-lived login token, which can be used to log in using the
 /// `m.login.token` mechanism.
-pub fn create_login_token(user_id: &UserId, token: &str) -> AppResult<u64> {
+pub async fn create_login_token(user_id: &UserId, token: &str) -> AppResult<u64> {
     let expires_in = crate::config::get().login_token_ttl;
     let now = UnixMillis::now().get();
     let expires_at = now.saturating_add(expires_in).min(i64::MAX as u64) as i64;
@@ -250,18 +264,20 @@ pub fn create_login_token(user_id: &UserId, token: &str) -> AppResult<u64> {
         .on_conflict(user_login_tokens::token)
         .do_update()
         .set(user_login_tokens::expires_at.eq(expires_at))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
 
     Ok(expires_in)
 }
 
 /// Find out which user a login token belongs to.
 /// Removes the token to prevent double-use attacks.
-pub fn take_login_token(token: &str) -> AppResult<OwnedUserId> {
+pub async fn take_login_token(token: &str) -> AppResult<OwnedUserId> {
     let Ok((user_id, expires_at)) = user_login_tokens::table
         .filter(user_login_tokens::token.eq(token))
         .select((user_login_tokens::user_id, user_login_tokens::expires_at))
-        .first::<(OwnedUserId, UnixMillis)>(&mut connect()?)
+        .first::<(OwnedUserId, UnixMillis)>(&mut connect().await?)
+        .await
     else {
         return Err(MatrixError::forbidden("Login token is unrecognised.", None).into());
     };
@@ -269,23 +285,30 @@ pub fn take_login_token(token: &str) -> AppResult<OwnedUserId> {
     if expires_at < UnixMillis::now() {
         trace!(?user_id, ?token, "Removing expired login token");
         diesel::delete(user_login_tokens::table.filter(user_login_tokens::token.eq(token)))
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         return Err(MatrixError::forbidden("Login token is expired.", None).into());
     }
 
     diesel::delete(user_login_tokens::table.filter(user_login_tokens::token.eq(token)))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
 
     Ok(user_id)
 }
 
-pub fn valid_refresh_token(user_id: &UserId, device_id: &DeviceId, token: &str) -> AppResult<()> {
+pub async fn valid_refresh_token(
+    user_id: &UserId,
+    device_id: &DeviceId,
+    token: &str,
+) -> AppResult<()> {
     let Ok(expires_at) = user_refresh_tokens::table
         .filter(user_refresh_tokens::user_id.eq(user_id))
         .filter(user_refresh_tokens::device_id.eq(device_id))
         .filter(user_refresh_tokens::token.eq(token))
         .select(user_refresh_tokens::expires_at)
-        .first::<i64>(&mut connect()?)
+        .first::<i64>(&mut connect().await?)
+        .await
     else {
         return Err(MatrixError::unauthorized("Invalid refresh token.").into());
     };
@@ -295,40 +318,42 @@ pub fn valid_refresh_token(user_id: &UserId, device_id: &DeviceId, token: &str) 
     Ok(())
 }
 
-pub fn make_user_admin(user_id: &UserId) -> AppResult<()> {
+pub async fn make_user_admin(user_id: &UserId) -> AppResult<()> {
     let user_id = user_id.to_owned();
     diesel::update(users::table.filter(users::id.eq(&user_id)))
         .set(users::is_admin.eq(true))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
 /// Places one event in the account data of the user and removes the previous entry.
 #[tracing::instrument(skip(room_id, user_id, event_type, json_data))]
-pub fn set_data(
+pub async fn set_data(
     user_id: &UserId,
     room_id: Option<OwnedRoomId>,
     event_type: &str,
     json_data: JsonValue,
 ) -> DataResult<DbUserData> {
-    let user_data = data::user::set_data(user_id, room_id, event_type, json_data)?;
+    let user_data = data::user::set_data(user_id, room_id, event_type, json_data).await?;
     Ok(user_data)
 }
 
-pub fn get_data<E: DeserializeOwned>(
+pub async fn get_data<E: DeserializeOwned>(
     user_id: &UserId,
     room_id: Option<&RoomId>,
     kind: &str,
 ) -> DataResult<E> {
-    let data = data::user::get_data::<E>(user_id, room_id, kind)?;
+    let data = data::user::get_data::<E>(user_id, room_id, kind).await?;
     Ok(data)
 }
 
-pub fn get_global_datas(user_id: &UserId) -> DataResult<Vec<DbUserData>> {
+pub async fn get_global_datas(user_id: &UserId) -> DataResult<Vec<DbUserData>> {
     let datas = user_datas::table
         .filter(user_datas::user_id.eq(user_id))
         .filter(user_datas::room_id.is_null())
-        .load::<DbUserData>(&mut connect()?)?;
+        .load::<DbUserData>(&mut connect().await?)
+        .await?;
     Ok(datas)
 }
 
@@ -336,7 +361,8 @@ pub async fn delete_all_media(user_id: &UserId) -> AppResult<i64> {
     let medias = media_metadatas::table
         .filter(media_metadatas::created_by.eq(user_id))
         .select((media_metadatas::origin_server, media_metadatas::media_id))
-        .load::<(OwnedServerName, String)>(&mut connect()?)?;
+        .load::<(OwnedServerName, String)>(&mut connect().await?)
+        .await?;
 
     for (origin_server, media_id) in &medias {
         if let Err(e) = crate::media::delete_media(origin_server, media_id).await {
@@ -349,6 +375,7 @@ pub async fn delete_all_media(user_id: &UserId) -> AppResult<i64> {
 pub async fn deactivate_account(user_id: &UserId) -> AppResult<()> {
     diesel::update(users::table.find(user_id))
         .set(users::deactivated_at.eq(UnixMillis::now()))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }

--- a/crates/server/src/user/key.rs
+++ b/crates/server/src/user/key.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap, hash_map};
 use std::time::Instant;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use serde_json::json;
 
@@ -24,7 +25,7 @@ use crate::exts::*;
 use crate::user::clean_signatures;
 use crate::{AppError, AppResult, BAD_QUERY_RATE_LIMITER, MatrixError, config, data, sending};
 
-pub async fn query_keys<F: Fn(&UserId) -> bool>(
+pub async fn query_keys<F: Fn(&UserId) -> bool + Send + Sync>(
     sender_id: Option<&UserId>,
     device_keys_input: &BTreeMap<OwnedUserId, Vec<OwnedDeviceId>>,
     allowed_signatures: F,
@@ -47,9 +48,11 @@ pub async fn query_keys<F: Fn(&UserId) -> bool>(
 
         if device_ids.is_empty() {
             let mut container = BTreeMap::new();
-            for device_id in data::user::all_device_ids(user_id)? {
-                if let Some(mut keys) = data::user::get_device_keys_and_sigs(user_id, &device_id)? {
-                    let device = data::user::device::get_device(user_id, &device_id)?;
+            for device_id in data::user::all_device_ids(user_id).await? {
+                if let Some(mut keys) =
+                    data::user::get_device_keys_and_sigs(user_id, &device_id).await?
+                {
+                    let device = data::user::device::get_device(user_id, &device_id).await?;
                     if let Some(display_name) = &device.display_name {
                         keys.unsigned.device_display_name = display_name.to_owned().into();
                     }
@@ -60,7 +63,9 @@ pub async fn query_keys<F: Fn(&UserId) -> bool>(
         } else {
             for device_id in device_ids {
                 let mut container = BTreeMap::new();
-                if let Some(keys) = data::user::get_device_keys_and_sigs(user_id, device_id)? {
+                if let Some(keys) =
+                    data::user::get_device_keys_and_sigs(user_id, device_id).await?
+                {
                     container.insert(device_id.to_owned(), keys);
                 }
                 device_keys.insert(user_id.to_owned(), container);
@@ -68,17 +73,18 @@ pub async fn query_keys<F: Fn(&UserId) -> bool>(
         }
 
         if let Some(master_key) =
-            crate::user::get_allowed_master_key(sender_id, user_id, &allowed_signatures)?
+            crate::user::get_allowed_master_key(sender_id, user_id, &allowed_signatures).await?
         {
             master_keys.insert(user_id.to_owned(), master_key);
         }
         if let Some(self_signing_key) =
-            crate::user::get_allowed_self_signing_key(sender_id, user_id, &allowed_signatures)?
+            crate::user::get_allowed_self_signing_key(sender_id, user_id, &allowed_signatures)
+                .await?
         {
             self_signing_keys.insert(user_id.to_owned(), self_signing_key);
         }
         if Some(&**user_id) == sender_id
-            && let Some(user_signing_key) = crate::user::get_user_signing_key(user_id)?
+            && let Some(user_signing_key) = crate::user::get_user_signing_key(user_id).await?
         {
             user_signing_keys.insert(user_id.to_owned(), user_signing_key);
         }
@@ -130,7 +136,9 @@ pub async fn query_keys<F: Fn(&UserId) -> bool>(
                         sender_id,
                         &user_id,
                         &allowed_signatures,
-                    )? {
+                    )
+                    .await?
+                    {
                         master_key.signatures.extend(our_master_key.signatures);
                     }
                     let json = serde_json::to_value(master_key).expect("to_value always works");
@@ -140,7 +148,8 @@ pub async fn query_keys<F: Fn(&UserId) -> bool>(
                         &user_id, &raw, &None, &None,
                         false, /* Dont notify. A notification would trigger another key request
                                * resulting in an endless loop */
-                    )?;
+                    )
+                    .await?;
                     master_keys.insert(user_id.to_owned(), raw);
                 }
 
@@ -180,7 +189,7 @@ pub async fn claim_one_time_keys(
         let mut container = BTreeMap::new();
         for (device_id, key_algorithm) in map {
             if let Some(one_time_keys) =
-                crate::user::claim_one_time_key(user_id, device_id, key_algorithm)?
+                crate::user::claim_one_time_key(user_id, device_id, key_algorithm).await?
             {
                 let mut c = BTreeMap::new();
                 c.insert(one_time_keys.0, one_time_keys.1);
@@ -236,12 +245,13 @@ pub async fn claim_one_time_keys(
     })
 }
 
-pub fn get_master_key(user_id: &UserId) -> AppResult<Option<CrossSigningKey>> {
+pub async fn get_master_key(user_id: &UserId) -> AppResult<Option<CrossSigningKey>> {
     let key_data = e2e_cross_signing_keys::table
         .filter(e2e_cross_signing_keys::user_id.eq(user_id))
         .filter(e2e_cross_signing_keys::key_type.eq("master"))
         .select(e2e_cross_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect()?)
+        .first::<JsonValue>(&mut connect().await?)
+        .await
         .optional()?;
     if let Some(key_data) = key_data {
         Ok(serde_json::from_value(key_data).ok())
@@ -250,17 +260,18 @@ pub fn get_master_key(user_id: &UserId) -> AppResult<Option<CrossSigningKey>> {
     }
 }
 
-pub fn get_allowed_master_key(
+pub async fn get_allowed_master_key(
     sender_id: Option<&UserId>,
     user_id: &UserId,
-    allowed_signatures: &dyn Fn(&UserId) -> bool,
+    allowed_signatures: &(dyn Fn(&UserId) -> bool + Send + Sync),
 ) -> AppResult<Option<CrossSigningKey>> {
     let key_data = e2e_cross_signing_keys::table
         .filter(e2e_cross_signing_keys::user_id.eq(user_id))
         .filter(e2e_cross_signing_keys::key_type.eq("master"))
         .order_by(e2e_cross_signing_keys::id.desc())
         .select(e2e_cross_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect()?)
+        .first::<JsonValue>(&mut connect().await?)
+        .await
         .optional()?;
     if let Some(mut key_data) = key_data {
         clean_signatures(&mut key_data, sender_id, user_id, allowed_signatures)?;
@@ -270,13 +281,14 @@ pub fn get_allowed_master_key(
     }
 }
 
-pub fn get_self_signing_key(user_id: &UserId) -> AppResult<Option<CrossSigningKey>> {
+pub async fn get_self_signing_key(user_id: &UserId) -> AppResult<Option<CrossSigningKey>> {
     let key_data = e2e_cross_signing_keys::table
         .filter(e2e_cross_signing_keys::user_id.eq(user_id))
         .filter(e2e_cross_signing_keys::key_type.eq("self_signing"))
         .order_by(e2e_cross_signing_keys::id.desc())
         .select(e2e_cross_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect()?)
+        .first::<JsonValue>(&mut connect().await?)
+        .await
         .optional()?;
     if let Some(key_data) = key_data {
         Ok(serde_json::from_value(key_data).ok())
@@ -284,17 +296,18 @@ pub fn get_self_signing_key(user_id: &UserId) -> AppResult<Option<CrossSigningKe
         Ok(None)
     }
 }
-pub fn get_allowed_self_signing_key(
+pub async fn get_allowed_self_signing_key(
     sender_id: Option<&UserId>,
     user_id: &UserId,
-    allowed_signatures: &dyn Fn(&UserId) -> bool,
+    allowed_signatures: &(dyn Fn(&UserId) -> bool + Send + Sync),
 ) -> AppResult<Option<CrossSigningKey>> {
     let key_data = e2e_cross_signing_keys::table
         .filter(e2e_cross_signing_keys::user_id.eq(user_id))
         .filter(e2e_cross_signing_keys::key_type.eq("self_signing"))
         .order_by(e2e_cross_signing_keys::id.desc())
         .select(e2e_cross_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect()?)
+        .first::<JsonValue>(&mut connect().await?)
+        .await
         .optional()?;
     if let Some(mut key_data) = key_data {
         clean_signatures(&mut key_data, sender_id, user_id, allowed_signatures)?;
@@ -304,20 +317,21 @@ pub fn get_allowed_self_signing_key(
     }
 }
 
-pub fn get_user_signing_key(user_id: &UserId) -> AppResult<Option<CrossSigningKey>> {
+pub async fn get_user_signing_key(user_id: &UserId) -> AppResult<Option<CrossSigningKey>> {
     e2e_cross_signing_keys::table
         .filter(e2e_cross_signing_keys::user_id.eq(user_id))
         .filter(e2e_cross_signing_keys::key_type.eq("user_signing"))
         .order_by(e2e_cross_signing_keys::id.desc())
         .select(e2e_cross_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect()?)
+        .first::<JsonValue>(&mut connect().await?)
+        .await
         .map(|data| serde_json::from_value(data).ok())
         .optional()
         .map(|v| v.flatten())
         .map_err(Into::into)
 }
 
-pub fn add_one_time_key(
+pub async fn add_one_time_key(
     user_id: &UserId,
     device_id: &DeviceId,
     key_id: &DeviceKeyId,
@@ -340,11 +354,12 @@ pub fn add_one_time_key(
         ))
         .do_update()
         .set(e2e_one_time_keys::key_data.eq(serde_json::to_value(one_time_key).unwrap()))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
-pub fn claim_one_time_key(
+pub async fn claim_one_time_key(
     user_id: &UserId,
     device_id: &DeviceId,
     key_algorithm: &DeviceKeyAlgorithm,
@@ -354,7 +369,8 @@ pub fn claim_one_time_key(
         .filter(e2e_one_time_keys::device_id.eq(device_id))
         .filter(e2e_one_time_keys::algorithm.eq(key_algorithm.as_ref()))
         .order(e2e_one_time_keys::id.asc())
-        .first::<DbOneTimeKey>(&mut connect()?)
+        .first::<DbOneTimeKey>(&mut connect().await?)
+        .await
         .optional()?;
     if let Some(DbOneTimeKey {
         id,
@@ -363,7 +379,9 @@ pub fn claim_one_time_key(
         ..
     }) = one_time_key
     {
-        diesel::delete(e2e_one_time_keys::table.find(id)).execute(&mut connect()?)?;
+        diesel::delete(e2e_one_time_keys::table.find(id))
+            .execute(&mut connect().await?)
+            .await?;
         Ok(Some((
             key_id,
             serde_json::from_value::<OneTimeKey>(key_data)?,
@@ -373,18 +391,18 @@ pub fn claim_one_time_key(
     }
 }
 
-pub fn add_device_keys(
+pub async fn add_device_keys(
     user_id: &UserId,
     device_id: &DeviceId,
     device_keys: &DeviceKeys,
 ) -> AppResult<()> {
-    data::user::add_device_keys(user_id, device_id, device_keys)?;
-    mark_device_key_update(user_id, device_id)?;
-    send_device_key_update(user_id, device_id)?;
+    data::user::add_device_keys(user_id, device_id, device_keys).await?;
+    mark_device_key_update(user_id, device_id).await?;
+    send_device_key_update(user_id, device_id).await?;
     Ok(())
 }
 
-pub fn add_cross_signing_keys(
+pub async fn add_cross_signing_keys(
     user_id: &UserId,
     master_key: &CrossSigningKey,
     self_signing_key: &Option<CrossSigningKey>,
@@ -398,7 +416,8 @@ pub fn add_cross_signing_keys(
             key_type: "master".to_owned(),
             key_data: serde_json::to_value(master_key)?,
         })
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
 
     // Self-signing key
     if let Some(self_signing_key) = self_signing_key {
@@ -424,7 +443,8 @@ pub fn add_cross_signing_keys(
                 key_type: "self_signing".to_owned(),
                 key_data: serde_json::to_value(self_signing_key)?,
             })
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     }
 
     // User-signing key
@@ -451,17 +471,18 @@ pub fn add_cross_signing_keys(
                 key_type: "user_signing".to_owned(),
                 key_data: serde_json::to_value(user_signing_key)?,
             })
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     }
 
     if notify {
-        mark_signing_key_update(user_id)?;
+        mark_signing_key_update(user_id).await?;
     }
 
     Ok(())
 }
 
-pub fn sign_key(
+pub async fn sign_key(
     target_user_id: &UserId,
     target_device_id: &str,
     signature: (String, String),
@@ -490,14 +511,15 @@ pub fn sign_key(
             target_device_id: OwnedDeviceId::from(target_device_id),
             signature: signature.1,
         })
-        .execute(&mut connect()?)?;
-    mark_signing_key_update(target_user_id)
+        .execute(&mut connect().await?)
+        .await?;
+    mark_signing_key_update(target_user_id).await
 }
 
-pub fn mark_signing_key_update(user_id: &UserId) -> AppResult<()> {
+pub async fn mark_signing_key_update(user_id: &UserId) -> AppResult<()> {
     let changed_at = UnixMillis::now();
 
-    let joined_rooms = data::user::joined_rooms(user_id)?;
+    let joined_rooms = data::user::joined_rooms(user_id).await?;
     for room_id in &joined_rooms {
         // // Don't send key updates to unencrypted rooms
         // if state::get_state(&room_id, &StateEventType::RoomEncryption, "")?.is_none() {
@@ -508,7 +530,7 @@ pub fn mark_signing_key_update(user_id: &UserId) -> AppResult<()> {
             user_id: user_id.to_owned(),
             room_id: Some(room_id.to_owned()),
             changed_at,
-            occur_sn: data::next_sn()?,
+            occur_sn: data::next_sn().await?,
         };
 
         diesel::delete(
@@ -516,17 +538,19 @@ pub fn mark_signing_key_update(user_id: &UserId) -> AppResult<()> {
                 .filter(e2e_key_changes::user_id.eq(user_id))
                 .filter(e2e_key_changes::room_id.eq(room_id)),
         )
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
         diesel::insert_into(e2e_key_changes::table)
             .values(&change)
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     }
 
     let change = NewDbKeyChange {
         user_id: user_id.to_owned(),
         room_id: None,
         changed_at,
-        occur_sn: data::next_sn()?,
+        occur_sn: data::next_sn().await?,
     };
 
     diesel::delete(
@@ -534,31 +558,34 @@ pub fn mark_signing_key_update(user_id: &UserId) -> AppResult<()> {
             .filter(e2e_key_changes::user_id.eq(user_id))
             .filter(e2e_key_changes::room_id.is_null()),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     diesel::insert_into(e2e_key_changes::table)
         .values(&change)
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
 
     if user_id.is_local() {
         let remote_servers = room_joined_servers::table
             .filter(room_joined_servers::room_id.eq_any(joined_rooms))
             .select(room_joined_servers::server_id)
             .distinct()
-            .load::<OwnedServerName>(&mut connect()?)?;
+            .load::<OwnedServerName>(&mut connect().await?)
+            .await?;
 
         let content = SigningKeyUpdateContent::new(user_id.to_owned());
         let edu = Edu::SigningKeyUpdate(content);
 
-        let _ = sending::send_edu_servers(remote_servers.into_iter(), &edu);
+        let _ = sending::send_edu_servers(remote_servers.into_iter(), &edu).await;
     }
 
     Ok(())
 }
 
-pub fn mark_device_key_update(user_id: &UserId, _device_id: &DeviceId) -> AppResult<()> {
+pub async fn mark_device_key_update(user_id: &UserId, _device_id: &DeviceId) -> AppResult<()> {
     let changed_at = UnixMillis::now();
-    let joined_rooms = data::user::joined_rooms(user_id)?;
-    let occur_sn = data::next_sn()?;
+    let joined_rooms = data::user::joined_rooms(user_id).await?;
+    let occur_sn = data::next_sn().await?;
     for room_id in &joined_rooms {
         // comment for testing
         // // Don't send key updates to unencrypted rooms
@@ -578,10 +605,12 @@ pub fn mark_device_key_update(user_id: &UserId, _device_id: &DeviceId) -> AppRes
                 .filter(e2e_key_changes::user_id.eq(user_id))
                 .filter(e2e_key_changes::room_id.eq(room_id)),
         )
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
         diesel::insert_into(e2e_key_changes::table)
             .values(&change)
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     }
 
     let change = NewDbKeyChange {
@@ -596,21 +625,23 @@ pub fn mark_device_key_update(user_id: &UserId, _device_id: &DeviceId) -> AppRes
             .filter(e2e_key_changes::user_id.eq(user_id))
             .filter(e2e_key_changes::room_id.is_null()),
     )
-    .execute(&mut connect()?)?;
+    .execute(&mut connect().await?)
+    .await?;
     diesel::insert_into(e2e_key_changes::table)
         .values(&change)
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
 
     Ok(())
 }
 
-pub fn mark_device_key_update_with_joined_rooms(
+pub async fn mark_device_key_update_with_joined_rooms(
     user_id: &UserId,
     _device_id: &DeviceId,
     joined_rooms: &[OwnedRoomId],
 ) -> AppResult<()> {
     let changed_at = UnixMillis::now();
-    let occur_sn = data::next_sn()?;
+    let occur_sn = data::next_sn().await?;
     for room_id in joined_rooms {
         let change = NewDbKeyChange {
             user_id: user_id.to_owned(),
@@ -624,20 +655,22 @@ pub fn mark_device_key_update_with_joined_rooms(
                 .filter(e2e_key_changes::user_id.eq(user_id))
                 .filter(e2e_key_changes::room_id.eq(room_id)),
         )
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
         diesel::insert_into(e2e_key_changes::table)
             .values(&change)
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
     }
     Ok(())
 }
 
-pub fn send_device_key_update(user_id: &UserId, device_id: &DeviceId) -> AppResult<()> {
-    let joined_rooms = data::user::joined_rooms(user_id)?;
-    send_device_key_update_with_joined_rooms(user_id, device_id, &joined_rooms)
+pub async fn send_device_key_update(user_id: &UserId, device_id: &DeviceId) -> AppResult<()> {
+    let joined_rooms = data::user::joined_rooms(user_id).await?;
+    send_device_key_update_with_joined_rooms(user_id, device_id, &joined_rooms).await
 }
 
-fn send_device_key_update_with_joined_rooms(
+async fn send_device_key_update_with_joined_rooms(
     user_id: &UserId,
     device_id: &DeviceId,
     joined_rooms: &[OwnedRoomId],
@@ -649,14 +682,15 @@ fn send_device_key_update_with_joined_rooms(
         .filter(room_joined_servers::room_id.eq_any(joined_rooms))
         .select(room_joined_servers::server_id)
         .distinct()
-        .load::<OwnedServerName>(&mut connect()?)?;
+        .load::<OwnedServerName>(&mut connect().await?)
+        .await?;
 
     let content = DeviceListUpdateContent::new(
         user_id.to_owned(),
         device_id.to_owned(),
-        data::next_sn()? as u64,
+        data::next_sn().await? as u64,
     );
     let edu = Edu::DeviceListUpdate(content);
 
-    sending::send_edu_servers(remote_servers.into_iter(), &edu)
+    sending::send_edu_servers(remote_servers.into_iter(), &edu).await
 }

--- a/crates/server/src/user/password.rs
+++ b/crates/server/src/user/password.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use super::DbUser;
 use crate::core::UnixMillis;
@@ -21,10 +22,11 @@ pub fn ensure_account_usable(user: &DbUser) -> AppResult<()> {
     Ok(())
 }
 
-pub fn verify_password(user: &DbUser, password: &str) -> AppResult<()> {
+pub async fn verify_password(user: &DbUser, password: &str) -> AppResult<()> {
     ensure_account_usable(user)?;
 
     let hash = crate::user::get_password_hash(&user.id)
+        .await
         .map_err(|_| MatrixError::unauthorized("wrong username or password."))?;
     if hash.is_empty() {
         return Err(MatrixError::user_deactivated("the user has been deactivated").into());
@@ -39,17 +41,18 @@ pub fn verify_password(user: &DbUser, password: &str) -> AppResult<()> {
     }
 }
 
-pub fn get_password_hash(user_id: &UserId) -> AppResult<String> {
+pub async fn get_password_hash(user_id: &UserId) -> AppResult<String> {
     user_passwords::table
         .filter(user_passwords::user_id.eq(user_id))
         .order_by(user_passwords::id.desc())
         .select(user_passwords::hash)
-        .first::<String>(&mut connect()?)
+        .first::<String>(&mut connect().await?)
+        .await
         .map_err(Into::into)
 }
 
 /// Set/update password hash for a user
-pub fn set_password(user_id: &UserId, password: &str) -> AppResult<()> {
+pub async fn set_password(user_id: &UserId, password: &str) -> AppResult<()> {
     let hash = crate::utils::hash_password(password)?;
     diesel::insert_into(user_passwords::table)
         .values(NewDbPassword {
@@ -57,9 +60,11 @@ pub fn set_password(user_id: &UserId, password: &str) -> AppResult<()> {
             hash: hash.to_owned(),
             created_at: UnixMillis::now(),
         })
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     diesel::update(users::table.find(user_id))
         .set(users::is_guest.eq(false))
-        .execute(&mut connect()?)?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }

--- a/crates/server/src/user/presence.rs
+++ b/crates/server/src/user/presence.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::core::federation::transaction::Edu;
 use crate::core::presence::{PresenceContent, PresenceState, PresenceUpdate};
@@ -9,14 +10,14 @@ use crate::data::user::{NewDbPresence, last_presence};
 use crate::{AppResult, config, data, sending};
 
 /// Resets the presence timeout, so the user will stay in their current presence state.
-pub fn ping_presence(user_id: &UserId, new_state: &PresenceState) -> AppResult<()> {
+pub async fn ping_presence(user_id: &UserId, new_state: &PresenceState) -> AppResult<()> {
     if !config::get().presence.allow_local {
         return Ok(());
     }
 
     const REFRESH_TIMEOUT: u64 = 60 * 1000;
 
-    let last_presence = last_presence(user_id);
+    let last_presence = last_presence(user_id).await;
     let state_changed = match last_presence {
         Err(_) => true,
         Ok(ref presence) => presence.content.presence != *new_state,
@@ -51,12 +52,13 @@ pub fn ping_presence(user_id: &UserId, new_state: &PresenceState) -> AppResult<(
             occur_sn: None,
         },
         false,
-    )?;
+    )
+    .await?;
     Ok(())
 }
 
 /// Adds a presence event which will be saved until a new event replaces it.
-pub fn set_presence(
+pub async fn set_presence(
     sender_id: &UserId,
     presence_state: Option<PresenceState>,
     status_msg: Option<String>,
@@ -67,7 +69,7 @@ pub fn set_presence(
     }
 
     let Some(presence_state) = presence_state else {
-        data::user::remove_presence(sender_id)?;
+        data::user::remove_presence(sender_id).await?;
         return Ok(false);
     };
     let db_presence = NewDbPresence {
@@ -82,7 +84,7 @@ pub fn set_presence(
         occur_sn: None,
     };
 
-    let state_changed = data::user::set_presence(db_presence, force)?;
+    let state_changed = data::user::set_presence(db_presence, force).await?;
     if state_changed {
         let edu = Edu::Presence(PresenceContent {
             push: vec![PresenceUpdate {
@@ -94,14 +96,15 @@ pub fn set_presence(
             }],
         });
 
-        let joined_rooms = data::user::joined_rooms(sender_id)?;
+        let joined_rooms = data::user::joined_rooms(sender_id).await?;
         let remote_servers = room_joined_servers::table
             .filter(room_joined_servers::room_id.eq_any(joined_rooms))
             .select(room_joined_servers::server_id)
             .distinct()
-            .load::<OwnedServerName>(&mut connect()?)?;
+            .load::<OwnedServerName>(&mut connect().await?)
+            .await?;
 
-        sending::send_edu_servers(remote_servers.into_iter(), &edu)?;
+        sending::send_edu_servers(remote_servers.into_iter(), &edu).await?;
     }
 
     Ok(state_changed)

--- a/crates/server/src/user/pusher.rs
+++ b/crates/server/src/user/pusher.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use palpo_core::push::PusherIds;
 use url::Url;
 
@@ -19,7 +20,7 @@ use crate::event::PduEvent;
 use crate::utils::url_guard;
 use crate::{AppError, AppResult, AuthedInfo, data, room, sending};
 
-pub fn set_pusher(authed: &AuthedInfo, pusher: PusherAction) -> AppResult<()> {
+pub async fn set_pusher(authed: &AuthedInfo, pusher: PusherAction) -> AppResult<()> {
     match pusher {
         PusherAction::Post(data) => {
             let PusherPostData {
@@ -42,7 +43,8 @@ pub fn set_pusher(authed: &AuthedInfo, pusher: PusherAction) -> AppResult<()> {
                         .filter(user_pushers::pushkey.eq(&pushkey))
                         .filter(user_pushers::app_id.eq(&app_id)),
                 )
-                .execute(&mut connect()?)?;
+                .execute(&mut connect().await?)
+                .await?;
             }
             diesel::insert_into(user_pushers::table)
                 .values(&NewDbPusher {
@@ -60,7 +62,8 @@ pub fn set_pusher(authed: &AuthedInfo, pusher: PusherAction) -> AppResult<()> {
                     enabled: true, // TODO
                     created_at: UnixMillis::now(),
                 })
-                .execute(&mut connect()?)?;
+                .execute(&mut connect().await?)
+                .await?;
         }
         PusherAction::Delete(ids) => {
             diesel::delete(
@@ -69,7 +72,8 @@ pub fn set_pusher(authed: &AuthedInfo, pusher: PusherAction) -> AppResult<()> {
                     .filter(user_pushers::pushkey.eq(ids.pushkey))
                     .filter(user_pushers::app_id.eq(ids.app_id)),
             )
-            .execute(&mut connect()?)?;
+            .execute(&mut connect().await?)
+            .await?;
         }
     }
     Ok(())
@@ -249,8 +253,8 @@ async fn send_notice(
                         event.state_key.as_deref() == Some(event.sender.as_str());
                 }
                 notification.sender_display_name =
-                    data::user::display_name(&event.sender).ok().flatten();
-                notification.room_name = room::get_name(&event.room_id).ok();
+                    data::user::display_name(&event.sender).await.ok().flatten();
+                notification.room_name = room::get_name(&event.room_id).await.ok();
 
                 crate::sending::post(url)
                     .stuff(SendEventNotificationReqBody::new(notification))?

--- a/crates/server/src/watcher.rs
+++ b/crates/server/src/watcher.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 use std::time::Duration;
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use futures_util::StreamExt;
 use futures_util::stream::FuturesUnordered;
 
@@ -13,7 +14,7 @@ use crate::data::schema::*;
 use crate::data::{self, connect};
 
 pub async fn watch(user_id: &UserId, device_id: &DeviceId) -> AppResult<()> {
-    let mut conn = connect()?;
+    let mut conn = connect().await?;
 
     let inbox_id = device_inboxes::table
         .filter(device_inboxes::user_id.eq(user_id))
@@ -21,27 +22,31 @@ pub async fn watch(user_id: &UserId, device_id: &DeviceId) -> AppResult<()> {
         .order_by(device_inboxes::id.desc())
         .select(device_inboxes::id)
         .first::<i64>(&mut conn)
+        .await
         .unwrap_or_default();
     let key_change_id = e2e_key_changes::table
         .filter(e2e_key_changes::user_id.eq(user_id))
         .order_by(e2e_key_changes::id.desc())
         .select(e2e_key_changes::id)
         .first::<i64>(&mut conn)
+        .await
         .unwrap_or_default();
     let room_user_id = room_users::table
         .filter(room_users::user_id.eq(user_id))
         .order_by(room_users::id.desc())
         .select(room_users::id)
         .first::<i64>(&mut conn)
+        .await
         .unwrap_or_default();
 
-    let room_ids = data::user::joined_rooms(user_id)?;
+    let room_ids = data::user::joined_rooms(user_id).await?;
     let last_event_sn = event_points::table
         .filter(event_points::room_id.eq_any(&room_ids))
         .filter(event_points::frame_id.is_not_null())
         .order_by(event_points::event_sn.desc())
         .select(event_points::event_sn)
         .first::<Seqnum>(&mut conn)
+        .await
         .unwrap_or_default();
 
     let push_rule_sn = user_datas::table
@@ -49,6 +54,7 @@ pub async fn watch(user_id: &UserId, device_id: &DeviceId) -> AppResult<()> {
         .order_by(user_datas::occur_sn.desc())
         .select(user_datas::occur_sn)
         .first::<i64>(&mut conn)
+        .await
         .unwrap_or_default();
 
     // Get the current max typing occur_sn for this user's rooms
@@ -56,6 +62,7 @@ pub async fn watch(user_id: &UserId, device_id: &DeviceId) -> AppResult<()> {
         .filter(room_typings::room_id.eq_any(&room_ids))
         .select(diesel::dsl::max(room_typings::occur_sn))
         .first::<Option<i64>>(&mut conn)
+        .await
         .unwrap_or(None)
         .unwrap_or_default();
 
@@ -79,7 +86,7 @@ pub async fn watch(user_id: &UserId, device_id: &DeviceId) -> AppResult<()> {
             tokio::time::sleep(POLL_INTERVAL).await;
 
             // Re-fetch room_ids to handle joins/leaves during the wait
-            let current_room_ids = match data::user::joined_rooms(user_id) {
+            let current_room_ids = match data::user::joined_rooms(user_id).await {
                 Ok(ids) => ids,
                 Err(e) => {
                     tracing::warn!("watcher: failed to fetch joined rooms: {e}");
@@ -87,13 +94,14 @@ pub async fn watch(user_id: &UserId, device_id: &DeviceId) -> AppResult<()> {
                 }
             };
 
-            let mut conn = connect()?;
+            let mut conn = connect().await?;
 
             // Check typing changes (DB-backed, works across instances)
             let new_typing_sn = room_typings::table
                 .filter(room_typings::room_id.eq_any(&current_room_ids))
                 .select(diesel::dsl::max(room_typings::occur_sn))
                 .first::<Option<i64>>(&mut conn)
+                .await
                 .unwrap_or(None)
                 .unwrap_or_default();
             if last_typing_sn < new_typing_sn {
@@ -106,6 +114,7 @@ pub async fn watch(user_id: &UserId, device_id: &DeviceId) -> AppResult<()> {
                 .order_by(device_inboxes::id.desc())
                 .select(device_inboxes::id)
                 .first::<i64>(&mut conn)
+                .await
                 .unwrap_or_default();
             if inbox_id < new_inbox_id {
                 return Ok(());
@@ -116,6 +125,7 @@ pub async fn watch(user_id: &UserId, device_id: &DeviceId) -> AppResult<()> {
                 .order_by(e2e_key_changes::id.desc())
                 .select(e2e_key_changes::id)
                 .first::<i64>(&mut conn)
+                .await
                 .unwrap_or_default();
             if key_change_id < new_key_change_id {
                 return Ok(());
@@ -126,6 +136,7 @@ pub async fn watch(user_id: &UserId, device_id: &DeviceId) -> AppResult<()> {
                 .order_by(room_users::id.desc())
                 .select(room_users::id)
                 .first::<i64>(&mut conn)
+                .await
                 .unwrap_or_default();
             if room_user_id < new_room_user_id {
                 return Ok(());
@@ -137,6 +148,7 @@ pub async fn watch(user_id: &UserId, device_id: &DeviceId) -> AppResult<()> {
                 .order_by(event_points::event_sn.desc())
                 .select(event_points::event_sn)
                 .first::<Seqnum>(&mut conn)
+                .await
                 .unwrap_or_default();
             if last_event_sn < new_event_sn {
                 return Ok(());
@@ -147,6 +159,7 @@ pub async fn watch(user_id: &UserId, device_id: &DeviceId) -> AppResult<()> {
                 .order_by(user_datas::occur_sn.desc())
                 .select(user_datas::occur_sn)
                 .first::<i64>(&mut conn)
+                .await
                 .unwrap_or_default();
             if push_rule_sn < new_push_rule_sn {
                 return Ok(());

--- a/crates/server/src/watcher.rs
+++ b/crates/server/src/watcher.rs
@@ -14,6 +14,12 @@ use crate::data::schema::*;
 use crate::data::{self, connect};
 
 pub async fn watch(user_id: &UserId, device_id: &DeviceId) -> AppResult<()> {
+    // Resolve joined rooms *before* checking out a pooled connection. This call
+    // acquires its own connection internally; doing it while `conn` below is
+    // held would pin two connections per in-flight long-poll and can exhaust
+    // the (small) pool under concurrent syncs.
+    let room_ids = data::user::joined_rooms(user_id).await?;
+
     let mut conn = connect().await?;
 
     let inbox_id = device_inboxes::table
@@ -39,7 +45,6 @@ pub async fn watch(user_id: &UserId, device_id: &DeviceId) -> AppResult<()> {
         .await
         .unwrap_or_default();
 
-    let room_ids = data::user::joined_rooms(user_id).await?;
     let last_event_sn = event_points::table
         .filter(event_points::room_id.eq_any(&room_ids))
         .filter(event_points::frame_id.is_not_null())

--- a/tests/complement/Dockerfile.github
+++ b/tests/complement/Dockerfile.github
@@ -49,7 +49,8 @@ RUN find crates -name '*.rs' -exec touch {} +
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     cargo build \
-    && cp target/debug/palpo palpo
+    && cp target/debug/palpo palpo \
+    && rm -rf target
 
 COPY tests/complement/palpo.toml palpo.toml
 COPY tests/complement/caddy.json caddy.json


### PR DESCRIPTION
## Summary

The DB layer used **synchronous diesel + r2d2**, and request handlers called `connect()` and ran queries **directly on the tokio worker threads**. Under concurrency this blocked the async runtime — `connect()` (r2d2 `.get()`) and every query stalled a worker thread, starving the executor. Symptoms in production: intermittent federation `M_UNKNOWN: timeout waiting for server response`, spurious `CORS Missing Allow Origin` errors (the browser's way of reporting dropped/hung responses), and exhaustion of the small per-tenant pool (`pool_size = 10`).

This migrates the entire stack to **async DB access** so `connect()` and queries no longer block worker threads.

## What changed

**Pool / infrastructure**
- Replace r2d2 `Pool<ConnectionManager<PgConnection>>` with diesel-async **deadpool** `Pool<AsyncPgConnection>`. `connect()` is now `async`.
- `statement_timeout` moved into the deadpool `custom_setup` hook (replacing the r2d2 `CustomizeConnection`); `connection_timeout` maps to deadpool's wait/create/recycle timeouts.
- Migrations run on a one-off **synchronous** `PgConnection::establish` (diesel migrations are sync-only), which also serves as a fail-fast startup connectivity check.

**Data + server crates**
- `.await` every query terminal; make all DB-touching functions `async`; propagate `.await` up to the (already-async) handlers.
- Convert the 5 transactions to diesel-async 0.9 `async |conn|` closures (0.9 dropped `scope_boxed`).
- `diesel_exists!` macro now awaits internally.
- Bump `recursion_limit` to 512 for the deeply nested async future types.

**Dependencies**
- Add `diesel-async 0.9` (postgres) to the data + server crates; add `deadpool 0.13` (managed, rt_tokio_1) to the data crate.
- Drop the diesel `r2d2` feature and `scheduled-thread-pool` from the data crate.

## Stats
168 files changed, ~5k insertions / ~3.5k deletions.

## Reviewer notes / follow-ups
- ⚠️ **Compile-verified only** — `cargo check --workspace --all-targets` is clean (0 errors, 0 warnings), but this has **not been run against a live Postgres**. Runtime + integration testing is the next step.
- ⚠️ **`event/resolver.rs`** bridges `palpo_core`'s **synchronous** `resolve` callback with `block_in_place` + `Handle::block_on` (2 sites). It compiles, but carries a deadlock risk under pool exhaustion; the proper fix is to make `core::state::resolve` accept an async callback (larger change, intentionally out of scope here). Worth a close look.
- **TLS-to-Postgres** (`enforce_tls`) is not yet supported by the async pool — `AsyncPgConnection` uses tokio-postgres/`NoTls`. It is `false` by default and unused in current deployments; needs a TLS connector if ever enabled.
- `min_idle` / `helper_threads` config fields are now unused (deadpool's model differs); kept for config back-compat.

## Test plan
- [ ] Build and run against a Postgres instance; smoke-test login, sync (incl. long-poll `/sync` and sliding sync), send message, profile fetch, federation join.
- [ ] Verify `statement_timeout` is applied on pooled connections.
- [ ] Load-test concurrent sync to confirm worker threads no longer block on DB and the pool no longer exhausts under modest load.
- [ ] Exercise the `event/resolver.rs` state-resolution path (federated room with conflicting state) and watch for stalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)