### PR TITLE
fix(pagination): accept legacy unprefixed batch tokens; fix search context tokens

### DIFF
--- a/crates/server/src/event/batch_token.rs
+++ b/crates/server/src/event/batch_token.rs
@@ -100,11 +100,53 @@ impl FromStr for BatchToken {
                 stream_ordering,
                 topological_ordering,
             })
+        } else if let Ok(stream_ordering) = input.parse::<Seqnum>() {
+            // Backward compatibility: older builds (pre-#69) and some paths
+            // serialized the raw `stream_ordering` without the leading 's'
+            // (e.g. "128"). Clients persist these tokens in local storage and
+            // replay them on back-pagination long after the server is upgraded,
+            // so reject-on-missing-prefix would brick history loading until
+            // every client cleared its cache. Treat a bare integer as a live
+            // token, which is exactly what those builds meant by it.
+            Ok(BatchToken::Live { stream_ordering })
         } else {
             Err(MatrixError::invalid_param(
                 "invalid batch token: must start with 's' or 't'",
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_live_and_historic_tokens() {
+        assert_eq!(
+            "s2633508".parse::<BatchToken>().unwrap(),
+            BatchToken::Live { stream_ordering: 2633508 }
+        );
+        assert_eq!(
+            "t426-2633508".parse::<BatchToken>().unwrap(),
+            BatchToken::Historic { stream_ordering: 2633508, topological_ordering: 426 }
+        );
+    }
+
+    #[test]
+    fn accepts_bare_numeric_token_for_backward_compat() {
+        // Tokens minted by pre-#69 builds (and replayed from client storage)
+        // have no 's' prefix; they must still resolve to a live token.
+        assert_eq!(
+            "128".parse::<BatchToken>().unwrap(),
+            BatchToken::Live { stream_ordering: 128 }
+        );
+    }
+
+    #[test]
+    fn rejects_non_numeric_garbage() {
+        assert!("garbage".parse::<BatchToken>().is_err());
+        assert!("".parse::<BatchToken>().is_err());
     }
 }
 

--- a/crates/server/src/event/search.rs
+++ b/crates/server/src/event/search.rs
@@ -174,8 +174,13 @@ async fn calc_event_context(
     }
 
     let context = EventContextResult {
-        start: before_pdus.iter().next().map(|(sn, _)| sn.to_string()),
-        end: after_pdus.last().map(|(sn, _)| sn.to_string()),
+        start: before_pdus
+            .iter()
+            .next()
+            .map(|(sn, _)| BatchToken::new_live(*sn).to_string()),
+        end: after_pdus
+            .last()
+            .map(|(sn, _)| BatchToken::new_live(*sn).to_string()),
         events_before: before_pdus
             .into_iter()
             .map(|(_, pdu)| pdu.to_room_event())


### PR DESCRIPTION
## Problem

Deployed instances intermittently fail to load room history — rooms sit on an endless loading spinner, and the network log shows `GET /rooms/{id}/messages?dir=b&from=...` returning:

```
{"errcode":"M_INVALID_PARAM","error":"invalid batch token: must start with 's' or 't'"}
```

### Root cause

Clients persist batch tokens (`/sync` `prev_batch`, `/messages` `end`, search result `context.start`/`end`) in local storage and replay them on back-pagination — including across server upgrades.

Builds before #69 serialized the raw `stream_ordering` with no `s`/`t` prefix (e.g. `"128"`). After upgrading, `BatchToken::from_str` rejects those replayed tokens, so history never loads until **every client clears its cache**. That's why the symptom looks like "deployed instances are permanently broken."

#69 fixed the sliding-sync and left-room emit paths, but two gaps remained:
1. Tokens already minted by old builds are still in client storage and keep getting rejected.
2. `event/search.rs` still emits search-result `context.start`/`end` as a **raw `Seqnum`** — the last unprefixed-token path #69 missed.

## Changes

- **`BatchToken::from_str`** — treat a bare integer as a live token, restoring compatibility with tokens from older builds. No client-side cache clear needed after upgrade. Non-numeric input still errors as before.
- **`event/search.rs`** — emit `context.start`/`context.end` via `BatchToken::new_live(..)` instead of `Seqnum::to_string()`.
- Unit tests for live/historic parsing, bare-numeric backward-compat, and rejection of non-numeric garbage.

## Testing

- `cargo check -p palpo` ✅
- `cargo test -p palpo batch_token` ✅ (3 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)