### PR TITLE
refactor(data): centralize phase-1 DB access into data crate

### DIFF
--- a/crates/data/src/appservice.rs
+++ b/crates/data/src/appservice.rs
@@ -1,0 +1,201 @@
+use std::fmt;
+
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+use serde::{Deserialize, Serialize};
+
+use crate::core::appservice::Registration;
+use crate::core::serde::JsonValue;
+use crate::schema::*;
+use crate::{DataResult, connect};
+
+#[derive(Identifiable, Queryable, Insertable, Serialize, Deserialize, Clone)]
+#[diesel(table_name = appservice_registrations)]
+pub struct DbRegistration {
+    /// A unique, user - defined ID of the application service which will never change.
+    pub id: String,
+
+    /// The URL for the application service.
+    ///
+    /// Optionally set to `null` if no traffic is required.
+    pub url: Option<String>,
+
+    /// A unique token for application services to use to authenticate requests to HomeServers.
+    pub as_token: String,
+
+    /// A unique token for HomeServers to use to authenticate requests to application services.
+    pub hs_token: String,
+
+    /// The localpart of the user associated with the application service.
+    pub sender_localpart: String,
+
+    /// A list of users, aliases and rooms namespaces that the application service controls.
+    pub namespaces: JsonValue,
+
+    /// Whether requests from masqueraded users are rate-limited.
+    ///
+    /// The sender is excluded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_limited: Option<bool>,
+
+    /// The external protocols which the application service provides (e.g. IRC).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protocols: Option<JsonValue>,
+
+    /// Whether the application service wants to receive ephemeral data.
+    ///
+    /// Defaults to `false`.
+    pub receive_ephemeral: bool,
+
+    /// Whether the application service wants to do device management, as part of MSC4190.
+    ///
+    /// Defaults to `false`
+    #[serde(default, rename = "io.element.msc4190")]
+    pub device_management: bool,
+
+    /// Whether this appservice is administratively disabled.
+    ///
+    /// Disabled appservices are loaded but not returned by the enabled list, so
+    /// they neither receive events nor authenticate requests.
+    #[serde(default)]
+    pub disabled: bool,
+}
+
+// Custom Debug implementation to prevent leaking as_token and hs_token
+impl fmt::Debug for DbRegistration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DbRegistration")
+            .field("id", &self.id)
+            .field("url", &self.url)
+            .field("as_token", &"[REDACTED]")
+            .field("hs_token", &"[REDACTED]")
+            .field("sender_localpart", &self.sender_localpart)
+            .field("namespaces", &self.namespaces)
+            .field("rate_limited", &self.rate_limited)
+            .field("protocols", &self.protocols)
+            .field("receive_ephemeral", &self.receive_ephemeral)
+            .field("device_management", &self.device_management)
+            .field("disabled", &self.disabled)
+            .finish()
+    }
+}
+
+impl From<Registration> for DbRegistration {
+    fn from(value: Registration) -> Self {
+        let Registration {
+            id,
+            url,
+            as_token,
+            hs_token,
+            sender_localpart,
+            namespaces,
+            rate_limited,
+            protocols,
+            receive_ephemeral,
+            device_management,
+        } = value;
+        Self {
+            id,
+            url,
+            as_token,
+            hs_token,
+            sender_localpart,
+            namespaces: serde_json::to_value(namespaces).unwrap_or_default(),
+            rate_limited,
+            protocols: protocols
+                .map(|protocols| serde_json::to_value(protocols).unwrap_or_default()),
+            receive_ephemeral,
+            device_management,
+            disabled: false,
+        }
+    }
+}
+impl TryFrom<DbRegistration> for Registration {
+    type Error = serde_json::Error;
+
+    fn try_from(value: DbRegistration) -> Result<Self, Self::Error> {
+        let DbRegistration {
+            id,
+            url,
+            as_token,
+            hs_token,
+            sender_localpart,
+            namespaces,
+            rate_limited,
+            protocols,
+            receive_ephemeral,
+            device_management,
+            disabled: _,
+        } = value;
+        let protocols = if let Some(protocols) = protocols {
+            serde_json::from_value(protocols)?
+        } else {
+            None
+        };
+        Ok(Self {
+            id,
+            url,
+            as_token,
+            hs_token,
+            sender_localpart,
+            namespaces: serde_json::from_value(namespaces)?,
+            rate_limited,
+            protocols,
+            receive_ephemeral,
+            device_management,
+        })
+    }
+}
+
+/// Insert a new appservice registration.
+pub async fn insert_registration(registration: &DbRegistration) -> DataResult<()> {
+    diesel::insert_into(appservice_registrations::table)
+        .values(registration)
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Delete an appservice registration by id.
+pub async fn delete_registration(id: &str) -> DataResult<()> {
+    diesel::delete(appservice_registrations::table.find(id))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Set the `disabled` flag on an appservice. Returns true if a row was updated.
+pub async fn set_disabled(id: &str, disabled: bool) -> DataResult<bool> {
+    let affected = diesel::update(appservice_registrations::table.find(id))
+        .set(appservice_registrations::disabled.eq(disabled))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(affected > 0)
+}
+
+/// Load every registration, including administratively disabled ones.
+pub async fn all_registrations() -> DataResult<Vec<DbRegistration>> {
+    appservice_registrations::table
+        .load::<DbRegistration>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// Load only enabled (not administratively disabled) registrations.
+pub async fn enabled_registrations() -> DataResult<Vec<DbRegistration>> {
+    appservice_registrations::table
+        .filter(appservice_registrations::disabled.eq(false))
+        .load::<DbRegistration>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// Fetch a single registration by id.
+pub async fn find_registration(id: &str) -> DataResult<Option<DbRegistration>> {
+    appservice_registrations::table
+        .find(id)
+        .first::<DbRegistration>(&mut connect().await?)
+        .await
+        .optional()
+        .map_err(Into::into)
+}

--- a/crates/data/src/lib.rs
+++ b/crates/data/src/lib.rs
@@ -18,6 +18,7 @@ pub mod full_text_search;
 pub mod pool;
 pub use pool::{DieselPool, PgPooledConnection, PoolError};
 
+pub mod appservice;
 pub mod media;
 pub mod misc;
 pub mod room;

--- a/crates/data/src/misc.rs
+++ b/crates/data/src/misc.rs
@@ -1,8 +1,10 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::core::serde::JsonValue;
-use crate::core::{OwnedServerName, UnixMillis};
+use crate::core::{OwnedServerName, ServerName, UnixMillis};
 use crate::schema::*;
+use crate::{DataResult, connect};
 
 #[derive(Identifiable, Queryable, Insertable, Debug, Clone)]
 #[diesel(table_name = server_signing_keys, primary_key(server_id))]
@@ -11,4 +13,38 @@ pub struct DbServerSigningKeys {
     pub key_data: JsonValue,
     pub updated_at: UnixMillis,
     pub created_at: UnixMillis,
+}
+
+/// Fetch the raw signing-key JSON blob stored for a server, if any.
+pub async fn signing_keys_data(server: &ServerName) -> DataResult<Option<JsonValue>> {
+    server_signing_keys::table
+        .filter(server_signing_keys::server_id.eq(server))
+        .select(server_signing_keys::key_data)
+        .first::<JsonValue>(&mut connect().await?)
+        .await
+        .optional()
+        .map_err(Into::into)
+}
+
+/// Insert or update the signing-key JSON blob for a server.
+///
+/// Callers are responsible for any merge logic; this performs a plain upsert of
+/// the already-merged `key_data`.
+pub async fn upsert_signing_keys(server: &ServerName, key_data: JsonValue) -> DataResult<()> {
+    diesel::insert_into(server_signing_keys::table)
+        .values(DbServerSigningKeys {
+            server_id: server.to_owned(),
+            key_data: key_data.clone(),
+            updated_at: UnixMillis::now(),
+            created_at: UnixMillis::now(),
+        })
+        .on_conflict(server_signing_keys::server_id)
+        .do_update()
+        .set((
+            server_signing_keys::key_data.eq(key_data),
+            server_signing_keys::updated_at.eq(UnixMillis::now()),
+        ))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
 }

--- a/crates/data/src/room.rs
+++ b/crates/data/src/room.rs
@@ -14,6 +14,7 @@ pub mod event_report;
 pub mod peek;
 pub mod receipt;
 pub mod timeline;
+pub mod transaction_id;
 pub use event_report::*;
 
 #[derive(Insertable, Identifiable, Queryable, Debug, Clone)]

--- a/crates/data/src/room/transaction_id.rs
+++ b/crates/data/src/room/transaction_id.rs
@@ -1,0 +1,83 @@
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+
+use crate::core::identifiers::*;
+use crate::core::{DeviceId, TransactionId, UnixMillis, UserId};
+use crate::room::NewDbEventIdempotent;
+use crate::schema::*;
+use crate::{DataResult, connect};
+
+/// Record a transaction id together with the event it produced for idempotency.
+pub async fn add_txn_id(
+    txn_id: &TransactionId,
+    user_id: &UserId,
+    device_id: Option<&DeviceId>,
+    room_id: Option<&RoomId>,
+    event_id: Option<&EventId>,
+) -> DataResult<()> {
+    diesel::insert_into(event_idempotents::table)
+        .values(&NewDbEventIdempotent {
+            txn_id: txn_id.to_owned(),
+            user_id: user_id.to_owned(),
+            device_id: device_id.map(|d| d.to_owned()),
+            room_id: room_id.map(|r| r.to_owned()),
+            event_id: event_id.map(|e| e.to_owned()),
+            created_at: UnixMillis::now(),
+        })
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Check whether a `(user, device, txn_id)` combination has already been seen.
+pub async fn txn_id_exists(
+    txn_id: &TransactionId,
+    user_id: &UserId,
+    device_id: Option<&DeviceId>,
+) -> DataResult<bool> {
+    if let Some(device_id) = device_id {
+        let query = event_idempotents::table
+            .filter(event_idempotents::user_id.eq(user_id))
+            .filter(event_idempotents::device_id.eq(device_id))
+            .filter(event_idempotents::txn_id.eq(txn_id))
+            .select(event_idempotents::event_id);
+        diesel_exists!(query, &mut connect().await?).map_err(Into::into)
+    } else {
+        let query = event_idempotents::table
+            .filter(event_idempotents::user_id.eq(user_id))
+            .filter(event_idempotents::device_id.is_null())
+            .filter(event_idempotents::txn_id.eq(txn_id))
+            .select(event_idempotents::event_id);
+        diesel_exists!(query, &mut connect().await?).map_err(Into::into)
+    }
+}
+
+/// Look up the event id previously recorded for a transaction.
+pub async fn get_event_id(
+    txn_id: &TransactionId,
+    user_id: &UserId,
+    device_id: Option<&DeviceId>,
+    room_id: Option<&RoomId>,
+) -> DataResult<Option<OwnedEventId>> {
+    let mut query = event_idempotents::table
+        .filter(event_idempotents::user_id.eq(user_id))
+        .filter(event_idempotents::txn_id.eq(txn_id))
+        .into_boxed();
+    if let Some(device_id) = device_id {
+        query = query.filter(event_idempotents::device_id.eq(device_id));
+    } else {
+        query = query.filter(event_idempotents::device_id.is_null());
+    }
+    if let Some(room_id) = room_id {
+        query = query.filter(event_idempotents::room_id.eq(room_id));
+    } else {
+        query = query.filter(event_idempotents::room_id.is_null());
+    }
+    query
+        .select(event_idempotents::event_id)
+        .first::<Option<OwnedEventId>>(&mut connect().await?)
+        .await
+        .optional()
+        .map(|v| v.flatten())
+        .map_err(Into::into)
+}

--- a/crates/data/src/sending.rs
+++ b/crates/data/src/sending.rs
@@ -5,8 +5,17 @@ use diesel_async::RunQueryDsl;
 
 use crate::core::identifiers::*;
 pub use crate::core::sending::*;
+use crate::core::UnixMillis;
 use crate::schema::*;
 use crate::{DataResult, connect};
+
+/// Selector identifying which active outgoing-request rows a retry-state update
+/// applies to. Mirrors the variants of the server-side `OutgoingKind`.
+pub enum OutgoingDestination<'a> {
+    Normal(&'a ServerName),
+    Appservice(&'a str),
+    Push { user_id: &'a UserId, pushkey: &'a str },
+}
 
 #[derive(Identifiable, Queryable, Insertable, Debug, Clone)]
 #[diesel(table_name = outgoing_requests)]
@@ -65,6 +74,61 @@ pub async fn get_destination_rooms(server: &ServerName) -> DataResult<Vec<OwnedR
         .load(&mut connect().await?)
         .await?;
     Ok(rooms)
+}
+
+/// Persist retry state for the active outgoing requests of a destination so
+/// other instances can respect the same backoff window.
+pub async fn persist_retry_state(
+    dest: OutgoingDestination<'_>,
+    tries: u32,
+) -> DataResult<()> {
+    let now = UnixMillis::now().get() as i64;
+    match dest {
+        OutgoingDestination::Normal(server_name) => {
+            diesel::update(
+                outgoing_requests::table
+                    .filter(outgoing_requests::kind.eq("normal"))
+                    .filter(outgoing_requests::server_id.eq(server_name))
+                    .filter(outgoing_requests::state.eq("active")),
+            )
+            .set((
+                outgoing_requests::retry_count.eq(tries as i32),
+                outgoing_requests::last_failed_at.eq(Some(now)),
+            ))
+            .execute(&mut connect().await?)
+            .await?;
+        }
+        OutgoingDestination::Appservice(id) => {
+            diesel::update(
+                outgoing_requests::table
+                    .filter(outgoing_requests::kind.eq("appservice"))
+                    .filter(outgoing_requests::appservice_id.eq(id))
+                    .filter(outgoing_requests::state.eq("active")),
+            )
+            .set((
+                outgoing_requests::retry_count.eq(tries as i32),
+                outgoing_requests::last_failed_at.eq(Some(now)),
+            ))
+            .execute(&mut connect().await?)
+            .await?;
+        }
+        OutgoingDestination::Push { user_id, pushkey } => {
+            diesel::update(
+                outgoing_requests::table
+                    .filter(outgoing_requests::kind.eq("push"))
+                    .filter(outgoing_requests::user_id.eq(user_id))
+                    .filter(outgoing_requests::pushkey.eq(pushkey))
+                    .filter(outgoing_requests::state.eq("active")),
+            )
+            .set((
+                outgoing_requests::retry_count.eq(tries as i32),
+                outgoing_requests::last_failed_at.eq(Some(now)),
+            ))
+            .execute(&mut connect().await?)
+            .await?;
+        }
+    }
+    Ok(())
 }
 
 /// Reset retry timings for a destination

--- a/crates/data/src/user.rs
+++ b/crates/data/src/user.rs
@@ -24,6 +24,7 @@ pub use session::*;
 pub mod external_id;
 pub mod presence;
 pub mod registration_token;
+pub mod uiaa;
 use std::mem;
 
 use diesel::dsl;

--- a/crates/data/src/user/uiaa.rs
+++ b/crates/data/src/user/uiaa.rs
@@ -1,0 +1,105 @@
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+
+use crate::core::client::uiaa::UiaaInfo;
+use crate::core::identifiers::*;
+use crate::core::serde::{CanonicalJsonValue, JsonValue};
+use crate::schema::*;
+use crate::{DataResult, connect};
+
+/// Upsert (when `uiaa_info` is `Some`) or delete (when `None`) the UIAA session
+/// row for a `(user, device, session)` triple.
+pub async fn update_session(
+    user_id: &UserId,
+    device_id: &DeviceId,
+    session: &str,
+    uiaa_info: Option<&UiaaInfo>,
+) -> DataResult<()> {
+    if let Some(uiaa_info) = uiaa_info {
+        let uiaa_info = serde_json::to_value(uiaa_info)?;
+        diesel::insert_into(user_uiaa_datas::table)
+            .values((
+                user_uiaa_datas::user_id.eq(user_id),
+                user_uiaa_datas::device_id.eq(device_id),
+                user_uiaa_datas::session.eq(session),
+                user_uiaa_datas::uiaa_info.eq(&uiaa_info),
+            ))
+            .on_conflict((
+                user_uiaa_datas::user_id,
+                user_uiaa_datas::device_id,
+                user_uiaa_datas::session,
+            ))
+            .do_update()
+            .set(user_uiaa_datas::uiaa_info.eq(&uiaa_info))
+            .execute(&mut connect().await?)
+            .await?;
+    } else {
+        diesel::delete(
+            user_uiaa_datas::table
+                .filter(user_uiaa_datas::user_id.eq(user_id))
+                .filter(user_uiaa_datas::device_id.eq(device_id))
+                .filter(user_uiaa_datas::session.eq(session)),
+        )
+        .execute(&mut connect().await?)
+        .await?;
+    };
+    Ok(())
+}
+
+/// Fetch the stored `UiaaInfo` for a `(user, device, session)` triple.
+pub async fn get_session(
+    user_id: &UserId,
+    device_id: &DeviceId,
+    session: &str,
+) -> DataResult<UiaaInfo> {
+    let uiaa_info = user_uiaa_datas::table
+        .filter(user_uiaa_datas::user_id.eq(user_id))
+        .filter(user_uiaa_datas::device_id.eq(device_id))
+        .filter(user_uiaa_datas::session.eq(session))
+        .select(user_uiaa_datas::uiaa_info)
+        .first::<JsonValue>(&mut connect().await?)
+        .await?;
+    Ok(serde_json::from_value(uiaa_info)?)
+}
+
+/// Store the UIAA request body in the database for cross-instance access.
+pub async fn set_uiaa_request(
+    user_id: &UserId,
+    device_id: &DeviceId,
+    session: &str,
+    request: &CanonicalJsonValue,
+) -> DataResult<()> {
+    let request_body = serde_json::to_value(request)?;
+    diesel::update(
+        user_uiaa_datas::table
+            .filter(user_uiaa_datas::user_id.eq(user_id))
+            .filter(user_uiaa_datas::device_id.eq(device_id))
+            .filter(user_uiaa_datas::session.eq(session)),
+    )
+    .set(user_uiaa_datas::request_body.eq(Some(&request_body)))
+    .execute(&mut connect().await?)
+    .await?;
+    Ok(())
+}
+
+/// Get the UIAA request body from the database.
+pub async fn get_uiaa_request(
+    user_id: &UserId,
+    device_id: &DeviceId,
+    session: &str,
+) -> DataResult<Option<CanonicalJsonValue>> {
+    let request_body = user_uiaa_datas::table
+        .filter(user_uiaa_datas::user_id.eq(user_id))
+        .filter(user_uiaa_datas::device_id.eq(device_id))
+        .filter(user_uiaa_datas::session.eq(session))
+        .select(user_uiaa_datas::request_body)
+        .first::<Option<JsonValue>>(&mut connect().await?)
+        .await
+        .optional()?
+        .flatten();
+
+    match request_body {
+        Some(body) => Ok(Some(serde_json::from_value(body)?)),
+        None => Ok(None),
+    }
+}

--- a/crates/server/src/appservice.rs
+++ b/crates/server/src/appservice.rs
@@ -1,19 +1,13 @@
 use std::collections::BTreeMap;
-use std::fmt;
 use std::time::Duration;
 
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
 use regex::RegexSet;
-use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
 
 use crate::core::appservice::{Namespace, Registration};
 use crate::core::identifiers::*;
-use crate::core::serde::JsonValue;
-use crate::data::connect;
-use crate::data::schema::*;
-use crate::{AppError, AppResult, sending};
+pub use crate::data::appservice::DbRegistration;
+use crate::{AppError, AppResult, data, sending};
 
 /// Compiled regular expressions for a namespace.
 #[derive(Clone, Debug)]
@@ -133,151 +127,10 @@ impl TryFrom<DbRegistration> for RegistrationInfo {
     }
 }
 
-#[derive(Identifiable, Queryable, Insertable, Serialize, Deserialize, Clone)]
-#[diesel(table_name = appservice_registrations)]
-pub struct DbRegistration {
-    /// A unique, user - defined ID of the application service which will never change.
-    pub id: String,
-
-    /// The URL for the application service.
-    ///
-    /// Optionally set to `null` if no traffic is required.
-    pub url: Option<String>,
-
-    /// A unique token for application services to use to authenticate requests to HomeServers.
-    pub as_token: String,
-
-    /// A unique token for HomeServers to use to authenticate requests to application services.
-    pub hs_token: String,
-
-    /// The localpart of the user associated with the application service.
-    pub sender_localpart: String,
-
-    /// A list of users, aliases and rooms namespaces that the application service controls.
-    pub namespaces: JsonValue,
-
-    /// Whether requests from masqueraded users are rate-limited.
-    ///
-    /// The sender is excluded.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub rate_limited: Option<bool>,
-
-    /// The external protocols which the application service provides (e.g. IRC).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub protocols: Option<JsonValue>,
-
-    /// Whether the application service wants to receive ephemeral data.
-    ///
-    /// Defaults to `false`.
-    pub receive_ephemeral: bool,
-
-    /// Whether the application service wants to do device management, as part of MSC4190.
-    ///
-    /// Defaults to `false`
-    #[serde(default, rename = "io.element.msc4190")]
-    pub device_management: bool,
-
-    /// Whether this appservice is administratively disabled.
-    ///
-    /// Disabled appservices are loaded but not returned by `all()`, so they
-    /// neither receive events nor authenticate requests.
-    #[serde(default)]
-    pub disabled: bool,
-}
-
-// Custom Debug implementation to prevent leaking as_token and hs_token
-impl fmt::Debug for DbRegistration {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DbRegistration")
-            .field("id", &self.id)
-            .field("url", &self.url)
-            .field("as_token", &"[REDACTED]")
-            .field("hs_token", &"[REDACTED]")
-            .field("sender_localpart", &self.sender_localpart)
-            .field("namespaces", &self.namespaces)
-            .field("rate_limited", &self.rate_limited)
-            .field("protocols", &self.protocols)
-            .field("receive_ephemeral", &self.receive_ephemeral)
-            .field("device_management", &self.device_management)
-            .field("disabled", &self.disabled)
-            .finish()
-    }
-}
-
-impl From<Registration> for DbRegistration {
-    fn from(value: Registration) -> Self {
-        let Registration {
-            id,
-            url,
-            as_token,
-            hs_token,
-            sender_localpart,
-            namespaces,
-            rate_limited,
-            protocols,
-            receive_ephemeral,
-            device_management,
-        } = value;
-        Self {
-            id,
-            url,
-            as_token,
-            hs_token,
-            sender_localpart,
-            namespaces: serde_json::to_value(namespaces).unwrap_or_default(),
-            rate_limited,
-            protocols: protocols
-                .map(|protocols| serde_json::to_value(protocols).unwrap_or_default()),
-            receive_ephemeral,
-            device_management,
-            disabled: false,
-        }
-    }
-}
-impl TryFrom<DbRegistration> for Registration {
-    type Error = serde_json::Error;
-
-    fn try_from(value: DbRegistration) -> Result<Self, Self::Error> {
-        let DbRegistration {
-            id,
-            url,
-            as_token,
-            hs_token,
-            sender_localpart,
-            namespaces,
-            rate_limited,
-            protocols,
-            receive_ephemeral,
-            device_management,
-            disabled: _,
-        } = value;
-        let protocols = if let Some(protocols) = protocols {
-            serde_json::from_value(protocols)?
-        } else {
-            None
-        };
-        Ok(Self {
-            id,
-            url,
-            as_token,
-            hs_token,
-            sender_localpart,
-            namespaces: serde_json::from_value(namespaces)?,
-            rate_limited,
-            protocols,
-            receive_ephemeral,
-            device_management,
-        })
-    }
-}
-
 /// Registers an appservice and returns the ID to the caller
 pub async fn register_appservice(registration: Registration) -> AppResult<String> {
     let db_registration: DbRegistration = registration.into();
-    diesel::insert_into(appservice_registrations::table)
-        .values(&db_registration)
-        .execute(&mut connect().await?)
-        .await?;
+    data::appservice::insert_registration(&db_registration).await?;
     Ok(db_registration.id)
 }
 
@@ -287,26 +140,18 @@ pub async fn register_appservice(registration: Registration) -> AppResult<String
 ///
 /// * `service_name` - the name you send to register the service previously
 pub async fn unregister_appservice(id: &str) -> AppResult<()> {
-    diesel::delete(appservice_registrations::table.find(id))
-        .execute(&mut connect().await?)
-        .await?;
+    data::appservice::delete_registration(id).await?;
     Ok(())
 }
 
 /// Set the `disabled` flag on an appservice. Returns true if a row was updated.
 pub async fn set_appservice_disabled(id: &str, disabled: bool) -> AppResult<bool> {
-    let affected = diesel::update(appservice_registrations::table.find(id))
-        .set(appservice_registrations::disabled.eq(disabled))
-        .execute(&mut connect().await?)
-        .await?;
-    Ok(affected > 0)
+    Ok(data::appservice::set_disabled(id, disabled).await?)
 }
 
 /// List all registrations in the database, including disabled ones.
 pub async fn list_all_registrations() -> AppResult<Vec<(DbRegistration, bool)>> {
-    let regs = appservice_registrations::table
-        .load::<DbRegistration>(&mut connect().await?)
-        .await?;
+    let regs = data::appservice::all_registrations().await?;
     Ok(regs
         .into_iter()
         .map(|r| {
@@ -317,12 +162,7 @@ pub async fn list_all_registrations() -> AppResult<Vec<(DbRegistration, bool)>> 
 }
 
 pub async fn get_registration(id: &str) -> AppResult<Option<Registration>> {
-    if let Some(registration) = appservice_registrations::table
-        .find(id)
-        .first::<DbRegistration>(&mut connect().await?)
-        .await
-        .optional()?
-    {
+    if let Some(registration) = data::appservice::find_registration(id).await? {
         Ok(Some(registration.try_into()?))
     } else {
         Ok(None)
@@ -375,10 +215,7 @@ pub async fn is_exclusive_room_id(room_id: &RoomId) -> AppResult<bool> {
 }
 
 pub async fn all() -> AppResult<BTreeMap<String, RegistrationInfo>> {
-    let registrations = appservice_registrations::table
-        .filter(appservice_registrations::disabled.eq(false))
-        .load::<DbRegistration>(&mut connect().await?)
-        .await?;
+    let registrations = data::appservice::enabled_registrations().await?;
     Ok(registrations
         .into_iter()
         .filter_map(|db_registration| {

--- a/crates/server/src/global.rs
+++ b/crates/server/src/global.rs
@@ -18,9 +18,8 @@ use crate::appservice::DbRegistration;
 use crate::core::appservice::Registration;
 use crate::core::federation::discovery::{OldVerifyKey, ServerSigningKeys};
 use crate::core::identifiers::*;
-use crate::core::serde::{Base64, JsonValue};
+use crate::core::serde::Base64;
 use crate::core::{Seqnum, UnixMillis};
-use crate::data::misc::DbServerSigningKeys;
 use crate::data::schema::*;
 use crate::data::user::{NewDbUser, NewDbUserDevice};
 use crate::data::{connect, diesel_exists};
@@ -267,12 +266,7 @@ pub async fn add_signing_key_from_trusted_server(
     from_server: &ServerName,
     new_keys: ServerSigningKeys,
 ) -> AppResult<SigningKeys> {
-    let key_data = server_signing_keys::table
-        .filter(server_signing_keys::server_id.eq(from_server))
-        .select(server_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect().await?)
-        .await
-        .optional()?;
+    let key_data = crate::data::misc::signing_keys_data(from_server).await?;
 
     let prev_keys: Option<ServerSigningKeys> = key_data.map(serde_json::from_value).transpose()?;
 
@@ -287,37 +281,11 @@ pub async fn add_signing_key_from_trusted_server(
         prev_keys.old_verify_keys.extend(old_verify_keys);
         prev_keys.valid_until_ts = new_keys.valid_until_ts;
 
-        diesel::insert_into(server_signing_keys::table)
-            .values(DbServerSigningKeys {
-                server_id: from_server.to_owned(),
-                key_data: serde_json::to_value(&prev_keys)?,
-                updated_at: UnixMillis::now(),
-                created_at: UnixMillis::now(),
-            })
-            .on_conflict(server_signing_keys::server_id)
-            .do_update()
-            .set((
-                server_signing_keys::key_data.eq(serde_json::to_value(&prev_keys)?),
-                server_signing_keys::updated_at.eq(UnixMillis::now()),
-            ))
-            .execute(&mut connect().await?)
+        crate::data::misc::upsert_signing_keys(from_server, serde_json::to_value(&prev_keys)?)
             .await?;
         Ok(prev_keys.into())
     } else {
-        diesel::insert_into(server_signing_keys::table)
-            .values(DbServerSigningKeys {
-                server_id: from_server.to_owned(),
-                key_data: serde_json::to_value(&new_keys)?,
-                updated_at: UnixMillis::now(),
-                created_at: UnixMillis::now(),
-            })
-            .on_conflict(server_signing_keys::server_id)
-            .do_update()
-            .set((
-                server_signing_keys::key_data.eq(serde_json::to_value(&new_keys)?),
-                server_signing_keys::updated_at.eq(UnixMillis::now()),
-            ))
-            .execute(&mut connect().await?)
+        crate::data::misc::upsert_signing_keys(from_server, serde_json::to_value(&new_keys)?)
             .await?;
         Ok(new_keys.into())
     }
@@ -326,12 +294,7 @@ pub async fn add_signing_key_from_origin(
     origin: &ServerName,
     new_keys: ServerSigningKeys,
 ) -> AppResult<SigningKeys> {
-    let key_data = server_signing_keys::table
-        .filter(server_signing_keys::server_id.eq(origin))
-        .select(server_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect().await?)
-        .await
-        .optional()?;
+    let key_data = crate::data::misc::signing_keys_data(origin).await?;
 
     let prev_keys: Option<ServerSigningKeys> = key_data.map(serde_json::from_value).transpose()?;
 
@@ -355,38 +318,10 @@ pub async fn add_signing_key_from_origin(
         prev_keys.old_verify_keys.extend(old_verify_keys);
         prev_keys.valid_until_ts = new_keys.valid_until_ts;
 
-        diesel::insert_into(server_signing_keys::table)
-            .values(DbServerSigningKeys {
-                server_id: origin.to_owned(),
-                key_data: serde_json::to_value(&prev_keys)?,
-                updated_at: UnixMillis::now(),
-                created_at: UnixMillis::now(),
-            })
-            .on_conflict(server_signing_keys::server_id)
-            .do_update()
-            .set((
-                server_signing_keys::key_data.eq(serde_json::to_value(&prev_keys)?),
-                server_signing_keys::updated_at.eq(UnixMillis::now()),
-            ))
-            .execute(&mut connect().await?)
-            .await?;
+        crate::data::misc::upsert_signing_keys(origin, serde_json::to_value(&prev_keys)?).await?;
         Ok(prev_keys.into())
     } else {
-        diesel::insert_into(server_signing_keys::table)
-            .values(DbServerSigningKeys {
-                server_id: origin.to_owned(),
-                key_data: serde_json::to_value(&new_keys)?,
-                updated_at: UnixMillis::now(),
-                created_at: UnixMillis::now(),
-            })
-            .on_conflict(server_signing_keys::server_id)
-            .do_update()
-            .set((
-                server_signing_keys::key_data.eq(serde_json::to_value(&new_keys)?),
-                server_signing_keys::updated_at.eq(UnixMillis::now()),
-            ))
-            .execute(&mut connect().await?)
-            .await?;
+        crate::data::misc::upsert_signing_keys(origin, serde_json::to_value(&new_keys)?).await?;
         Ok(new_keys.into())
     }
 }

--- a/crates/server/src/sending/guard.rs
+++ b/crates/server/src/sending/guard.rs
@@ -3,8 +3,6 @@ use std::future::pending;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::{Mutex, mpsc};
 
@@ -17,9 +15,7 @@ use crate::core::events::receipt::{ReceiptContent, ReceiptData, ReceiptMap, Rece
 use crate::core::federation::transaction::Edu;
 use crate::core::identifiers::*;
 use crate::core::presence::{PresenceContent, PresenceUpdate};
-use crate::core::{Seqnum, UnixMillis, device_id};
-use crate::data::connect;
-use crate::data::schema::*;
+use crate::core::{Seqnum, device_id};
 use crate::exts::*;
 use crate::room::state;
 use crate::{AppResult, data, room};
@@ -259,52 +255,15 @@ async fn select_events(
 
 /// Persist retry state to the database so other instances can respect backoff.
 async fn persist_retry_state(outgoing_kind: &OutgoingKind, tries: u32) -> AppResult<()> {
-    let now = UnixMillis::now().get() as i64;
-    match outgoing_kind {
-        OutgoingKind::Normal(server_name) => {
-            diesel::update(
-                outgoing_requests::table
-                    .filter(outgoing_requests::kind.eq("normal"))
-                    .filter(outgoing_requests::server_id.eq(server_name))
-                    .filter(outgoing_requests::state.eq("active")),
-            )
-            .set((
-                outgoing_requests::retry_count.eq(tries as i32),
-                outgoing_requests::last_failed_at.eq(Some(now)),
-            ))
-            .execute(&mut connect().await?)
-            .await?;
-        }
-        OutgoingKind::Appservice(id) => {
-            diesel::update(
-                outgoing_requests::table
-                    .filter(outgoing_requests::kind.eq("appservice"))
-                    .filter(outgoing_requests::appservice_id.eq(id))
-                    .filter(outgoing_requests::state.eq("active")),
-            )
-            .set((
-                outgoing_requests::retry_count.eq(tries as i32),
-                outgoing_requests::last_failed_at.eq(Some(now)),
-            ))
-            .execute(&mut connect().await?)
-            .await?;
-        }
-        OutgoingKind::Push(user_id, pushkey) => {
-            diesel::update(
-                outgoing_requests::table
-                    .filter(outgoing_requests::kind.eq("push"))
-                    .filter(outgoing_requests::user_id.eq(user_id))
-                    .filter(outgoing_requests::pushkey.eq(pushkey))
-                    .filter(outgoing_requests::state.eq("active")),
-            )
-            .set((
-                outgoing_requests::retry_count.eq(tries as i32),
-                outgoing_requests::last_failed_at.eq(Some(now)),
-            ))
-            .execute(&mut connect().await?)
-            .await?;
-        }
-    }
+    let dest = match outgoing_kind {
+        OutgoingKind::Normal(server_name) => data::sending::OutgoingDestination::Normal(server_name),
+        OutgoingKind::Appservice(id) => data::sending::OutgoingDestination::Appservice(id),
+        OutgoingKind::Push(user_id, pushkey) => data::sending::OutgoingDestination::Push {
+            user_id,
+            pushkey,
+        },
+    };
+    data::sending::persist_retry_state(dest, tries).await?;
     Ok(())
 }
 

--- a/crates/server/src/server_key.rs
+++ b/crates/server/src/server_key.rs
@@ -6,25 +6,20 @@ use std::collections::BTreeMap;
 use std::time::Duration;
 
 pub use acquire::*;
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
 pub use request::*;
 use serde_json::value::RawValue as RawJsonValue;
 pub use verify::*;
 
 use crate::core::federation::discovery::{ServerSigningKeys, VerifyKey};
 use crate::core::room_version_rules::RoomVersionRules;
-use crate::core::serde::{Base64, CanonicalJsonObject, JsonValue, RawJson};
+use crate::core::serde::{Base64, CanonicalJsonObject, RawJson};
 use crate::core::signatures::{self, PublicKeyMap, PublicKeySet};
 use crate::core::{
     OwnedServerSigningKeyId, RoomVersionId, ServerName, ServerSigningKeyId, UnixMillis,
 };
-use crate::data::connect;
-use crate::data::misc::DbServerSigningKeys;
-use crate::data::schema::*;
 use crate::exts::*;
 use crate::utils::timepoint_from_now;
-use crate::{AppError, AppResult, config};
+use crate::{AppError, AppResult, config, data};
 
 pub type VerifyKeys = BTreeMap<OwnedServerSigningKeyId, VerifyKey>;
 pub type PubKeyMap = PublicKeyMap;
@@ -52,32 +47,13 @@ pub(crate) async fn add_signing_keys(new_keys: ServerSigningKeys) -> AppResult<(
     let server = new_keys.server_name.clone();
 
     // (timo) Not atomic, but this is not critical
-    let existing = server_signing_keys::table
-        .find(&server)
-        .select(server_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect().await?)
-        .await
-        .optional()?;
-    let existing = existing
+    let existing = data::misc::signing_keys_data(&server)
+        .await?
         .map(serde_json::from_value::<ServerSigningKeys>)
         .transpose()?;
     let keys = merge_signing_keys_for_storage(existing, new_keys);
 
-    diesel::insert_into(server_signing_keys::table)
-        .values(DbServerSigningKeys {
-            server_id: server.clone(),
-            key_data: serde_json::to_value(&keys)?,
-            updated_at: UnixMillis::now(),
-            created_at: UnixMillis::now(),
-        })
-        .on_conflict(server_signing_keys::server_id)
-        .do_update()
-        .set((
-            server_signing_keys::key_data.eq(serde_json::to_value(&keys)?),
-            server_signing_keys::updated_at.eq(UnixMillis::now()),
-        ))
-        .execute(&mut connect().await?)
-        .await?;
+    data::misc::upsert_signing_keys(&server, serde_json::to_value(&keys)?).await?;
     Ok(())
 }
 
@@ -87,12 +63,7 @@ pub async fn verify_key_exists(
 ) -> AppResult<bool> {
     type KeysMap<'a> = BTreeMap<&'a str, &'a RawJsonValue>;
 
-    let key_data = server_signing_keys::table
-        .filter(server_signing_keys::server_id.eq(server))
-        .select(server_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect().await?)
-        .await
-        .optional()?;
+    let key_data = data::misc::signing_keys_data(server).await?;
 
     let Some(keys) = key_data else {
         return Ok(false);
@@ -136,11 +107,9 @@ pub async fn verify_keys_for(server: &ServerName) -> VerifyKeys {
 }
 
 pub async fn signing_keys_for(server: &ServerName) -> AppResult<ServerSigningKeys> {
-    let key_data = server_signing_keys::table
-        .filter(server_signing_keys::server_id.eq(server))
-        .select(server_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect().await?)
-        .await?;
+    let key_data = data::misc::signing_keys_data(server)
+        .await?
+        .ok_or_else(|| AppError::public("no signing keys found for server"))?;
     Ok(serde_json::from_value(key_data)?)
 }
 

--- a/crates/server/src/transaction_id.rs
+++ b/crates/server/src/transaction_id.rs
@@ -1,13 +1,7 @@
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
-use palpo_core::UnixMillis;
-
 use crate::AppResult;
 use crate::core::identifiers::*;
 use crate::core::{DeviceId, TransactionId, UserId};
-use crate::data::room::NewDbEventIdempotent;
-use crate::data::schema::*;
-use crate::data::{connect, diesel_exists};
+use crate::data;
 
 pub async fn add_txn_id(
     txn_id: &TransactionId,
@@ -16,17 +10,7 @@ pub async fn add_txn_id(
     room_id: Option<&RoomId>,
     event_id: Option<&EventId>,
 ) -> AppResult<()> {
-    diesel::insert_into(event_idempotents::table)
-        .values(&NewDbEventIdempotent {
-            txn_id: txn_id.to_owned(),
-            user_id: user_id.to_owned(),
-            device_id: device_id.map(|d| d.to_owned()),
-            room_id: room_id.map(|r| r.to_owned()),
-            event_id: event_id.map(|e| e.to_owned()),
-            created_at: UnixMillis::now(),
-        })
-        .execute(&mut connect().await?)
-        .await?;
+    data::room::transaction_id::add_txn_id(txn_id, user_id, device_id, room_id, event_id).await?;
     Ok(())
 }
 
@@ -35,21 +19,7 @@ pub async fn txn_id_exists(
     user_id: &UserId,
     device_id: Option<&DeviceId>,
 ) -> AppResult<bool> {
-    if let Some(device_id) = device_id {
-        let query = event_idempotents::table
-            .filter(event_idempotents::user_id.eq(user_id))
-            .filter(event_idempotents::device_id.eq(device_id))
-            .filter(event_idempotents::txn_id.eq(txn_id))
-            .select(event_idempotents::event_id);
-        diesel_exists!(query, &mut connect().await?).map_err(Into::into)
-    } else {
-        let query = event_idempotents::table
-            .filter(event_idempotents::user_id.eq(user_id))
-            .filter(event_idempotents::device_id.is_null())
-            .filter(event_idempotents::txn_id.eq(txn_id))
-            .select(event_idempotents::event_id);
-        diesel_exists!(query, &mut connect().await?).map_err(Into::into)
-    }
+    Ok(data::room::transaction_id::txn_id_exists(txn_id, user_id, device_id).await?)
 }
 
 pub async fn get_event_id(
@@ -58,25 +28,5 @@ pub async fn get_event_id(
     device_id: Option<&DeviceId>,
     room_id: Option<&RoomId>,
 ) -> AppResult<Option<OwnedEventId>> {
-    let mut query = event_idempotents::table
-        .filter(event_idempotents::user_id.eq(user_id))
-        .filter(event_idempotents::txn_id.eq(txn_id))
-        .into_boxed();
-    if let Some(device_id) = device_id {
-        query = query.filter(event_idempotents::device_id.eq(device_id));
-    } else {
-        query = query.filter(event_idempotents::device_id.is_null());
-    }
-    if let Some(room_id) = room_id {
-        query = query.filter(event_idempotents::room_id.eq(room_id));
-    } else {
-        query = query.filter(event_idempotents::room_id.is_null());
-    }
-    query
-        .select(event_idempotents::event_id)
-        .first::<Option<OwnedEventId>>(&mut connect().await?)
-        .await
-        .optional()
-        .map(|v| v.flatten())
-        .map_err(Into::into)
+    Ok(data::room::transaction_id::get_event_id(txn_id, user_id, device_id, room_id).await?)
 }

--- a/crates/server/src/uiaa.rs
+++ b/crates/server/src/uiaa.rs
@@ -1,14 +1,10 @@
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
 use subtle::ConstantTimeEq;
 
 use crate::core::client::uiaa::{
     AuthData, AuthError, AuthType, Password, UiaaInfo, UserIdentifier,
 };
 use crate::core::identifiers::*;
-use crate::core::serde::{CanonicalJsonValue, JsonValue};
-use crate::data::connect;
-use crate::data::schema::*;
+use crate::core::serde::CanonicalJsonValue;
 use crate::{AppResult, MatrixError, SESSION_ID_LENGTH, data, utils};
 
 /// Creates a new Uiaa session. Make sure the session token is unique.
@@ -32,34 +28,7 @@ pub async fn update_session(
     session: &str,
     uiaa_info: Option<&UiaaInfo>,
 ) -> AppResult<()> {
-    if let Some(uiaa_info) = uiaa_info {
-        let uiaa_info = serde_json::to_value(uiaa_info)?;
-        diesel::insert_into(user_uiaa_datas::table)
-            .values((
-                user_uiaa_datas::user_id.eq(user_id),
-                user_uiaa_datas::device_id.eq(device_id),
-                user_uiaa_datas::session.eq(session),
-                user_uiaa_datas::uiaa_info.eq(&uiaa_info),
-            ))
-            .on_conflict((
-                user_uiaa_datas::user_id,
-                user_uiaa_datas::device_id,
-                user_uiaa_datas::session,
-            ))
-            .do_update()
-            .set(user_uiaa_datas::uiaa_info.eq(&uiaa_info))
-            .execute(&mut connect().await?)
-            .await?;
-    } else {
-        diesel::delete(
-            user_uiaa_datas::table
-                .filter(user_uiaa_datas::user_id.eq(user_id))
-                .filter(user_uiaa_datas::device_id.eq(device_id))
-                .filter(user_uiaa_datas::session.eq(session)),
-        )
-        .execute(&mut connect().await?)
-        .await?;
-    };
+    data::user::uiaa::update_session(user_id, device_id, session, uiaa_info).await?;
     Ok(())
 }
 pub async fn get_session(
@@ -67,14 +36,7 @@ pub async fn get_session(
     device_id: &DeviceId,
     session: &str,
 ) -> AppResult<UiaaInfo> {
-    let uiaa_info = user_uiaa_datas::table
-        .filter(user_uiaa_datas::user_id.eq(user_id))
-        .filter(user_uiaa_datas::device_id.eq(device_id))
-        .filter(user_uiaa_datas::session.eq(session))
-        .select(user_uiaa_datas::uiaa_info)
-        .first::<JsonValue>(&mut connect().await?)
-        .await?;
-    Ok(serde_json::from_value(uiaa_info)?)
+    Ok(data::user::uiaa::get_session(user_id, device_id, session).await?)
 }
 pub async fn try_auth(
     user_id: &UserId,
@@ -185,16 +147,7 @@ pub async fn set_uiaa_request(
     session: &str,
     request: CanonicalJsonValue,
 ) -> AppResult<()> {
-    let request_body = serde_json::to_value(&request)?;
-    diesel::update(
-        user_uiaa_datas::table
-            .filter(user_uiaa_datas::user_id.eq(user_id))
-            .filter(user_uiaa_datas::device_id.eq(device_id))
-            .filter(user_uiaa_datas::session.eq(session)),
-    )
-    .set(user_uiaa_datas::request_body.eq(Some(&request_body)))
-    .execute(&mut connect().await?)
-    .await?;
+    data::user::uiaa::set_uiaa_request(user_id, device_id, session, &request).await?;
     Ok(())
 }
 
@@ -204,15 +157,8 @@ pub async fn get_uiaa_request(
     device_id: &DeviceId,
     session: &str,
 ) -> Option<CanonicalJsonValue> {
-    let request_body = user_uiaa_datas::table
-        .filter(user_uiaa_datas::user_id.eq(user_id))
-        .filter(user_uiaa_datas::device_id.eq(device_id))
-        .filter(user_uiaa_datas::session.eq(session))
-        .select(user_uiaa_datas::request_body)
-        .first::<Option<JsonValue>>(&mut connect().await.ok()?)
+    data::user::uiaa::get_uiaa_request(user_id, device_id, session)
         .await
         .ok()
-        .flatten()?;
-
-    serde_json::from_value(request_body).ok()
+        .flatten()
 }


### PR DESCRIPTION
## Background

Database access is currently spread across multiple crates, with many diesel queries written directly inside `crates/server` (`crate::data::connect()` + `schema::*` + diesel DSL). The overall goal of this refactor is to make **`crates/data` the only layer that directly touches the database**, leaving `server` with business logic only.

This is **Phase 1** of a staged refactor: the lowest-risk "zero-dependency pure CRUD" modules.

## Changes

Business logic (regex matching, the UIAA flow, signing-key merging, retry backoff) stays in `server`; all SQL is pushed down into the data layer.

**New data modules**
- `data::appservice` — CRUD for `appservice_registrations` + the `DbRegistration` model
- `data::user::uiaa` — `user_uiaa_datas` session / request-body access
- `data::room::transaction_id` — `event_idempotents` transaction-ID idempotency queries

**Extended data modules**
- `data::misc` — `server_signing_keys` read / upsert helpers
- `data::sending` — `persist_retry_state` for `outgoing_requests`

**Server side becomes a delegation layer**

The 5 files `appservice` / `uiaa` / `transaction_id` / `server_key` / `sending::guard` **no longer** reference `connect()` / `schema` / `diesel` at all; they call into the data layer instead. `DbRegistration` is re-exported from `crate::appservice` for source compatibility, so all existing call sites are unchanged.

`global.rs` still keeps the diesel code that creates users/devices in `appservices()` — that part is intertwined with business logic and is deferred to a later phase.

## Verification

- `cargo build -p palpo` ✅ Finished (exit 0)
- `cargo clippy -p palpo-data` / `-p palpo` ✅ no new warnings (exit 0)
- `cargo test -p palpo-data` ✅ 3 passed

## Stats

14 files changed; roughly 290 fewer lines of direct DB-access code on the server side.

## Later phases (not in this PR)

Phase 2 remaining `user` → Phase 3 `room` (biggest payoff) → Phase 4 `event` → Phase 5 sync/watcher/federation + auth/appservices split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
