### PR TITLE
refactor(data): centralize phase-3b room receipt/typing/thread DB access into data crate

### DIFF
--- a/crates/data/src/room.rs
+++ b/crates/data/src/room.rs
@@ -15,6 +15,7 @@ pub mod peek;
 pub mod receipt;
 pub mod timeline;
 pub mod transaction_id;
+pub mod typing;
 pub use event_report::*;
 
 #[derive(Insertable, Identifiable, Queryable, Debug, Clone)]
@@ -512,6 +513,51 @@ pub async fn set_alias(alias: DbRoomAlias) -> DataResult<()> {
 /// Remove a local alias.
 pub async fn remove_alias(alias_id: &RoomAliasId) -> DataResult<()> {
     diesel::delete(room_aliases::table.filter(room_aliases::alias_id.eq(alias_id)))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// List a room's thread roots as `(event_id, event_sn)`, newest activity first,
+/// optionally only those with `event_sn <= before_sn`.
+pub async fn list_threads(
+    room_id: &RoomId,
+    before_sn: Option<i64>,
+    limit: i64,
+) -> DataResult<Vec<(OwnedEventId, i64)>> {
+    let mut query = threads::table
+        .filter(threads::room_id.eq(room_id))
+        .into_boxed();
+    if let Some(before_sn) = before_sn {
+        query = query.filter(threads::event_sn.le(before_sn));
+    }
+    query
+        .select((threads::event_id, threads::event_sn))
+        .order_by(threads::last_sn.desc())
+        .limit(limit)
+        .load::<(OwnedEventId, i64)>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// Set the thread id an event belongs to.
+pub async fn set_event_thread_id(event_id: &EventId, thread_id: &EventId) -> DataResult<()> {
+    diesel::update(event_points::table.find(event_id))
+        .set(event_points::thread_id.eq(thread_id))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Insert a thread root, updating its latest event if it already exists.
+pub async fn upsert_thread(thread: DbThread) -> DataResult<()> {
+    let last_id = thread.last_id.clone();
+    let last_sn = thread.last_sn;
+    diesel::insert_into(threads::table)
+        .values(thread)
+        .on_conflict(threads::event_id)
+        .do_update()
+        .set((threads::last_id.eq(last_id), threads::last_sn.eq(last_sn)))
         .execute(&mut connect().await?)
         .await?;
     Ok(())

--- a/crates/data/src/room/receipt.rs
+++ b/crates/data/src/room/receipt.rs
@@ -106,3 +106,29 @@ pub async fn last_private_read_update_sn(user_id: &UserId, room_id: &RoomId) -> 
 
     Ok(event_sn)
 }
+
+/// Insert a fully-built receipt row.
+pub async fn insert_receipt(receipt: &DbReceipt) -> DataResult<()> {
+    diesel::insert_into(event_receipts::table)
+        .values(receipt)
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Event id of the user's most recent private read receipt in a room.
+pub async fn last_private_read_event_id(
+    user_id: &UserId,
+    room_id: &RoomId,
+) -> DataResult<Option<OwnedEventId>> {
+    event_receipts::table
+        .filter(event_receipts::room_id.eq(room_id))
+        .filter(event_receipts::user_id.eq(user_id))
+        .filter(event_receipts::ty.eq(ReceiptType::ReadPrivate.to_string()))
+        .order_by(event_receipts::sn.desc())
+        .select(event_receipts::event_id)
+        .first::<OwnedEventId>(&mut connect().await?)
+        .await
+        .optional()
+        .map_err(Into::into)
+}

--- a/crates/data/src/room/typing.rs
+++ b/crates/data/src/room/typing.rs
@@ -1,0 +1,83 @@
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+
+use crate::core::Seqnum;
+use crate::core::identifiers::*;
+use crate::schema::*;
+use crate::{DataResult, connect};
+
+/// Mark a user as typing until `timeout_at`, replacing any existing entry.
+pub async fn upsert_typing(
+    room_id: &RoomId,
+    user_id: &UserId,
+    timeout_at: i64,
+    occur_sn: Seqnum,
+) -> DataResult<()> {
+    diesel::insert_into(room_typings::table)
+        .values((
+            room_typings::room_id.eq(room_id),
+            room_typings::user_id.eq(user_id),
+            room_typings::timeout_at.eq(timeout_at),
+            room_typings::occur_sn.eq(occur_sn),
+        ))
+        .on_conflict((room_typings::room_id, room_typings::user_id))
+        .do_update()
+        .set((
+            room_typings::timeout_at.eq(timeout_at),
+            room_typings::occur_sn.eq(occur_sn),
+        ))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Mark a user as no longer typing by zeroing the timeout and bumping `occur_sn`
+/// so sync still observes the "stopped" transition before cleanup.
+pub async fn stop_typing(room_id: &RoomId, user_id: &UserId, occur_sn: Seqnum) -> DataResult<()> {
+    diesel::update(
+        room_typings::table
+            .filter(room_typings::room_id.eq(room_id))
+            .filter(room_typings::user_id.eq(user_id)),
+    )
+    .set((
+        room_typings::timeout_at.eq(0i64),
+        room_typings::occur_sn.eq(occur_sn),
+    ))
+    .execute(&mut connect().await?)
+    .await?;
+    Ok(())
+}
+
+/// Delete typing rows whose timeout is strictly before `now_ms`.
+pub async fn delete_expired_typings(room_id: &RoomId, now_ms: i64) -> DataResult<()> {
+    diesel::delete(
+        room_typings::table
+            .filter(room_typings::room_id.eq(room_id))
+            .filter(room_typings::timeout_at.lt(now_ms)),
+    )
+    .execute(&mut connect().await?)
+    .await?;
+    Ok(())
+}
+
+/// Sequence number of the most recent typing update in a room (0 if none).
+pub async fn last_typing_sn(room_id: &RoomId) -> DataResult<Seqnum> {
+    let sn = room_typings::table
+        .filter(room_typings::room_id.eq(room_id))
+        .select(diesel::dsl::max(room_typings::occur_sn))
+        .first::<Option<Seqnum>>(&mut connect().await?)
+        .await
+        .unwrap_or(None)
+        .unwrap_or_default();
+    Ok(sn)
+}
+
+/// Users with a typing row in a room (callers should expire stale rows first).
+pub async fn typing_user_ids(room_id: &RoomId) -> DataResult<Vec<OwnedUserId>> {
+    room_typings::table
+        .filter(room_typings::room_id.eq(room_id))
+        .select(room_typings::user_id)
+        .load::<OwnedUserId>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}

--- a/crates/server/src/room/receipt.rs
+++ b/crates/server/src/room/receipt.rs
@@ -1,19 +1,14 @@
 use std::collections::BTreeMap;
 
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
-
 use crate::core::UnixMillis;
 use crate::core::events::receipt::{
-    Receipt, ReceiptContent, ReceiptData, ReceiptEvent, ReceiptEventContent, ReceiptMap,
-    ReceiptType, Receipts,
+    Receipt, ReceiptContent, ReceiptData, ReceiptEvent, ReceiptEventContent, ReceiptMap, Receipts,
 };
 use crate::core::federation::transaction::Edu;
 use crate::core::identifiers::*;
+use crate::data::next_sn;
 use crate::data::room::DbReceipt;
-use crate::data::schema::*;
-use crate::data::{connect, next_sn};
-use crate::{AppResult, sending};
+use crate::{AppResult, MatrixError, data, sending};
 
 /// Replaces the previous read receipt.
 #[tracing::instrument]
@@ -45,15 +40,7 @@ pub async fn update_read(
                     json_data: serde_json::to_value(receipt)?,
                     receipt_at,
                 };
-                // Acquire the connection inline for the insert only. Holding a
-                // named `conn` across `next_sn()` above (which checks out its
-                // own connection) would pin two connections at once and risk
-                // exhausting the pool on this fairly hot receipt path.
-                if let Err(e) = diesel::insert_into(event_receipts::table)
-                    .values(&receipt)
-                    .execute(&mut connect().await?)
-                    .await
-                {
+                if let Err(e) = data::room::receipt::insert_receipt(&receipt).await {
                     error!("failed to insert receipt: {}", e);
                 }
             }
@@ -82,14 +69,10 @@ pub async fn last_private_read(
     user_id: &UserId,
     room_id: &RoomId,
 ) -> AppResult<ReceiptEventContent> {
-    let event_id = event_receipts::table
-        .filter(event_receipts::room_id.eq(room_id))
-        .filter(event_receipts::user_id.eq(user_id))
-        .filter(event_receipts::ty.eq(ReceiptType::ReadPrivate.to_string()))
-        .order_by(event_receipts::sn.desc())
-        .select(event_receipts::event_id)
-        .first::<OwnedEventId>(&mut connect().await?)
-        .await?;
+    let Some(event_id) = data::room::receipt::last_private_read_event_id(user_id, room_id).await?
+    else {
+        return Err(MatrixError::not_found("No private read receipt.").into());
+    };
 
     // let room_sn = crate::room::get_room_sn(room_id)
     //     .map_err(|e| MatrixError::bad_state(format!("room does not exist in database for

--- a/crates/server/src/room/thread.rs
+++ b/crates/server/src/room/thread.rs
@@ -1,16 +1,12 @@
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
 use serde_json::json;
 
 use crate::core::client::room::IncludeThreads;
 use crate::core::events::relation::BundledThread;
 use crate::core::identifiers::*;
 use crate::core::serde::CanonicalJsonValue;
-use crate::data::connect;
 use crate::data::room::DbThread;
-use crate::data::schema::*;
 use crate::room::timeline;
-use crate::{AppResult, SnPduEvent};
+use crate::{AppResult, SnPduEvent, data};
 
 pub async fn get_threads(
     room_id: &RoomId,
@@ -18,24 +14,7 @@ pub async fn get_threads(
     limit: i64,
     from_token: Option<i64>,
 ) -> AppResult<(Vec<(OwnedEventId, SnPduEvent)>, Option<i64>)> {
-    let items = if let Some(from_token) = from_token {
-        threads::table
-            .filter(threads::room_id.eq(room_id))
-            .filter(threads::event_sn.le(from_token))
-            .select((threads::event_id, threads::event_sn))
-            .order_by(threads::last_sn.desc())
-            .limit(limit)
-            .load::<(OwnedEventId, i64)>(&mut connect().await?)
-            .await?
-    } else {
-        threads::table
-            .filter(threads::room_id.eq(room_id))
-            .select((threads::event_id, threads::event_sn))
-            .order_by(threads::last_sn.desc())
-            .limit(limit)
-            .load::<(OwnedEventId, i64)>(&mut connect().await?)
-            .await?
-    };
+    let items = data::room::list_threads(room_id, from_token, limit).await?;
     let next_token = items.last().map(|(_, sn)| *sn - 1);
 
     let mut events = Vec::with_capacity(items.len());
@@ -95,26 +74,15 @@ pub async fn add_to_thread(thread_id: &EventId, pdu: &SnPduEvent) -> AppResult<(
         timeline::replace_pdu(thread_id, &root_pdu_json).await?;
     }
 
-    diesel::update(event_points::table.find(&pdu.event_id))
-        .set(event_points::thread_id.eq(thread_id))
-        .execute(&mut connect().await?)
-        .await?;
+    data::room::set_event_thread_id(&pdu.event_id, thread_id).await?;
 
-    diesel::insert_into(threads::table)
-        .values(DbThread {
-            event_id: root_pdu.event_id.clone(),
-            event_sn: root_pdu.event_sn,
-            room_id: root_pdu.room_id.clone(),
-            last_id: pdu.event_id.clone(),
-            last_sn: pdu.event_sn,
-        })
-        .on_conflict(threads::event_id)
-        .do_update()
-        .set((
-            threads::last_id.eq(&pdu.event_id),
-            threads::last_sn.eq(pdu.event_sn),
-        ))
-        .execute(&mut connect().await?)
-        .await?;
+    data::room::upsert_thread(DbThread {
+        event_id: root_pdu.event_id.clone(),
+        event_sn: root_pdu.event_sn,
+        room_id: root_pdu.room_id.clone(),
+        last_id: pdu.event_id.clone(),
+        last_sn: pdu.event_sn,
+    })
+    .await?;
     Ok(())
 }

--- a/crates/server/src/room/typing.rs
+++ b/crates/server/src/room/typing.rs
@@ -1,7 +1,5 @@
 use std::sync::LazyLock;
 
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
 use tokio::sync::broadcast;
 
 use crate::core::UnixMillis;
@@ -9,8 +7,6 @@ use crate::core::events::SyncEphemeralRoomEvent;
 use crate::core::events::typing::{TypingContent, TypingEventContent};
 use crate::core::federation::transaction::Edu;
 use crate::core::identifiers::*;
-use crate::data::connect;
-use crate::data::schema::*;
 use crate::{AppResult, IsRemoteOrLocal, data, sending};
 
 /// Local broadcast channel for same-instance fast notification.
@@ -27,21 +23,7 @@ pub async fn add_typing(
     broadcast: bool,
 ) -> AppResult<()> {
     let event_sn = data::next_sn().await?;
-    diesel::insert_into(room_typings::table)
-        .values((
-            room_typings::room_id.eq(room_id),
-            room_typings::user_id.eq(user_id),
-            room_typings::timeout_at.eq(timeout as i64),
-            room_typings::occur_sn.eq(event_sn),
-        ))
-        .on_conflict((room_typings::room_id, room_typings::user_id))
-        .do_update()
-        .set((
-            room_typings::timeout_at.eq(timeout as i64),
-            room_typings::occur_sn.eq(event_sn),
-        ))
-        .execute(&mut connect().await?)
-        .await?;
+    data::room::typing::upsert_typing(room_id, user_id, timeout as i64, event_sn).await?;
 
     // Notify same-instance watchers immediately
     let _ = TYPING_UPDATE_SENDER.send(room_id.to_owned());
@@ -57,17 +39,7 @@ pub async fn add_typing(
 /// so that sync picks up the "typing stopped" change before cleanup.
 pub async fn remove_typing(user_id: &UserId, room_id: &RoomId, broadcast: bool) -> AppResult<()> {
     let event_sn = data::next_sn().await?;
-    diesel::update(
-        room_typings::table
-            .filter(room_typings::room_id.eq(room_id))
-            .filter(room_typings::user_id.eq(user_id)),
-    )
-    .set((
-        room_typings::timeout_at.eq(0i64),
-        room_typings::occur_sn.eq(event_sn),
-    ))
-    .execute(&mut connect().await?)
-    .await?;
+    data::room::typing::stop_typing(room_id, user_id, event_sn).await?;
 
     // Notify same-instance watchers immediately
     let _ = TYPING_UPDATE_SENDER.send(room_id.to_owned());
@@ -94,13 +66,7 @@ pub async fn wait_for_update(room_id: &RoomId) -> AppResult<()> {
 /// Removes expired typing entries from the database.
 async fn maintain_typings(room_id: &RoomId) -> AppResult<()> {
     let current_timestamp = UnixMillis::now().get() as i64;
-    diesel::delete(
-        room_typings::table
-            .filter(room_typings::room_id.eq(room_id))
-            .filter(room_typings::timeout_at.lt(current_timestamp)),
-    )
-    .execute(&mut connect().await?)
-    .await?;
+    data::room::typing::delete_expired_typings(room_id, current_timestamp).await?;
     Ok(())
 }
 
@@ -109,14 +75,7 @@ async fn maintain_typings(room_id: &RoomId) -> AppResult<()> {
 /// We query max occur_sn BEFORE cleanup so that "stop typing" events
 /// (which set timeout_at=0) are still visible to sync.
 pub async fn last_typing_update(room_id: &RoomId) -> AppResult<i64> {
-    let sn = room_typings::table
-        .filter(room_typings::room_id.eq(room_id))
-        .select(diesel::dsl::max(room_typings::occur_sn))
-        .first::<Option<i64>>(&mut connect().await?)
-        .await
-        .unwrap_or(None)
-        .unwrap_or_default();
-    Ok(sn)
+    Ok(data::room::typing::last_typing_sn(room_id).await?)
 }
 
 /// Returns a new typing EDU with currently typing users from the database.
@@ -124,11 +83,7 @@ pub async fn all_typings(
     room_id: &RoomId,
 ) -> AppResult<SyncEphemeralRoomEvent<TypingEventContent>> {
     maintain_typings(room_id).await?;
-    let user_ids = room_typings::table
-        .filter(room_typings::room_id.eq(room_id))
-        .select(room_typings::user_id)
-        .load::<OwnedUserId>(&mut connect().await?)
-        .await?;
+    let user_ids = data::room::typing::typing_user_ids(room_id).await?;
 
     Ok(SyncEphemeralRoomEvent {
         content: TypingEventContent { user_ids },


### PR DESCRIPTION
@
## Background

Continues the staged refactor from #227 / #235 / #236, whose goal is to make **`crates/data` the only layer that directly touches the database**, leaving `server` with business logic only.

This is **Phase 3b** of the `room` module: the receipt, typing and thread leaf modules. All direct diesel queries move into `palpo-data`; EDU fan-out, thread-relation bundling and sync content building stay in the server.

## Changes

**New data module**
- `data::room::typing` — `upsert_typing`, `stop_typing`, `delete_expired_typings`, `last_typing_sn`, `typing_user_ids`

**Extended data modules**
- `data::room::receipt` — `insert_receipt`, `last_private_read_event_id`
- `data::room` — `list_threads`, `set_event_thread_id`, `upsert_thread`

**Server side becomes a delegation layer**
- `room/typing.rs`, `room/thread.rs`, `room/receipt.rs` no longer reference `connect()` / `schema` / `diesel`.

## Verification

- `cargo build -p palpo-data` / `-p palpo` ✅ Finished (exit 0)
- `cargo clippy -p palpo` ✅ no new warnings in changed files
- The three touched server files have **zero** `connect()` / `schema` / `diesel` references (grep-verified)

## Notes for reviewers

- `last_private_read` previously propagated the diesel `NotFound` error when no private read receipt existed; it now maps the missing case to `M_NOT_FOUND`. Its only caller (`sync_v5`) uses `.ok()`, so the observable behaviour (→ `None`) is unchanged.
- `room/typing.rs` keeps its same-instance `broadcast` channel and the `maintain_typings` (expire-before-read) ordering; only the SQL moved.

## Remaining phase-3 sub-phases (not in this PR)

3c pdu_metadata/lazy_loading/current → 3d state(+field/frame/diff) → 3e timeline(+backfill/stream/topolo) → 3f push_action → 3g room/user.rs → 3h room.rs root (largest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@