### PR TITLE
Fix UIA session persistence and completion handling

### DIFF
--- a/crates/server/src/routing/client/account.rs
+++ b/crates/server/src/routing/client/account.rs
@@ -9,9 +9,7 @@ use crate::core::client::account::{
 };
 use crate::core::client::uiaa::{AuthFlow, AuthType, UiaaInfo};
 use crate::exts::*;
-use crate::{
-    AuthArgs, EmptyResult, JsonResult, MatrixError, SESSION_ID_LENGTH, data, hoops, json_ok, utils,
-};
+use crate::{AuthArgs, EmptyResult, JsonResult, MatrixError, data, hoops, json_ok};
 
 pub fn public_router() -> Router {
     Router::with_path("account")
@@ -118,12 +116,20 @@ async fn deactivate(
     };
 
     let Some(auth) = &body.auth else {
-        uiaa_info.session = Some(utils::random_string(SESSION_ID_LENGTH));
+        crate::uiaa::create_challenge_session(authed.user_id(), authed.device_id(), &mut uiaa_info)
+            .await?;
         return Err(uiaa_info.into());
     };
-    if crate::uiaa::try_auth(authed.user_id(), authed.device_id(), auth, &uiaa_info).await.is_err() {
-        res.status_code(StatusCode::UNAUTHORIZED);
-        return Err(MatrixError::forbidden("Authentication failed.", None).into());
+    let (authenticated, uiaa) =
+        match crate::uiaa::try_auth(authed.user_id(), authed.device_id(), auth, &uiaa_info).await {
+            Ok(result) => result,
+            Err(_) => {
+                res.status_code(StatusCode::UNAUTHORIZED);
+                return Err(MatrixError::forbidden("Authentication failed.", None).into());
+            }
+        };
+    if !authenticated {
+        return Err(uiaa.into());
     }
 
     // Remove devices and mark account as deactivated

--- a/crates/server/src/routing/client/account/password.rs
+++ b/crates/server/src/routing/client/account/password.rs
@@ -8,7 +8,7 @@ use crate::core::client::uiaa::{AuthFlow, AuthType, UiaaInfo};
 use crate::data::connect;
 use crate::data::schema::*;
 use crate::exts::*;
-use crate::{AuthArgs, EmptyResult, SESSION_ID_LENGTH, empty_ok, hoops, utils};
+use crate::{AuthArgs, EmptyResult, empty_ok, hoops};
 
 pub fn authed_router() -> Router {
     Router::with_path("password")
@@ -48,36 +48,25 @@ async fn change_password(
         auth_error: None,
     };
     let Some(auth) = &body.auth else {
-        // Generate a UIA session and persist it so the client's follow-up
-        // call (with credentials attached) can be matched back to it.
-        // Without this `update_session` write, `try_auth → get_session`
-        // on the second call returns NotFound, the handler issues yet
-        // another fresh challenge, and the loop never terminates.
-        uiaa_info.session = Some(utils::random_string(SESSION_ID_LENGTH));
-        crate::uiaa::update_session(
-            authed.user_id(),
-            authed.device_id(),
-            uiaa_info.session.as_ref().expect("just set above"),
-            Some(&uiaa_info),
-        )
-        .await?;
+        crate::uiaa::create_challenge_session(authed.user_id(), authed.device_id(), &mut uiaa_info)
+            .await?;
         return Err(uiaa_info.into());
     };
-    if crate::uiaa::try_auth(authed.user_id(), authed.device_id(), auth, &uiaa_info)
-        .await
-        .is_err()
-    {
-        // Same idea on retry: hand the client a fresh session and persist
-        // it so the next attempt can be matched.
-        uiaa_info.session = Some(utils::random_string(SESSION_ID_LENGTH));
-        crate::uiaa::update_session(
-            authed.user_id(),
-            authed.device_id(),
-            uiaa_info.session.as_ref().expect("just set above"),
-            Some(&uiaa_info),
-        )
-        .await?;
-        return Err(uiaa_info.into());
+    let (authenticated, uiaa) =
+        match crate::uiaa::try_auth(authed.user_id(), authed.device_id(), auth, &uiaa_info).await {
+            Ok(result) => result,
+            Err(_) => {
+                crate::uiaa::create_challenge_session(
+                    authed.user_id(),
+                    authed.device_id(),
+                    &mut uiaa_info,
+                )
+                .await?;
+                return Err(uiaa_info.into());
+            }
+        };
+    if !authenticated {
+        return Err(uiaa.into());
     }
 
     crate::user::set_password(authed.user_id(), &body.new_password).await?;

--- a/crates/server/src/routing/client/device.rs
+++ b/crates/server/src/routing/client/device.rs
@@ -14,8 +14,8 @@ use crate::data::connect;
 use crate::data::schema::*;
 use crate::data::user::DbUserDevice;
 use crate::{
-    AppError, AuthArgs, DEVICE_ID_LENGTH, DepotExt, EmptyResult, JsonResult, MatrixError,
-    SESSION_ID_LENGTH, data, empty_ok, json_ok, utils,
+    AppError, AuthArgs, DEVICE_ID_LENGTH, DepotExt, EmptyResult, JsonResult, MatrixError, data,
+    empty_ok, json_ok, utils,
 };
 
 pub fn authed_router() -> Router {
@@ -157,27 +157,47 @@ async fn delete_device(
         auth_error: None,
     };
     let Some(auth) = auth else {
-        uiaa_info.session = Some(utils::random_string(SESSION_ID_LENGTH));
         uiaa_info.auth_error = Some(AuthError::new(
             ErrorKind::Unauthorized,
             "Missing authentication data",
         ));
+        crate::uiaa::create_challenge_session(authed.user_id(), authed.device_id(), &mut uiaa_info)
+            .await?;
         return Err(uiaa_info.into());
     };
 
-    if let Err(e) = crate::uiaa::try_auth(authed.user_id(), authed.device_id(), &auth, &uiaa_info).await {
-        if let AppError::Matrix(e) = e
-            && let ErrorKind::Forbidden = e.kind
-        {
-            return Err(e.into());
+    let (authenticated, uiaa) = match crate::uiaa::try_auth(
+        authed.user_id(),
+        authed.device_id(),
+        &auth,
+        &uiaa_info,
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            if let AppError::Matrix(e) = e
+                && let ErrorKind::Forbidden = e.kind
+            {
+                return Err(e.into());
+            }
+            uiaa_info.auth_error = Some(AuthError::new(
+                ErrorKind::Forbidden,
+                "Invalid authentication data",
+            ));
+            crate::uiaa::create_challenge_session(
+                authed.user_id(),
+                authed.device_id(),
+                &mut uiaa_info,
+            )
+            .await?;
+            res.status_code(StatusCode::UNAUTHORIZED); // TestDeviceManagement asks http code 401
+            return Err(uiaa_info.into());
         }
-        uiaa_info.session = Some(utils::random_string(SESSION_ID_LENGTH));
-        uiaa_info.auth_error = Some(AuthError::new(
-            ErrorKind::Forbidden,
-            "Invalid authentication data",
-        ));
+    };
+    if !authenticated {
         res.status_code(StatusCode::UNAUTHORIZED); // TestDeviceManagement asks http code 401
-        return Err(uiaa_info.into());
+        return Err(uiaa.into());
     }
     data::user::device::remove_device(authed.user_id(), &device_id).await?;
     empty_ok()
@@ -203,7 +223,7 @@ async fn delete_devices(
     let DeleteDevicesReqBody { devices, auth } = body.into_inner();
 
     // UIAA
-    let uiaa_info = UiaaInfo {
+    let mut uiaa_info = UiaaInfo {
         flows: vec![AuthFlow {
             stages: vec![AuthType::Password],
         }],
@@ -213,17 +233,19 @@ async fn delete_devices(
         auth_error: None,
     };
     let Some(auth) = auth else {
+        crate::uiaa::create_challenge_session(authed.user_id(), authed.device_id(), &mut uiaa_info)
+            .await?;
         return Err(uiaa_info.into());
     };
 
-    crate::uiaa::try_auth(authed.user_id(), authed.device_id(), &auth, &uiaa_info).await?;
-    diesel::delete(
-        user_devices::table
-            .filter(user_devices::user_id.eq(authed.device_id()))
-            .filter(user_devices::device_id.eq_any(&devices)),
-    )
-    .execute(&mut connect().await?)
-    .await?;
+    let (authenticated, uiaa) =
+        crate::uiaa::try_auth(authed.user_id(), authed.device_id(), &auth, &uiaa_info).await?;
+    if !authenticated {
+        return Err(uiaa.into());
+    }
+    for device_id in devices {
+        data::user::device::remove_device(authed.user_id(), &device_id).await?;
+    }
 
     empty_ok()
 }

--- a/crates/server/src/routing/client/key/device_signing.rs
+++ b/crates/server/src/routing/client/key/device_signing.rs
@@ -42,6 +42,12 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
     } else {
         None
     };
+    if body.as_ref().is_ok_and(|body| {
+        auth_only_retry_missing_challenged_payload(body, challenged_body.as_ref())
+    }) {
+        return Err(MatrixError::bad_json("missing challenged signing key payload").into());
+    }
+
     // When delegated auth (OIDC) is enabled, UIA is not used — the OIDC
     // token already proves the user's identity.  Pasion calls
     // `allow_cross_signing_reset` to set a time-limited bypass before
@@ -132,6 +138,15 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
 
 fn signing_key_payload_missing(body: &UploadSigningKeysReqBody) -> bool {
     body.master_key.is_none() && body.self_signing_key.is_none() && body.user_signing_key.is_none()
+}
+
+fn auth_only_retry_missing_challenged_payload(
+    body: &UploadSigningKeysReqBody,
+    challenged_body: Option<&UploadSigningKeysReqBody>,
+) -> bool {
+    signing_key_payload_missing(body)
+        && body.auth.as_ref().and_then(|auth| auth.session()).is_some()
+        && challenged_body.is_none()
 }
 
 fn signing_key_payload_for_uia<'a>(
@@ -230,6 +245,21 @@ mod tests {
         .unwrap()
     }
 
+    fn auth_only_upload_body(session: &str) -> UploadSigningKeysReqBody {
+        serde_json::from_value(serde_json::json!({
+            "auth": {
+                "type": "m.login.password",
+                "identifier": {
+                    "type": "m.id.user",
+                    "user": "@alice:example.com"
+                },
+                "password": "secret",
+                "session": session
+            }
+        }))
+        .unwrap()
+    }
+
     #[test]
     fn signing_key_payload_changed_ignores_omitted_existing_keys() {
         let master_body = upload_body_with_master_key("@alice:example.com");
@@ -263,6 +293,17 @@ mod tests {
             None,
             existing_self_body.self_signing_key.as_ref(),
             None,
+        ));
+    }
+
+    #[test]
+    fn auth_only_retry_requires_challenged_payload() {
+        let body = auth_only_upload_body("uia-session");
+
+        assert!(auth_only_retry_missing_challenged_payload(&body, None));
+        assert!(!auth_only_retry_missing_challenged_payload(
+            &body,
+            Some(&upload_body_with_master_key("@alice:example.com")),
         ));
     }
 

--- a/crates/server/src/routing/client/key/device_signing.rs
+++ b/crates/server/src/routing/client/key/device_signing.rs
@@ -29,6 +29,19 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
         auth_error: None,
     };
     let body = serde_json::from_slice::<UploadSigningKeysReqBody>(payload);
+    let mut challenged_body = if let Ok(body) = &body {
+        if signing_key_payload_missing(body) {
+            if let Some(session) = body.auth.as_ref().and_then(|auth| auth.session()) {
+                load_challenged_signing_key_payload(sender_id, authed.device_id(), session).await?
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
     // When delegated auth (OIDC) is enabled, UIA is not used — the OIDC
     // token already proves the user's identity.  Pasion calls
     // `allow_cross_signing_reset` to set a time-limited bypass before
@@ -51,6 +64,7 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
             // Bypass still valid — skip UIA
             now_ms >= expires_ts
         } else {
+            let body = signing_key_payload_for_uia(body, challenged_body.as_ref());
             signing_key_payload_changed(
                 body,
                 exist_master_key.as_ref(),
@@ -81,18 +95,12 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
             return Err(MatrixError::not_json("auth is none should not happend").into());
         };
 
-        let challenged_body = if let Some(session) = auth.session() {
-            crate::uiaa::get_uiaa_request(sender_id, authed.device_id(), session)
-                .await
-                .map(|request| {
-                    serde_json::from_value::<UploadSigningKeysReqBody>(serde_json::to_value(
-                        request,
-                    )?)
-                })
-                .transpose()?
-        } else {
-            None
-        };
+        if challenged_body.is_none()
+            && let Some(session) = auth.session()
+        {
+            challenged_body =
+                load_challenged_signing_key_payload(sender_id, authed.device_id(), session).await?;
+        }
 
         let (authenticated, uiaa) =
             crate::uiaa::try_auth(sender_id, authed.device_id(), auth, &uiaa_info).await?;
@@ -124,6 +132,31 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
 
 fn signing_key_payload_missing(body: &UploadSigningKeysReqBody) -> bool {
     body.master_key.is_none() && body.self_signing_key.is_none() && body.user_signing_key.is_none()
+}
+
+fn signing_key_payload_for_uia<'a>(
+    body: &'a UploadSigningKeysReqBody,
+    challenged_body: Option<&'a UploadSigningKeysReqBody>,
+) -> &'a UploadSigningKeysReqBody {
+    if signing_key_payload_missing(body) {
+        challenged_body.unwrap_or(body)
+    } else {
+        body
+    }
+}
+
+async fn load_challenged_signing_key_payload(
+    sender_id: &crate::core::identifiers::UserId,
+    device_id: &crate::core::identifiers::DeviceId,
+    session: &str,
+) -> crate::AppResult<Option<UploadSigningKeysReqBody>> {
+    crate::uiaa::get_uiaa_request(sender_id, device_id, session)
+        .await
+        .map(|request| {
+            serde_json::from_value::<UploadSigningKeysReqBody>(serde_json::to_value(request)?)
+        })
+        .transpose()
+        .map_err(Into::into)
 }
 
 fn signing_key_changed(
@@ -231,6 +264,30 @@ mod tests {
             existing_self_body.self_signing_key.as_ref(),
             None,
         ));
+    }
+
+    #[test]
+    fn signing_key_payload_for_uia_uses_challenged_payload_for_auth_only_body() {
+        let body = empty_upload_body();
+        let challenged_body = upload_body_with_master_key("@alice:example.com");
+
+        assert!(
+            signing_key_payload_for_uia(&body, Some(&challenged_body))
+                .master_key
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn signing_key_payload_for_uia_keeps_current_payload_when_keys_are_present() {
+        let body = upload_body_with_self_signing_key("@alice:example.com", "ed25519:self");
+        let challenged_body = upload_body_with_master_key("@alice:example.com");
+
+        assert!(
+            signing_key_payload_for_uia(&body, Some(&challenged_body))
+                .self_signing_key
+                .is_some()
+        );
     }
 
     #[test]

--- a/crates/server/src/routing/client/key/device_signing.rs
+++ b/crates/server/src/routing/client/key/device_signing.rs
@@ -2,6 +2,7 @@ use salvo::prelude::*;
 
 use crate::core::client::key::UploadSigningKeysReqBody;
 use crate::core::client::uiaa::{AuthFlow, AuthType, UiaaInfo};
+use crate::core::encryption::CrossSigningKey;
 use crate::core::serde::CanonicalJsonValue;
 use crate::{
     AuthArgs, DepotExt, EmptyResult, MatrixError, SESSION_ID_LENGTH, config, data, empty_ok, utils,
@@ -50,9 +51,12 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
             // Bypass still valid — skip UIA
             now_ms >= expires_ts
         } else {
-            exist_master_key.as_ref() != body.master_key.as_ref()
-                || exist_self_signing_key.as_ref() != body.self_signing_key.as_ref()
-                || exist_user_signing_key.as_ref() != body.user_signing_key.as_ref()
+            signing_key_payload_changed(
+                body,
+                exist_master_key.as_ref(),
+                exist_self_signing_key.as_ref(),
+                exist_user_signing_key.as_ref(),
+            )
         }
     } else {
         true
@@ -98,12 +102,19 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
         restore_signing_key_payload(&mut body, challenged_body)?;
     }
 
-    if let Some(master_key) = &body.master_key {
-        crate::user::add_cross_signing_keys(
+    if !signing_key_payload_missing(&body) {
+        if body.master_key.is_none()
+            && (body.self_signing_key.is_some() || body.user_signing_key.is_some())
+            && crate::user::key::get_master_key(sender_id).await?.is_none()
+        {
+            return Err(MatrixError::invalid_param("Missing master signing key.").into());
+        }
+
+        crate::user::add_cross_signing_key_updates(
             sender_id,
-            master_key,
-            &body.self_signing_key,
-            &body.user_signing_key,
+            body.master_key.as_ref(),
+            body.self_signing_key.as_ref(),
+            body.user_signing_key.as_ref(),
             true, // notify so that other users see the new keys
         )
         .await?;
@@ -113,6 +124,24 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
 
 fn signing_key_payload_missing(body: &UploadSigningKeysReqBody) -> bool {
     body.master_key.is_none() && body.self_signing_key.is_none() && body.user_signing_key.is_none()
+}
+
+fn signing_key_changed(
+    existing_key: Option<&CrossSigningKey>,
+    provided_key: Option<&CrossSigningKey>,
+) -> bool {
+    provided_key.is_some_and(|provided_key| existing_key != Some(provided_key))
+}
+
+fn signing_key_payload_changed(
+    body: &UploadSigningKeysReqBody,
+    existing_master_key: Option<&CrossSigningKey>,
+    existing_self_signing_key: Option<&CrossSigningKey>,
+    existing_user_signing_key: Option<&CrossSigningKey>,
+) -> bool {
+    signing_key_changed(existing_master_key, body.master_key.as_ref())
+        || signing_key_changed(existing_self_signing_key, body.self_signing_key.as_ref())
+        || signing_key_changed(existing_user_signing_key, body.user_signing_key.as_ref())
 }
 
 fn restore_signing_key_payload(
@@ -153,6 +182,55 @@ mod tests {
             }
         }))
         .unwrap()
+    }
+
+    fn upload_body_with_self_signing_key(user_id: &str, key_id: &str) -> UploadSigningKeysReqBody {
+        serde_json::from_value(serde_json::json!({
+            "self_signing_key": {
+                "user_id": user_id,
+                "usage": ["self_signing"],
+                "keys": {
+                    key_id: "abc"
+                }
+            }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn signing_key_payload_changed_ignores_omitted_existing_keys() {
+        let master_body = upload_body_with_master_key("@alice:example.com");
+        let self_body = upload_body_with_self_signing_key("@alice:example.com", "ed25519:self");
+        let existing_master_key = master_body.master_key.as_ref().unwrap();
+        let existing_self_signing_key = self_body.self_signing_key.as_ref().unwrap();
+
+        assert!(!signing_key_payload_changed(
+            &self_body,
+            Some(existing_master_key),
+            Some(existing_self_signing_key),
+            None,
+        ));
+    }
+
+    #[test]
+    fn signing_key_payload_changed_detects_new_provided_key() {
+        let self_body = upload_body_with_self_signing_key("@alice:example.com", "ed25519:self");
+
+        assert!(signing_key_payload_changed(&self_body, None, None, None));
+    }
+
+    #[test]
+    fn signing_key_payload_changed_detects_replacement_key() {
+        let existing_self_body =
+            upload_body_with_self_signing_key("@alice:example.com", "ed25519:self");
+        let new_self_body = upload_body_with_self_signing_key("@alice:example.com", "ed25519:new");
+
+        assert!(signing_key_payload_changed(
+            &new_self_body,
+            None,
+            existing_self_body.self_signing_key.as_ref(),
+            None,
+        ));
     }
 
     #[test]

--- a/crates/server/src/routing/client/key/device_signing.rs
+++ b/crates/server/src/routing/client/key/device_signing.rs
@@ -71,10 +71,23 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
             return Err(MatrixError::not_json("no json body was sent when required").into());
         }
     };
-    let body = body.expect("body should be ok");
+    let mut body = body.expect("body should be ok");
     if uia_required {
         let Some(auth) = &body.auth else {
             return Err(MatrixError::not_json("auth is none should not happend").into());
+        };
+
+        let challenged_body = if let Some(session) = auth.session() {
+            crate::uiaa::get_uiaa_request(sender_id, authed.device_id(), session)
+                .await
+                .map(|request| {
+                    serde_json::from_value::<UploadSigningKeysReqBody>(serde_json::to_value(
+                        request,
+                    )?)
+                })
+                .transpose()?
+        } else {
+            None
         };
 
         let (authenticated, uiaa) =
@@ -82,6 +95,7 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
         if !authenticated {
             return Err(uiaa.into());
         }
+        restore_signing_key_payload(&mut body, challenged_body)?;
     }
 
     if let Some(master_key) = &body.master_key {
@@ -95,4 +109,86 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
         .await?;
     }
     empty_ok()
+}
+
+fn signing_key_payload_missing(body: &UploadSigningKeysReqBody) -> bool {
+    body.master_key.is_none() && body.self_signing_key.is_none() && body.user_signing_key.is_none()
+}
+
+fn restore_signing_key_payload(
+    body: &mut UploadSigningKeysReqBody,
+    challenged_body: Option<UploadSigningKeysReqBody>,
+) -> Result<(), MatrixError> {
+    if let Some(challenged_body) = challenged_body {
+        *body = challenged_body;
+    }
+
+    if signing_key_payload_missing(body) {
+        return Err(MatrixError::bad_json("missing signing key payload"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_upload_body() -> UploadSigningKeysReqBody {
+        UploadSigningKeysReqBody {
+            auth: None,
+            master_key: None,
+            self_signing_key: None,
+            user_signing_key: None,
+        }
+    }
+
+    fn upload_body_with_master_key(user_id: &str) -> UploadSigningKeysReqBody {
+        serde_json::from_value(serde_json::json!({
+            "master_key": {
+                "user_id": user_id,
+                "usage": ["master"],
+                "keys": {
+                    "ed25519:abc": "abc"
+                }
+            }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn restore_signing_key_payload_restores_challenged_payload() {
+        let mut body = empty_upload_body();
+
+        restore_signing_key_payload(
+            &mut body,
+            Some(upload_body_with_master_key("@alice:example.com")),
+        )
+        .unwrap();
+
+        assert!(body.master_key.is_some());
+    }
+
+    #[test]
+    fn restore_signing_key_payload_prefers_challenged_payload() {
+        let mut body = upload_body_with_master_key("@bob:example.com");
+
+        restore_signing_key_payload(
+            &mut body,
+            Some(upload_body_with_master_key("@alice:example.com")),
+        )
+        .unwrap();
+
+        assert_eq!(
+            body.master_key.as_ref().unwrap().user_id.as_str(),
+            "@alice:example.com"
+        );
+    }
+
+    #[test]
+    fn restore_signing_key_payload_rejects_missing_payload() {
+        let mut body = empty_upload_body();
+
+        assert!(restore_signing_key_payload(&mut body, None).is_err());
+        assert!(restore_signing_key_payload(&mut body, Some(empty_upload_body())).is_err());
+    }
 }

--- a/crates/server/src/routing/client/key/device_signing.rs
+++ b/crates/server/src/routing/client/key/device_signing.rs
@@ -146,7 +146,9 @@ fn auth_only_retry_missing_challenged_payload(
 ) -> bool {
     signing_key_payload_missing(body)
         && body.auth.as_ref().and_then(|auth| auth.session()).is_some()
-        && challenged_body.is_none()
+        && challenged_body
+            .map(signing_key_payload_missing)
+            .unwrap_or(true)
 }
 
 fn signing_key_payload_for_uia<'a>(
@@ -304,6 +306,10 @@ mod tests {
         assert!(!auth_only_retry_missing_challenged_payload(
             &body,
             Some(&upload_body_with_master_key("@alice:example.com")),
+        ));
+        assert!(auth_only_retry_missing_challenged_payload(
+            &body,
+            Some(&empty_upload_body()),
         ));
     }
 

--- a/crates/server/src/routing/client/key/device_signing.rs
+++ b/crates/server/src/routing/client/key/device_signing.rs
@@ -28,14 +28,13 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
         auth_error: None,
     };
     let body = serde_json::from_slice::<UploadSigningKeysReqBody>(payload);
-    let none_auth = body.as_ref().map(|b| b.auth.is_none()).unwrap_or(true);
     // When delegated auth (OIDC) is enabled, UIA is not used — the OIDC
     // token already proves the user's identity.  Pasion calls
     // `allow_cross_signing_reset` to set a time-limited bypass before
     // Element uploads new keys, so we also honour that flag.
     let uia_required = if config::get().enabled_delegated_auth().is_some() {
         false
-    } else if none_auth {
+    } else if let Ok(body) = &body {
         let exist_master_key = crate::user::key::get_master_key(sender_id).await?;
         let exist_self_signing_key = crate::user::key::get_self_signing_key(sender_id).await?;
         let exist_user_signing_key = crate::user::key::get_user_signing_key(sender_id).await?;
@@ -51,24 +50,19 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
             // Bypass still valid — skip UIA
             now_ms >= expires_ts
         } else {
-            exist_master_key.as_ref()
-                != body.as_ref().map(|b| b.master_key.as_ref()).unwrap_or(None)
-                || exist_self_signing_key.as_ref()
-                    != body
-                        .as_ref()
-                        .map(|b| b.self_signing_key.as_ref())
-                        .unwrap_or(None)
-                || exist_user_signing_key.as_ref()
-                    != body
-                        .as_ref()
-                        .map(|b| b.user_signing_key.as_ref())
-                        .unwrap_or(None)
+            exist_master_key.as_ref() != body.master_key.as_ref()
+                || exist_self_signing_key.as_ref() != body.self_signing_key.as_ref()
+                || exist_user_signing_key.as_ref() != body.user_signing_key.as_ref()
         }
     } else {
-        false
+        true
     };
 
-    if body.is_err() || uia_required {
+    if body.is_err()
+        || body
+            .as_ref()
+            .is_ok_and(|body| uia_required && body.auth.is_none())
+    {
         if let Ok(json) = serde_json::from_slice::<CanonicalJsonValue>(payload) {
             uiaa_info.session = Some(utils::random_string(SESSION_ID_LENGTH));
             crate::uiaa::create_session(sender_id, authed.device_id(), &uiaa_info, json).await?;
@@ -83,7 +77,11 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
             return Err(MatrixError::not_json("auth is none should not happend").into());
         };
 
-        crate::uiaa::try_auth(sender_id, authed.device_id(), auth, &uiaa_info).await?;
+        let (authenticated, uiaa) =
+            crate::uiaa::try_auth(sender_id, authed.device_id(), auth, &uiaa_info).await?;
+        if !authenticated {
+            return Err(uiaa.into());
+        }
     }
 
     if let Some(master_key) = &body.master_key {

--- a/crates/server/src/routing/client/register.rs
+++ b/crates/server/src/routing/client/register.rs
@@ -20,8 +20,7 @@ use crate::data::{connect, diesel_exists};
 use crate::exts::*;
 use crate::{
     AppError, AuthArgs, DEVICE_ID_LENGTH, EmptyResult, JsonResult, MatrixError,
-    RANDOM_USER_ID_LENGTH, SESSION_ID_LENGTH, TOKEN_LENGTH, config, data, empty_ok, hoops,
-    membership, room, utils,
+    RANDOM_USER_ID_LENGTH, TOKEN_LENGTH, config, data, empty_ok, hoops, membership, room, utils,
 };
 
 pub fn public_router() -> Router {
@@ -151,13 +150,12 @@ async fn register(
                 return Err(AppError::Uiaa(uiaa));
             }
         } else {
-            uiaa_info.session = Some(utils::random_string(SESSION_ID_LENGTH));
-            crate::uiaa::update_session(
-                &UserId::parse_with_server_name("", &config::get().server_name)
-                    .expect("we know this is valid"),
+            let uiaa_user_id = UserId::parse_with_server_name("", &config::get().server_name)
+                .expect("we know this is valid");
+            crate::uiaa::create_challenge_session(
+                &uiaa_user_id,
                 &body.device_id.clone().unwrap_or_else(|| "".into()),
-                uiaa_info.session.as_ref().expect("session is always set"),
-                Some(&uiaa_info),
+                &mut uiaa_info,
             )
             .await?;
             return Err(uiaa_info.into());

--- a/crates/server/src/routing/client/session.rs
+++ b/crates/server/src/routing/client/session.rs
@@ -367,7 +367,7 @@ async fn get_access_token(
         }
     } else if let Ok(json) = serde_json::from_slice::<CanonicalJsonValue>(payload) {
         uiaa_info.session = Some(utils::random_string(SESSION_ID_LENGTH));
-        let _ = crate::uiaa::create_session(sender_id, device_id, &uiaa_info, json).await;
+        crate::uiaa::create_session(sender_id, device_id, &uiaa_info, json).await?;
         return Err(AppError::Uiaa(uiaa_info));
     } else {
         return Err(MatrixError::not_json("No JSON body was sent when required.").into());

--- a/crates/server/src/uiaa.rs
+++ b/crates/server/src/uiaa.rs
@@ -26,6 +26,21 @@ pub async fn create_session(
     Ok(())
 }
 
+pub async fn create_challenge_session(
+    user_id: &UserId,
+    device_id: &DeviceId,
+    uiaa_info: &mut UiaaInfo,
+) -> AppResult<()> {
+    uiaa_info.session = Some(utils::random_string(SESSION_ID_LENGTH));
+    update_session(
+        user_id,
+        device_id,
+        uiaa_info.session.as_ref().expect("session should be set"),
+        Some(uiaa_info),
+    )
+    .await
+}
+
 pub async fn update_session(
     user_id: &UserId,
     device_id: &DeviceId,
@@ -116,6 +131,9 @@ pub async fn try_auth(
                 return Err(MatrixError::unauthorized("user not found.").into());
             };
             crate::user::verify_password(&user, password).await?;
+            if !uiaa_info.completed.contains(&AuthType::Password) {
+                uiaa_info.completed.push(AuthType::Password);
+            }
         }
         AuthData::RegistrationToken(t) => {
             let token_valid = conf

--- a/crates/server/src/user/key.rs
+++ b/crates/server/src/user/key.rs
@@ -409,17 +409,28 @@ pub async fn add_cross_signing_keys(
     user_signing_key: &Option<CrossSigningKey>,
     notify: bool,
 ) -> AppResult<()> {
-    // TODO: Check signatures
-    diesel::insert_into(e2e_cross_signing_keys::table)
-        .values(NewDbCrossSigningKey {
-            user_id: user_id.to_owned(),
-            key_type: "master".to_owned(),
-            key_data: serde_json::to_value(master_key)?,
-        })
-        .execute(&mut connect().await?)
-        .await?;
+    add_cross_signing_key_updates(
+        user_id,
+        Some(master_key),
+        self_signing_key.as_ref(),
+        user_signing_key.as_ref(),
+        notify,
+    )
+    .await
+}
 
-    // Self-signing key
+pub async fn add_cross_signing_key_updates(
+    user_id: &UserId,
+    master_key: Option<&CrossSigningKey>,
+    self_signing_key: Option<&CrossSigningKey>,
+    user_signing_key: Option<&CrossSigningKey>,
+    notify: bool,
+) -> AppResult<()> {
+    // TODO: Check signatures
+    if let Some(master_key) = master_key {
+        add_cross_signing_key(user_id, "master", master_key).await?;
+    }
+
     if let Some(self_signing_key) = self_signing_key {
         let mut self_signing_key_ids = self_signing_key.keys.values();
 
@@ -437,17 +448,9 @@ pub async fn add_cross_signing_keys(
             .into());
         }
 
-        diesel::insert_into(e2e_cross_signing_keys::table)
-            .values(NewDbCrossSigningKey {
-                user_id: user_id.to_owned(),
-                key_type: "self_signing".to_owned(),
-                key_data: serde_json::to_value(self_signing_key)?,
-            })
-            .execute(&mut connect().await?)
-            .await?;
+        add_cross_signing_key(user_id, "self_signing", self_signing_key).await?;
     }
 
-    // User-signing key
     if let Some(user_signing_key) = user_signing_key {
         let mut user_signing_key_ids = user_signing_key.keys.values();
 
@@ -465,19 +468,29 @@ pub async fn add_cross_signing_keys(
             .into());
         }
 
-        diesel::insert_into(e2e_cross_signing_keys::table)
-            .values(NewDbCrossSigningKey {
-                user_id: user_id.to_owned(),
-                key_type: "user_signing".to_owned(),
-                key_data: serde_json::to_value(user_signing_key)?,
-            })
-            .execute(&mut connect().await?)
-            .await?;
+        add_cross_signing_key(user_id, "user_signing", user_signing_key).await?;
     }
 
     if notify {
         mark_signing_key_update(user_id).await?;
     }
+
+    Ok(())
+}
+
+async fn add_cross_signing_key(
+    user_id: &UserId,
+    key_type: &str,
+    key: &CrossSigningKey,
+) -> AppResult<()> {
+    diesel::insert_into(e2e_cross_signing_keys::table)
+        .values(NewDbCrossSigningKey {
+            user_id: user_id.to_owned(),
+            key_type: key_type.to_owned(),
+            key_data: serde_json::to_value(key)?,
+        })
+        .execute(&mut connect().await?)
+        .await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- centralize UIA challenge session creation so returned sessions are persisted before clients retry
- mark `m.login.password` as completed after successful password verification and require callers to honor incomplete UIA results
- apply persisted challenge sessions to account deactivation and device deletion flows, and keep existing request-body-backed UIA sessions error-checked
- require cross-signing key uploads that need UIA to actually verify supplied `auth` data instead of treating the field as sufficient
- route multi-device deletion through `remove_device` so ownership checks and token/pusher cleanup run for each removed device

## Root cause
PR #228 fixed the immediate `/account/password` loop, but the same pattern existed in other UIA endpoints: handlers generated a random `session` and returned it in a 401 response without writing it to `user_uiaa_datas`. On retry, `try_auth` calls `get_session` for supplied sessions, so those follow-up requests could not be matched.

The audit also found that successful password verification was not marking the password stage as completed, and some callers ignored the `bool` returned by `try_auth`, allowing incomplete UIA attempts to proceed.

While reviewing the device endpoint, the multi-device deletion path was also still deleting directly from `user_devices` with the authenticated device id as the user id. Reusing `remove_device` keeps the path aligned with single-device deletion.

## Validation
- `cargo check -p palpo`
- `git diff --check`