### PR TITLE
refactor(data): centralize phase-3a room alias/directory DB access into data crate

### DIFF
--- a/crates/data/src/room.rs
+++ b/crates/data/src/room.rs
@@ -439,6 +439,84 @@ pub async fn is_public(room_id: &RoomId) -> DataResult<bool> {
         .map_err(Into::into)
 }
 
+/// Set whether a room is published in the public room directory.
+pub async fn set_public(room_id: &RoomId, value: bool) -> DataResult<()> {
+    diesel::update(rooms::table.find(room_id))
+        .set(rooms::is_public.eq(value))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Resolve a local alias to the room id it points at.
+pub async fn get_alias_room_id(alias_id: &RoomAliasId) -> DataResult<Option<OwnedRoomId>> {
+    room_aliases::table
+        .filter(room_aliases::alias_id.eq(alias_id))
+        .select(room_aliases::room_id)
+        .first::<OwnedRoomId>(&mut connect().await?)
+        .await
+        .optional()
+        .map_err(Into::into)
+}
+
+/// Fetch the full record for a local alias.
+pub async fn get_alias(alias_id: &RoomAliasId) -> DataResult<Option<DbRoomAlias>> {
+    room_aliases::table
+        .find(alias_id)
+        .first::<DbRoomAlias>(&mut connect().await?)
+        .await
+        .optional()
+        .map_err(Into::into)
+}
+
+/// All local aliases pointing at a room.
+pub async fn local_aliases_for_room(room_id: &RoomId) -> DataResult<Vec<OwnedRoomAliasId>> {
+    room_aliases::table
+        .filter(room_aliases::room_id.eq(room_id))
+        .select(room_aliases::alias_id)
+        .load::<OwnedRoomAliasId>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// All local `(room_id, alias_id)` pairs.
+pub async fn all_local_aliases() -> DataResult<Vec<(OwnedRoomId, OwnedRoomAliasId)>> {
+    room_aliases::table
+        .select((room_aliases::room_id, room_aliases::alias_id))
+        .load::<(OwnedRoomId, OwnedRoomAliasId)>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// Whether the alias already exists but points at a different room.
+pub async fn alias_exists_for_other_room(
+    alias_id: &RoomAliasId,
+    room_id: &RoomId,
+) -> DataResult<bool> {
+    let query = room_aliases::table
+        .filter(room_aliases::alias_id.eq(alias_id))
+        .filter(room_aliases::room_id.ne(room_id));
+    Ok(diesel_exists!(query, &mut connect().await?)?)
+}
+
+/// Insert an alias, ignoring conflicts with an existing one.
+pub async fn set_alias(alias: DbRoomAlias) -> DataResult<()> {
+    diesel::insert_into(room_aliases::table)
+        .values(alias)
+        .on_conflict_do_nothing()
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Remove a local alias.
+pub async fn remove_alias(alias_id: &RoomAliasId) -> DataResult<()> {
+    diesel::delete(room_aliases::table.filter(room_aliases::alias_id.eq(alias_id)))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
 #[derive(Insertable, Debug, Clone)]
 #[diesel(table_name = timeline_gaps)]
 pub struct NewDbTimelineGap {

--- a/crates/server/src/room/alias.rs
+++ b/crates/server/src/room/alias.rs
@@ -1,5 +1,3 @@
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
 use rand::seq::SliceRandom;
 use serde_json::value::to_raw_value;
 
@@ -10,24 +8,14 @@ use crate::core::events::TimelineEventType;
 use crate::core::events::room::canonical_alias::RoomCanonicalAliasEventContent;
 use crate::core::federation::query::directory_request;
 use crate::core::identifiers::*;
-use crate::data::connect;
-use crate::data::schema::*;
+use crate::data::room::DbRoomAlias;
 use crate::data::user::DbUser;
 use crate::exts::*;
 use crate::room::{StateEventType, timeline};
-use crate::{AppError, AppResult, GetUrlOrigin, MatrixError, PduBuilder, config};
+use crate::{AppError, AppResult, GetUrlOrigin, MatrixError, PduBuilder, config, data};
 
 mod remote;
 use remote::remote_resolve;
-
-#[derive(Insertable, Identifiable, Queryable, Debug, Clone)]
-#[diesel(table_name = room_aliases, primary_key(alias_id))]
-pub struct DbRoomAlias {
-    pub alias_id: OwnedRoomAliasId,
-    pub room_id: OwnedRoomId,
-    pub created_by: OwnedUserId,
-    pub created_at: UnixMillis,
-}
 
 #[inline]
 pub async fn resolve(room: &RoomOrAliasId) -> AppResult<OwnedRoomId> {
@@ -77,13 +65,9 @@ pub async fn resolve_alias(
 
 #[tracing::instrument(level = "debug")]
 pub async fn resolve_local_alias(alias_id: &RoomAliasId) -> AppResult<OwnedRoomId> {
-    let room_id = room_aliases::table
-        .filter(room_aliases::alias_id.eq(alias_id))
-        .select(room_aliases::room_id)
-        .first::<String>(&mut connect().await?)
-        .await?;
-
-    RoomId::parse(room_id).map_err(|_| AppError::public("Room ID is invalid."))
+    data::room::get_alias_room_id(alias_id)
+        .await?
+        .ok_or_else(|| MatrixError::not_found("Room alias not found.").into())
 }
 
 async fn resolve_appservice_alias(room_alias: &RoomAliasId) -> AppResult<OwnedRoomId> {
@@ -137,17 +121,10 @@ async fn resolve_appservice_alias(room_alias: &RoomAliasId) -> AppResult<OwnedRo
 }
 
 pub async fn local_aliases_for_room(room_id: &RoomId) -> AppResult<Vec<OwnedRoomAliasId>> {
-    room_aliases::table
-        .filter(room_aliases::room_id.eq(room_id))
-        .select(room_aliases::alias_id)
-        .load::<OwnedRoomAliasId>(&mut connect().await?)
-        .await
-        .map_err(Into::into)
+    Ok(data::room::local_aliases_for_room(room_id).await?)
 }
 pub async fn all_local_aliases() -> AppResult<Vec<(OwnedRoomId, String)>> {
-    let lists = room_aliases::table
-        .select((room_aliases::room_id, room_aliases::alias_id))
-        .load::<(OwnedRoomId, OwnedRoomAliasId)>(&mut connect().await?)
+    let lists = data::room::all_local_aliases()
         .await?
         .into_iter()
         .map(|(room_id, alias_id)| (room_id, alias_id.alias().to_owned()))
@@ -177,18 +154,13 @@ pub async fn set_alias(
     let alias_id = alias_id.into();
     let room_id = room_id.into();
 
-    diesel::insert_into(room_aliases::table)
-        .values(DbRoomAlias {
-            alias_id,
-            room_id,
-            created_by: created_by.into(),
-            created_at: UnixMillis::now(),
-        })
-        .on_conflict_do_nothing()
-        .execute(&mut connect().await?)
-        .await
-        .map(|_| ())
-        .map_err(Into::into)
+    Ok(data::room::set_alias(DbRoomAlias {
+        alias_id,
+        room_id,
+        created_by: created_by.into(),
+        created_at: UnixMillis::now(),
+    })
+    .await?)
 }
 
 pub async fn get_alias_response(room_alias: OwnedRoomAliasId) -> AppResult<AliasResBody> {
@@ -267,9 +239,7 @@ pub async fn remove_alias(alias_id: &RoomAliasId, user: &DbUser) -> AppResult<()
             .await
             .ok();
         }
-        diesel::delete(room_aliases::table.filter(room_aliases::alias_id.eq(alias_id)))
-            .execute(&mut connect().await?)
-            .await?;
+        data::room::remove_alias(alias_id).await?;
 
         Ok(())
     } else {
@@ -280,10 +250,9 @@ pub async fn remove_alias(alias_id: &RoomAliasId, user: &DbUser) -> AppResult<()
 async fn user_can_remove_alias(alias_id: &RoomAliasId, user: &DbUser) -> AppResult<bool> {
     let room_id = resolve_local_alias(alias_id).await?;
 
-    let alias = room_aliases::table
-        .find(alias_id)
-        .first::<DbRoomAlias>(&mut connect().await?)
-        .await?;
+    let alias = data::room::get_alias(alias_id)
+        .await?
+        .ok_or_else(|| MatrixError::not_found("Room alias not found."))?;
 
     // The creator of an alias can remove it
     if alias.created_by == user.id

--- a/crates/server/src/room/directory.rs
+++ b/crates/server/src/room/directory.rs
@@ -1,29 +1,17 @@
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
-
 use crate::AppResult;
 use crate::core::RoomId;
 use crate::core::room::Visibility;
-use crate::data::connect;
-use crate::data::schema::*;
+use crate::data;
 
 #[tracing::instrument]
 pub async fn set_public(room_id: &RoomId, value: bool) -> AppResult<()> {
-    diesel::update(rooms::table.find(room_id))
-        .set(rooms::is_public.eq(value))
-        .execute(&mut connect().await?)
-        .await?;
+    data::room::set_public(room_id, value).await?;
     Ok(())
 }
 
 #[tracing::instrument]
 pub async fn is_public(room_id: &RoomId) -> AppResult<bool> {
-    rooms::table
-        .find(room_id)
-        .select(rooms::is_public)
-        .first::<bool>(&mut connect().await?)
-        .await
-        .map_err(Into::into)
+    Ok(data::room::is_public(room_id).await?)
 }
 
 #[tracing::instrument]

--- a/crates/server/src/routing/client/directory/alias.rs
+++ b/crates/server/src/routing/client/directory/alias.rs
@@ -1,14 +1,10 @@
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
 use salvo::oapi::extract::{JsonBody, PathParam};
 use salvo::prelude::*;
 
 use crate::core::client::room::{AliasResBody, SetAliasReqBody};
 use crate::core::identifiers::*;
-use crate::data::schema::*;
-use crate::data::{connect, diesel_exists};
 use crate::exts::*;
-use crate::{AuthArgs, EmptyResult, JsonResult, MatrixError, empty_ok, json_ok};
+use crate::{AuthArgs, EmptyResult, JsonResult, MatrixError, data, empty_ok, json_ok};
 
 /// #GET /_matrix/client/r0/directory/room/{room_alias}
 /// Resolve an alias locally or over federation.
@@ -55,10 +51,7 @@ pub(super) async fn upsert_alias(
         return Err(MatrixError::forbidden("alias already exists", None).into());
     }
 
-    let query = room_aliases::table
-        .filter(room_aliases::alias_id.eq(&alias_id))
-        .filter(room_aliases::room_id.ne(&body.room_id));
-    if diesel_exists!(query, &mut connect().await?)? {
+    if data::room::alias_exists_for_other_room(&alias_id, &body.room_id).await? {
         return Err(StatusError::conflict()
             .brief("a room alias with that name already exists")
             .into());


### PR DESCRIPTION
@
## Background

Continues the staged refactor from #227 / #235, whose goal is to make **`crates/data` the only layer that directly touches the database**, leaving `server` with business logic only.

This opens **Phase 3** (the `room` module — the largest surface, ~400 direct query sites across ~20 files). Like phase 2, it is split into self-contained sub-phases. This PR is **Phase 3a**: the room-discovery slice (public-directory visibility + room aliases).

## Changes

All direct diesel queries for the `rooms.is_public` flag and the `room_aliases` table move into `palpo-data`. Appservice/federation alias resolution and permission checks stay in the server.

**Extended `data::room`**
- `set_public` (the existing `is_public` is reused)
- `get_alias_room_id`, `get_alias`, `local_aliases_for_room`, `all_local_aliases`
- `set_alias`, `remove_alias`, `alias_exists_for_other_room`

**Server side becomes a delegation layer**
- `room/directory.rs`, `room/alias.rs`, `routing/client/directory/alias.rs` no longer reference `connect()` / `schema` / `diesel`.
- The duplicate `DbRoomAlias` struct in `room/alias.rs` is dropped in favour of the existing `data::room::DbRoomAlias`.

## Verification

- `cargo build -p palpo-data` / `-p palpo` ✅ Finished (exit 0)
- `cargo clippy -p palpo` ✅ no new warnings in changed files
- The three touched server files have **zero** `connect()` / `schema` / `diesel` references (grep-verified)

## Notes for reviewers

- `resolve_local_alias` previously loaded the room id as a `String` and re-parsed it with a custom "Room ID is invalid" error; it now loads `OwnedRoomId` directly and maps the not-found case to `M_NOT_FOUND`. Callers only branch on `Ok`/`Err`, so behaviour is unchanged.

## Remaining phase-3 sub-phases (not in this PR)

3b receipt/typing/thread → 3c pdu_metadata/lazy_loading/current → 3d state(+field/frame/diff) → 3e timeline(+backfill/stream/topolo) → 3f push_action → 3g room/user.rs → 3h room.rs root (largest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@