### PR TITLE
Surface real error detail instead of opaque M_UNKNOWN

### DIFF
--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -228,7 +228,15 @@ impl Writer for AppError {
                         | Self::Send(_)
                         | Self::OpenDal(_)
                 );
-                let mut matrix = MatrixError::unknown(e.to_string());
+                // A reqwest error's Display embeds the request URL, which for appservice
+                // requests carries the homeserver `access_token` query parameter. Strip
+                // the URL before it can reach a client; the full value is still logged
+                // above via `tracing::error!`.
+                let message = match e {
+                    Self::Reqwest(err) => format!("reqwest error: {}", err.without_url()),
+                    other => other.to_string(),
+                };
+                let mut matrix = MatrixError::unknown(message);
                 if is_upstream {
                     // Failures talking to an upstream (federation peer, object store,
                     // db pool) are gateway errors, not malformed client requests.

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -152,8 +152,8 @@ impl Writer for AppError {
             Self::FrequentlyRequest => MatrixError::unknown("frequently request resource"),
             Self::Public(msg) => MatrixError::unknown(msg),
             Self::Internal(msg) => {
-                error!(error = ?msg, "internal error");
-                MatrixError::unknown("unknown error")
+                error!(error = %msg, "internal error");
+                MatrixError::unknown(format!("internal error: {msg}"))
             }
             // Self::LocalUnableProcess(msg) => MatrixError::unrecognized(msg),
             Self::Matrix(e) => e,
@@ -215,8 +215,26 @@ impl Writer for AppError {
                 return;
             }
             e => {
-                tracing::error!(error = ?e, "unknown error");
-                MatrixError::unknown("unknown error happened")
+                // These are unexpected errors that aren't mapped to a specific Matrix
+                // error. Log the full detail at error level and surface the underlying
+                // message to the caller instead of an opaque "unknown error happened",
+                // so federation/transport/internal failures are actually diagnosable.
+                tracing::error!(error = ?e, error_display = %e, "unhandled application error");
+                let is_upstream = matches!(
+                    e,
+                    Self::Reqwest(_)
+                        | Self::ReqwestMiddleware(_)
+                        | Self::Pool(_)
+                        | Self::Send(_)
+                        | Self::OpenDal(_)
+                );
+                let mut matrix = MatrixError::unknown(e.to_string());
+                if is_upstream {
+                    // Failures talking to an upstream (federation peer, object store,
+                    // db pool) are gateway errors, not malformed client requests.
+                    matrix.status_code = Some(StatusCode::BAD_GATEWAY);
+                }
+                matrix
             }
         };
         matrix.write(req, depot, res).await;


### PR DESCRIPTION
## Problem

Follow-up to #215. After that PR stopped masking alias-resolution failures, a federation directory lookup that fails surfaced to the client as:

```json
{"errcode":"M_UNKNOWN","error":"unknown error happened"}
```

with HTTP 400 and no usable detail. The cause: the catch-all arm of `AppError`'s `Writer` impl (`crates/server/src/error.rs`) maps *every* unhandled error variant to a fixed `MatrixError::unknown("unknown error happened")`. The real failure here is an `AppError::Reqwest` — a transport error from one homeserver trying to reach another over federation — which is not one of the explicitly-handled variants, so it falls through and its detail is discarded.

## Fix

- **Catch-all** now logs the full error at `error` level (both `Debug` and `Display`) and puts the underlying error message into the response body instead of a fixed string, so federation/transport/internal failures are actually diagnosable from the client and the logs.
- **Upstream/transport failures** (`Reqwest`, `ReqwestMiddleware`, `Pool`, `Send`, `OpenDal`) now return **502 Bad Gateway** rather than a misleading 400 — these are gateway errors, not malformed client requests.
- The **`Internal`** arm likewise surfaces its message and logs it at `error` level.

## Note on exposing internals

This intentionally includes the underlying error string in the response for the `M_UNKNOWN` bucket (already reserved for unexpected errors; Synapse behaves similarly). That is the desired behaviour for diagnosing a live deployment. If leaking internal detail to clients is a concern, a follow-up could gate the message behind a config flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)