### PR TITLE
fix(account/password): persist UIA session on first call

### DIFF
--- a/crates/server/src/routing/client/account/password.rs
+++ b/crates/server/src/routing/client/account/password.rs
@@ -48,14 +48,35 @@ async fn change_password(
         auth_error: None,
     };
     let Some(auth) = &body.auth else {
+        // Generate a UIA session and persist it so the client's follow-up
+        // call (with credentials attached) can be matched back to it.
+        // Without this `update_session` write, `try_auth → get_session`
+        // on the second call returns NotFound, the handler issues yet
+        // another fresh challenge, and the loop never terminates.
         uiaa_info.session = Some(utils::random_string(SESSION_ID_LENGTH));
+        crate::uiaa::update_session(
+            authed.user_id(),
+            authed.device_id(),
+            uiaa_info.session.as_ref().expect("just set above"),
+            Some(&uiaa_info),
+        )
+        .await?;
         return Err(uiaa_info.into());
     };
     if crate::uiaa::try_auth(authed.user_id(), authed.device_id(), auth, &uiaa_info)
         .await
         .is_err()
     {
+        // Same idea on retry: hand the client a fresh session and persist
+        // it so the next attempt can be matched.
         uiaa_info.session = Some(utils::random_string(SESSION_ID_LENGTH));
+        crate::uiaa::update_session(
+            authed.user_id(),
+            authed.device_id(),
+            uiaa_info.session.as_ref().expect("just set above"),
+            Some(&uiaa_info),
+        )
+        .await?;
         return Err(uiaa_info.into());
     }
 


### PR DESCRIPTION
The /account/password handler generated a random UIA session string, returned it to the client in the 401 challenge, but never wrote it to user_uiaa_datas. On the client's follow-up call (with credentials attached) `try_auth → get_session` then returned NotFound, the handler generated yet another fresh session, and the loop never terminated — verify_password was never reached.

Reproduces against matrix-sdk's `client.account().change_password(...)` flow and any direct curl POST: every retry returns 401 with a new session, no matter how correct the password is.

Fix: call `crate::uiaa::update_session(..., Some(&uiaa_info))` immediately after generating the session in both the no-auth and try_auth-failed branches, so subsequent get_session lookups succeed and the password check actually runs.

Verified by reproducing the failure (login with the same password succeeded; /account/password with the same password returned 401 in a loop) and confirming the patched build accepts the credential and updates user_passwords.