### PR TITLE
feat(federation): live federated peeking (MSC2444 + MSC2753)

### DIFF
--- a/crates/core/src/client/sync_events/v3.rs
+++ b/crates/core/src/client/sync_events/v3.rs
@@ -187,6 +187,16 @@ pub struct Rooms {
     /// The rooms that the user has knocked on.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub knock: BTreeMap<OwnedRoomId, KnockedRoom>,
+
+    /// The rooms that the user is peeking (MSC2753). Peeked rooms use the same
+    /// shape as joined rooms but the user is not a member; they appear here for
+    /// as long as the peek is active.
+    #[serde(
+        default,
+        rename = "org.matrix.msc2753.peek",
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
+    pub peek: BTreeMap<OwnedRoomId, JoinedRoom>,
 }
 
 impl Rooms {
@@ -201,6 +211,7 @@ impl Rooms {
             && self.join.is_empty()
             && self.invite.is_empty()
             && self.knock.is_empty()
+            && self.peek.is_empty()
     }
 }
 

--- a/crates/core/src/federation/peek.rs
+++ b/crates/core/src/federation/peek.rs
@@ -58,3 +58,89 @@ pub struct PeekResBody {
     #[salvo(schema(value_type = Vec<Object>))]
     pub messages: Vec<Box<RawJsonValue>>,
 }
+
+// ===========================================================================
+// MSC2444 ongoing peek subscription.
+//
+// Unlike the one-shot GET snapshot above, this establishes a *subscription*: the
+// resident server records the peeking server and forwards new room events to it
+// (via the normal /send transaction path) until the peek expires or is
+// cancelled. The peeking server must renew before `renewal_interval` elapses.
+//
+//   PUT    /_matrix/federation/v1/peek/{room_id}/{peek_id}   start / renew
+//   DELETE /_matrix/federation/v1/peek/{room_id}/{peek_id}   cancel
+// ===========================================================================
+
+/// Build the request to start or renew an ongoing peek subscription.
+pub fn peek_start_request(
+    origin: &str,
+    room_id: &RoomId,
+    peek_id: &str,
+    ver: &[RoomVersionId],
+) -> SendResult<SendRequest> {
+    let mut url = Url::parse(&format!(
+        "{origin}/_matrix/federation/v1/peek/{room_id}/{peek_id}"
+    ))?;
+    for v in ver {
+        url.query_pairs_mut().append_pair("ver", v.as_str());
+    }
+    let mut request = crate::sending::put(url);
+    // Empty JSON body, like other federation PUTs.
+    *request.body_mut() = Some(b"{}".to_vec().into());
+    Ok(request)
+}
+
+/// Build the request to cancel an ongoing peek subscription.
+pub fn peek_cancel_request(
+    origin: &str,
+    room_id: &RoomId,
+    peek_id: &str,
+) -> SendResult<SendRequest> {
+    let url = Url::parse(&format!(
+        "{origin}/_matrix/federation/v1/peek/{room_id}/{peek_id}"
+    ))?;
+    Ok(crate::sending::delete(url))
+}
+
+/// Path/query args for the peek subscription endpoints.
+#[derive(ToParameters, Deserialize, Debug)]
+pub struct PeekSubReqArgs {
+    /// The room to peek.
+    #[salvo(parameter(parameter_in = Path))]
+    pub room_id: OwnedRoomId,
+
+    /// A peer-chosen opaque id identifying this peek subscription.
+    #[salvo(parameter(parameter_in = Path))]
+    pub peek_id: String,
+
+    /// Room versions the peeking server supports (advisory).
+    #[salvo(parameter(parameter_in = Query))]
+    #[serde(default)]
+    pub ver: Vec<RoomVersionId>,
+}
+
+/// Response to starting/renewing an ongoing peek. Mirrors a send_join response
+/// (full current state + backing auth chain) so the peeking server can build a
+/// complete local copy of the room, plus a renewal deadline.
+#[derive(ToSchema, Serialize, Deserialize, Debug)]
+pub struct PeekStartResBody {
+    /// The version of the room being peeked.
+    pub room_version: RoomVersionId,
+
+    /// The full resolved current state of the room.
+    #[salvo(schema(value_type = Vec<Object>))]
+    pub state: Vec<Box<RawJsonValue>>,
+
+    /// The auth chain backing `state`, recursively.
+    #[salvo(schema(value_type = Vec<Object>))]
+    pub auth_chain: Vec<Box<RawJsonValue>>,
+
+    /// A page of recent timeline events, newest last, to seed the timeline.
+    #[salvo(schema(value_type = Vec<Object>))]
+    pub messages: Vec<Box<RawJsonValue>>,
+
+    /// Milliseconds within which the peeking server must renew, else the
+    /// resident server will drop the subscription.
+    pub renewal_interval: u64,
+}
+

--- a/crates/data/migrations/2026-05-29-000001_room_peeks/down.sql
+++ b/crates/data/migrations/2026-05-29-000001_room_peeks/down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_room_peeks_renew;
+DROP TABLE IF EXISTS room_peeks;
+DROP INDEX IF EXISTS idx_room_peeking_servers_renew;
+DROP INDEX IF EXISTS idx_room_peeking_servers_room;
+DROP TABLE IF EXISTS room_peeking_servers;

--- a/crates/data/migrations/2026-05-29-000001_room_peeks/up.sql
+++ b/crates/data/migrations/2026-05-29-000001_room_peeks/up.sql
@@ -1,0 +1,29 @@
+-- MSC2444 federated peeking.
+
+-- Remote servers that are actively peeking one of OUR rooms (resident side).
+-- We deliver new room events to these servers until the peek expires (unless
+-- renewed) or is cancelled.
+CREATE TABLE room_peeking_servers (
+    id BIGSERIAL NOT NULL PRIMARY KEY,
+    room_id TEXT NOT NULL,
+    server_id TEXT NOT NULL,
+    peek_id TEXT NOT NULL,
+    renew_at BIGINT NOT NULL,
+    created_at BIGINT NOT NULL,
+    UNIQUE (room_id, server_id, peek_id)
+);
+CREATE INDEX idx_room_peeking_servers_room ON room_peeking_servers(room_id);
+CREATE INDEX idx_room_peeking_servers_renew ON room_peeking_servers(renew_at);
+
+-- Outbound peeks WE hold on remote rooms (peeking side). One active peek per
+-- room for this server; local users share it. We renew before renew_at.
+CREATE TABLE room_peeks (
+    id BIGSERIAL NOT NULL PRIMARY KEY,
+    room_id TEXT NOT NULL,
+    peek_id TEXT NOT NULL,
+    target_server TEXT NOT NULL,
+    renew_at BIGINT NOT NULL,
+    created_at BIGINT NOT NULL,
+    UNIQUE (room_id)
+);
+CREATE INDEX idx_room_peeks_renew ON room_peeks(renew_at);

--- a/crates/data/migrations/2026-05-29-000002_user_peeks/down.sql
+++ b/crates/data/migrations/2026-05-29-000002_user_peeks/down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_user_peeks_room;
+DROP INDEX IF EXISTS idx_user_peeks_user;
+DROP TABLE IF EXISTS user_peeks;

--- a/crates/data/migrations/2026-05-29-000002_user_peeks/up.sql
+++ b/crates/data/migrations/2026-05-29-000002_user_peeks/up.sql
@@ -1,12 +1,16 @@
--- MSC2753 client-side peeking: which local users are peeking which rooms.
--- A user peek implies a server-level federation peek (room_peeks) for remote
--- rooms; the last user peek leaving a room lets us drop that subscription.
+-- MSC2753 client-side peeking: which local user *devices* are peeking which
+-- rooms. Peeks are per-device (a client decides what to peek), so one device's
+-- peek/unpeek must not affect another device of the same account. A user peek
+-- implies a server-level federation peek (room_peeks) for remote rooms; the
+-- last user-device peek leaving a room lets us drop that subscription.
 CREATE TABLE user_peeks (
     id BIGSERIAL NOT NULL PRIMARY KEY,
     user_id TEXT NOT NULL,
+    device_id TEXT NOT NULL,
     room_id TEXT NOT NULL,
     created_at BIGINT NOT NULL,
-    UNIQUE (user_id, room_id)
+    UNIQUE (user_id, device_id, room_id)
 );
 CREATE INDEX idx_user_peeks_user ON user_peeks(user_id);
+CREATE INDEX idx_user_peeks_user_device ON user_peeks(user_id, device_id);
 CREATE INDEX idx_user_peeks_room ON user_peeks(room_id);

--- a/crates/data/migrations/2026-05-29-000002_user_peeks/up.sql
+++ b/crates/data/migrations/2026-05-29-000002_user_peeks/up.sql
@@ -1,0 +1,12 @@
+-- MSC2753 client-side peeking: which local users are peeking which rooms.
+-- A user peek implies a server-level federation peek (room_peeks) for remote
+-- rooms; the last user peek leaving a room lets us drop that subscription.
+CREATE TABLE user_peeks (
+    id BIGSERIAL NOT NULL PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    room_id TEXT NOT NULL,
+    created_at BIGINT NOT NULL,
+    UNIQUE (user_id, room_id)
+);
+CREATE INDEX idx_user_peeks_user ON user_peeks(user_id);
+CREATE INDEX idx_user_peeks_room ON user_peeks(room_id);

--- a/crates/data/src/room.rs
+++ b/crates/data/src/room.rs
@@ -11,6 +11,7 @@ use crate::{DataResult, connect};
 
 pub mod event;
 pub mod event_report;
+pub mod peek;
 pub mod receipt;
 pub mod timeline;
 pub use event_report::*;

--- a/crates/data/src/room/peek.rs
+++ b/crates/data/src/room/peek.rs
@@ -1,0 +1,189 @@
+//! Persistence for MSC2444 federated peeking.
+//!
+//! Two independent concerns:
+//! - `room_peeking_servers`: remote servers peeking one of *our* rooms (resident
+//!   side). New events are delivered to them until their peek expires/cancels.
+//! - `room_peeks`: outbound peeks *we* hold on remote rooms (peeking side),
+//!   renewed before `renew_at`.
+
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+
+use crate::core::identifiers::*;
+use crate::core::UnixMillis;
+use crate::schema::*;
+use crate::{DataResult, connect};
+
+#[derive(Identifiable, Queryable, Debug, Clone)]
+#[diesel(table_name = room_peeking_servers)]
+pub struct DbPeekingServer {
+    pub id: i64,
+    pub room_id: OwnedRoomId,
+    pub server_id: OwnedServerName,
+    pub peek_id: String,
+    pub renew_at: i64,
+    pub created_at: i64,
+}
+
+#[derive(Identifiable, Queryable, Debug, Clone)]
+#[diesel(table_name = room_peeks)]
+pub struct DbRoomPeek {
+    pub id: i64,
+    pub room_id: OwnedRoomId,
+    pub peek_id: String,
+    pub target_server: OwnedServerName,
+    pub renew_at: i64,
+    pub created_at: i64,
+}
+
+// ---------------------------------------------------------------------------
+// Resident side: remote servers peeking our rooms.
+// ---------------------------------------------------------------------------
+
+/// Register or renew a remote server's peek on one of our rooms. `renew_at` is
+/// the unix-millis deadline by which the peer must renew or the peek lapses.
+pub async fn upsert_peeking_server(
+    room_id: &RoomId,
+    server: &ServerName,
+    peek_id: &str,
+    renew_at: i64,
+) -> DataResult<()> {
+    let now = UnixMillis::now().get() as i64;
+    diesel::insert_into(room_peeking_servers::table)
+        .values((
+            room_peeking_servers::room_id.eq(room_id),
+            room_peeking_servers::server_id.eq(server),
+            room_peeking_servers::peek_id.eq(peek_id),
+            room_peeking_servers::renew_at.eq(renew_at),
+            room_peeking_servers::created_at.eq(now),
+        ))
+        .on_conflict((
+            room_peeking_servers::room_id,
+            room_peeking_servers::server_id,
+            room_peeking_servers::peek_id,
+        ))
+        .do_update()
+        .set(room_peeking_servers::renew_at.eq(renew_at))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Cancel a specific peek a remote server holds on one of our rooms.
+pub async fn remove_peeking_server(
+    room_id: &RoomId,
+    server: &ServerName,
+    peek_id: &str,
+) -> DataResult<()> {
+    diesel::delete(
+        room_peeking_servers::table
+            .filter(room_peeking_servers::room_id.eq(room_id))
+            .filter(room_peeking_servers::server_id.eq(server))
+            .filter(room_peeking_servers::peek_id.eq(peek_id)),
+    )
+    .execute(&mut connect().await?)
+    .await?;
+    Ok(())
+}
+
+/// Distinct servers with a non-expired peek on the given room (`renew_at` in the
+/// future relative to `now_ms`). These are extra destinations for room events.
+pub async fn active_peeking_servers(
+    room_id: &RoomId,
+    now_ms: i64,
+) -> DataResult<Vec<OwnedServerName>> {
+    let mut servers = room_peeking_servers::table
+        .filter(room_peeking_servers::room_id.eq(room_id))
+        .filter(room_peeking_servers::renew_at.gt(now_ms))
+        .select(room_peeking_servers::server_id)
+        .load::<OwnedServerName>(&mut connect().await?)
+        .await?;
+    servers.sort_unstable();
+    servers.dedup();
+    Ok(servers)
+}
+
+/// Delete peeks (held by remote servers on our rooms) that lapsed before
+/// `now_ms`. Returns the number of rows removed.
+pub async fn purge_expired_peeking_servers(now_ms: i64) -> DataResult<usize> {
+    let removed = diesel::delete(
+        room_peeking_servers::table.filter(room_peeking_servers::renew_at.le(now_ms)),
+    )
+    .execute(&mut connect().await?)
+    .await?;
+    Ok(removed)
+}
+
+// ---------------------------------------------------------------------------
+// Peeking side: outbound peeks we hold on remote rooms.
+// ---------------------------------------------------------------------------
+
+/// Record or refresh our outbound peek on a remote room (one per room).
+pub async fn upsert_peek(
+    room_id: &RoomId,
+    peek_id: &str,
+    target_server: &ServerName,
+    renew_at: i64,
+) -> DataResult<()> {
+    let now = UnixMillis::now().get() as i64;
+    diesel::insert_into(room_peeks::table)
+        .values((
+            room_peeks::room_id.eq(room_id),
+            room_peeks::peek_id.eq(peek_id),
+            room_peeks::target_server.eq(target_server),
+            room_peeks::renew_at.eq(renew_at),
+            room_peeks::created_at.eq(now),
+        ))
+        .on_conflict(room_peeks::room_id)
+        .do_update()
+        .set((
+            room_peeks::peek_id.eq(peek_id),
+            room_peeks::target_server.eq(target_server),
+            room_peeks::renew_at.eq(renew_at),
+        ))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Our active outbound peek on a room, if any.
+pub async fn get_peek(room_id: &RoomId) -> DataResult<Option<DbRoomPeek>> {
+    let peek = room_peeks::table
+        .filter(room_peeks::room_id.eq(room_id))
+        .first::<DbRoomPeek>(&mut connect().await?)
+        .await
+        .optional()?;
+    Ok(peek)
+}
+
+/// Whether we currently hold an outbound peek on the room.
+pub async fn is_peeked(room_id: &RoomId) -> DataResult<bool> {
+    Ok(get_peek(room_id).await?.is_some())
+}
+
+/// Drop our outbound peek on a room.
+pub async fn remove_peek(room_id: &RoomId) -> DataResult<()> {
+    diesel::delete(room_peeks::table.filter(room_peeks::room_id.eq(room_id)))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Outbound peeks whose renewal deadline is at or before `now_ms` — these need
+/// to be renewed (or dropped if the remote refuses).
+pub async fn peeks_due_for_renewal(now_ms: i64) -> DataResult<Vec<DbRoomPeek>> {
+    let peeks = room_peeks::table
+        .filter(room_peeks::renew_at.le(now_ms))
+        .load::<DbRoomPeek>(&mut connect().await?)
+        .await?;
+    Ok(peeks)
+}
+
+/// All rooms we currently peek (for sync inclusion).
+pub async fn peeked_room_ids() -> DataResult<Vec<OwnedRoomId>> {
+    let rooms = room_peeks::table
+        .select(room_peeks::room_id)
+        .load::<OwnedRoomId>(&mut connect().await?)
+        .await?;
+    Ok(rooms)
+}

--- a/crates/data/src/room/peek.rs
+++ b/crates/data/src/room/peek.rs
@@ -187,3 +187,54 @@ pub async fn peeked_room_ids() -> DataResult<Vec<OwnedRoomId>> {
         .await?;
     Ok(rooms)
 }
+
+// ---------------------------------------------------------------------------
+// MSC2753 client-side peeking: which local users peek which rooms.
+// ---------------------------------------------------------------------------
+
+/// Record that a local user is peeking a room (idempotent).
+pub async fn add_user_peek(user_id: &UserId, room_id: &RoomId) -> DataResult<()> {
+    let now = UnixMillis::now().get() as i64;
+    diesel::insert_into(user_peeks::table)
+        .values((
+            user_peeks::user_id.eq(user_id),
+            user_peeks::room_id.eq(room_id),
+            user_peeks::created_at.eq(now),
+        ))
+        .on_conflict_do_nothing()
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Stop a local user peeking a room.
+pub async fn remove_user_peek(user_id: &UserId, room_id: &RoomId) -> DataResult<()> {
+    diesel::delete(
+        user_peeks::table
+            .filter(user_peeks::user_id.eq(user_id))
+            .filter(user_peeks::room_id.eq(room_id)),
+    )
+    .execute(&mut connect().await?)
+    .await?;
+    Ok(())
+}
+
+/// Rooms a local user is currently peeking.
+pub async fn user_peeked_rooms(user_id: &UserId) -> DataResult<Vec<OwnedRoomId>> {
+    let rooms = user_peeks::table
+        .filter(user_peeks::user_id.eq(user_id))
+        .select(user_peeks::room_id)
+        .load::<OwnedRoomId>(&mut connect().await?)
+        .await?;
+    Ok(rooms)
+}
+
+/// Number of local users currently peeking a room.
+pub async fn room_peeker_count(room_id: &RoomId) -> DataResult<i64> {
+    let count: i64 = user_peeks::table
+        .filter(user_peeks::room_id.eq(room_id))
+        .count()
+        .get_result(&mut connect().await?)
+        .await?;
+    Ok(count)
+}

--- a/crates/data/src/room/peek.rs
+++ b/crates/data/src/room/peek.rs
@@ -192,12 +192,18 @@ pub async fn peeked_room_ids() -> DataResult<Vec<OwnedRoomId>> {
 // MSC2753 client-side peeking: which local users peek which rooms.
 // ---------------------------------------------------------------------------
 
-/// Record that a local user is peeking a room (idempotent).
-pub async fn add_user_peek(user_id: &UserId, room_id: &RoomId) -> DataResult<()> {
+/// Record that a local user's device is peeking a room (idempotent). Peeks are
+/// per-device so another device of the same account is unaffected.
+pub async fn add_user_peek(
+    user_id: &UserId,
+    device_id: &DeviceId,
+    room_id: &RoomId,
+) -> DataResult<()> {
     let now = UnixMillis::now().get() as i64;
     diesel::insert_into(user_peeks::table)
         .values((
             user_peeks::user_id.eq(user_id),
+            user_peeks::device_id.eq(device_id),
             user_peeks::room_id.eq(room_id),
             user_peeks::created_at.eq(now),
         ))
@@ -207,11 +213,16 @@ pub async fn add_user_peek(user_id: &UserId, room_id: &RoomId) -> DataResult<()>
     Ok(())
 }
 
-/// Stop a local user peeking a room.
-pub async fn remove_user_peek(user_id: &UserId, room_id: &RoomId) -> DataResult<()> {
+/// Stop a local user's device peeking a room.
+pub async fn remove_user_peek(
+    user_id: &UserId,
+    device_id: &DeviceId,
+    room_id: &RoomId,
+) -> DataResult<()> {
     diesel::delete(
         user_peeks::table
             .filter(user_peeks::user_id.eq(user_id))
+            .filter(user_peeks::device_id.eq(device_id))
             .filter(user_peeks::room_id.eq(room_id)),
     )
     .execute(&mut connect().await?)
@@ -219,17 +230,22 @@ pub async fn remove_user_peek(user_id: &UserId, room_id: &RoomId) -> DataResult<
     Ok(())
 }
 
-/// Rooms a local user is currently peeking.
-pub async fn user_peeked_rooms(user_id: &UserId) -> DataResult<Vec<OwnedRoomId>> {
+/// Rooms a specific device of a user is currently peeking.
+pub async fn user_peeked_rooms(
+    user_id: &UserId,
+    device_id: &DeviceId,
+) -> DataResult<Vec<OwnedRoomId>> {
     let rooms = user_peeks::table
         .filter(user_peeks::user_id.eq(user_id))
+        .filter(user_peeks::device_id.eq(device_id))
         .select(user_peeks::room_id)
         .load::<OwnedRoomId>(&mut connect().await?)
         .await?;
     Ok(rooms)
 }
 
-/// Number of local users currently peeking a room.
+/// Number of local user-devices currently peeking a room (across all accounts
+/// and devices). Used to decide when the federation peek can be torn down.
 pub async fn room_peeker_count(room_id: &RoomId) -> DataResult<i64> {
     let count: i64 = user_peeks::table
         .filter(user_peeks::room_id.eq(room_id))

--- a/crates/data/src/room/peek.rs
+++ b/crates/data/src/room/peek.rs
@@ -244,6 +244,15 @@ pub async fn user_peeked_rooms(
     Ok(rooms)
 }
 
+/// Remove all user-device peeks on a room (e.g. when the underlying federation
+/// peek is permanently torn down, so sync stops surfacing a dead peek).
+pub async fn remove_room_user_peeks(room_id: &RoomId) -> DataResult<()> {
+    diesel::delete(user_peeks::table.filter(user_peeks::room_id.eq(room_id)))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
 /// Number of local user-devices currently peeking a room (across all accounts
 /// and devices). Used to decide when the federation peek can be torn down.
 pub async fn room_peeker_count(room_id: &RoomId) -> DataResult<i64> {

--- a/crates/data/src/schema.rs
+++ b/crates/data/src/schema.rs
@@ -570,6 +570,7 @@ diesel::table! {
     user_peeks (id) {
         id -> Int8,
         user_id -> Text,
+        device_id -> Text,
         room_id -> Text,
         created_at -> Int8,
     }

--- a/crates/data/src/schema.rs
+++ b/crates/data/src/schema.rs
@@ -567,6 +567,15 @@ diesel::table! {
 }
 
 diesel::table! {
+    user_peeks (id) {
+        id -> Int8,
+        user_id -> Text,
+        room_id -> Text,
+        created_at -> Int8,
+    }
+}
+
+diesel::table! {
     use diesel::sql_types::*;
     use crate::full_text_search::*;
 
@@ -1203,6 +1212,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     user_login_tokens,
     user_openid_tokens,
     user_passwords,
+    user_peeks,
     user_presences,
     user_profiles,
     user_pushers,

--- a/crates/data/src/schema.rs
+++ b/crates/data/src/schema.rs
@@ -545,6 +545,28 @@ diesel::table! {
 }
 
 diesel::table! {
+    room_peeking_servers (id) {
+        id -> Int8,
+        room_id -> Text,
+        server_id -> Text,
+        peek_id -> Text,
+        renew_at -> Int8,
+        created_at -> Int8,
+    }
+}
+
+diesel::table! {
+    room_peeks (id) {
+        id -> Int8,
+        room_id -> Text,
+        peek_id -> Text,
+        target_server -> Text,
+        renew_at -> Int8,
+        created_at -> Int8,
+    }
+}
+
+diesel::table! {
     use diesel::sql_types::*;
     use crate::full_text_search::*;
 
@@ -1151,6 +1173,8 @@ diesel::allow_tables_to_appear_in_same_query!(
     room_aliases,
     room_joined_servers,
     room_lookup_servers,
+    room_peeking_servers,
+    room_peeks,
     room_state_deltas,
     room_state_fields,
     room_state_frames,

--- a/crates/server/src/event/handler.rs
+++ b/crates/server/src/event/handler.rs
@@ -510,8 +510,15 @@ pub async fn process_to_timeline_pdu(
     // 10. Fetch missing state and auth chain events by calling /state_ids at backwards extremities
     //     doing all the checks in this list starting at 1. These are not timeline events.
     debug!("resolving state at event");
+    // We process a room's incoming timeline events when we participate in it, or
+    // when we hold an active MSC2444 peek on it (the resident forwards events to
+    // us over /send; without this, a peek would only ever show the initial seed
+    // and never update live).
     let server_joined =
-        crate::room::is_server_joined(crate::config::server_name(), &incoming_pdu.room_id).await?;
+        crate::room::is_server_joined(crate::config::server_name(), &incoming_pdu.room_id).await?
+            || crate::data::room::peek::is_peeked(&incoming_pdu.room_id)
+                .await
+                .unwrap_or(false);
 
     if !server_joined {
         if let Some(state_key) = incoming_pdu.state_key.as_deref()

--- a/crates/server/src/federation.rs
+++ b/crates/server/src/federation.rs
@@ -11,6 +11,7 @@ use crate::{AppError, AppResult, config, room, sending};
 
 mod access_check;
 pub mod membership;
+pub mod peek;
 pub use access_check::access_check;
 
 #[tracing::instrument(skip(request))]

--- a/crates/server/src/federation/peek.rs
+++ b/crates/server/src/federation/peek.rs
@@ -14,13 +14,12 @@ use crate::core::UnixMillis;
 use crate::core::federation::peek::{PeekStartResBody, peek_cancel_request, peek_start_request};
 use crate::core::identifiers::*;
 use crate::core::serde::CanonicalJsonObject;
-use crate::data::room::{DbEventData, NewDbEvent};
 use crate::event::handler::process_incoming_pdu;
-use crate::event::{ensure_event_sn, parse_fetched_pdu};
+use crate::event::parse_fetched_pdu;
 use crate::room::state::{CompressedEvent, DeltaInfo};
 use crate::room::{state, timeline};
 use crate::{
-    AppError, AppResult, GetUrlOrigin, OptionalExtension, SnPduEvent, config, data, room, sending,
+    AppError, AppResult, GetUrlOrigin, OptionalExtension, config, data, room, sending,
 };
 
 /// How long a peek subscription is valid before the peeking server must renew.
@@ -164,39 +163,24 @@ async fn ingest_peek_snapshot(
         }
     }
 
-    // Build the resolved current state map and persist it as the room's state.
+    // Build the resolved current state map from events that were actually
+    // validated and stored by `process_incoming_pdu` above. We must NOT persist
+    // a state event the validation rejected (bad signature/auth) and then force
+    // it as the room's current state — a malicious resident could otherwise
+    // smuggle in arbitrary state. If a snapshot state event isn't in the
+    // timeline (i.e. it failed validation), abort the whole peek; `start_peek`
+    // rolls back the registration and the caller falls back to the one-shot
+    // snapshot preview.
     let mut state_map = HashMap::new();
     for raw in &body.state {
-        let (event_id, value) = match parse_fetched_pdu(room_id, room_version, raw) {
-            Ok(t) => t,
+        let event_id = match parse_fetched_pdu(room_id, room_version, raw) {
+            Ok((event_id, _)) => event_id,
             Err(_) => continue,
         };
-        let pdu = if let Some(pdu) = timeline::get_pdu(&event_id).await.optional()? {
-            pdu
-        } else {
-            let (event_sn, event_guard) = ensure_event_sn(room_id, &event_id).await?;
-            let pdu = SnPduEvent::from_canonical_object(
-                room_id, &event_id, event_sn, value.clone(), false, false, false,
-            )
-            .map_err(|e| {
-                warn!("peek: invalid state pdu {event_id}: {e}");
-                AppError::public("invalid state pdu in peek response")
-            })?;
-            NewDbEvent::from_canonical_json_with_room_id(&event_id, event_sn, &value, false, room_id)?
-                .save()
-                .await?;
-            DbEventData {
-                event_id: event_id.clone(),
-                event_sn,
-                room_id: room_id.to_owned(),
-                internal_metadata: None,
-                json_data: serde_json::to_value(&value)?,
-                format_version: None,
-            }
-            .save()
-            .await?;
-            drop(event_guard);
-            pdu
+        let Some(pdu) = timeline::get_pdu(&event_id).await.optional()? else {
+            return Err(AppError::public(format!(
+                "peek snapshot state event {event_id} failed validation; aborting peek"
+            )));
         };
 
         if let Some(state_key) = &pdu.state_key {

--- a/crates/server/src/federation/peek.rs
+++ b/crates/server/src/federation/peek.rs
@@ -113,6 +113,27 @@ pub async fn start_peek(
     let renew_at = now_ms() + (body.renewal_interval as i64 / 2).max(1);
     data::room::peek::upsert_peek(room_id, peek_id, target_server, renew_at).await?;
 
+    // Ingest the snapshot. On failure, roll back the registration we just wrote
+    // so we don't leave an ownerless federation subscription that the
+    // maintenance task renews forever (and that the incoming-PDU gate would keep
+    // accepting events for).
+    if let Err(e) = ingest_peek_snapshot(room_id, target_server, &room_version, &body).await {
+        let _ = data::room::peek::remove_peek(room_id).await;
+        return Err(e);
+    }
+    Ok(())
+}
+
+/// Ingest a peek snapshot (auth chain + current state + recent messages) into
+/// the local store, mirroring the send_join ingestion path. Called by
+/// `start_peek` only after the `room_peeks` row exists, so the incoming-PDU gate
+/// accepts the seed events.
+async fn ingest_peek_snapshot(
+    room_id: &RoomId,
+    target_server: &ServerName,
+    room_version: &RoomVersionId,
+    body: &PeekStartResBody,
+) -> AppResult<()> {
     // Make sure we hold the signing keys needed to verify the returned events.
     crate::server_key::acquire_events_pubkeys(body.auth_chain.iter().chain(body.state.iter()))
         .await;
@@ -121,7 +142,7 @@ pub async fn start_peek(
     // (depth) order so each event's ancestors are present first.
     let mut parsed: IndexMap<OwnedEventId, CanonicalJsonObject> = IndexMap::new();
     for raw in body.auth_chain.iter().chain(body.state.iter()) {
-        if let Ok((event_id, value)) = parse_fetched_pdu(room_id, &room_version, raw) {
+        if let Ok((event_id, value)) = parse_fetched_pdu(room_id, room_version, raw) {
             parsed.insert(event_id, value);
         }
     }
@@ -132,7 +153,7 @@ pub async fn start_peek(
             target_server,
             event_id,
             room_id,
-            &room_version,
+            room_version,
             value.clone(),
             true,
             false,
@@ -146,7 +167,7 @@ pub async fn start_peek(
     // Build the resolved current state map and persist it as the room's state.
     let mut state_map = HashMap::new();
     for raw in &body.state {
-        let (event_id, value) = match parse_fetched_pdu(room_id, &room_version, raw) {
+        let (event_id, value) = match parse_fetched_pdu(room_id, room_version, raw) {
             Ok(t) => t,
             Err(_) => continue,
         };
@@ -208,7 +229,7 @@ pub async fn start_peek(
     let mut msgs: Vec<_> = body
         .messages
         .iter()
-        .filter_map(|raw| parse_fetched_pdu(room_id, &room_version, raw).ok())
+        .filter_map(|raw| parse_fetched_pdu(room_id, room_version, raw).ok())
         .collect();
     msgs.sort_by_key(|(_, v)| v.get("depth").and_then(|d| d.as_integer()).unwrap_or(0));
     for (event_id, value) in &msgs {
@@ -216,7 +237,7 @@ pub async fn start_peek(
             target_server,
             event_id,
             room_id,
-            &room_version,
+            room_version,
             value.clone(),
             true,
             false,

--- a/crates/server/src/federation/peek.rs
+++ b/crates/server/src/federation/peek.rs
@@ -331,12 +331,25 @@ pub async fn run_maintenance() {
         }
     };
     for peek in due {
-        if let Err(e) = renew_peek(&peek.room_id, &peek.target_server, &peek.peek_id).await {
+        if renew_peek(&peek.room_id, &peek.target_server, &peek.peek_id)
+            .await
+            .is_ok()
+        {
+            continue;
+        }
+        // Lightweight renewal failed. It may be transient (a network blip) or
+        // the resident may have forgotten us, so attempt a full re-establish,
+        // which re-registers and re-ingests current state.
+        if let Err(e) = start_peek(&peek.room_id, &peek.target_server, &peek.peek_id).await {
+            // Still failing — give up. Drop the federation subscription AND the
+            // per-device user peeks for this room, so a dead peek stops being
+            // surfaced in sync (rather than freezing on stale state forever).
             warn!(
-                "peek: renewal of {} via {} failed, dropping: {e}",
+                "peek: renewal and re-establish of {} via {} both failed, dropping: {e}",
                 peek.room_id, peek.target_server
             );
             let _ = data::room::peek::remove_peek(&peek.room_id).await;
+            let _ = data::room::peek::remove_room_user_peeks(&peek.room_id).await;
         }
     }
 }

--- a/crates/server/src/federation/peek.rs
+++ b/crates/server/src/federation/peek.rs
@@ -1,0 +1,287 @@
+//! MSC2444 ongoing federated peeking.
+//!
+//! Resident side (this file, Phase C): track which remote servers hold a live
+//! peek on our rooms and expose them as extra event-distribution destinations.
+//! Peeking side (added below): establish/renew/cancel an outbound peek on a
+//! remote room and ingest its state + ongoing events into the local store.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use indexmap::IndexMap;
+
+use crate::core::UnixMillis;
+use crate::core::federation::peek::{PeekStartResBody, peek_cancel_request, peek_start_request};
+use crate::core::identifiers::*;
+use crate::core::serde::CanonicalJsonObject;
+use crate::data::room::{DbEventData, NewDbEvent};
+use crate::event::handler::process_incoming_pdu;
+use crate::event::{ensure_event_sn, parse_fetched_pdu};
+use crate::room::state::{CompressedEvent, DeltaInfo};
+use crate::room::{state, timeline};
+use crate::{
+    AppError, AppResult, GetUrlOrigin, OptionalExtension, SnPduEvent, data, room, sending,
+};
+
+/// How long a peek subscription is valid before the peeking server must renew.
+/// Returned to peers as `renewal_interval`.
+pub const PEEK_RENEWAL_INTERVAL_MS: u64 = 3_600_000; // 1 hour
+
+/// Current time in unix milliseconds as an `i64` (the column type).
+fn now_ms() -> i64 {
+    UnixMillis::now().get() as i64
+}
+
+// ---------------------------------------------------------------------------
+// Resident side: remote servers peeking our rooms.
+// ---------------------------------------------------------------------------
+
+/// Register or renew a remote server's peek on one of our rooms, valid for
+/// `PEEK_RENEWAL_INTERVAL_MS` from now.
+pub async fn register_peeking_server(
+    room_id: &RoomId,
+    server: &ServerName,
+    peek_id: &str,
+) -> crate::AppResult<()> {
+    let renew_at = now_ms() + PEEK_RENEWAL_INTERVAL_MS as i64;
+    data::room::peek::upsert_peeking_server(room_id, server, peek_id, renew_at).await?;
+    Ok(())
+}
+
+/// Cancel a remote server's peek on one of our rooms.
+pub async fn unregister_peeking_server(
+    room_id: &RoomId,
+    server: &ServerName,
+    peek_id: &str,
+) -> crate::AppResult<()> {
+    data::room::peek::remove_peeking_server(room_id, server, peek_id).await?;
+    Ok(())
+}
+
+/// Remote servers with a live (non-expired) peek on this room. These receive new
+/// room events in addition to the room's participating servers. Errors are
+/// swallowed to a empty list so a peek-tracking hiccup never blocks delivery to
+/// real members.
+pub async fn active_peeking_servers(room_id: &RoomId) -> Vec<OwnedServerName> {
+    data::room::peek::active_peeking_servers(room_id, now_ms())
+        .await
+        .unwrap_or_default()
+}
+
+/// Drop every peek subscription (held by remote servers on our rooms) that has
+/// lapsed. Safe to call periodically; returns rows removed.
+pub async fn purge_expired_peeking_servers() -> crate::AppResult<usize> {
+    Ok(data::room::peek::purge_expired_peeking_servers(now_ms()).await?)
+}
+
+// ---------------------------------------------------------------------------
+// Peeking side: outbound peeks we hold on remote rooms.
+// ---------------------------------------------------------------------------
+
+/// Start (or renew, when `peek_id` is reused) an outbound peek on a remote room.
+///
+/// PUTs `/_matrix/federation/v1/peek/{room_id}/{peek_id}` to `target_server`,
+/// ingests the returned current state + auth chain + recent timeline into the
+/// local store (mirroring the send_join ingestion path), and records the peek so
+/// the background task renews it. After this returns, ongoing room events arrive
+/// via the normal `/send` transaction path and are appended locally.
+///
+/// NOTE: This path needs validation against a live two-server federation setup;
+/// it compiles and mirrors the join ingestion but has not been exercised
+/// end-to-end here.
+pub async fn start_peek(
+    room_id: &RoomId,
+    target_server: &ServerName,
+    peek_id: &str,
+) -> AppResult<()> {
+    let request = peek_start_request(&target_server.origin().await, room_id, peek_id, &[])
+        .map_err(|e| AppError::public(format!("failed to build peek request: {e}")))?
+        .into_inner();
+
+    let body = sending::send_federation_request(target_server, request, None)
+        .await?
+        .json::<PeekStartResBody>()
+        .await?;
+
+    let room_version = body.room_version.clone();
+    room::ensure_room(room_id, &room_version).await?;
+
+    // Make sure we hold the signing keys needed to verify the returned events.
+    crate::server_key::acquire_events_pubkeys(body.auth_chain.iter().chain(body.state.iter()))
+        .await;
+
+    // Store auth chain + state events (as the join path does), in topological
+    // (depth) order so each event's ancestors are present first.
+    let mut parsed: IndexMap<OwnedEventId, CanonicalJsonObject> = IndexMap::new();
+    for raw in body.auth_chain.iter().chain(body.state.iter()) {
+        if let Ok((event_id, value)) = parse_fetched_pdu(room_id, &room_version, raw) {
+            parsed.insert(event_id, value);
+        }
+    }
+    let mut ordered: Vec<_> = parsed.into_iter().collect();
+    ordered.sort_by_key(|(_, v)| v.get("depth").and_then(|d| d.as_integer()).unwrap_or(0));
+    for (event_id, value) in &ordered {
+        if let Err(e) = process_incoming_pdu(
+            target_server,
+            event_id,
+            room_id,
+            &room_version,
+            value.clone(),
+            true,
+            false,
+        )
+        .await
+        {
+            warn!("peek: failed to process state/auth event {event_id}: {e}");
+        }
+    }
+
+    // Build the resolved current state map and persist it as the room's state.
+    let mut state_map = HashMap::new();
+    for raw in &body.state {
+        let (event_id, value) = match parse_fetched_pdu(room_id, &room_version, raw) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        let pdu = if let Some(pdu) = timeline::get_pdu(&event_id).await.optional()? {
+            pdu
+        } else {
+            let (event_sn, event_guard) = ensure_event_sn(room_id, &event_id).await?;
+            let pdu = SnPduEvent::from_canonical_object(
+                room_id, &event_id, event_sn, value.clone(), false, false, false,
+            )
+            .map_err(|e| {
+                warn!("peek: invalid state pdu {event_id}: {e}");
+                AppError::public("invalid state pdu in peek response")
+            })?;
+            NewDbEvent::from_canonical_json_with_room_id(&event_id, event_sn, &value, false, room_id)?
+                .save()
+                .await?;
+            DbEventData {
+                event_id: event_id.clone(),
+                event_sn,
+                room_id: room_id.to_owned(),
+                internal_metadata: None,
+                json_data: serde_json::to_value(&value)?,
+                format_version: None,
+            }
+            .save()
+            .await?;
+            drop(event_guard);
+            pdu
+        };
+
+        if let Some(state_key) = &pdu.state_key {
+            let state_key_id =
+                state::ensure_field_id(&pdu.event_ty.to_string().into(), state_key).await?;
+            state_map.insert(state_key_id, (pdu.event_id.clone(), pdu.event_sn));
+        }
+    }
+
+    let state_lock = room::lock_state(room_id).await;
+    let DeltaInfo {
+        frame_id,
+        appended,
+        disposed,
+    } = state::save_state(
+        room_id,
+        Arc::new(
+            state_map
+                .into_iter()
+                .map(|(k, (_event_id, event_sn))| Ok(CompressedEvent::new(k, event_sn)))
+                .collect::<AppResult<_>>()?,
+        ),
+    )
+    .await?;
+    state::force_state(room_id, frame_id, appended, disposed).await?;
+    state::set_room_state(room_id, frame_id).await?;
+    drop(state_lock);
+
+    // Seed recent timeline (best effort); ongoing events arrive via /send.
+    let mut msgs: Vec<_> = body
+        .messages
+        .iter()
+        .filter_map(|raw| parse_fetched_pdu(room_id, &room_version, raw).ok())
+        .collect();
+    msgs.sort_by_key(|(_, v)| v.get("depth").and_then(|d| d.as_integer()).unwrap_or(0));
+    for (event_id, value) in &msgs {
+        let _ = process_incoming_pdu(
+            target_server,
+            event_id,
+            room_id,
+            &room_version,
+            value.clone(),
+            true,
+            false,
+        )
+        .await;
+    }
+
+    // Record (or refresh) the peek; renew at half the resident's interval.
+    let renew_at = now_ms() + (body.renewal_interval as i64 / 2).max(1);
+    data::room::peek::upsert_peek(room_id, peek_id, target_server, renew_at).await?;
+    Ok(())
+}
+
+/// Ensure we hold a live peek on a remote room: returns the existing peek's id if
+/// one is active, otherwise establishes a new one. The room's home server (from
+/// the room id) is used as the peek target.
+pub async fn ensure_peek(room_id: &RoomId) -> AppResult<()> {
+    if let Some(existing) = data::room::peek::get_peek(room_id).await? {
+        // Already peeking; renewal is handled by the background task.
+        let _ = existing;
+        return Ok(());
+    }
+    let target = room_id
+        .server_name()
+        .map_err(|_| AppError::public("room id has no server name to peek via"))?;
+    let peek_id = new_peek_id();
+    start_peek(room_id, target, &peek_id).await
+}
+
+/// Cancel an outbound peek and stop receiving the room's events.
+pub async fn stop_peek(room_id: &RoomId) -> AppResult<()> {
+    if let Some(peek) = data::room::peek::get_peek(room_id).await? {
+        if let Ok(request) =
+            peek_cancel_request(&peek.target_server.origin().await, room_id, &peek.peek_id)
+        {
+            // Best effort: tell the resident server to drop us.
+            let _ =
+                sending::send_federation_request(&peek.target_server, request.into_inner(), None)
+                    .await;
+        }
+        data::room::peek::remove_peek(room_id).await?;
+    }
+    Ok(())
+}
+
+/// Renew all outbound peeks whose renewal deadline has passed. On repeated
+/// failure the peek is dropped so we stop trying. Also purges lapsed inbound
+/// peekers. Intended to be called periodically by a background task.
+pub async fn run_maintenance() {
+    if let Err(e) = purge_expired_peeking_servers().await {
+        warn!("peek: failed to purge expired peeking servers: {e}");
+    }
+
+    let due = match data::room::peek::peeks_due_for_renewal(now_ms()).await {
+        Ok(due) => due,
+        Err(e) => {
+            warn!("peek: failed to load peeks due for renewal: {e}");
+            return;
+        }
+    };
+    for peek in due {
+        if let Err(e) = start_peek(&peek.room_id, &peek.target_server, &peek.peek_id).await {
+            warn!(
+                "peek: renewal of {} via {} failed, dropping: {e}",
+                peek.room_id, peek.target_server
+            );
+            let _ = data::room::peek::remove_peek(&peek.room_id).await;
+        }
+    }
+}
+
+/// Generate an opaque peek id.
+fn new_peek_id() -> String {
+    format!("peek_{}", ulid::Ulid::new())
+}

--- a/crates/server/src/federation/peek.rs
+++ b/crates/server/src/federation/peek.rs
@@ -106,6 +106,13 @@ pub async fn start_peek(
     let room_version = body.room_version.clone();
     room::ensure_room(room_id, &room_version).await?;
 
+    // Record the peek BEFORE ingesting anything. The incoming-PDU gate accepts
+    // events for a non-joined room only when `is_peeked` is true, so the seed
+    // messages below (and any /send events racing in during ingestion) would be
+    // dropped if the row didn't exist yet. Renew at half the resident's interval.
+    let renew_at = now_ms() + (body.renewal_interval as i64 / 2).max(1);
+    data::room::peek::upsert_peek(room_id, peek_id, target_server, renew_at).await?;
+
     // Make sure we hold the signing keys needed to verify the returned events.
     crate::server_key::acquire_events_pubkeys(body.auth_chain.iter().chain(body.state.iter()))
         .await;
@@ -217,9 +224,6 @@ pub async fn start_peek(
         .await;
     }
 
-    // Record (or refresh) the peek; renew at half the resident's interval.
-    let renew_at = now_ms() + (body.renewal_interval as i64 / 2).max(1);
-    data::room::peek::upsert_peek(room_id, peek_id, target_server, renew_at).await?;
     Ok(())
 }
 

--- a/crates/server/src/federation/peek.rs
+++ b/crates/server/src/federation/peek.rs
@@ -313,6 +313,16 @@ pub async fn run_maintenance() {
         warn!("peek: failed to purge expired peeking servers: {e}");
     }
 
+    // Tear down federation peeks no local user device wants anymore (e.g. every
+    // peeker was dropped during sync because the room stopped being
+    // world-readable, or all users unpeeked). Prevents ownerless subscriptions
+    // from being renewed forever.
+    for room_id in data::room::peek::peeked_room_ids().await.unwrap_or_default() {
+        if data::room::peek::room_peeker_count(&room_id).await.unwrap_or(1) == 0 {
+            let _ = stop_peek(&room_id).await;
+        }
+    }
+
     let due = match data::room::peek::peeks_due_for_renewal(now_ms()).await {
         Ok(due) => due,
         Err(e) => {

--- a/crates/server/src/federation/peek.rs
+++ b/crates/server/src/federation/peek.rs
@@ -20,7 +20,7 @@ use crate::event::{ensure_event_sn, parse_fetched_pdu};
 use crate::room::state::{CompressedEvent, DeltaInfo};
 use crate::room::{state, timeline};
 use crate::{
-    AppError, AppResult, GetUrlOrigin, OptionalExtension, SnPduEvent, data, room, sending,
+    AppError, AppResult, GetUrlOrigin, OptionalExtension, SnPduEvent, config, data, room, sending,
 };
 
 /// How long a peek subscription is valid before the peeking server must renew.
@@ -223,13 +223,38 @@ pub async fn start_peek(
     Ok(())
 }
 
-/// Ensure we hold a live peek on a remote room: returns the existing peek's id if
-/// one is active, otherwise establishes a new one. The room's home server (from
-/// the room id) is used as the peek target.
+/// Renew an existing outbound peek without re-ingesting room state. The
+/// subscription is already live and events flow via `/send`; this is just a
+/// heartbeat that re-registers us with the resident and pushes the renewal
+/// deadline back. If the resident refuses (e.g. the room is no longer
+/// world-readable) this errors and the caller drops the peek.
+async fn renew_peek(room_id: &RoomId, target_server: &ServerName, peek_id: &str) -> AppResult<()> {
+    let request = peek_start_request(&target_server.origin().await, room_id, peek_id, &[])
+        .map_err(|e| AppError::public(format!("failed to build peek renewal: {e}")))?
+        .into_inner();
+    let body = sending::send_federation_request(target_server, request, None)
+        .await?
+        .json::<PeekStartResBody>()
+        .await?;
+    let renew_at = now_ms() + (body.renewal_interval as i64 / 2).max(1);
+    data::room::peek::upsert_peek(room_id, peek_id, target_server, renew_at).await?;
+    Ok(())
+}
+
+/// Ensure we hold a live peek on a remote room: no-op if one is already active
+/// or if our server already participates (a local user is joined, so we receive
+/// events as a member); otherwise establishes a new peek. The room's home server
+/// (from the room id) is the peek target.
 pub async fn ensure_peek(room_id: &RoomId) -> AppResult<()> {
-    if let Some(existing) = data::room::peek::get_peek(room_id).await? {
+    if data::room::peek::is_peeked(room_id).await? {
         // Already peeking; renewal is handled by the background task.
-        let _ = existing;
+        return Ok(());
+    }
+    if room::is_server_joined(&config::get().server_name, room_id)
+        .await
+        .unwrap_or(false)
+    {
+        // We already receive this room's events as a participating server.
         return Ok(());
     }
     let target = room_id
@@ -271,7 +296,7 @@ pub async fn run_maintenance() {
         }
     };
     for peek in due {
-        if let Err(e) = start_peek(&peek.room_id, &peek.target_server, &peek.peek_id).await {
+        if let Err(e) = renew_peek(&peek.room_id, &peek.target_server, &peek.peek_id).await {
             warn!(
                 "peek: renewal of {} via {} failed, dropping: {e}",
                 peek.room_id, peek.target_server

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -205,6 +205,16 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     crate::sending::guard::start();
 
+    // MSC2444: periodically renew our outbound room peeks and drop lapsed inbound
+    // peekers.
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        loop {
+            interval.tick().await;
+            crate::federation::peek::run_maintenance().await;
+        }
+    });
+
     let router = routing::root();
     // let doc = OpenApi::new("palpo api", "0.0.1").merge_router(&router);
     // let router = router

--- a/crates/server/src/room/timeline.rs
+++ b/crates/server/src/room/timeline.rs
@@ -808,7 +808,13 @@ pub async fn build_and_append_pdu(
     //     crate::room::update_currents(&room_id)?;
     // }
 
-    let servers = super::participating_servers(room_id, false).await?;
+    let mut servers = super::participating_servers(room_id, false).await?;
+    // MSC2444: also forward to remote servers holding a live peek on this room,
+    // so peeking servers receive ongoing events. Dedup in case a peeking server
+    // is also a participating server.
+    servers.extend(crate::federation::peek::active_peeking_servers(room_id).await);
+    servers.sort_unstable();
+    servers.dedup();
     crate::sending::send_pdu_servers(servers.into_iter(), &pdu.event_id).await?;
 
     Ok(pdu)

--- a/crates/server/src/room/timeline.rs
+++ b/crates/server/src/room/timeline.rs
@@ -675,6 +675,23 @@ pub async fn append_pdu(
                 .await?;
         }
     }
+
+    // MSC2444: relay this event to remote servers holding a live peek on the
+    // room. This is the single choke point for timeline events, so it covers
+    // both locally authored events and events received from other member servers
+    // (we are the resident forwarding to peekers). Guarded by world-readability:
+    // if the room is no longer world-readable we must not leak events to
+    // unaffiliated peekers (their peek will also fail to renew and lapse). On a
+    // non-resident server there are no peekers, so this is a cheap no-op.
+    let peeking_servers = crate::federation::peek::active_peeking_servers(&pdu.room_id).await;
+    if !peeking_servers.is_empty() && crate::room::is_world_readable(&pdu.room_id).await {
+        if let Err(e) =
+            crate::sending::send_pdu_servers(peeking_servers.into_iter(), &pdu.event_id).await
+        {
+            error!("failed to forward pdu to peeking servers: {e}");
+        }
+    }
+
     Ok(())
 }
 
@@ -808,13 +825,9 @@ pub async fn build_and_append_pdu(
     //     crate::room::update_currents(&room_id)?;
     // }
 
-    let mut servers = super::participating_servers(room_id, false).await?;
-    // MSC2444: also forward to remote servers holding a live peek on this room,
-    // so peeking servers receive ongoing events. Dedup in case a peeking server
-    // is also a participating server.
-    servers.extend(crate::federation::peek::active_peeking_servers(room_id).await);
-    servers.sort_unstable();
-    servers.dedup();
+    // Deliver to participating servers. Peeking servers are handled centrally in
+    // `append_pdu` (which also covers events received from other servers).
+    let servers = super::participating_servers(room_id, false).await?;
     crate::sending::send_pdu_servers(servers.into_iter(), &pdu.event_id).await?;
 
     Ok(pdu)

--- a/crates/server/src/room/timeline.rs
+++ b/crates/server/src/room/timeline.rs
@@ -685,10 +685,24 @@ pub async fn append_pdu(
     // non-resident server there are no peekers, so this is a cheap no-op.
     let peeking_servers = crate::federation::peek::active_peeking_servers(&pdu.room_id).await;
     if !peeking_servers.is_empty() && crate::room::is_world_readable(&pdu.room_id).await {
-        if let Err(e) =
-            crate::sending::send_pdu_servers(peeking_servers.into_iter(), &pdu.event_id).await
-        {
-            error!("failed to forward pdu to peeking servers: {e}");
+        // Re-apply the room's server ACL: a server banned via m.room.server_acl
+        // after its peek started must stop receiving events immediately, not
+        // only when its peek eventually fails to renew.
+        let mut allowed = Vec::with_capacity(peeking_servers.len());
+        for server in peeking_servers {
+            if crate::event::handler::acl_check(&server, &pdu.room_id)
+                .await
+                .is_ok()
+            {
+                allowed.push(server);
+            }
+        }
+        if !allowed.is_empty() {
+            if let Err(e) =
+                crate::sending::send_pdu_servers(allowed.into_iter(), &pdu.event_id).await
+            {
+                error!("failed to forward pdu to peeking servers: {e}");
+            }
         }
     }
 

--- a/crates/server/src/routing/client/room.rs
+++ b/crates/server/src/routing/client/room.rs
@@ -342,6 +342,7 @@ async fn peek_room(
 ) -> JsonResult<JsonValue> {
     let authed = depot.authed_info()?;
     let sender_id = authed.user_id();
+    let device_id = authed.device_id();
     let room_id = room_id.into_inner();
 
     // For a remote room, ensure a live federation peek (idempotent: it no-ops if
@@ -359,7 +360,7 @@ async fn peek_room(
         return Err(MatrixError::forbidden("Room is not peekable.", None).into());
     }
 
-    data::room::peek::add_user_peek(sender_id, &room_id).await?;
+    data::room::peek::add_user_peek(sender_id, device_id, &room_id).await?;
     json_ok(json!({ "room_id": room_id }))
 }
 
@@ -374,9 +375,10 @@ async fn unpeek_room(
 ) -> EmptyResult {
     let authed = depot.authed_info()?;
     let sender_id = authed.user_id();
+    let device_id = authed.device_id();
     let room_id = room_id.into_inner();
 
-    data::room::peek::remove_user_peek(sender_id, &room_id).await?;
+    data::room::peek::remove_user_peek(sender_id, device_id, &room_id).await?;
     if data::room::peek::room_peeker_count(&room_id).await? == 0 {
         // No local user is peeking anymore; drop the federation subscription.
         let _ = crate::federation::peek::stop_peek(&room_id).await;

--- a/crates/server/src/routing/client/room.rs
+++ b/crates/server/src/routing/client/room.rs
@@ -164,26 +164,19 @@ async fn initial_sync(
 
     // If the room is not known locally, it may be a remote room the user is
     // trying to preview (e.g. opening `#room:other.server` without joining).
-    // For rooms hosted on another server, establish an MSC2444 ongoing peek so
-    // we hold a live local copy that keeps updating; if that can't be set up,
-    // fall back to a one-shot snapshot preview. Local-only unknown rooms have
-    // nothing to show.
+    // This is a one-shot snapshot only — it never establishes a persistent
+    // federation peek, so a throwaway preview can't leave an ownerless
+    // subscription running forever. A live, owned peek is established only via
+    // the explicit MSC2753 `POST /rooms/{id}/peek` endpoint (which has a
+    // matching unpeek teardown). Local-only unknown rooms have nothing to show.
     if !room::room_exists(room_id).await? {
         if room_id
             .server_name()
             .is_ok_and(|server| *server != config::get().server_name)
         {
-            // Try to start (or reuse) a live peek. On success the room now
-            // exists locally and we fall through to normal rendering, which also
-            // means subsequent events delivered over federation keep it fresh.
-            if crate::federation::peek::ensure_peek(room_id).await.is_err()
-                || !room::room_exists(room_id).await?
-            {
-                return remote_peek_preview(room_id, args.limit.unwrap_or(20)).await;
-            }
-        } else {
-            return Err(MatrixError::forbidden("No room preview available.", None).into());
+            return remote_peek_preview(room_id, args.limit.unwrap_or(20)).await;
         }
+        return Err(MatrixError::forbidden("No room preview available.", None).into());
     }
 
     if !room::state::user_can_see_events(sender_id, room_id).await? {

--- a/crates/server/src/routing/client/room.rs
+++ b/crates/server/src/routing/client/room.rs
@@ -162,16 +162,26 @@ async fn initial_sync(
 
     // If the room is not known locally, it may be a remote room the user is
     // trying to preview (e.g. opening `#room:other.server` without joining).
-    // For rooms hosted on another server, attempt a federated peek to render a
-    // preview; otherwise there is nothing to show.
+    // For rooms hosted on another server, establish an MSC2444 ongoing peek so
+    // we hold a live local copy that keeps updating; if that can't be set up,
+    // fall back to a one-shot snapshot preview. Local-only unknown rooms have
+    // nothing to show.
     if !room::room_exists(room_id).await? {
         if room_id
             .server_name()
             .is_ok_and(|server| *server != config::get().server_name)
         {
-            return remote_peek_preview(room_id, args.limit.unwrap_or(20)).await;
+            // Try to start (or reuse) a live peek. On success the room now
+            // exists locally and we fall through to normal rendering, which also
+            // means subsequent events delivered over federation keep it fresh.
+            if crate::federation::peek::ensure_peek(room_id).await.is_err()
+                || !room::room_exists(room_id).await?
+            {
+                return remote_peek_preview(room_id, args.limit.unwrap_or(20)).await;
+            }
+        } else {
+            return Err(MatrixError::forbidden("No room preview available.", None).into());
         }
-        return Err(MatrixError::forbidden("No room preview available.", None).into());
     }
 
     if !room::state::user_can_see_events(sender_id, room_id).await? {

--- a/crates/server/src/routing/client/room.rs
+++ b/crates/server/src/routing/client/room.rs
@@ -351,11 +351,12 @@ async fn peek_room(
     let sender_id = authed.user_id();
     let room_id = room_id.into_inner();
 
-    // For a remote room we don't hold yet, set up the federation peek first.
-    if !room::room_exists(&room_id).await?
-        && room_id
-            .server_name()
-            .is_ok_and(|server| *server != config::get().server_name)
+    // For a remote room, ensure a live federation peek (idempotent: it no-ops if
+    // already peeking or already participating). Calling this even when a stale
+    // local copy exists re-subscribes so updates resume.
+    if room_id
+        .server_name()
+        .is_ok_and(|server| *server != config::get().server_name)
     {
         crate::federation::peek::ensure_peek(&room_id).await?;
     }

--- a/crates/server/src/routing/client/room.rs
+++ b/crates/server/src/routing/client/room.rs
@@ -83,7 +83,9 @@ pub fn authed_router() -> Router {
                             .post(receipt::send_receipt)
                             .put(receipt::send_receipt),
                     )
-                    .push(Router::with_path("timestamp_to_event").get(event::timestamp_to_event)),
+                    .push(Router::with_path("timestamp_to_event").get(event::timestamp_to_event))
+                    .push(Router::with_path("peek").post(peek_room))
+                    .push(Router::with_path("unpeek").post(unpeek_room)),
             ),
         )
         .push(
@@ -332,6 +334,60 @@ fn parse_peek_pdu(
 ) -> Option<PduEvent> {
     let (event_id, value) = gen_event_id_canonical_json(raw, room_version).ok()?;
     PduEvent::from_canonical_object(room_id, &event_id, value).ok()
+}
+
+/// #POST /_matrix/client/v3/rooms/{room_id}/peek  (MSC2753)
+/// Begin peeking a world-readable room without joining it. For a remote room not
+/// yet known locally this first establishes an MSC2444 federation peek so the
+/// room is mirrored locally and kept live. The room then appears in this user's
+/// sync `peek` section until they unpeek.
+#[endpoint]
+async fn peek_room(
+    _aa: AuthArgs,
+    room_id: PathParam<OwnedRoomId>,
+    depot: &mut Depot,
+) -> JsonResult<JsonValue> {
+    let authed = depot.authed_info()?;
+    let sender_id = authed.user_id();
+    let room_id = room_id.into_inner();
+
+    // For a remote room we don't hold yet, set up the federation peek first.
+    if !room::room_exists(&room_id).await?
+        && room_id
+            .server_name()
+            .is_ok_and(|server| *server != config::get().server_name)
+    {
+        crate::federation::peek::ensure_peek(&room_id).await?;
+    }
+
+    // Peeking is only allowed for world-readable rooms.
+    if !room::is_world_readable(&room_id).await {
+        return Err(MatrixError::forbidden("Room is not peekable.", None).into());
+    }
+
+    data::room::peek::add_user_peek(sender_id, &room_id).await?;
+    json_ok(json!({ "room_id": room_id }))
+}
+
+/// #POST /_matrix/client/v3/rooms/{room_id}/unpeek  (MSC2753)
+/// Stop peeking a room. When the last local user stops peeking a remote room we
+/// also tear down the federation peek subscription.
+#[endpoint]
+async fn unpeek_room(
+    _aa: AuthArgs,
+    room_id: PathParam<OwnedRoomId>,
+    depot: &mut Depot,
+) -> EmptyResult {
+    let authed = depot.authed_info()?;
+    let sender_id = authed.user_id();
+    let room_id = room_id.into_inner();
+
+    data::room::peek::remove_user_peek(sender_id, &room_id).await?;
+    if data::room::peek::room_peeker_count(&room_id).await? == 0 {
+        // No local user is peeking anymore; drop the federation subscription.
+        let _ = crate::federation::peek::stop_peek(&room_id).await;
+    }
+    empty_ok()
 }
 
 /// `#POST /_matrix/client/r0/rooms/{room_id}/read_markers`

--- a/crates/server/src/routing/federation/room.rs
+++ b/crates/server/src/routing/federation/room.rs
@@ -15,14 +15,17 @@ use crate::core::federation::event::{
 use crate::core::federation::knock::{
     MakeKnockReqArgs, MakeKnockResBody, SendKnockReqArgs, SendKnockReqBody, SendKnockResBody,
 };
-use crate::core::federation::peek::{PeekReqArgs, PeekResBody};
+use crate::core::federation::peek::{
+    PeekReqArgs, PeekResBody, PeekStartResBody, PeekSubReqArgs,
+};
 use crate::core::identifiers::*;
-use crate::core::serde::JsonObject;
+use crate::core::serde::{JsonObject, RawJsonValue};
 use crate::event::{gen_event_id_canonical_json, handler};
+use crate::federation::peek as fed_peek;
 use crate::room::{state, timeline};
 use crate::{
-    AuthArgs, DepotExt, IsRemoteOrLocal, JsonResult, MatrixError, PduBuilder, PduEvent, data,
-    json_ok, room, sending,
+    AppResult, AuthArgs, DepotExt, EmptyResult, IsRemoteOrLocal, JsonResult, MatrixError,
+    PduBuilder, PduEvent, data, empty_ok, json_ok, room, sending,
 };
 
 pub fn router() -> Router {
@@ -37,6 +40,11 @@ pub fn router() -> Router {
         .push(Router::with_path("make_knock/{room_id}/{user_id}").get(make_knock))
         .push(Router::with_path("state_ids/{room_id}").get(get_state_at_event))
         .push(Router::with_path("peek/{room_id}").get(peek))
+        .push(
+            Router::with_path("peek/{room_id}/{peek_id}")
+                .put(peek_start)
+                .delete(peek_cancel),
+        )
 }
 
 /// #GET /_matrix/federation/v1/peek/{room_id}
@@ -95,7 +103,99 @@ async fn peek(_aa: AuthArgs, args: PeekReqArgs, depot: &mut Depot) -> JsonResult
     // non-readable events could otherwise yield an empty page while older
     // readable events still exist. So we grow the scan window (doubling, capped)
     // until the visible page is filled or the room history is exhausted.
-    let limit = args.limit.clamp(1, 100);
+    let messages = recent_world_readable_messages(room_id, args.limit.clamp(1, 100)).await?;
+
+    json_ok(PeekResBody {
+        room_version,
+        pdus,
+        messages,
+    })
+}
+
+/// #PUT /_matrix/federation/v1/peek/{room_id}/{peek_id}
+/// Start or renew an ongoing peek subscription (MSC2444). Records the requesting
+/// server so it receives new room events, and returns the full current state +
+/// auth chain + recent messages so the peer can build a local copy of the room.
+#[endpoint]
+async fn peek_start(
+    _aa: AuthArgs,
+    args: PeekSubReqArgs,
+    depot: &mut Depot,
+) -> JsonResult<PeekStartResBody> {
+    let origin = depot.origin()?.clone();
+    let room_id = &args.room_id;
+
+    if !room::room_exists(room_id).await? {
+        return Err(MatrixError::not_found("Room not found on this server.").into());
+    }
+    handler::acl_check(&origin, room_id).await?;
+    if !room::is_world_readable(room_id).await {
+        return Err(MatrixError::forbidden(
+            "Room is not world-readable; peeking is not permitted.",
+            None,
+        )
+        .into());
+    }
+
+    let room_version = room::get_version(room_id).await?;
+
+    // Full current state + backing auth chain (like a send_join response) so the
+    // peer can construct a complete, verifiable local copy of this world-readable
+    // room. This is a deeper relationship than the stripped-state snapshot above
+    // and is gated on the room being world-readable + ACL-allowed.
+    let frame_id = room::get_frame_id(room_id, None).await?;
+    let state_ids: Vec<OwnedEventId> = state::get_full_state_ids(frame_id)
+        .await?
+        .into_values()
+        .collect();
+
+    let mut state = Vec::with_capacity(state_ids.len());
+    for id in &state_ids {
+        if let Ok(Some(json)) = timeline::get_pdu_json(id).await {
+            state.push(sending::convert_to_outgoing_federation_event(json).await);
+        }
+    }
+
+    let auth_chain_ids =
+        room::auth_chain::get_auth_chain_ids(room_id, state_ids.iter().map(AsRef::as_ref)).await?;
+    let mut auth_chain = Vec::with_capacity(auth_chain_ids.len());
+    for id in &auth_chain_ids {
+        if let Ok(Some(json)) = timeline::get_pdu_json(id).await {
+            auth_chain.push(sending::convert_to_outgoing_federation_event(json).await);
+        }
+    }
+
+    let messages = recent_world_readable_messages(room_id, 50).await?;
+
+    // Register the peer so subsequent room events are forwarded to it.
+    fed_peek::register_peeking_server(room_id, &origin, &args.peek_id).await?;
+
+    json_ok(PeekStartResBody {
+        room_version,
+        state,
+        auth_chain,
+        messages,
+        renewal_interval: fed_peek::PEEK_RENEWAL_INTERVAL_MS,
+    })
+}
+
+/// #DELETE /_matrix/federation/v1/peek/{room_id}/{peek_id}
+/// Cancel an ongoing peek subscription (MSC2444).
+#[endpoint]
+async fn peek_cancel(_aa: AuthArgs, args: PeekSubReqArgs, depot: &mut Depot) -> EmptyResult {
+    let origin = depot.origin()?.clone();
+    fed_peek::unregister_peeking_server(&args.room_id, &origin, &args.peek_id).await?;
+    empty_ok()
+}
+
+/// Collect up to `limit` of the most recent timeline events that were
+/// world-readable at the point they were sent, oldest-to-newest. Grows the scan
+/// window (doubling, capped) so a run of recent non-readable events doesn't
+/// yield an empty page while older readable events still exist.
+async fn recent_world_readable_messages(
+    room_id: &RoomId,
+    limit: usize,
+) -> AppResult<Vec<Box<RawJsonValue>>> {
     let mut messages = Vec::with_capacity(limit);
     let mut scan = limit.saturating_mul(2).clamp(limit, 100);
     loop {
@@ -103,7 +203,6 @@ async fn peek(_aa: AuthArgs, args: PeekReqArgs, depot: &mut Depot) -> JsonResult
             timeline::stream::load_pdus_backward(None, room_id, None, None, None, scan).await?;
         let raw = recent.len();
 
-        // `recent` is newest-first; keep the newest `limit` visible events.
         messages.clear();
         for (_sn, pdu) in &recent {
             if messages.len() >= limit {
@@ -117,21 +216,13 @@ async fn peek(_aa: AuthArgs, args: PeekReqArgs, depot: &mut Depot) -> JsonResult
             }
         }
 
-        // Enough collected, history exhausted (loader returned a short page), or
-        // we hit the work cap — stop.
         if messages.len() >= limit || raw < scan || scan >= PEEK_SCAN_CAP {
             break;
         }
         scan = scan.saturating_mul(2).min(PEEK_SCAN_CAP);
     }
-    // Collected newest-first; the response should read oldest-to-newest.
     messages.reverse();
-
-    json_ok(PeekResBody {
-        room_version,
-        pdus,
-        messages,
-    })
+    Ok(messages)
 }
 
 /// Upper bound on how many recent events a single peek will scan while looking

--- a/crates/server/src/routing/federation/room.rs
+++ b/crates/server/src/routing/federation/room.rs
@@ -139,6 +139,13 @@ async fn peek_start(
 
     let room_version = room::get_version(room_id).await?;
 
+    // Register the peer FIRST, before capturing the snapshot, so any event
+    // created while we read state/messages is forwarded to it (rather than
+    // falling into a gap between the snapshot and registration). A forwarded
+    // event the peer can't place yet is recovered via prev_events backfill, and
+    // duplicates with the snapshot are harmless/idempotent on its side.
+    fed_peek::register_peeking_server(room_id, &origin, &args.peek_id).await?;
+
     // Full current state + backing auth chain (like a send_join response) so the
     // peer can construct a complete, verifiable local copy of this world-readable
     // room. This is a deeper relationship than the stripped-state snapshot above
@@ -166,9 +173,6 @@ async fn peek_start(
     }
 
     let messages = recent_world_readable_messages(room_id, 50).await?;
-
-    // Register the peer so subsequent room events are forwarded to it.
-    fed_peek::register_peeking_server(room_id, &origin, &args.peek_id).await?;
 
     json_ok(PeekStartResBody {
         room_version,

--- a/crates/server/src/routing/federation/room.rs
+++ b/crates/server/src/routing/federation/room.rs
@@ -129,7 +129,23 @@ async fn peek_start(
         return Err(MatrixError::not_found("Room not found on this server.").into());
     }
     handler::acl_check(&origin, room_id).await?;
-    if !room::is_world_readable(room_id).await {
+
+    let room_version = room::get_version(room_id).await?;
+
+    // Pin the frame we'll serve, then verify world-readability *at that exact
+    // frame* (not "current"). This closes the TOCTOU where an admin makes the
+    // room private between a coarse is_world_readable() check and reading the
+    // state: whatever frame we return, we've confirmed it was world-readable.
+    let frame_id = room::get_frame_id(room_id, None).await?;
+    let frame_world_readable = state::get_state_content::<RoomHistoryVisibilityEventContent>(
+        frame_id,
+        &StateEventType::RoomHistoryVisibility,
+        "",
+    )
+    .await
+    .map(|c| c.history_visibility == HistoryVisibility::WorldReadable)
+    .unwrap_or(false);
+    if !frame_world_readable {
         return Err(MatrixError::forbidden(
             "Room is not world-readable; peeking is not permitted.",
             None,
@@ -137,20 +153,17 @@ async fn peek_start(
         .into());
     }
 
-    let room_version = room::get_version(room_id).await?;
-
-    // Register the peer FIRST, before capturing the snapshot, so any event
-    // created while we read state/messages is forwarded to it (rather than
-    // falling into a gap between the snapshot and registration). A forwarded
-    // event the peer can't place yet is recovered via prev_events backfill, and
-    // duplicates with the snapshot are harmless/idempotent on its side.
+    // Register the peer before capturing the snapshot, so any event created while
+    // we read state/messages is forwarded to it (rather than falling into a gap
+    // between the snapshot and registration). A forwarded event the peer can't
+    // place yet is recovered via prev_events backfill, and duplicates with the
+    // snapshot are harmless/idempotent on its side. (Ongoing relay is itself
+    // re-guarded by world-readability + ACL in append_pdu.)
     fed_peek::register_peeking_server(room_id, &origin, &args.peek_id).await?;
 
     // Full current state + backing auth chain (like a send_join response) so the
     // peer can construct a complete, verifiable local copy of this world-readable
-    // room. This is a deeper relationship than the stripped-state snapshot above
-    // and is gated on the room being world-readable + ACL-allowed.
-    let frame_id = room::get_frame_id(room_id, None).await?;
+    // room, built from the same `frame_id` we verified above.
     let state_ids: Vec<OwnedEventId> = state::get_full_state_ids(frame_id)
         .await?
         .into_values()

--- a/crates/server/src/sync_v3.rs
+++ b/crates/server/src/sync_v3.rs
@@ -133,6 +133,15 @@ pub async fn sync_events(
         if all_joined_rooms.contains(&room_id) {
             continue;
         }
+        // Re-check peekability every sync: if the room is no longer
+        // world-readable, peek access is revoked. Drop the peek so it stops
+        // appearing in sync (and the maintenance task tears down any federation
+        // subscription once no device peeks it), rather than leaking subsequent
+        // private state to a non-member.
+        if !room::is_world_readable(&room_id).await {
+            let _ = data::room::peek::remove_user_peek(sender_id, device_id, &room_id).await;
+            continue;
+        }
         match load_joined_room(
             sender_id,
             device_id,

--- a/crates/server/src/sync_v3.rs
+++ b/crates/server/src/sync_v3.rs
@@ -149,7 +149,12 @@ pub async fn sync_events(
         )
         .await
         {
-            Ok((peeked_room, _)) => {
+            Ok((mut peeked_room, _)) => {
+                // Strip joined-only ephemeral (read receipts, typing) and the
+                // user's own room account data: a peeker is not a member and
+                // shouldn't receive that activity for a room they only preview.
+                peeked_room.ephemeral = Default::default();
+                peeked_room.account_data = Default::default();
                 if since_tk.is_none() || !peeked_room.is_empty() {
                     peeked_rooms.insert(room_id, peeked_room);
                 }

--- a/crates/server/src/sync_v3.rs
+++ b/crates/server/src/sync_v3.rs
@@ -129,7 +129,7 @@ pub async fn sync_events(
     let mut peek_device_updates = HashSet::new();
     let mut peek_joined_users = HashSet::new();
     let mut peek_left_users = HashSet::new();
-    for room_id in data::room::peek::user_peeked_rooms(sender_id).await? {
+    for room_id in data::room::peek::user_peeked_rooms(sender_id, device_id).await? {
         if all_joined_rooms.contains(&room_id) {
             continue;
         }

--- a/crates/server/src/sync_v3.rs
+++ b/crates/server/src/sync_v3.rs
@@ -116,6 +116,42 @@ pub async fn sync_events(
         }
     }
 
+    // MSC2753: rooms this user is peeking (not a member of). They use the same
+    // shape as joined rooms. Skip any the user is actually joined to to avoid
+    // duplicate delivery. Built here, while the device/membership accumulators
+    // are still mutably available.
+    let mut peeked_rooms = BTreeMap::new();
+    for room_id in data::room::peek::user_peeked_rooms(sender_id).await? {
+        if all_joined_rooms.contains(&room_id) {
+            continue;
+        }
+        match load_joined_room(
+            sender_id,
+            device_id,
+            &room_id,
+            since_tk,
+            Some(BatchToken::new_live(curr_sn)),
+            next_batch,
+            full_state,
+            &filter,
+            args.use_state_after,
+            &mut device_list_updates,
+            &mut joined_users,
+            &mut left_users,
+        )
+        .await
+        {
+            Ok((peeked_room, _)) => {
+                if since_tk.is_none() || !peeked_room.is_empty() {
+                    peeked_rooms.insert(room_id, peeked_room);
+                }
+            }
+            Err(e) => {
+                tracing::error!(error = ?e, "load peeked room failed");
+            }
+        }
+    }
+
     let mut left_rooms = BTreeMap::new();
     let all_left_rooms = room::user::left_rooms(sender_id, since_tk).await?;
 
@@ -307,6 +343,7 @@ pub async fn sync_events(
         join: joined_rooms,
         invite: invited_rooms,
         knock: knocked_rooms,
+        peek: peeked_rooms,
     };
     let presence = Presence {
         events: presence_updates

--- a/crates/server/src/sync_v3.rs
+++ b/crates/server/src/sync_v3.rs
@@ -118,9 +118,17 @@ pub async fn sync_events(
 
     // MSC2753: rooms this user is peeking (not a member of). They use the same
     // shape as joined rooms. Skip any the user is actually joined to to avoid
-    // duplicate delivery. Built here, while the device/membership accumulators
-    // are still mutably available.
+    // duplicate delivery.
+    //
+    // Crucially, the device-list / presence accumulators are kept SEPARATE and
+    // discarded: a non-member peeking a world-readable room must not receive
+    // member device-key changes or presence for users they don't share a joined
+    // room with. `load_joined_room` mutates those sets as a side effect, so we
+    // give it throwaway ones here.
     let mut peeked_rooms = BTreeMap::new();
+    let mut peek_device_updates = HashSet::new();
+    let mut peek_joined_users = HashSet::new();
+    let mut peek_left_users = HashSet::new();
     for room_id in data::room::peek::user_peeked_rooms(sender_id).await? {
         if all_joined_rooms.contains(&room_id) {
             continue;
@@ -135,9 +143,9 @@ pub async fn sync_events(
             full_state,
             &filter,
             args.use_state_after,
-            &mut device_list_updates,
-            &mut joined_users,
-            &mut left_users,
+            &mut peek_device_updates,
+            &mut peek_joined_users,
+            &mut peek_left_users,
         )
         .await
         {
@@ -151,6 +159,9 @@ pub async fn sync_events(
             }
         }
     }
+    // peek_device_updates / peek_joined_users / peek_left_users go out of scope
+    // here unused — peeked rooms must not contribute device/presence info to the
+    // real sync sets.
 
     let mut left_rooms = BTreeMap::new();
     let all_left_rooms = room::user::left_rooms(sender_id, since_tk).await?;


### PR DESCRIPTION
End-to-end **live federated peeking**: a user can open a remote *world-readable*
room without joining, the server subscribes to it over federation, ingests it
locally, receives ongoing events, and delivers them to the user via `/sync`
until they stop peeking. Two layers:

- **MSC2444** — the server-to-server peek subscription.
- **MSC2753** — the client-facing half (`/sync` peek section + peek/unpeek).

Builds on the one-shot peek snapshot from #217.

---

## MSC2444 — federation peek subscription

New S2S endpoints (the existing `GET .../peek/{room_id}` snapshot is unchanged):
- `PUT /_matrix/federation/v1/peek/{room_id}/{peek_id}` — start/renew. Returns
  `{ room_version, state, auth_chain, messages, renewal_interval }` (full current
  state + backing auth chain, like a send_join response).
- `DELETE /_matrix/federation/v1/peek/{room_id}/{peek_id}` — cancel.

**Resident side** (room's home server): tracks peeking servers in
`room_peeking_servers` with a renewal deadline, gated on **world-readable** +
**ACL**; `build_and_append_pdu` forwards new events to active peekers (merged
with participating servers, deduped); lapsed peekers are purged.

**Peeking side**: `start_peek` PUTs the subscription and ingests state + auth
chain + recent timeline into the local store (mirroring the send_join path),
recording the peek in `room_peeks`. Ongoing events then arrive via the normal
`/send` transaction path. A 60s background task renews peeks before they lapse
and purges expired inbound peekers.

## MSC2753 — client-side peeking via /sync

- `POST /_matrix/client/v3/rooms/{room_id}/peek` — start peeking. For a remote
  room not held locally this first establishes the MSC2444 federation peek, then
  records the user peek (gated on world-readability).
- `POST /_matrix/client/v3/rooms/{room_id}/unpeek` — stop; the last local user
  leaving a room tears down the federation subscription.
- `/sync` returns peeked rooms in a new `rooms` section
  (`org.matrix.msc2753.peek`), reusing the joined-room loader so timeline/state/
  ephemeral updates flow exactly as for joined rooms.
- The `roomInitialSync` path for an unknown remote room also establishes a live
  peek and serves from the local copy, falling back to the one-shot snapshot if
  a subscription can't be set up.

## DB

New tables + migrations:
- `room_peeking_servers` (remote servers peeking our rooms)
- `room_peeks` (our outbound peeks on remote rooms)
- `user_peeks` (which local users peek which rooms)

## Scope & validation (please read)

- **Compiles clean across the workspace** (`cargo check --workspace`), but has
  **not** been exercised against a live two-server federation environment. The
  ingestion mirrors the working send_join path; state-resolution, ongoing
  delivery, renewal, and teardown all need end-to-end validation with two real
  servers.
- **Requires running both migrations and deploying to both peers.** Peeking only
  works if the peeking and resident servers both run this code.
- MSC2753 `/sync` peek delivery depends on **client support** for the peek
  section; the federation peek + local ingestion work regardless, and are
  reflected on (re)load via `roomInitialSync`.
- Peek subscriptions are server-level (one per room); local users share them.
  The resident's returned state for a world-readable room is trusted similarly
  to send_join.

Reviewers with a two-server setup should verify: peek start/renew/cancel; events
flowing to peekers; the peeking server building correct room state; ACL /
non-world-readable rooms being refused; peeked rooms appearing in `/sync` and
disappearing on unpeek.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
