### PR TITLE
refactor(data): centralize phase-2 user DB access into data crate

### DIFF
--- a/crates/data/src/media.rs
+++ b/crates/data/src/media.rs
@@ -36,6 +36,16 @@ pub struct NewDbMetadata {
     pub created_at: UnixMillis,
 }
 
+/// List `(origin_server, media_id)` for every media item created by a user.
+pub async fn list_media_created_by(user_id: &UserId) -> DataResult<Vec<(OwnedServerName, String)>> {
+    media_metadatas::table
+        .filter(media_metadatas::created_by.eq(user_id))
+        .select((media_metadatas::origin_server, media_metadatas::media_id))
+        .load::<(OwnedServerName, String)>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
 pub async fn get_metadata(
     server_name: &ServerName,
     media_id: &str,

--- a/crates/data/src/room.rs
+++ b/crates/data/src/room.rs
@@ -404,6 +404,19 @@ pub async fn add_joined_server(room_id: &RoomId, server_name: &ServerName) -> Da
     Ok(())
 }
 
+/// Return the distinct set of servers joined to any of the given rooms.
+pub async fn joined_servers_for_rooms(
+    room_ids: &[OwnedRoomId],
+) -> DataResult<Vec<OwnedServerName>> {
+    room_joined_servers::table
+        .filter(room_joined_servers::room_id.eq_any(room_ids))
+        .select(room_joined_servers::server_id)
+        .distinct()
+        .load::<OwnedServerName>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
 #[derive(Insertable, Debug, Clone)]
 #[diesel(table_name = banned_rooms)]
 pub struct NewDbBannedRoom {

--- a/crates/data/src/user.rs
+++ b/crates/data/src/user.rs
@@ -22,6 +22,8 @@ pub use key_backup::*;
 pub mod session;
 pub use session::*;
 pub mod external_id;
+pub mod login_token;
+pub mod openid_token;
 pub mod presence;
 pub mod registration_token;
 pub mod uiaa;
@@ -212,6 +214,27 @@ pub async fn get_user(user_id: &UserId) -> DataResult<DbUser> {
         .first::<DbUser>(&mut connect().await?)
         .await
         .map_err(Into::into)
+}
+
+/// Insert a user, updating the existing row if one already exists.
+pub async fn create_user(new_user: &NewDbUser) -> DataResult<DbUser> {
+    diesel::insert_into(users::table)
+        .values(new_user)
+        .on_conflict(users::id)
+        .do_update()
+        .set(new_user)
+        .get_result::<DbUser>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// Mark a user account as deactivated without touching its other data.
+pub async fn mark_deactivated(user_id: &UserId) -> DataResult<()> {
+    diesel::update(users::table.find(user_id))
+        .set(users::deactivated_at.eq(UnixMillis::now()))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
 }
 
 /// Returns the number of users registered on this server.

--- a/crates/data/src/user/data.rs
+++ b/crates/data/src/user/data.rs
@@ -162,6 +162,16 @@ pub async fn get_global_data<E: DeserializeOwned>(
     }
 }
 
+/// Load all global account-data rows for a user.
+pub async fn get_global_datas(user_id: &UserId) -> DataResult<Vec<DbUserData>> {
+    user_datas::table
+        .filter(user_datas::user_id.eq(user_id))
+        .filter(user_datas::room_id.is_null())
+        .load::<DbUserData>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
 /// Get all global account data for a user
 pub async fn get_global_account_data(user_id: &UserId) -> DataResult<HashMap<String, JsonValue>> {
     user_datas::table

--- a/crates/data/src/user/key.rs
+++ b/crates/data/src/user/key.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
-use crate::core::encryption::DeviceKeys;
+use crate::core::encryption::{CrossSigningKey, DeviceKeys, OneTimeKey};
 use crate::core::identifiers::*;
 use crate::core::serde::JsonValue;
 use crate::core::{DeviceKeyAlgorithm, Seqnum, UnixMillis};
@@ -283,4 +283,135 @@ pub async fn get_cross_signing_replacement_allowed(user_id: &UserId) -> DataResu
         .await
         .optional()
         .map_err(Into::into)
+}
+
+/// Return the raw `key_data` JSON of the latest cross-signing key of a kind.
+pub async fn get_cross_signing_key(
+    user_id: &UserId,
+    key_type: &str,
+) -> DataResult<Option<JsonValue>> {
+    e2e_cross_signing_keys::table
+        .filter(e2e_cross_signing_keys::user_id.eq(user_id))
+        .filter(e2e_cross_signing_keys::key_type.eq(key_type))
+        .order_by(e2e_cross_signing_keys::id.desc())
+        .select(e2e_cross_signing_keys::key_data)
+        .first::<JsonValue>(&mut connect().await?)
+        .await
+        .optional()
+        .map_err(Into::into)
+}
+
+/// Insert a cross-signing key of the given kind.
+pub async fn add_cross_signing_key(
+    user_id: &UserId,
+    key_type: &str,
+    key: &CrossSigningKey,
+) -> DataResult<()> {
+    diesel::insert_into(e2e_cross_signing_keys::table)
+        .values(NewDbCrossSigningKey {
+            user_id: user_id.to_owned(),
+            key_type: key_type.to_owned(),
+            key_data: serde_json::to_value(key)?,
+        })
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Insert a cross-signing signature row.
+pub async fn add_cross_signing_sig(signature: NewDbCrossSignature) -> DataResult<()> {
+    diesel::insert_into(e2e_cross_signing_sigs::table)
+        .values(signature)
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Insert or replace a one-time key for a device.
+pub async fn add_one_time_key(
+    user_id: &UserId,
+    device_id: &DeviceId,
+    key_id: &DeviceKeyId,
+    one_time_key: &OneTimeKey,
+) -> DataResult<()> {
+    diesel::insert_into(e2e_one_time_keys::table)
+        .values(&NewDbOneTimeKey {
+            user_id: user_id.to_owned(),
+            device_id: device_id.to_owned(),
+            algorithm: key_id.algorithm().to_string(),
+            key_id: key_id.to_owned(),
+            key_data: serde_json::to_value(one_time_key)?,
+            created_at: UnixMillis::now(),
+        })
+        .on_conflict((
+            e2e_one_time_keys::user_id,
+            e2e_one_time_keys::device_id,
+            e2e_one_time_keys::algorithm,
+            e2e_one_time_keys::key_id,
+        ))
+        .do_update()
+        .set(e2e_one_time_keys::key_data.eq(serde_json::to_value(one_time_key)?))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Claim (read and remove) the oldest one-time key for a device and algorithm.
+pub async fn claim_one_time_key(
+    user_id: &UserId,
+    device_id: &DeviceId,
+    key_algorithm: &DeviceKeyAlgorithm,
+) -> DataResult<Option<(OwnedDeviceKeyId, OneTimeKey)>> {
+    let one_time_key = e2e_one_time_keys::table
+        .filter(e2e_one_time_keys::user_id.eq(user_id))
+        .filter(e2e_one_time_keys::device_id.eq(device_id))
+        .filter(e2e_one_time_keys::algorithm.eq(key_algorithm.as_ref()))
+        .order(e2e_one_time_keys::id.asc())
+        .first::<DbOneTimeKey>(&mut connect().await?)
+        .await
+        .optional()?;
+    if let Some(DbOneTimeKey {
+        id,
+        key_id,
+        key_data,
+        ..
+    }) = one_time_key
+    {
+        diesel::delete(e2e_one_time_keys::table.find(id))
+            .execute(&mut connect().await?)
+            .await?;
+        Ok(Some((key_id, serde_json::from_value::<OneTimeKey>(key_data)?)))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Replace the key-change marker for a `(user, room)` (or global when
+/// `change.room_id` is `None`) with a fresh row.
+pub async fn replace_key_change(change: &NewDbKeyChange) -> DataResult<()> {
+    match &change.room_id {
+        Some(room_id) => {
+            diesel::delete(
+                e2e_key_changes::table
+                    .filter(e2e_key_changes::user_id.eq(&change.user_id))
+                    .filter(e2e_key_changes::room_id.eq(room_id)),
+            )
+            .execute(&mut connect().await?)
+            .await?;
+        }
+        None => {
+            diesel::delete(
+                e2e_key_changes::table
+                    .filter(e2e_key_changes::user_id.eq(&change.user_id))
+                    .filter(e2e_key_changes::room_id.is_null()),
+            )
+            .execute(&mut connect().await?)
+            .await?;
+        }
+    }
+    diesel::insert_into(e2e_key_changes::table)
+        .values(change)
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
 }

--- a/crates/data/src/user/login_token.rs
+++ b/crates/data/src/user/login_token.rs
@@ -1,0 +1,42 @@
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+
+use crate::core::UnixMillis;
+use crate::core::identifiers::*;
+use crate::schema::*;
+use crate::{DataResult, connect};
+
+/// Create or refresh a short-lived `m.login.token` login token.
+pub async fn upsert_login_token(user_id: &UserId, token: &str, expires_at: i64) -> DataResult<()> {
+    diesel::insert_into(user_login_tokens::table)
+        .values((
+            user_login_tokens::user_id.eq(user_id),
+            user_login_tokens::token.eq(token),
+            user_login_tokens::expires_at.eq(expires_at),
+        ))
+        .on_conflict(user_login_tokens::token)
+        .do_update()
+        .set(user_login_tokens::expires_at.eq(expires_at))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Look up the user and expiry recorded for a login token.
+pub async fn get_login_token(token: &str) -> DataResult<Option<(OwnedUserId, UnixMillis)>> {
+    user_login_tokens::table
+        .filter(user_login_tokens::token.eq(token))
+        .select((user_login_tokens::user_id, user_login_tokens::expires_at))
+        .first::<(OwnedUserId, UnixMillis)>(&mut connect().await?)
+        .await
+        .optional()
+        .map_err(Into::into)
+}
+
+/// Remove a login token.
+pub async fn delete_login_token(token: &str) -> DataResult<()> {
+    diesel::delete(user_login_tokens::table.filter(user_login_tokens::token.eq(token)))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}

--- a/crates/data/src/user/openid_token.rs
+++ b/crates/data/src/user/openid_token.rs
@@ -1,0 +1,26 @@
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+
+use crate::core::UnixMillis;
+use crate::core::identifiers::*;
+use crate::schema::*;
+use crate::{DataResult, connect};
+
+/// Look up the user and expiry recorded for an OpenID token.
+pub async fn get_openid_token(token: &str) -> DataResult<Option<(OwnedUserId, UnixMillis)>> {
+    user_openid_tokens::table
+        .filter(user_openid_tokens::token.eq(token))
+        .select((user_openid_tokens::user_id, user_openid_tokens::expires_at))
+        .first::<(OwnedUserId, UnixMillis)>(&mut connect().await?)
+        .await
+        .optional()
+        .map_err(Into::into)
+}
+
+/// Remove an OpenID token.
+pub async fn delete_openid_token(token: &str) -> DataResult<()> {
+    diesel::delete(user_openid_tokens::table.filter(user_openid_tokens::token.eq(token)))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}

--- a/crates/data/src/user/password.rs
+++ b/crates/data/src/user/password.rs
@@ -1,8 +1,10 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::core::UnixMillis;
 use crate::core::identifiers::*;
 use crate::schema::*;
+use crate::{DataResult, connect};
 
 #[derive(Identifiable, Debug, Clone)]
 #[diesel(table_name = user_passwords)]
@@ -18,4 +20,32 @@ pub struct NewDbPassword {
     pub user_id: OwnedUserId,
     pub hash: String,
     pub created_at: UnixMillis,
+}
+
+/// Return the most recent password hash for a user.
+pub async fn get_password_hash(user_id: &UserId) -> DataResult<String> {
+    user_passwords::table
+        .filter(user_passwords::user_id.eq(user_id))
+        .order_by(user_passwords::id.desc())
+        .select(user_passwords::hash)
+        .first::<String>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// Store a new password hash for a user and clear the guest flag.
+pub async fn set_password_hash(user_id: &UserId, hash: &str) -> DataResult<()> {
+    diesel::insert_into(user_passwords::table)
+        .values(NewDbPassword {
+            user_id: user_id.to_owned(),
+            hash: hash.to_owned(),
+            created_at: UnixMillis::now(),
+        })
+        .execute(&mut connect().await?)
+        .await?;
+    diesel::update(users::table.find(user_id))
+        .set(users::is_guest.eq(false))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
 }

--- a/crates/data/src/user/profile.rs
+++ b/crates/data/src/user/profile.rs
@@ -32,6 +32,15 @@ pub struct NewDbProfile {
     pub blurhash: Option<String>,
 }
 
+/// Insert a profile row.
+pub async fn create_profile(profile: &NewDbProfile) -> DataResult<()> {
+    diesel::insert_into(user_profiles::table)
+        .values(profile)
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
 pub async fn get_profile(user_id: &UserId, room_id: Option<&RoomId>) -> DataResult<Option<DbProfile>> {
     let profile = if let Some(room_id) = room_id {
         user_profiles::table

--- a/crates/data/src/user/pusher.rs
+++ b/crates/data/src/user/pusher.rs
@@ -161,3 +161,25 @@ pub async fn delete_device_pushers(user_id: &UserId, device_id: &DeviceId) -> Da
     .await?;
     Ok(())
 }
+
+/// Remove the pusher identified by `(user_id, app_id, pushkey)`.
+pub async fn delete_pusher(user_id: &UserId, app_id: &str, pushkey: &str) -> DataResult<()> {
+    diesel::delete(
+        user_pushers::table
+            .filter(user_pushers::user_id.eq(user_id))
+            .filter(user_pushers::pushkey.eq(pushkey))
+            .filter(user_pushers::app_id.eq(app_id)),
+    )
+    .execute(&mut connect().await?)
+    .await?;
+    Ok(())
+}
+
+/// Insert a pusher row.
+pub async fn insert_pusher(new_pusher: &NewDbPusher) -> DataResult<()> {
+    diesel::insert_into(user_pushers::table)
+        .values(new_pusher)
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}

--- a/crates/data/src/user/refresh_token.rs
+++ b/crates/data/src/user/refresh_token.rs
@@ -1,8 +1,10 @@
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::core::UnixMillis;
 use crate::core::identifiers::*;
 use crate::schema::*;
+use crate::{DataResult, connect};
 
 #[derive(Identifiable, Queryable, Debug, Clone)]
 #[diesel(table_name = user_refresh_tokens)]
@@ -46,4 +48,21 @@ impl NewDbRefreshToken {
             created_at: UnixMillis::now(),
         }
     }
+}
+
+/// Return the expiry of a refresh token if it exists for this `(user, device)`.
+pub async fn get_refresh_token_expires_at(
+    user_id: &UserId,
+    device_id: &DeviceId,
+    token: &str,
+) -> DataResult<Option<i64>> {
+    user_refresh_tokens::table
+        .filter(user_refresh_tokens::user_id.eq(user_id))
+        .filter(user_refresh_tokens::device_id.eq(device_id))
+        .filter(user_refresh_tokens::token.eq(token))
+        .select(user_refresh_tokens::expires_at)
+        .first::<i64>(&mut connect().await?)
+        .await
+        .optional()
+        .map_err(Into::into)
 }

--- a/crates/server/src/user.rs
+++ b/crates/server/src/user.rs
@@ -10,8 +10,6 @@ pub mod presence;
 pub mod session;
 use std::{collections::BTreeSet, mem};
 
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
 pub use presence::*;
 use serde::de::DeserializeOwned;
 
@@ -21,9 +19,8 @@ use crate::core::events::ignored_user_list::IgnoredUserListEvent;
 use crate::core::events::room::power_levels::RoomPowerLevelsEventContent;
 use crate::core::identifiers::*;
 use crate::core::serde::JsonValue;
-use crate::data::schema::*;
 use crate::data::user::{DbUser, DbUserData, NewDbUser};
-use crate::data::{DataResult, connect};
+use crate::data::DataResult;
 use crate::room::timeline;
 use crate::{AppError, AppResult, IsRemoteOrLocal, MatrixError, PduBuilder, config, data, room};
 
@@ -63,29 +60,21 @@ async fn create_user_inner(
         appservice_id: None,
         created_at: UnixMillis::now(),
     };
-    let user = diesel::insert_into(users::table)
-        .values(&new_user)
-        .on_conflict(users::id)
-        .do_update()
-        .set(&new_user)
-        .get_result::<DbUser>(&mut connect().await?)
-        .await?;
+    let user = data::user::create_user(&new_user).await?;
     // Default to pretty display_name
     let display_name = user_id.localpart().to_owned();
     // // If enabled append lightning bolt to display name (default true)
     // if config::enable_lightning_bolt() {
     //     display_name.push_str(" ⚡️");
     // }
-    diesel::insert_into(user_profiles::table)
-        .values(data::user::NewDbProfile {
-            user_id: user_id.clone(),
-            room_id: None,
-            display_name: Some(display_name.clone()),
-            avatar_url: None,
-            blurhash: None,
-        })
-        .execute(&mut connect().await?)
-        .await?;
+    data::user::create_profile(&data::user::NewDbProfile {
+        user_id: user_id.clone(),
+        room_id: None,
+        display_name: Some(display_name.clone()),
+        avatar_url: None,
+        blurhash: None,
+    })
+    .await?;
     if let Some(password) = password {
         crate::user::set_password(&user.id, password).await?;
     }
@@ -96,11 +85,7 @@ async fn create_user_inner(
 }
 
 pub async fn list_local_users() -> AppResult<Vec<OwnedUserId>> {
-    let users = user_passwords::table
-        .select(user_passwords::user_id)
-        .load::<OwnedUserId>(&mut connect().await?)
-        .await?;
-    Ok(users)
+    Ok(data::user::list_local_users().await?)
 }
 /// Ensure that a user only sees signatures from themselves and the target user
 pub fn clean_signatures<F: Fn(&UserId) -> bool>(
@@ -228,19 +213,13 @@ pub async fn full_user_deactivate(
 
 /// Find out which user an OpenID access token belongs to.
 pub async fn find_from_openid_token(token: &str) -> AppResult<OwnedUserId> {
-    let Ok((user_id, expires_at)) = user_openid_tokens::table
-        .filter(user_openid_tokens::token.eq(token))
-        .select((user_openid_tokens::user_id, user_openid_tokens::expires_at))
-        .first::<(OwnedUserId, UnixMillis)>(&mut connect().await?)
-        .await
+    let Some((user_id, expires_at)) = data::user::openid_token::get_openid_token(token).await?
     else {
         return Err(MatrixError::unauthorized("OpenID token is unrecognised").into());
     };
     if expires_at < UnixMillis::now() {
         tracing::warn!("OpenID token is expired, removing");
-        diesel::delete(user_openid_tokens::table.filter(user_openid_tokens::token.eq(token)))
-            .execute(&mut connect().await?)
-            .await?;
+        data::user::openid_token::delete_openid_token(token).await?;
 
         return Err(MatrixError::unauthorized("OpenID token is expired").into());
     }
@@ -255,17 +234,7 @@ pub async fn create_login_token(user_id: &UserId, token: &str) -> AppResult<u64>
     let now = UnixMillis::now().get();
     let expires_at = now.saturating_add(expires_in).min(i64::MAX as u64) as i64;
 
-    diesel::insert_into(user_login_tokens::table)
-        .values((
-            user_login_tokens::user_id.eq(user_id),
-            user_login_tokens::token.eq(token),
-            user_login_tokens::expires_at.eq(expires_at),
-        ))
-        .on_conflict(user_login_tokens::token)
-        .do_update()
-        .set(user_login_tokens::expires_at.eq(expires_at))
-        .execute(&mut connect().await?)
-        .await?;
+    data::user::login_token::upsert_login_token(user_id, token, expires_at).await?;
 
     Ok(expires_in)
 }
@@ -273,26 +242,18 @@ pub async fn create_login_token(user_id: &UserId, token: &str) -> AppResult<u64>
 /// Find out which user a login token belongs to.
 /// Removes the token to prevent double-use attacks.
 pub async fn take_login_token(token: &str) -> AppResult<OwnedUserId> {
-    let Ok((user_id, expires_at)) = user_login_tokens::table
-        .filter(user_login_tokens::token.eq(token))
-        .select((user_login_tokens::user_id, user_login_tokens::expires_at))
-        .first::<(OwnedUserId, UnixMillis)>(&mut connect().await?)
-        .await
+    let Some((user_id, expires_at)) = data::user::login_token::get_login_token(token).await?
     else {
         return Err(MatrixError::forbidden("Login token is unrecognised.", None).into());
     };
 
     if expires_at < UnixMillis::now() {
         trace!(?user_id, ?token, "Removing expired login token");
-        diesel::delete(user_login_tokens::table.filter(user_login_tokens::token.eq(token)))
-            .execute(&mut connect().await?)
-            .await?;
+        data::user::login_token::delete_login_token(token).await?;
         return Err(MatrixError::forbidden("Login token is expired.", None).into());
     }
 
-    diesel::delete(user_login_tokens::table.filter(user_login_tokens::token.eq(token)))
-        .execute(&mut connect().await?)
-        .await?;
+    data::user::login_token::delete_login_token(token).await?;
 
     Ok(user_id)
 }
@@ -302,13 +263,8 @@ pub async fn valid_refresh_token(
     device_id: &DeviceId,
     token: &str,
 ) -> AppResult<()> {
-    let Ok(expires_at) = user_refresh_tokens::table
-        .filter(user_refresh_tokens::user_id.eq(user_id))
-        .filter(user_refresh_tokens::device_id.eq(device_id))
-        .filter(user_refresh_tokens::token.eq(token))
-        .select(user_refresh_tokens::expires_at)
-        .first::<i64>(&mut connect().await?)
-        .await
+    let Some(expires_at) =
+        data::user::get_refresh_token_expires_at(user_id, device_id, token).await?
     else {
         return Err(MatrixError::unauthorized("Invalid refresh token.").into());
     };
@@ -319,11 +275,7 @@ pub async fn valid_refresh_token(
 }
 
 pub async fn make_user_admin(user_id: &UserId) -> AppResult<()> {
-    let user_id = user_id.to_owned();
-    diesel::update(users::table.filter(users::id.eq(&user_id)))
-        .set(users::is_admin.eq(true))
-        .execute(&mut connect().await?)
-        .await?;
+    data::user::set_admin(user_id, true).await?;
     Ok(())
 }
 
@@ -349,20 +301,11 @@ pub async fn get_data<E: DeserializeOwned>(
 }
 
 pub async fn get_global_datas(user_id: &UserId) -> DataResult<Vec<DbUserData>> {
-    let datas = user_datas::table
-        .filter(user_datas::user_id.eq(user_id))
-        .filter(user_datas::room_id.is_null())
-        .load::<DbUserData>(&mut connect().await?)
-        .await?;
-    Ok(datas)
+    data::user::get_global_datas(user_id).await
 }
 
 pub async fn delete_all_media(user_id: &UserId) -> AppResult<i64> {
-    let medias = media_metadatas::table
-        .filter(media_metadatas::created_by.eq(user_id))
-        .select((media_metadatas::origin_server, media_metadatas::media_id))
-        .load::<(OwnedServerName, String)>(&mut connect().await?)
-        .await?;
+    let medias = data::media::list_media_created_by(user_id).await?;
 
     for (origin_server, media_id) in &medias {
         if let Err(e) = crate::media::delete_media(origin_server, media_id).await {
@@ -373,9 +316,6 @@ pub async fn delete_all_media(user_id: &UserId) -> AppResult<i64> {
 }
 
 pub async fn deactivate_account(user_id: &UserId) -> AppResult<()> {
-    diesel::update(users::table.find(user_id))
-        .set(users::deactivated_at.eq(UnixMillis::now()))
-        .execute(&mut connect().await?)
-        .await?;
+    data::user::mark_deactivated(user_id).await?;
     Ok(())
 }

--- a/crates/server/src/user/key.rs
+++ b/crates/server/src/user/key.rs
@@ -1,8 +1,6 @@
 use std::collections::{BTreeMap, HashMap, hash_map};
 use std::time::Instant;
 
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use serde_json::json;
 
@@ -14,13 +12,8 @@ use crate::core::federation::key::{
 };
 use crate::core::federation::transaction::{Edu, SigningKeyUpdateContent};
 use crate::core::identifiers::*;
-use crate::core::serde::JsonValue;
 use crate::core::{DeviceKeyAlgorithm, UnixMillis, client, federation};
-use crate::data::connect;
-use crate::data::schema::*;
-use crate::data::user::{
-    DbOneTimeKey, NewDbCrossSignature, NewDbCrossSigningKey, NewDbKeyChange, NewDbOneTimeKey,
-};
+use crate::data::user::{NewDbCrossSignature, NewDbKeyChange};
 use crate::exts::*;
 use crate::user::clean_signatures;
 use crate::{AppError, AppResult, BAD_QUERY_RATE_LIMITER, MatrixError, config, data, sending};
@@ -246,13 +239,7 @@ pub async fn claim_one_time_keys(
 }
 
 pub async fn get_master_key(user_id: &UserId) -> AppResult<Option<CrossSigningKey>> {
-    let key_data = e2e_cross_signing_keys::table
-        .filter(e2e_cross_signing_keys::user_id.eq(user_id))
-        .filter(e2e_cross_signing_keys::key_type.eq("master"))
-        .select(e2e_cross_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect().await?)
-        .await
-        .optional()?;
+    let key_data = data::user::key::get_cross_signing_key(user_id, "master").await?;
     if let Some(key_data) = key_data {
         Ok(serde_json::from_value(key_data).ok())
     } else {
@@ -265,14 +252,7 @@ pub async fn get_allowed_master_key(
     user_id: &UserId,
     allowed_signatures: &(dyn Fn(&UserId) -> bool + Send + Sync),
 ) -> AppResult<Option<CrossSigningKey>> {
-    let key_data = e2e_cross_signing_keys::table
-        .filter(e2e_cross_signing_keys::user_id.eq(user_id))
-        .filter(e2e_cross_signing_keys::key_type.eq("master"))
-        .order_by(e2e_cross_signing_keys::id.desc())
-        .select(e2e_cross_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect().await?)
-        .await
-        .optional()?;
+    let key_data = data::user::key::get_cross_signing_key(user_id, "master").await?;
     if let Some(mut key_data) = key_data {
         clean_signatures(&mut key_data, sender_id, user_id, allowed_signatures)?;
         Ok(serde_json::from_value(key_data).ok())
@@ -282,14 +262,7 @@ pub async fn get_allowed_master_key(
 }
 
 pub async fn get_self_signing_key(user_id: &UserId) -> AppResult<Option<CrossSigningKey>> {
-    let key_data = e2e_cross_signing_keys::table
-        .filter(e2e_cross_signing_keys::user_id.eq(user_id))
-        .filter(e2e_cross_signing_keys::key_type.eq("self_signing"))
-        .order_by(e2e_cross_signing_keys::id.desc())
-        .select(e2e_cross_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect().await?)
-        .await
-        .optional()?;
+    let key_data = data::user::key::get_cross_signing_key(user_id, "self_signing").await?;
     if let Some(key_data) = key_data {
         Ok(serde_json::from_value(key_data).ok())
     } else {
@@ -301,14 +274,7 @@ pub async fn get_allowed_self_signing_key(
     user_id: &UserId,
     allowed_signatures: &(dyn Fn(&UserId) -> bool + Send + Sync),
 ) -> AppResult<Option<CrossSigningKey>> {
-    let key_data = e2e_cross_signing_keys::table
-        .filter(e2e_cross_signing_keys::user_id.eq(user_id))
-        .filter(e2e_cross_signing_keys::key_type.eq("self_signing"))
-        .order_by(e2e_cross_signing_keys::id.desc())
-        .select(e2e_cross_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect().await?)
-        .await
-        .optional()?;
+    let key_data = data::user::key::get_cross_signing_key(user_id, "self_signing").await?;
     if let Some(mut key_data) = key_data {
         clean_signatures(&mut key_data, sender_id, user_id, allowed_signatures)?;
         Ok(serde_json::from_value(key_data).ok())
@@ -318,17 +284,8 @@ pub async fn get_allowed_self_signing_key(
 }
 
 pub async fn get_user_signing_key(user_id: &UserId) -> AppResult<Option<CrossSigningKey>> {
-    e2e_cross_signing_keys::table
-        .filter(e2e_cross_signing_keys::user_id.eq(user_id))
-        .filter(e2e_cross_signing_keys::key_type.eq("user_signing"))
-        .order_by(e2e_cross_signing_keys::id.desc())
-        .select(e2e_cross_signing_keys::key_data)
-        .first::<JsonValue>(&mut connect().await?)
-        .await
-        .map(|data| serde_json::from_value(data).ok())
-        .optional()
-        .map(|v| v.flatten())
-        .map_err(Into::into)
+    let key_data = data::user::key::get_cross_signing_key(user_id, "user_signing").await?;
+    Ok(key_data.and_then(|data| serde_json::from_value(data).ok()))
 }
 
 pub async fn add_one_time_key(
@@ -337,25 +294,7 @@ pub async fn add_one_time_key(
     key_id: &DeviceKeyId,
     one_time_key: &OneTimeKey,
 ) -> AppResult<()> {
-    diesel::insert_into(e2e_one_time_keys::table)
-        .values(&NewDbOneTimeKey {
-            user_id: user_id.to_owned(),
-            device_id: device_id.to_owned(),
-            algorithm: key_id.algorithm().to_string(),
-            key_id: key_id.to_owned(),
-            key_data: serde_json::to_value(one_time_key).unwrap(),
-            created_at: UnixMillis::now(),
-        })
-        .on_conflict((
-            e2e_one_time_keys::user_id,
-            e2e_one_time_keys::device_id,
-            e2e_one_time_keys::algorithm,
-            e2e_one_time_keys::key_id,
-        ))
-        .do_update()
-        .set(e2e_one_time_keys::key_data.eq(serde_json::to_value(one_time_key).unwrap()))
-        .execute(&mut connect().await?)
-        .await?;
+    data::user::key::add_one_time_key(user_id, device_id, key_id, one_time_key).await?;
     Ok(())
 }
 
@@ -364,31 +303,7 @@ pub async fn claim_one_time_key(
     device_id: &DeviceId,
     key_algorithm: &DeviceKeyAlgorithm,
 ) -> AppResult<Option<(OwnedDeviceKeyId, OneTimeKey)>> {
-    let one_time_key = e2e_one_time_keys::table
-        .filter(e2e_one_time_keys::user_id.eq(user_id))
-        .filter(e2e_one_time_keys::device_id.eq(device_id))
-        .filter(e2e_one_time_keys::algorithm.eq(key_algorithm.as_ref()))
-        .order(e2e_one_time_keys::id.asc())
-        .first::<DbOneTimeKey>(&mut connect().await?)
-        .await
-        .optional()?;
-    if let Some(DbOneTimeKey {
-        id,
-        key_id,
-        key_data,
-        ..
-    }) = one_time_key
-    {
-        diesel::delete(e2e_one_time_keys::table.find(id))
-            .execute(&mut connect().await?)
-            .await?;
-        Ok(Some((
-            key_id,
-            serde_json::from_value::<OneTimeKey>(key_data)?,
-        )))
-    } else {
-        Ok(None)
-    }
+    Ok(data::user::key::claim_one_time_key(user_id, device_id, key_algorithm).await?)
 }
 
 pub async fn add_device_keys(
@@ -483,15 +398,7 @@ async fn add_cross_signing_key(
     key_type: &str,
     key: &CrossSigningKey,
 ) -> AppResult<()> {
-    diesel::insert_into(e2e_cross_signing_keys::table)
-        .values(NewDbCrossSigningKey {
-            user_id: user_id.to_owned(),
-            key_type: key_type.to_owned(),
-            key_data: serde_json::to_value(key)?,
-        })
-        .execute(&mut connect().await?)
-        .await?;
-
+    data::user::key::add_cross_signing_key(user_id, key_type, key).await?;
     Ok(())
 }
 
@@ -516,16 +423,14 @@ pub async fn sign_key(
     //     .or_defaut()
     //     .insert(key_id.clone(), signature.1);
 
-    diesel::insert_into(e2e_cross_signing_sigs::table)
-        .values(NewDbCrossSignature {
-            origin_user_id: sender_id.to_owned(),
-            origin_key_id,
-            target_user_id: target_user_id.to_owned(),
-            target_device_id: OwnedDeviceId::from(target_device_id),
-            signature: signature.1,
-        })
-        .execute(&mut connect().await?)
-        .await?;
+    data::user::key::add_cross_signing_sig(NewDbCrossSignature {
+        origin_user_id: sender_id.to_owned(),
+        origin_key_id,
+        target_user_id: target_user_id.to_owned(),
+        target_device_id: OwnedDeviceId::from(target_device_id),
+        signature: signature.1,
+    })
+    .await?;
     mark_signing_key_update(target_user_id).await
 }
 
@@ -546,17 +451,7 @@ pub async fn mark_signing_key_update(user_id: &UserId) -> AppResult<()> {
             occur_sn: data::next_sn().await?,
         };
 
-        diesel::delete(
-            e2e_key_changes::table
-                .filter(e2e_key_changes::user_id.eq(user_id))
-                .filter(e2e_key_changes::room_id.eq(room_id)),
-        )
-        .execute(&mut connect().await?)
-        .await?;
-        diesel::insert_into(e2e_key_changes::table)
-            .values(&change)
-            .execute(&mut connect().await?)
-            .await?;
+        data::user::key::replace_key_change(&change).await?;
     }
 
     let change = NewDbKeyChange {
@@ -566,25 +461,10 @@ pub async fn mark_signing_key_update(user_id: &UserId) -> AppResult<()> {
         occur_sn: data::next_sn().await?,
     };
 
-    diesel::delete(
-        e2e_key_changes::table
-            .filter(e2e_key_changes::user_id.eq(user_id))
-            .filter(e2e_key_changes::room_id.is_null()),
-    )
-    .execute(&mut connect().await?)
-    .await?;
-    diesel::insert_into(e2e_key_changes::table)
-        .values(&change)
-        .execute(&mut connect().await?)
-        .await?;
+    data::user::key::replace_key_change(&change).await?;
 
     if user_id.is_local() {
-        let remote_servers = room_joined_servers::table
-            .filter(room_joined_servers::room_id.eq_any(joined_rooms))
-            .select(room_joined_servers::server_id)
-            .distinct()
-            .load::<OwnedServerName>(&mut connect().await?)
-            .await?;
+        let remote_servers = data::room::joined_servers_for_rooms(&joined_rooms).await?;
 
         let content = SigningKeyUpdateContent::new(user_id.to_owned());
         let edu = Edu::SigningKeyUpdate(content);
@@ -613,17 +493,7 @@ pub async fn mark_device_key_update(user_id: &UserId, _device_id: &DeviceId) -> 
             occur_sn,
         };
 
-        diesel::delete(
-            e2e_key_changes::table
-                .filter(e2e_key_changes::user_id.eq(user_id))
-                .filter(e2e_key_changes::room_id.eq(room_id)),
-        )
-        .execute(&mut connect().await?)
-        .await?;
-        diesel::insert_into(e2e_key_changes::table)
-            .values(&change)
-            .execute(&mut connect().await?)
-            .await?;
+        data::user::key::replace_key_change(&change).await?;
     }
 
     let change = NewDbKeyChange {
@@ -633,17 +503,7 @@ pub async fn mark_device_key_update(user_id: &UserId, _device_id: &DeviceId) -> 
         occur_sn,
     };
 
-    diesel::delete(
-        e2e_key_changes::table
-            .filter(e2e_key_changes::user_id.eq(user_id))
-            .filter(e2e_key_changes::room_id.is_null()),
-    )
-    .execute(&mut connect().await?)
-    .await?;
-    diesel::insert_into(e2e_key_changes::table)
-        .values(&change)
-        .execute(&mut connect().await?)
-        .await?;
+    data::user::key::replace_key_change(&change).await?;
 
     Ok(())
 }
@@ -663,17 +523,7 @@ pub async fn mark_device_key_update_with_joined_rooms(
             occur_sn,
         };
 
-        diesel::delete(
-            e2e_key_changes::table
-                .filter(e2e_key_changes::user_id.eq(user_id))
-                .filter(e2e_key_changes::room_id.eq(room_id)),
-        )
-        .execute(&mut connect().await?)
-        .await?;
-        diesel::insert_into(e2e_key_changes::table)
-            .values(&change)
-            .execute(&mut connect().await?)
-            .await?;
+        data::user::key::replace_key_change(&change).await?;
     }
     Ok(())
 }
@@ -691,12 +541,7 @@ async fn send_device_key_update_with_joined_rooms(
     if user_id.is_remote() {
         return Ok(());
     }
-    let remote_servers = room_joined_servers::table
-        .filter(room_joined_servers::room_id.eq_any(joined_rooms))
-        .select(room_joined_servers::server_id)
-        .distinct()
-        .load::<OwnedServerName>(&mut connect().await?)
-        .await?;
+    let remote_servers = data::room::joined_servers_for_rooms(joined_rooms).await?;
 
     let content = DeviceListUpdateContent::new(
         user_id.to_owned(),

--- a/crates/server/src/user/password.rs
+++ b/crates/server/src/user/password.rs
@@ -1,13 +1,6 @@
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
-
 use super::DbUser;
-use crate::core::UnixMillis;
 use crate::core::identifiers::*;
-use crate::data::connect;
-use crate::data::schema::*;
-use crate::data::user::NewDbPassword;
-use crate::{AppResult, MatrixError};
+use crate::{AppResult, MatrixError, data};
 
 pub fn ensure_account_usable(user: &DbUser) -> AppResult<()> {
     if user.deactivated_at.is_some() {
@@ -42,29 +35,12 @@ pub async fn verify_password(user: &DbUser, password: &str) -> AppResult<()> {
 }
 
 pub async fn get_password_hash(user_id: &UserId) -> AppResult<String> {
-    user_passwords::table
-        .filter(user_passwords::user_id.eq(user_id))
-        .order_by(user_passwords::id.desc())
-        .select(user_passwords::hash)
-        .first::<String>(&mut connect().await?)
-        .await
-        .map_err(Into::into)
+    Ok(data::user::get_password_hash(user_id).await?)
 }
 
 /// Set/update password hash for a user
 pub async fn set_password(user_id: &UserId, password: &str) -> AppResult<()> {
     let hash = crate::utils::hash_password(password)?;
-    diesel::insert_into(user_passwords::table)
-        .values(NewDbPassword {
-            user_id: user_id.to_owned(),
-            hash: hash.to_owned(),
-            created_at: UnixMillis::now(),
-        })
-        .execute(&mut connect().await?)
-        .await?;
-    diesel::update(users::table.find(user_id))
-        .set(users::is_guest.eq(false))
-        .execute(&mut connect().await?)
-        .await?;
+    data::user::set_password_hash(user_id, &hash).await?;
     Ok(())
 }

--- a/crates/server/src/user/presence.rs
+++ b/crates/server/src/user/presence.rs
@@ -1,11 +1,6 @@
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
-
 use crate::core::federation::transaction::Edu;
 use crate::core::presence::{PresenceContent, PresenceState, PresenceUpdate};
-use crate::core::{OwnedServerName, UnixMillis, UserId};
-use crate::data::connect;
-use crate::data::schema::*;
+use crate::core::{UnixMillis, UserId};
 use crate::data::user::{NewDbPresence, last_presence};
 use crate::{AppResult, config, data, sending};
 
@@ -97,12 +92,7 @@ pub async fn set_presence(
         });
 
         let joined_rooms = data::user::joined_rooms(sender_id).await?;
-        let remote_servers = room_joined_servers::table
-            .filter(room_joined_servers::room_id.eq_any(joined_rooms))
-            .select(room_joined_servers::server_id)
-            .distinct()
-            .load::<OwnedServerName>(&mut connect().await?)
-            .await?;
+        let remote_servers = data::room::joined_servers_for_rooms(&joined_rooms).await?;
 
         sending::send_edu_servers(remote_servers.into_iter(), &edu).await?;
     }

--- a/crates/server/src/user/pusher.rs
+++ b/crates/server/src/user/pusher.rs
@@ -1,5 +1,3 @@
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
 use palpo_core::push::PusherIds;
 use url::Url;
 
@@ -13,8 +11,6 @@ use crate::core::push::push_gateway::{
 use crate::core::push::{
     Action, HighlightTweakValue, PushFormat, Pusher, PusherKind, Ruleset, Tweak,
 };
-use crate::data::connect;
-use crate::data::schema::*;
 use crate::data::user::pusher::NewDbPusher;
 use crate::event::PduEvent;
 use crate::utils::url_guard;
@@ -37,43 +33,27 @@ pub async fn set_pusher(authed: &AuthedInfo, pusher: PusherAction) -> AppResult<
                 append,
             } = data;
             if !append {
-                diesel::delete(
-                    user_pushers::table
-                        .filter(user_pushers::user_id.eq(authed.user_id()))
-                        .filter(user_pushers::pushkey.eq(&pushkey))
-                        .filter(user_pushers::app_id.eq(&app_id)),
-                )
-                .execute(&mut connect().await?)
-                .await?;
+                data::user::pusher::delete_pusher(authed.user_id(), &app_id, &pushkey).await?;
             }
-            diesel::insert_into(user_pushers::table)
-                .values(&NewDbPusher {
-                    user_id: authed.user_id().to_owned(),
-                    profile_tag,
-                    kind: kind.name().to_owned(),
-                    app_id,
-                    app_display_name,
-                    device_id: authed.device_id().to_owned(),
-                    device_display_name,
-                    access_token_id: authed.access_token_id().to_owned(),
-                    pushkey,
-                    lang,
-                    data: kind.json_data()?,
-                    enabled: true, // TODO
-                    created_at: UnixMillis::now(),
-                })
-                .execute(&mut connect().await?)
-                .await?;
+            data::user::pusher::insert_pusher(&NewDbPusher {
+                user_id: authed.user_id().to_owned(),
+                profile_tag,
+                kind: kind.name().to_owned(),
+                app_id,
+                app_display_name,
+                device_id: authed.device_id().to_owned(),
+                device_display_name,
+                access_token_id: authed.access_token_id().to_owned(),
+                pushkey,
+                lang,
+                data: kind.json_data()?,
+                enabled: true, // TODO
+                created_at: UnixMillis::now(),
+            })
+            .await?;
         }
         PusherAction::Delete(ids) => {
-            diesel::delete(
-                user_pushers::table
-                    .filter(user_pushers::user_id.eq(authed.user_id()))
-                    .filter(user_pushers::pushkey.eq(ids.pushkey))
-                    .filter(user_pushers::app_id.eq(ids.app_id)),
-            )
-            .execute(&mut connect().await?)
-            .await?;
+            data::user::pusher::delete_pusher(authed.user_id(), &ids.app_id, &ids.pushkey).await?;
         }
     }
     Ok(())

--- a/palpo-example.toml
+++ b/palpo-example.toml
@@ -27,7 +27,13 @@
 #
 # server_name =
 
-# This item is undocumented. Please contribute documentation for it.
+# Optional homepage content source for `GET /`.
+#
+# If this is a local path, palpo serves that file directly.
+# If this starts with `http://` or `https://`, palpo fetches the remote HTML
+# at request time.
+# When the remote fetch fails, palpo logs a warning and falls back to the built-in default
+# page.
 #
 # home_page =
 
@@ -592,7 +598,7 @@
 # a normal palpo admin command. The reply will be publicly visible to
 # the room, originating from the sender.
 #
-# example: \\!admin debug ping example.com
+# example: \\!admin server show-config
 #
 # escape_commands =
 
@@ -610,7 +616,7 @@
 # For example: `./palpo --execute "server admin-notice palpo has
 # started up at $(date)"`
 #
-# example: admin_execute = ["debug ping example.com", "debug echo hi"]`
+# example: admin_execute = ["server admin-notice palpo started"]`
 #
 # startup_execute = []
 


### PR DESCRIPTION
@
## Background

Continues the staged refactor started in #227, whose goal is to make **`crates/data` the only layer that directly touches the database**, leaving `server` with business logic only.

This is **Phase 2**: the remaining `user` module. Every direct diesel query under `crates/server/src/user*` is pushed down into `palpo-data`; business logic (token expiry checks, signature cleaning, password hashing, key-update EDU fan-out, presence state-change decisions, federation key queries) stays in the server.

The work is split into three independently-compiling commits.

## Changes

### Phase 2a — `user.rs` (10 sites)
**New data modules**
- `data::user::openid_token` — `user_openid_tokens` get/delete
- `data::user::login_token` — `user_login_tokens` upsert/get/delete

**Extended data modules**
- `data::user` — `create_user`, `mark_deactivated`, `create_profile`, `get_global_datas`, `get_refresh_token_expires_at`
- `data::media` — `list_media_created_by`

Reuses existing `data::user::list_local_users` / `set_admin` (server had duplicate impls).

### Phase 2b — `user/{password,presence,pusher}.rs`
- `data::user::password` — `get_password_hash` / `set_password_hash`
- `data::user::pusher` — `delete_pusher` / `insert_pusher`
- `data::room` — `joined_servers_for_rooms` (shared distinct remote-server lookup)

### Phase 2c — `user/key.rs` (16 sites, the largest)
- `data::user::key` — `get_cross_signing_key`, `add_cross_signing_key`, `add_cross_signing_sig`, `add_one_time_key`, `claim_one_time_key`, `replace_key_change` (unifies the repeated delete+insert key-change marker pattern)
- The two remote-server lookups reuse `data::room::joined_servers_for_rooms`

## Verification

- `cargo build -p palpo-data` / `-p palpo` ✅ Finished (exit 0) for all three phases
- `cargo clippy -p palpo-data` / `-p palpo` ✅ no new warnings in changed files
- The entire server `user` module now has **zero** `connect()` / `schema` / `diesel` references (grep-verified)

## Notes for reviewers

- `crates/server/src/user/invite_rule.rs` is an orphan WIP stub not wired into the module tree (no `mod invite_rule` anywhere); left untouched.
- `deactivate_account` maps to a new `mark_deactivated` (timestamp only), deliberately **not** the existing `data::user::deactivate`, which also deletes threepids/access-tokens — different semantics.
- Cross-signing key getters now consistently `order_by(id desc)`; previously `get_master_key` was unordered while the others ordered. Functionally a no-op unless duplicate master keys exist, in which case the latest is now returned (matches the other getters).

## Later phases (not in this PR)

Phase 3 `room` (biggest payoff) → Phase 4 `event` → Phase 5 sync/watcher/federation + auth/appservices split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@