### PR TITLE
refactor(data): centralize phase-3d room state field/frame/delta DB access into data crate

### DIFF
--- a/crates/data/src/room.rs
+++ b/crates/data/src/room.rs
@@ -668,6 +668,171 @@ pub async fn is_event_soft_failed(event_id: &EventId) -> DataResult<bool> {
         .map_err(Into::into)
 }
 
+// ---------------------------------------------------------------------------
+// Room state: fields, frames and deltas
+// ---------------------------------------------------------------------------
+
+/// Look up a state field by its id.
+pub async fn get_state_field(field_id: i64) -> DataResult<DbRoomStateField> {
+    room_state_fields::table
+        .find(field_id)
+        .first::<DbRoomStateField>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// Id of the `(event_ty, state_key)` state field, if it exists.
+pub async fn get_state_field_id(event_ty: &StateEventType, state_key: &str) -> DataResult<i64> {
+    room_state_fields::table
+        .filter(room_state_fields::event_ty.eq(event_ty))
+        .filter(room_state_fields::state_key.eq(state_key))
+        .select(room_state_fields::id)
+        .first::<i64>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// Id of the `(event_ty, state_key)` state field, creating it if missing.
+pub async fn ensure_state_field_id(
+    event_ty: &StateEventType,
+    state_key: &str,
+) -> DataResult<i64> {
+    let id = diesel::insert_into(room_state_fields::table)
+        .values((
+            room_state_fields::event_ty.eq(event_ty),
+            room_state_fields::state_key.eq(state_key),
+        ))
+        .on_conflict_do_nothing()
+        .returning(room_state_fields::id)
+        .get_result::<i64>(&mut connect().await?)
+        .await
+        .optional()?;
+    if let Some(id) = id {
+        Ok(id)
+    } else {
+        room_state_fields::table
+            .filter(room_state_fields::event_ty.eq(event_ty))
+            .filter(room_state_fields::state_key.eq(state_key))
+            .select(room_state_fields::id)
+            .first::<i64>(&mut connect().await?)
+            .await
+            .map_err(Into::into)
+    }
+}
+
+/// The `(event_ty, state_key)` state field, creating it if missing.
+pub async fn ensure_state_field(
+    event_ty: &StateEventType,
+    state_key: &str,
+) -> DataResult<DbRoomStateField> {
+    let id = diesel::insert_into(room_state_fields::table)
+        .values((
+            room_state_fields::event_ty.eq(event_ty),
+            room_state_fields::state_key.eq(state_key),
+        ))
+        .on_conflict_do_nothing()
+        .returning(room_state_fields::id)
+        .get_result::<i64>(&mut connect().await?)
+        .await
+        .optional()?;
+    if let Some(id) = id {
+        room_state_fields::table
+            .find(id)
+            .first::<DbRoomStateField>(&mut connect().await?)
+            .await
+            .map_err(Into::into)
+    } else {
+        room_state_fields::table
+            .filter(room_state_fields::event_ty.eq(event_ty))
+            .filter(room_state_fields::state_key.eq(state_key))
+            .first::<DbRoomStateField>(&mut connect().await?)
+            .await
+            .map_err(Into::into)
+    }
+}
+
+/// Resolve the state frame id for a room, optionally at or before `until_sn`.
+pub async fn get_room_frame_id(room_id: &RoomId, until_sn: Option<i64>) -> DataResult<Option<i64>> {
+    if let Some(until_sn) = until_sn {
+        event_points::table
+            .filter(event_points::room_id.eq(room_id))
+            .filter(event_points::event_sn.le(until_sn))
+            .filter(event_points::frame_id.is_not_null())
+            .select(event_points::frame_id)
+            .order(event_points::event_sn.desc())
+            .first::<Option<i64>>(&mut connect().await?)
+            .await
+            .optional()
+            .map(Option::flatten)
+            .map_err(Into::into)
+    } else {
+        rooms::table
+            .find(room_id)
+            .select(rooms::state_frame_id)
+            .first::<Option<i64>>(&mut connect().await?)
+            .await
+            .optional()
+            .map(Option::flatten)
+            .map_err(Into::into)
+    }
+}
+
+/// State frame id recorded for an event, if any.
+pub async fn get_pdu_frame_id(event_id: &EventId) -> DataResult<Option<i64>> {
+    event_points::table
+        .filter(event_points::event_id.eq(event_id))
+        .select(event_points::frame_id)
+        .first::<Option<i64>>(&mut connect().await?)
+        .await
+        .optional()
+        .map(Option::flatten)
+        .map_err(Into::into)
+}
+
+/// Insert a state frame for `(room_id, hash_data)` and return its id.
+pub async fn ensure_state_frame(room_id: &RoomId, hash_data: Vec<u8>) -> DataResult<i64> {
+    diesel::insert_into(room_state_frames::table)
+        .values((
+            room_state_frames::room_id.eq(room_id),
+            room_state_frames::hash_data.eq(hash_data),
+        ))
+        .on_conflict_do_nothing()
+        .returning(room_state_frames::id)
+        .get_result(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// Id of an existing state frame for `(room_id, hash_data)`.
+pub async fn get_state_frame_id(room_id: &RoomId, hash_data: &[u8]) -> DataResult<i64> {
+    room_state_frames::table
+        .filter(room_state_frames::room_id.eq(room_id))
+        .filter(room_state_frames::hash_data.eq(hash_data))
+        .select(room_state_frames::id)
+        .get_result(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// The raw state delta row for a frame.
+pub async fn get_state_delta(frame_id: i64) -> DataResult<DbRoomStateDelta> {
+    room_state_deltas::table
+        .find(frame_id)
+        .first::<DbRoomStateDelta>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// Insert a state delta row, ignoring conflicts.
+pub async fn save_state_delta(delta: DbRoomStateDelta) -> DataResult<()> {
+    diesel::insert_into(room_state_deltas::table)
+        .values(delta)
+        .on_conflict_do_nothing()
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
 #[derive(Insertable, Debug, Clone)]
 #[diesel(table_name = timeline_gaps)]
 pub struct NewDbTimelineGap {

--- a/crates/server/src/room/state.rs
+++ b/crates/server/src/room/state.rs
@@ -41,24 +41,7 @@ pub static SERVER_VISIBILITY_CACHE: LazyLock<Mutex<LruCache<(OwnedServerName, i6
 pub static USER_VISIBILITY_CACHE: LazyLock<Mutex<LruCache<(OwnedUserId, i64), bool>>> =
     LazyLock::new(|| Mutex::new(LruCache::new(100)));
 
-#[derive(Insertable, Identifiable, Queryable, Debug, Clone)]
-#[diesel(table_name = room_state_deltas, primary_key(frame_id))]
-pub struct DbRoomStateDelta {
-    pub frame_id: i64,
-    pub room_id: OwnedRoomId,
-    pub parent_id: Option<i64>,
-    pub appended: Vec<u8>,
-    pub disposed: Vec<u8>,
-}
-// #[derive(Insertable, Debug, Clone)]
-// #[diesel(table_name = room_state_deltas)]
-// pub struct NewDbRoomStateDelta {
-//     pub room_id: OwnedRoomId,
-//     pub frame_id: i64,
-//     pub parent_id: Option<i64>,
-//     pub appended: Vec<u8>,
-//     pub disposed: Vec<u8>,
-// }
+pub use crate::data::room::DbRoomStateDelta;
 
 pub async fn server_joined_rooms(server_name: &ServerName) -> AppResult<Vec<OwnedRoomId>> {
     room_joined_servers::table

--- a/crates/server/src/room/state/diff.rs
+++ b/crates/server/src/room/state/diff.rs
@@ -3,12 +3,10 @@ use std::mem::size_of;
 use std::ops::Deref;
 use std::sync::Arc;
 
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
-
-use super::{DbRoomStateDelta, FrameInfo, room_state_deltas};
+use super::FrameInfo;
 use crate::core::{OwnedEventId, RoomId, Seqnum};
-use crate::data::connect;
+use crate::data;
+use crate::data::room::DbRoomStateDelta;
 use crate::{AppResult, utils};
 
 pub struct StateDiff {
@@ -82,11 +80,7 @@ pub fn compress_event(
 }
 
 pub async fn get_detla(frame_id: i64) -> AppResult<DbRoomStateDelta> {
-    room_state_deltas::table
-        .find(frame_id)
-        .first::<DbRoomStateDelta>(&mut connect().await?)
-        .await
-        .map_err(Into::into)
+    Ok(data::room::get_state_delta(frame_id).await?)
 }
 pub async fn load_state_diff(frame_id: i64) -> AppResult<StateDiff> {
     let DbRoomStateDelta {
@@ -94,10 +88,7 @@ pub async fn load_state_diff(frame_id: i64) -> AppResult<StateDiff> {
         appended,
         disposed,
         ..
-    } = room_state_deltas::table
-        .find(frame_id)
-        .first::<DbRoomStateDelta>(&mut connect().await?)
-        .await?;
+    } = data::room::get_state_delta(frame_id).await?;
     Ok(StateDiff {
         parent_id,
         appended: Arc::new(
@@ -121,25 +112,22 @@ pub async fn save_state_delta(room_id: &RoomId, frame_id: i64, diff: StateDiff) 
         appended,
         disposed,
     } = diff;
-    diesel::insert_into(room_state_deltas::table)
-        .values(DbRoomStateDelta {
-            frame_id,
-            room_id: room_id.to_owned(),
-            parent_id,
-            appended: appended
-                .iter()
-                .flat_map(|event| event.as_bytes())
-                .cloned()
-                .collect::<Vec<_>>(),
-            disposed: disposed
-                .iter()
-                .flat_map(|event| event.as_bytes())
-                .cloned()
-                .collect::<Vec<_>>(),
-        })
-        .on_conflict_do_nothing()
-        .execute(&mut connect().await?)
-        .await?;
+    data::room::save_state_delta(DbRoomStateDelta {
+        frame_id,
+        room_id: room_id.to_owned(),
+        parent_id,
+        appended: appended
+            .iter()
+            .flat_map(|event| event.as_bytes())
+            .cloned()
+            .collect::<Vec<_>>(),
+        disposed: disposed
+            .iter()
+            .flat_map(|event| event.as_bytes())
+            .cloned()
+            .collect::<Vec<_>>(),
+    })
+    .await?;
     Ok(())
 }
 /// Creates a new state_hash that often is just a diff to an already existing

--- a/crates/server/src/room/state/field.rs
+++ b/crates/server/src/room/state/field.rs
@@ -1,84 +1,20 @@
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
-
 use crate::AppResult;
 use crate::core::events::StateEventType;
-use crate::data::connect;
-use crate::data::schema::*;
-
-#[derive(Identifiable, Queryable, Debug, Clone)]
-#[diesel(table_name = room_state_fields)]
-pub struct DbRoomStateField {
-    pub id: i64,
-    pub event_ty: StateEventType,
-    pub state_key: String,
-}
+use crate::data;
+pub use crate::data::room::DbRoomStateField;
 
 pub async fn get_field(field_id: i64) -> AppResult<DbRoomStateField> {
-    room_state_fields::table
-        .find(field_id)
-        .first::<DbRoomStateField>(&mut connect().await?)
-        .await
-        .map_err(Into::into)
+    Ok(data::room::get_state_field(field_id).await?)
 }
 pub async fn get_field_id(event_ty: &StateEventType, state_key: &str) -> AppResult<i64> {
-    room_state_fields::table
-        .filter(room_state_fields::event_ty.eq(event_ty))
-        .filter(room_state_fields::state_key.eq(state_key))
-        .select(room_state_fields::id)
-        .first::<i64>(&mut connect().await?)
-        .await
-        .map_err(Into::into)
+    Ok(data::room::get_state_field_id(event_ty, state_key).await?)
 }
 pub async fn ensure_field_id(event_ty: &StateEventType, state_key: &str) -> AppResult<i64> {
-    let id = diesel::insert_into(room_state_fields::table)
-        .values((
-            room_state_fields::event_ty.eq(event_ty),
-            room_state_fields::state_key.eq(state_key),
-        ))
-        .on_conflict_do_nothing()
-        .returning(room_state_fields::id)
-        .get_result::<i64>(&mut connect().await?)
-        .await
-        .optional()?;
-    if let Some(id) = id {
-        Ok(id)
-    } else {
-        room_state_fields::table
-            .filter(room_state_fields::event_ty.eq(event_ty))
-            .filter(room_state_fields::state_key.eq(state_key))
-            .select(room_state_fields::id)
-            .first::<i64>(&mut connect().await?)
-            .await
-            .map_err(Into::into)
-    }
+    Ok(data::room::ensure_state_field_id(event_ty, state_key).await?)
 }
 pub async fn ensure_field(
     event_ty: &StateEventType,
     state_key: &str,
 ) -> AppResult<DbRoomStateField> {
-    let id = diesel::insert_into(room_state_fields::table)
-        .values((
-            room_state_fields::event_ty.eq(event_ty),
-            room_state_fields::state_key.eq(state_key),
-        ))
-        .on_conflict_do_nothing()
-        .returning(room_state_fields::id)
-        .get_result::<i64>(&mut connect().await?)
-        .await
-        .optional()?;
-    if let Some(id) = id {
-        room_state_fields::table
-            .find(id)
-            .first::<DbRoomStateField>(&mut connect().await?)
-            .await
-            .map_err(Into::into)
-    } else {
-        room_state_fields::table
-            .filter(room_state_fields::event_ty.eq(event_ty))
-            .filter(room_state_fields::state_key.eq(state_key))
-            .first::<DbRoomStateField>(&mut connect().await?)
-            .await
-            .map_err(Into::into)
-    }
+    Ok(data::room::ensure_state_field(event_ty, state_key).await?)
 }

--- a/crates/server/src/room/state/frame.rs
+++ b/crates/server/src/room/state/frame.rs
@@ -1,14 +1,10 @@
 use std::sync::{Arc, LazyLock, Mutex};
 
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
 use lru_cache::LruCache;
 
 use super::{CompressedState, StateDiff};
 use crate::core::identifiers::*;
-use crate::data::connect;
-use crate::data::schema::*;
-use crate::{AppResult, MatrixError};
+use crate::{AppResult, MatrixError, data};
 
 pub static STATE_INFO_CACHE: LazyLock<Mutex<LruCache<i64, Vec<FrameInfo>>>> =
     LazyLock::new(|| Mutex::new(LruCache::new(100_000)));
@@ -71,53 +67,21 @@ pub async fn load_frame_info(frame_id: i64) -> AppResult<Vec<FrameInfo>> {
 }
 
 pub async fn get_room_frame_id(room_id: &RoomId, until_sn: Option<i64>) -> AppResult<i64> {
-    let frame_id = if let Some(until_sn) = until_sn {
-        event_points::table
-            .filter(event_points::room_id.eq(room_id))
-            .filter(event_points::event_sn.le(until_sn))
-            .filter(event_points::frame_id.is_not_null())
-            .select(event_points::frame_id)
-            .order(event_points::event_sn.desc())
-            .first::<Option<i64>>(&mut connect().await?)
-            .await?
-    } else {
-        rooms::table
-            .find(room_id)
-            .select(rooms::state_frame_id)
-            .first::<Option<i64>>(&mut connect().await?)
-            .await?
-    };
-    frame_id.ok_or(MatrixError::not_found("room frame is not found").into())
+    data::room::get_room_frame_id(room_id, until_sn)
+        .await?
+        .ok_or(MatrixError::not_found("room frame is not found").into())
 }
 
 pub async fn get_pdu_frame_id(event_id: &EventId) -> AppResult<i64> {
-    let frame_id = event_points::table
-        .filter(event_points::event_id.eq(event_id))
-        .select(event_points::frame_id)
-        .first::<Option<i64>>(&mut connect().await?)
-        .await?;
-    frame_id.ok_or(MatrixError::not_found("pdu frame is not found").into())
+    data::room::get_pdu_frame_id(event_id)
+        .await?
+        .ok_or(MatrixError::not_found("pdu frame is not found").into())
 }
 /// Returns (state_hash, already_existed)
 pub async fn ensure_frame(room_id: &RoomId, hash_data: Vec<u8>) -> AppResult<i64> {
-    diesel::insert_into(room_state_frames::table)
-        .values((
-            room_state_frames::room_id.eq(room_id),
-            room_state_frames::hash_data.eq(hash_data),
-        ))
-        .on_conflict_do_nothing()
-        .returning(room_state_frames::id)
-        .get_result(&mut connect().await?)
-        .await
-        .map_err(Into::into)
+    Ok(data::room::ensure_state_frame(room_id, hash_data).await?)
 }
 
 pub async fn get_frame_id(room_id: &RoomId, hash_data: &[u8]) -> AppResult<i64> {
-    room_state_frames::table
-        .filter(room_state_frames::room_id.eq(room_id))
-        .filter(room_state_frames::hash_data.eq(hash_data))
-        .select(room_state_frames::id)
-        .get_result(&mut connect().await?)
-        .await
-        .map_err(Into::into)
+    Ok(data::room::get_state_frame_id(room_id, hash_data).await?)
 }


### PR DESCRIPTION
@
## Background

Continues the staged refactor from #227 / #235 / #236 / #237 / #238, whose goal is to make **`crates/data` the only layer that directly touches the database**, leaving `server` with business logic only.

This is **Phase 3d** of the `room` module: the room-state `field`, `frame` and `diff` (delta) submodules. All direct diesel queries move into `palpo-data`; the compressed-state diff algorithm and the frame-info LRU cache stay in the server.

The large `room/state.rs` root file is intentionally **not** included here — only its two duplicated model structs are removed (see below). It gets its own later sub-phase.

## Changes

**Extended `data::room`**
- `get_state_field`, `get_state_field_id`, `ensure_state_field_id`, `ensure_state_field`
- `get_room_frame_id`, `get_pdu_frame_id`, `ensure_state_frame`, `get_state_frame_id`
- `get_state_delta`, `save_state_delta`

**Server side becomes a delegation layer**
- `room/state/field.rs`, `room/state/frame.rs`, `room/state/diff.rs` no longer reference `connect()` / `schema` / `diesel`.
- The duplicate `DbRoomStateField` (in `state/field.rs`) and `DbRoomStateDelta` (in `state.rs`) structs are dropped in favour of the existing `data::room` definitions, **re-exported** so the public `state::DbRoomStateField` / `state::DbRoomStateDelta` paths used by `event/resolver.rs`, `routing/client/room/event.rs` and `sync_v3.rs` are unchanged.

## Verification

- `cargo build -p palpo-data` / `-p palpo` ✅ Finished (exit 0)
- `cargo clippy -p palpo-data` / `-p palpo` ✅ no new warnings in changed files
- The three touched submodule files have **zero** `connect()` / `schema` / `diesel` references, and `state.rs` no longer references `room_state_deltas` (grep-verified)

## Notes for reviewers

- `get_room_frame_id`/`get_pdu_frame_id` previously returned the diesel `NotFound` error when the row was absent; the data helpers now return `Option<i64>` (flattened over the nullable column) and the server maps `None` to `M_NOT_FOUND`. Net observable behaviour is unchanged.
- `ensure_frame`/`ensure_state_frame` keep their existing quirk (on-conflict-do-nothing + `RETURNING` errors when the frame already exists); the logic was moved verbatim, not "fixed".
- The compressed-state diff layering in `state/diff.rs` (`calc_and_save_state_delta`) is untouched; only `get_detla` / `load_state_diff` / `save_state_delta` now call the data layer.

## Remaining phase-3 sub-phases (not in this PR)

room/state.rs root → 3e timeline(+backfill/stream/topolo) → 3f push_action → 3g room/user.rs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@