### PR TITLE
fix(client): require auth for room initialSync (fixes 401 on room preview)

### DIFF
--- a/crates/server/src/routing/client.rs
+++ b/crates/server/src/routing/client.rs
@@ -50,7 +50,6 @@ pub fn router() -> Router {
                     .push(profile::public_router())
                     .push(register::public_router())
                     .push(session::public_router())
-                    .push(room::public_router())
                     .push(directory::public_router())
                     .push(media::self_auth_router())
                     .push(

--- a/crates/server/src/routing/client/room.rs
+++ b/crates/server/src/routing/client/room.rs
@@ -59,11 +59,6 @@ use crate::{
 
 const LIMIT_MAX: usize = 100;
 
-pub fn public_router() -> Router {
-    Router::with_path("rooms").push(
-        Router::with_path("{room_id}").push(Router::with_path("initialSync").get(initial_sync)),
-    )
-}
 pub fn authed_router() -> Router {
     Router::with_path("rooms")
         .push(
@@ -84,6 +79,7 @@ pub fn authed_router() -> Router {
                             .put(receipt::send_receipt),
                     )
                     .push(Router::with_path("timestamp_to_event").get(event::timestamp_to_event))
+                    .push(Router::with_path("initialSync").get(initial_sync))
                     .push(Router::with_path("peek").post(peek_room))
                     .push(Router::with_path("unpeek").post(unpeek_room)),
             ),


### PR DESCRIPTION
## The bug

`GET /_matrix/client/v3/rooms/{roomId}/initialSync` was registered in the client **public** router group (no `auth_by_access_token` hoop), but its handler begins with `depot.authed_info()?`. With the hoop never run, `authed_info` is absent, so the handler fails immediately and returns:

```json
{"errcode":"M_UNAUTHORIZED","error":"The request requires user authentication."}
```

…for **every** authenticated call, before any room-preview / peek logic executes.

This is why opening a remote room in a client (e.g. `#/room/#test:other.server`) returned a 401 on `initialSync` and got stuck on "Loading…", even though every other client endpoint — all under the authed router — worked fine with the same token. It also made the #217 preview and #218 peek paths unreachable (they live past that `authed_info()?` line).

## The fix

Move the `initialSync` route from `room::public_router()` into the authed `rooms/{room_id}` router so the access-token hoop runs and `authed_info` is populated. Remove the now-empty `room::public_router` and its mount point.

`cargo check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)