### PR TITLE
Stop masking room alias resolution failures as M_NOT_FOUND

### DIFF
--- a/crates/server/src/room/alias/remote.rs
+++ b/crates/server/src/room/alias/remote.rs
@@ -1,6 +1,6 @@
 use crate::core::federation::query::{RoomInfoResBody, directory_request};
 use crate::core::identifiers::*;
-use crate::{AppResult, GetUrlOrigin, MatrixError};
+use crate::{AppError, AppResult, GetUrlOrigin, MatrixError};
 
 pub(super) async fn remote_resolve(
     room_alias: &RoomAliasId,
@@ -11,9 +11,13 @@ pub(super) async fn remote_resolve(
 
     let mut resolved_servers = Vec::new();
     let mut resolved_room_id: Option<OwnedRoomId> = None;
+    let mut last_error: Option<AppError> = None;
     for server in servers {
         match remote_request(room_alias, &server).await {
-            Err(e) => tracing::error!("Failed to query for {room_alias:?} from {server}: {e}"),
+            Err(e) => {
+                tracing::error!("Failed to query for {room_alias:?} from {server}: {e}");
+                last_error = Some(e);
+            }
             Ok(RoomInfoResBody { room_id, servers }) => {
                 debug!(
                     "Server {server} answered with {room_id:?} for {room_alias:?} servers: \
@@ -30,11 +34,15 @@ pub(super) async fn remote_resolve(
         }
     }
 
-    resolved_room_id
-        .map(|room_id| (room_id, resolved_servers))
-        .ok_or_else(|| {
+    match resolved_room_id {
+        Some(room_id) => Ok((room_id, resolved_servers)),
+        // Surface the actual failure from the last queried server (e.g. a transport or
+        // signature error) so it is not masked as a plain "not found". Only fall back to
+        // the generic message when no server produced an error to report.
+        None => Err(last_error.unwrap_or_else(|| {
             MatrixError::not_found("No servers could assist in resolving the room alias").into()
-        })
+        })),
+    }
 }
 
 async fn remote_request(

--- a/crates/server/src/room/alias/remote.rs
+++ b/crates/server/src/room/alias/remote.rs
@@ -16,7 +16,13 @@ pub(super) async fn remote_resolve(
         match remote_request(room_alias, &server).await {
             Err(e) => {
                 tracing::error!("Failed to query for {room_alias:?} from {server}: {e}");
-                last_error = Some(e);
+                // Keep the most informative failure across candidate servers: a
+                // transport/signature/internal error from one server must not be
+                // overwritten by a later not-found, otherwise the client path would
+                // re-mask it as "Room with alias not found" depending on server order.
+                if !e.is_not_found() || last_error.as_ref().is_none_or(AppError::is_not_found) {
+                    last_error = Some(e);
+                }
             }
             Ok(RoomInfoResBody { room_id, servers }) => {
                 debug!(

--- a/crates/server/src/routing/client/directory/alias.rs
+++ b/crates/server/src/routing/client/directory/alias.rs
@@ -20,8 +20,16 @@ pub(super) async fn get_alias(
     room_alias: PathParam<OwnedRoomAliasId>,
 ) -> JsonResult<AliasResBody> {
     let room_alias = room_alias.into_inner();
-    let Ok((room_id, servers)) = crate::room::resolve_alias(&room_alias, None).await else {
-        return Err(MatrixError::not_found("Room with alias not found.").into());
+    let (room_id, servers) = match crate::room::resolve_alias(&room_alias, None).await {
+        Ok(resolved) => resolved,
+        // A genuinely unknown alias is reported as a clean `M_NOT_FOUND`, but any other
+        // failure (federation transport, signature rejection, internal error, ...) is
+        // propagated as-is so it stays visible to the client and in the logs instead of
+        // being masked as "room does not exist".
+        Err(e) if e.is_not_found() => {
+            return Err(MatrixError::not_found("Room with alias not found.").into());
+        }
+        Err(e) => return Err(e),
     };
     let servers = crate::room::room_available_servers(&room_id, &room_alias, servers).await?;
     debug!(?room_alias, ?room_id, "available servers: {servers:?}");


### PR DESCRIPTION
## Problem

A real deployment hit this: querying `GET /_matrix/client/v3/directory/room/#test:mudan.meldry.com` against another server (`taohua.meldry.com`) returned:

```json
{"errcode":"M_NOT_FOUND","error":"Room with alias not found."}
```

even when investigating a remote alias whose home server is reachable. The status code is the same regardless of whether the alias is genuinely unknown or the federation lookup failed for some other reason (transport error, signature rejection, internal error), so the failure is impossible to diagnose from the client side.

## Root cause

The alias resolution path swallowed errors in two places:

1. `get_alias` (`directory/alias.rs`) used `let Ok(..) = resolve_alias(..) else { return M_NOT_FOUND }`, discarding the real error and replacing it with a generic "Room with alias not found.".
2. `remote_resolve` (`room/alias/remote.rs`) logged each per-server federation error but discarded it, returning a generic "No servers could assist" not-found when nothing resolved.

So a federation transport/signature failure was reported to the client identically to a genuinely missing alias.

## Fix

- `get_alias` now propagates the real error and only maps a genuine not-found (`AppError::is_not_found()`) to the clean `M_NOT_FOUND` message.
- `remote_resolve` keeps the last underlying per-server error and returns it when no room could be resolved, so transport/signature failures surface with their real status and message.

## Receiving side

Verified the inbound federation handler `GET /_matrix/federation/v1/query/directory` (`routing/federation/query.rs`) is correct: an unknown local alias produces a diesel `NotFound`, which `error.rs` maps to a proper `404 M_NOT_FOUND` for GET requests. A genuinely missing alias therefore still reports as not found end to end; only non-not-found failures are now distinguishable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)