### PR TITLE
perf(data): index user_access_tokens.token for auth hot path

### DIFF
--- a/crates/data/migrations/2026-06-15-000001_access_token_index/down.sql
+++ b/crates/data/migrations/2026-06-15-000001_access_token_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS user_access_tokens_token_only_udx;

--- a/crates/data/migrations/2026-06-15-000001_access_token_index/up.sql
+++ b/crates/data/migrations/2026-06-15-000001_access_token_index/up.sql
@@ -1,0 +1,12 @@
+-- Access token authentication hot path.
+--
+-- Every authenticated client/federation-puppet request looks up
+-- `user_access_tokens` by `WHERE token = ?` (see crates/server/src/hoops/auth.rs).
+-- The table previously only had a UNIQUE (user_id, device_id) constraint
+-- (named user_access_tokens_token_udx, despite covering user_id+device_id), so
+-- the token lookup degraded to a sequential scan that grows with the number of
+-- active sessions. Tokens are 32-char random strings and are globally unique, so
+-- a UNIQUE index is both correct (guards against accidental collisions) and gives
+-- the planner an index-only equality lookup on the auth hot path.
+CREATE UNIQUE INDEX IF NOT EXISTS user_access_tokens_token_only_udx
+    ON user_access_tokens USING btree (token);


### PR DESCRIPTION
@
## What

Add a UNIQUE index on `user_access_tokens.token` via a new migration `2026-06-15-000001_access_token_index` (`up.sql` / `down.sql`).

## Why

Every authenticated client and federation-puppet request validates its bearer token by looking up `user_access_tokens` with `WHERE token = ?` (see `crates/server/src/hoops/auth.rs`). The table only had a `UNIQUE (user_id, device_id)` constraint — confusingly named `user_access_tokens_token_udx` despite *not* covering `token` — so the per-request token lookup degraded to a sequential scan that grows linearly with the number of active sessions.

Adding an index on `token` turns this hot-path lookup into an index equality probe. Tokens are random 32-char strings and globally unique, so a `UNIQUE` index is both correct (guards against accidental collisions) and optimal for the planner.

## Notes for reviewers

- The new index is named `user_access_tokens_token_only_udx` to avoid colliding with the existing (misnamed) `user_access_tokens_token_udx` constraint.
- Pure additive index change — no Rust / `schema.rs` changes, no recompile needed.
- Fresh installs are covered automatically: migrations run in order, so the baseline schema is intentionally left untouched (shipped migrations are immutable).
- `CREATE UNIQUE INDEX IF NOT EXISTS` is idempotent; will fail only if pre-existing duplicate tokens exist, which should never happen given random token generation.

## Follow-ups (not in this PR)

Broader index audit surfaced further hot-path candidates to evaluate separately: `events (room_id, sn)` for timeline/sync, `user_devices (user_id)`, `user_passwords (user_id, id DESC)`, plus a few medium-priority ones. Also worth doing: an in-memory access-token cache for the native (non-delegated) auth path, and bounding the introspection cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@