### PR TITLE
Handle invalid initial sync room IDs

### DIFF
--- a/crates/core/src/client/room.rs
+++ b/crates/core/src/client/room.rs
@@ -550,7 +550,7 @@ impl KnockResBody {
 pub struct InitialSyncReqArgs {
     /// The ID of the room.
     #[salvo(parameter(parameter_in = Path))]
-    pub room_id: OwnedRoomId,
+    pub room_id: String,
 
     /// Limit messages chunks size
     #[salvo(parameter(parameter_in = Query))]

--- a/crates/server/src/routing/client/room.rs
+++ b/crates/server/src/routing/client/room.rs
@@ -156,7 +156,13 @@ async fn initial_sync(
 ) -> JsonResult<InitialSyncResBody> {
     let authed = depot.authed_info()?;
     let sender_id = authed.user_id();
-    let room_id = &args.room_id;
+    let room_id = match OwnedRoomId::try_from(args.room_id.as_str()) {
+        Ok(room_id) => room_id,
+        Err(_) => {
+            return Err(MatrixError::forbidden("No room preview available.", None).into());
+        }
+    };
+    let room_id = &room_id;
 
     // If the room is not known locally, it may be a remote room the user is
     // trying to preview (e.g. opening `#room:other.server` without joining).


### PR DESCRIPTION
## Summary

- Accept the `initialSync` room path parameter as a raw string before Matrix room ID parsing.
- Return the existing no-preview Matrix error for invalid room IDs instead of letting request extraction fail with `M_BAD_JSON`.

## Root Cause

Element can restore a browser-local temporary room ID such as `local+m...` and call `/rooms/{room_id}/initialSync`. That value is not a valid Matrix room ID, so the typed path extractor rejected the request before the handler could apply the existing room-preview fallback behavior.

## Validation

- `cargo check -p palpo`
- `git diff --check -- crates/core/src/client/room.rs crates/server/src/routing/client/room.rs`