### PR TITLE
Allow delegated auth and password login to coexist

### DIFF
--- a/crates/server/src/auth.rs
+++ b/crates/server/src/auth.rs
@@ -30,6 +30,9 @@ impl AuthedInfo {
     pub fn appservice(&self) -> Option<&RegistrationInfo> {
         self.appservice.as_ref()
     }
+    pub fn is_delegated_auth(&self) -> bool {
+        self.access_token_id.is_none() && self.appservice.is_none()
+    }
     pub fn is_admin(&self) -> bool {
         self.user.is_admin
     }

--- a/crates/server/src/config/delegated_auth.rs
+++ b/crates/server/src/config/delegated_auth.rs
@@ -10,8 +10,9 @@ fn default_introspection_cache_ttl() -> u64 {
 #[derive(Clone, Debug, Deserialize, Default)]
 pub struct DelegatedAuthConfig {
     /// Enable MSC3861 delegated OIDC authentication.
-    /// When enabled, Palpo delegates token validation to an external
-    /// authorization server (like Pasion) via token introspection.
+    /// When enabled, Palpo accepts delegated OIDC access tokens from an
+    /// external authorization server (like Pasion) via token introspection.
+    /// Local password/appservice login remains available.
     ///
     /// default: false
     #[serde(default)]

--- a/crates/server/src/hoops/auth.rs
+++ b/crates/server/src/hoops/auth.rs
@@ -53,11 +53,21 @@ pub async fn auth_by_signatures(
 async fn auth_by_access_token_inner(aa: AuthArgs, depot: &mut Depot) -> AppResult<()> {
     let token = aa.require_access_token()?;
 
-    // Delegated auth: validate token via external introspection endpoint
+    if auth_by_local_token(token, &aa, depot).await? {
+        return Ok(());
+    }
+
+    // Delegated auth coexists with local tokens. Only fall back to external
+    // introspection after the token misses Palpo's local access/appservice
+    // stores, preserving existing password sessions when OIDC is enabled.
     if config::get().enabled_delegated_auth().is_some() {
         return auth_by_delegated_token(token, &aa, depot).await;
     }
 
+    Err(MatrixError::unknown_token("unknown access token", true).into())
+}
+
+async fn auth_by_local_token(token: &str, aa: &AuthArgs, depot: &mut Depot) -> AppResult<bool> {
     let access_token = match user_access_tokens::table
         .filter(user_access_tokens::token.eq(token))
         .first::<DbAccessToken>(&mut connect().await?)
@@ -90,7 +100,7 @@ async fn auth_by_access_token_inner(aa: AuthArgs, depot: &mut Depot) -> AppResul
             access_token_id: Some(access_token.id),
             appservice: None,
         });
-        Ok(())
+        Ok(true)
     } else {
         let appservices = crate::appservices().await;
         for appservice in appservices {
@@ -142,10 +152,10 @@ async fn auth_by_access_token_inner(aa: AuthArgs, depot: &mut Depot) -> AppResul
                     access_token_id: None,
                     appservice: Some(appservice_info),
                 });
-                return Ok(());
+                return Ok(true);
             }
         }
-        Err(MatrixError::unknown_token("unknown access token", true).into())
+        Ok(false)
     }
 }
 

--- a/crates/server/src/routing/client/key/device_signing.rs
+++ b/crates/server/src/routing/client/key/device_signing.rs
@@ -48,11 +48,12 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
         return Err(MatrixError::bad_json("missing challenged signing key payload").into());
     }
 
-    // When delegated auth (OIDC) is enabled, UIA is not used — the OIDC
-    // token already proves the user's identity.  Pasion calls
-    // `allow_cross_signing_reset` to set a time-limited bypass before
-    // Element uploads new keys, so we also honour that flag.
-    let uia_required = if config::get().enabled_delegated_auth().is_some() {
+    // When this request is authenticated by a delegated OIDC token, UIA is not
+    // used. Local password/appservice sessions still follow the legacy UIA
+    // path even when delegated auth is enabled globally.
+    let uia_required = if config::get().enabled_delegated_auth().is_some()
+        && authed.is_delegated_auth()
+    {
         false
     } else if let Ok(body) = &body {
         let exist_master_key = crate::user::key::get_master_key(sender_id).await?;

--- a/crates/server/src/routing/client/session.rs
+++ b/crates/server/src/routing/client/session.rs
@@ -81,6 +81,7 @@ fn supported_login_flows(delegated_auth_enabled: bool) -> Vec<LoginType> {
 /// supported login types.
 #[endpoint]
 async fn login(
+    aa: AuthArgs,
     body: JsonBody<LoginReqBody>,
     req: &mut Request,
     res: &mut Response,
@@ -240,13 +241,7 @@ async fn login(
             user_id
         }
         LoginInfo::Appservice(Appservice { identifier }) => {
-            let username = if let UserIdentifier::Matrix(user_id) = identifier {
-                user_id.user.to_lowercase()
-            } else {
-                return Err(MatrixError::forbidden("Bad login type.", None).into());
-            };
-            UserId::parse_with_server_name(username, &config::get().server_name)
-                .map_err(|_| MatrixError::invalid_username("Username is invalid."))?
+            authenticate_appservice_login(identifier, &aa).await?
         }
         _ => {
             warn!("Unsupported or unknown login type: {:?}", &body.login_info);
@@ -316,6 +311,44 @@ async fn login(
         refresh_token,
         expires_in: None,
     })
+}
+
+async fn authenticate_appservice_login(
+    identifier: &UserIdentifier,
+    aa: &AuthArgs,
+) -> AppResult<OwnedUserId> {
+    let user_id = appservice_login_user_id(identifier)?;
+    let token = aa.require_access_token()?;
+    let appservice = crate::appservice::find_from_token(token)
+        .await?
+        .ok_or_else(|| MatrixError::forbidden("Invalid application service token.", None))?;
+
+    ensure_appservice_can_login_as(&appservice, &user_id)?;
+    Ok(user_id)
+}
+
+fn appservice_login_user_id(identifier: &UserIdentifier) -> Result<OwnedUserId, MatrixError> {
+    let username = if let UserIdentifier::Matrix(user_id) = identifier {
+        user_id.user.to_lowercase()
+    } else {
+        return Err(MatrixError::forbidden("Bad login type.", None));
+    };
+    UserId::parse_with_server_name(username, &config::get().server_name)
+        .map_err(|_| MatrixError::invalid_username("Username is invalid."))
+}
+
+fn ensure_appservice_can_login_as(
+    appservice: &crate::appservice::RegistrationInfo,
+    user_id: &UserId,
+) -> Result<(), MatrixError> {
+    if appservice.is_user_match(user_id) {
+        Ok(())
+    } else {
+        Err(MatrixError::forbidden(
+            "User is not in appservice's namespace",
+            None,
+        ))
+    }
 }
 
 /// # `POST /_matrix/client/v1/login/get_token`
@@ -447,6 +480,32 @@ async fn revoke_delegated_token(
 mod tests {
     use super::*;
 
+    fn test_appservice_info() -> crate::appservice::RegistrationInfo {
+        use crate::core::appservice::{Namespace, Namespaces, Registration};
+
+        Registration {
+            id: "test".to_owned(),
+            url: None,
+            as_token: "as-token".to_owned(),
+            hs_token: "hs-token".to_owned(),
+            sender_localpart: "bridgebot".to_owned(),
+            namespaces: Namespaces {
+                users: vec![Namespace::new(
+                    true,
+                    r"^@bridge_.+:example\.com$".to_owned(),
+                )],
+                aliases: Vec::new(),
+                rooms: Vec::new(),
+            },
+            rate_limited: None,
+            protocols: None,
+            receive_ephemeral: false,
+            device_management: false,
+        }
+        .try_into()
+        .unwrap()
+    }
+
     #[test]
     fn delegated_auth_advertises_password_and_sso_login() {
         let flows = supported_login_flows(true);
@@ -471,6 +530,30 @@ mod tests {
             flow_types,
             vec!["m.login.password", "m.login.application_service"]
         );
+    }
+
+    #[test]
+    fn appservice_login_allows_namespaced_users() {
+        let appservice = test_appservice_info();
+        let user_id = UserId::parse("@bridge_alice:example.com").unwrap();
+
+        assert!(ensure_appservice_can_login_as(&appservice, &user_id).is_ok());
+    }
+
+    #[test]
+    fn appservice_login_allows_sender_localpart() {
+        let appservice = test_appservice_info();
+        let user_id = UserId::parse("@bridgebot:example.com").unwrap();
+
+        assert!(ensure_appservice_can_login_as(&appservice, &user_id).is_ok());
+    }
+
+    #[test]
+    fn appservice_login_rejects_users_outside_namespace() {
+        let appservice = test_appservice_info();
+        let user_id = UserId::parse("@alice:example.com").unwrap();
+
+        assert!(ensure_appservice_can_login_as(&appservice, &user_id).is_err());
     }
 }
 

--- a/crates/server/src/routing/client/session.rs
+++ b/crates/server/src/routing/client/session.rs
@@ -54,14 +54,19 @@ pub fn authed_router() -> Router {
 /// when logging in.
 #[endpoint]
 async fn login_types(_aa: AuthArgs) -> JsonResult<LoginTypesResBody> {
-    let flows = if config::get().enabled_delegated_auth().is_some() {
-        vec![LoginType::Sso(
+    Ok(Json(LoginTypesResBody::new(supported_login_flows(
+        config::get().enabled_delegated_auth().is_some(),
+    ))))
+}
+
+fn supported_login_flows(delegated_auth_enabled: bool) -> Vec<LoginType> {
+    let mut flows = vec![LoginType::password(), LoginType::appservice()];
+    if delegated_auth_enabled {
+        flows.push(LoginType::Sso(
             crate::core::client::session::SsoLoginType::new(),
-        )]
-    } else {
-        vec![LoginType::password(), LoginType::appservice()]
-    };
-    Ok(Json(LoginTypesResBody::new(flows)))
+        ));
+    }
+    flows
 }
 
 /// #POST /_matrix/client/r0/login
@@ -80,14 +85,6 @@ async fn login(
     req: &mut Request,
     res: &mut Response,
 ) -> JsonResult<LoginResBody> {
-    if config::get().enabled_delegated_auth().is_some() {
-        return Err(MatrixError::forbidden(
-            "This server uses delegated authentication. Use the OIDC provider to log in.",
-            None,
-        )
-        .into());
-    }
-
     // Validate login method
     // TODO: Other login methods
     let user_id = match &body.login_info {
@@ -396,9 +393,10 @@ async fn logout(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) -> EmptyRes
         return empty_ok();
     };
 
-    // When using delegated auth, also revoke the access token at the OIDC
-    // provider so that the browser session is properly invalidated.
-    if let Some(da) = config::get().enabled_delegated_auth()
+    // Delegated tokens are owned by the OIDC provider; local password/appservice
+    // sessions are revoked only from Palpo's local device tables below.
+    if authed.is_delegated_auth()
+        && let Some(da) = config::get().enabled_delegated_auth()
         && let Some(token) = req
             .headers()
             .get("authorization")
@@ -443,6 +441,37 @@ async fn revoke_delegated_token(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delegated_auth_advertises_password_and_sso_login() {
+        let flows = supported_login_flows(true);
+        let flow_types = flows.iter().map(LoginType::login_type).collect::<Vec<_>>();
+
+        assert_eq!(
+            flow_types,
+            vec![
+                "m.login.password",
+                "m.login.application_service",
+                "m.login.sso",
+            ]
+        );
+    }
+
+    #[test]
+    fn legacy_auth_keeps_existing_login_flows() {
+        let flows = supported_login_flows(false);
+        let flow_types = flows.iter().map(LoginType::login_type).collect::<Vec<_>>();
+
+        assert_eq!(
+            flow_types,
+            vec!["m.login.password", "m.login.application_service"]
+        );
+    }
 }
 
 /// #POST /_matrix/client/r0/logout/all

--- a/crates/server/src/routing/client/session.rs
+++ b/crates/server/src/routing/client/session.rs
@@ -319,6 +319,8 @@ async fn authenticate_appservice_login(
 ) -> AppResult<OwnedUserId> {
     let user_id = appservice_login_user_id(identifier)?;
     let token = aa.require_access_token()?;
+    // Ensure file-backed appservice registrations are loaded before token lookup.
+    crate::appservices().await;
     let appservice = crate::appservice::find_from_token(token)
         .await?
         .ok_or_else(|| MatrixError::forbidden("Invalid application service token.", None))?;

--- a/palpo-example.toml
+++ b/palpo-example.toml
@@ -1387,8 +1387,9 @@
 # [delegated_auth]
 
 # Enable MSC3861 delegated OIDC authentication.
-# When enabled, Palpo delegates token validation to an external
-# authorization server (like Pasion) via token introspection.
+# When enabled, Palpo accepts delegated OIDC access tokens from an
+# external authorization server (like Pasion) via token introspection.
+# Local password/appservice login remains available.
 #
 # enable = false
 


### PR DESCRIPTION
## Summary

- Keep `m.login.password` and appservice login advertised when delegated auth is enabled, and add `m.login.sso` alongside them.
- Allow local `/login` password/token/JWT/appservice flows to continue issuing Palpo-local access tokens under delegated auth.
- Authenticate Bearer tokens by checking local access/appservice tokens first, then falling back to delegated OIDC introspection.
- Limit OIDC token revocation and cross-signing UIA bypass to requests authenticated by delegated tokens.

## Why

Delegated/OIDC auth and legacy password login can coexist in Matrix deployments. Palpo previously treated `delegated_auth` as a global switch that disabled local password login and forced every Bearer token through introspection, which broke local password sessions and appservice auth once delegated auth was enabled.

## Validation

- `cargo test -p palpo`