### PR TITLE
perf(data): add hot-path query indexes for user/relation/send-queue tables

### DIFF
--- a/crates/data/migrations/2026-06-15-000002_hotpath_query_indexes/down.sql
+++ b/crates/data/migrations/2026-06-15-000002_hotpath_query_indexes/down.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS outgoing_requests_state_kind_idx;
+DROP INDEX IF EXISTS event_relations_event_id_idx;
+DROP INDEX IF EXISTS user_threepids_medium_address_idx;
+DROP INDEX IF EXISTS user_pushers_user_id_idx;
+DROP INDEX IF EXISTS user_passwords_user_id_idx;
+DROP INDEX IF EXISTS user_devices_user_id_idx;

--- a/crates/data/migrations/2026-06-15-000002_hotpath_query_indexes/up.sql
+++ b/crates/data/migrations/2026-06-15-000002_hotpath_query_indexes/up.sql
@@ -1,0 +1,39 @@
+-- Hot-path query indexes for small/medium tables.
+--
+-- Each index below covers a `WHERE` pattern that is exercised on a frequently
+-- hit path but had no usable index (the existing UNIQUE constraints don't have
+-- the filtered column as their left-most prefix). Verified against the actual
+-- query sites cited in each comment. The large per-event tables (events,
+-- event_points) are handled separately because building an index on them needs
+-- a non-transactional CONCURRENTLY migration.
+
+-- get_devices: `WHERE user_id = ?` (crates/data/src/user/device.rs).
+-- UNIQUE (device_id, user_id) can't serve a user_id-only lookup.
+CREATE INDEX IF NOT EXISTS user_devices_user_id_idx
+    ON user_devices USING btree (user_id);
+
+-- get_password_hash: `WHERE user_id = ? ORDER BY id DESC` (crates/data/src/user/password.rs).
+CREATE INDEX IF NOT EXISTS user_passwords_user_id_idx
+    ON user_passwords USING btree (user_id, id DESC);
+
+-- get_pushers / get_push_keys / delete_*: `WHERE user_id = ?`
+-- (crates/data/src/user/pusher.rs). Existing index is only (app_id, pushkey).
+CREATE INDEX IF NOT EXISTS user_pushers_user_id_idx
+    ON user_pushers USING btree (user_id);
+
+-- get_user_by_threepid: `WHERE medium = ? AND address = ?`
+-- (crates/data/src/user.rs) on the 3pid login path.
+CREATE INDEX IF NOT EXISTS user_threepids_medium_address_idx
+    ON user_threepids USING btree (medium, address);
+
+-- relation aggregation / thread fetch: `WHERE event_id = ?` (single and IN)
+-- (crates/data/src/room.rs, crates/server/src/room/timeline.rs).
+-- UNIQUE (room_id, event_id, child_id, rel_type) can't serve an event_id-only lookup.
+CREATE INDEX IF NOT EXISTS event_relations_event_id_idx
+    ON event_relations USING btree (event_id);
+
+-- federation send queue dispatch: `WHERE state = 'pending'` and
+-- `WHERE kind = ? AND state = 'pending' AND ...` (crates/server/src/sending.rs).
+-- state left-most also serves the state-only dispatcher poll.
+CREATE INDEX IF NOT EXISTS outgoing_requests_state_kind_idx
+    ON outgoing_requests USING btree (state, kind);


### PR DESCRIPTION
## What

Add a batch of indexes for frequently hit query patterns that currently have **no usable index** — the existing UNIQUE constraints don''t have the filtered column as their left-most prefix, so these lookups degrade to sequential scans.

| Table | Index | Query site | Path |
|---|---|---|---|
| `user_devices` | `(user_id)` | `get_devices` `WHERE user_id = ?` | every sync / device-list |
| `user_passwords` | `(user_id, id DESC)` | `get_password_hash` `WHERE user_id = ? ORDER BY id DESC` | every password login |
| `user_pushers` | `(user_id)` | `get_pushers` / `get_push_keys` / `delete_*` | push / sync |
| `user_threepids` | `(medium, address)` | `get_user_by_threepid` | 3pid login |
| `event_relations` | `(event_id)` | relation aggregation / thread fetch | timeline |
| `outgoing_requests` | `(state, kind)` | federation send-queue dispatch | background queue |

## Why

Each pattern was verified against its real query site (not inferred from schema):

- `user_devices` — `UNIQUE (device_id, user_id)` can''t serve a `user_id`-only lookup (`device_id` is left-most).
- `user_passwords` — no index at all; the index also covers the `ORDER BY id DESC`.
- `user_pushers` — existing index is only `(app_id, pushkey)`.
- `user_threepids` — no index; login does `WHERE medium = ? AND address = ?`.
- `event_relations` — `UNIQUE (room_id, event_id, child_id, rel_type)` can''t serve an `event_id`-only lookup (`room_id` is left-most). (Note: the actual filter column is `event_id`, not `child_id`.)
- `outgoing_requests` — no index; `state` left-most also serves the state-only dispatcher poll while still covering `kind = ? AND state = ?`.

## Notes for reviewers

- All target small/medium tables, so a plain `CREATE INDEX` is fine (short write-lock during build).
- The large per-event tables (`events`, `event_points`) are intentionally **excluded** — building indexes on them needs a non-transactional `CONCURRENTLY` migration and will land separately.
- `IF NOT EXISTS` everywhere; pure additive, no Rust / `schema.rs` changes.
- A separate audit found `event_push_summaries` / `event_push_actions` do **not** need new indexes (already covered by existing partial/composite indexes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)