### PR TITLE
fix(backup): update key backup version in place instead of recreating

### DIFF
--- a/crates/data/src/user/key_backup.rs
+++ b/crates/data/src/user/key_backup.rs
@@ -95,22 +95,29 @@ pub async fn create_backup(
         .map_err(Into::into)
 }
 
+/// Update an existing backup version's `auth_data` in place and bump its etag.
+///
+/// The version identifier is preserved (per the Matrix spec, `PUT
+/// /room_keys/version/{version}` updates the named version rather than creating
+/// a new one). Trashed versions are ignored. Returns `true` if a matching,
+/// live version was updated, `false` if no such version exists.
 pub async fn update_backup(
     user_id: &UserId,
     version: i64,
     algorithm: &BackupAlgorithm,
-) -> DataResult<()> {
-    diesel::update(
+) -> DataResult<bool> {
+    let affected = diesel::update(
         e2e_room_keys_versions::table
             .filter(e2e_room_keys_versions::user_id.eq(user_id))
-            .filter(e2e_room_keys_versions::version.eq(version)),
+            .filter(e2e_room_keys_versions::version.eq(version))
+            .filter(e2e_room_keys_versions::is_trashed.eq(false)),
     )
     .set((
         e2e_room_keys_versions::algorithm.eq(serde_json::to_value(algorithm)?),
         e2e_room_keys_versions::etag.eq(UnixMillis::now().get() as i64),
     ))
     .execute(&mut connect().await?).await?;
-    Ok(())
+    Ok(affected > 0)
 }
 
 pub async fn get_latest_room_key(user_id: &UserId) -> DataResult<Option<DbRoomKey>> {

--- a/crates/server/src/routing/client/room_key.rs
+++ b/crates/server/src/routing/client/room_key.rs
@@ -293,15 +293,25 @@ async fn create_version(
 
 /// #PUT /_matrix/client/r0/room_keys/version/{version}
 /// Update information about an existing backup. Only `auth_data` can be modified.
+///
+/// The version named in the path is updated in place; unlike `create_version`
+/// this must not mint a new version, otherwise clients that just signed the
+/// backup find their signature on a now-superseded version and never settle on
+/// a trusted backup.
 #[endpoint]
 async fn update_version(
     _aa: AuthArgs,
+    version: PathParam<i64>,
     body: JsonBody<CreateVersionReqBody>,
     depot: &mut Depot,
 ) -> EmptyResult {
     let authed = depot.authed_info()?;
-    let algorithm = body.into_inner().0;
-    key_backup::create_backup(authed.user_id(), &algorithm).await?;
+    let version = version.into_inner();
+    let algorithm = body.into_inner().0.deserialize()?;
+
+    if !key_backup::update_backup(authed.user_id(), version, &algorithm).await? {
+        return Err(MatrixError::not_found("Key backup does not exist.").into());
+    }
 
     empty_ok()
 }


### PR DESCRIPTION
## What

`PUT /_matrix/client/v3/room_keys/version/{version}` now updates the named backup version **in place** instead of minting a brand-new version on every call.

## Why

The `update_version` handler was calling `key_backup::create_backup`, which:

- generates a fresh version id from `UnixMillis::now()` on every request, and
- ignored the `{version}` path parameter entirely (it wasn't even in the handler signature).

Per the Matrix spec, `PUT /room_keys/version/{version}` must update the version named in the path (only `auth_data` is mutable); the version id stays the same.

The practical fallout: when a client (e.g. Element) creates a backup, signs the backup's `auth_data` with its cross-signing key, and PUTs the signed data back, palpo created a **new, superseded version** instead of updating the existing one. The client's signature therefore never landed on the live version, the backup's trust state never converged, and Element's encryption/backup panel spun on "loading" indefinitely.

Notably, the data layer already had a correct `update_backup` (in-place update + etag bump) — it just was never wired up.

## Changes

- **`update_version` route** ([crates/server/src/routing/client/room_key.rs](crates/server/src/routing/client/room_key.rs)): add the `version: PathParam<i64>` parameter, deserialize the body to `BackupAlgorithm`, call `update_backup`, and return `404 M_NOT_FOUND` when the version doesn't exist.
- **`update_backup`** ([crates/data/src/user/key_backup.rs](crates/data/src/user/key_backup.rs)): return `bool` (whether a live row matched) so the route can answer 404, and filter out `is_trashed` versions so a deleted version can't be silently resurrected.

## Testing

- `cargo check -p palpo -p palpo-data` passes.
- Recommended manual verification: in Element, open Encryption settings and reset/enable key storage. Confirm `PUT /room_keys/version/{version}` returns 200, the subsequent `GET /room_keys/version` returns a **stable** version id, and the Backup panel resolves to "active" instead of spinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)