### PR TITLE
Gate local password flows under delegated auth

### DIFF
--- a/crates/server/src/config/delegated_auth.rs
+++ b/crates/server/src/config/delegated_auth.rs
@@ -12,7 +12,9 @@ pub struct DelegatedAuthConfig {
     /// Enable MSC3861 delegated OIDC authentication.
     /// When enabled, Palpo accepts delegated OIDC access tokens from an
     /// external authorization server (like Pasion) via token introspection.
-    /// Local password/appservice login remains available.
+    /// Local password login, local user registration, and local password changes
+    /// are disabled while delegated auth is enabled; local appservice login
+    /// remains available for bridge/admin integrations.
     ///
     /// default: false
     #[serde(default)]

--- a/crates/server/src/routing/client.rs
+++ b/crates/server/src/routing/client.rs
@@ -159,14 +159,16 @@ fn get_capabilities(_aa: AuthArgs, depot: &mut Depot) -> JsonResult<Capabilities
     for room_version in &*config::STABLE_ROOM_VERSIONS {
         available.insert(room_version.clone(), RoomVersionStability::Stable);
     }
+    let change_password_enabled = conf.enabled_delegated_auth().is_none();
     json_ok(CapabilitiesResBody {
         capabilities: Capabilities {
             room_versions: RoomVersionsCapability {
                 default: conf.default_room_version.clone(),
                 available,
             },
-            // TODO: use config values
-            change_password: ChangePasswordCapability { enabled: true },
+            change_password: ChangePasswordCapability {
+                enabled: change_password_enabled,
+            },
             thirdparty_id_changes: ThirdPartyIdChangesCapability { enabled: true },
             profile_fields: Some(ProfileFieldsCapability::new(true)),
             account_moderation,

--- a/crates/server/src/routing/client/account/password.rs
+++ b/crates/server/src/routing/client/account/password.rs
@@ -8,7 +8,7 @@ use crate::core::client::uiaa::{AuthFlow, AuthType, UiaaInfo};
 use crate::data::connect;
 use crate::data::schema::*;
 use crate::exts::*;
-use crate::{AuthArgs, EmptyResult, empty_ok, hoops};
+use crate::{AuthArgs, EmptyResult, MatrixError, empty_ok, hoops};
 
 pub fn authed_router() -> Router {
     Router::with_path("password")
@@ -37,6 +37,14 @@ async fn change_password(
     depot: &mut Depot,
 ) -> EmptyResult {
     let authed = depot.authed_info()?;
+
+    if crate::config::get().enabled_delegated_auth().is_some() {
+        return Err(MatrixError::forbidden(
+            "Password changes are handled by the delegated authentication service.",
+            None,
+        )
+        .into());
+    }
 
     let mut uiaa_info = UiaaInfo {
         flows: vec![AuthFlow {

--- a/crates/server/src/routing/client/register.rs
+++ b/crates/server/src/routing/client/register.rs
@@ -66,6 +66,16 @@ async fn register(
         return Err(MatrixError::forbidden("registration has been disabled", None).into());
     }
 
+    if conf.enabled_delegated_auth().is_some()
+        && body.login_type != Some(LoginType::ApplicationService)
+    {
+        return Err(MatrixError::forbidden(
+            "Local registration is disabled while delegated authentication is enabled. Use SSO/OIDC registration.",
+            None,
+        )
+        .into());
+    }
+
     let is_guest = body.kind == RegistrationKind::Guest;
     let user_id = match (&body.username, is_guest) {
         (Some(username), false) => {
@@ -100,7 +110,8 @@ async fn register(
         // Constant-time comparison so we don't leak `as_token` bytes via
         // response timing. The same pattern is used in `hoops/auth.rs`.
         let matched = crate::appservices()
-            .await.iter()
+            .await
+            .iter()
             .find(|appservice| {
                 appservice
                     .as_token
@@ -312,6 +323,14 @@ async fn register(
 /// register
 #[endpoint]
 async fn available(username: QueryParam<String, true>) -> JsonResult<AvailableResBody> {
+    if config::get().enabled_delegated_auth().is_some() {
+        return Err(MatrixError::forbidden(
+            "Local registration is disabled while delegated authentication is enabled.",
+            None,
+        )
+        .into());
+    }
+
     let username = username.into_inner().to_lowercase();
     // Validate user id
     let server_name = &config::get().server_name;

--- a/crates/server/src/routing/client/session.rs
+++ b/crates/server/src/routing/client/session.rs
@@ -60,7 +60,11 @@ async fn login_types(_aa: AuthArgs) -> JsonResult<LoginTypesResBody> {
 }
 
 fn supported_login_flows(delegated_auth_enabled: bool) -> Vec<LoginType> {
-    let mut flows = vec![LoginType::password(), LoginType::appservice()];
+    let mut flows = Vec::new();
+    if !delegated_auth_enabled {
+        flows.push(LoginType::password());
+    }
+    flows.push(LoginType::appservice());
     if delegated_auth_enabled {
         flows.push(LoginType::Sso(
             crate::core::client::session::SsoLoginType::new(),
@@ -101,6 +105,14 @@ async fn login(
             };
             let user_id = UserId::parse_with_server_name(username, &config::get().server_name)
                 .map_err(|_| MatrixError::invalid_username("Username is invalid."))?;
+
+            if config::get().enabled_delegated_auth().is_some() {
+                return Err(MatrixError::forbidden(
+                    "Password login is disabled while delegated authentication is enabled. Use SSO/OIDC or a delegated access token.",
+                    None,
+                )
+                .into());
+            }
 
             // if let Some(ldap) = config::enabled_ldap() {
             //     let (user_dn, is_ldap_admin) = match ldap.bind_dn.as_ref() {
@@ -283,13 +295,8 @@ async fn login(
 
     // Determine if device_id was provided and exists in the db for this user
     if data::user::device::is_device_exists(&user_id, &device_id).await? {
-        data::user::device::set_access_token(
-            &user_id,
-            &device_id,
-            &access_token,
-            refresh_token_id,
-        )
-        .await?;
+        data::user::device::set_access_token(&user_id, &device_id, &access_token, refresh_token_id)
+            .await?;
     } else {
         data::user::device::create_device(
             &user_id,
@@ -374,6 +381,13 @@ async fn get_access_token(
         return Err(
             MatrixError::forbidden("login via an existing session is not enabled", None).into(),
         );
+    }
+    if conf.enabled_delegated_auth().is_some() {
+        return Err(MatrixError::forbidden(
+            "Login token issuance via password UIAA is disabled while delegated authentication is enabled.",
+            None,
+        )
+        .into());
     }
 
     // This route SHOULD have UIA
@@ -509,17 +523,13 @@ mod tests {
     }
 
     #[test]
-    fn delegated_auth_advertises_password_and_sso_login() {
+    fn delegated_auth_advertises_delegated_login_flows() {
         let flows = supported_login_flows(true);
         let flow_types = flows.iter().map(LoginType::login_type).collect::<Vec<_>>();
 
         assert_eq!(
             flow_types,
-            vec![
-                "m.login.password",
-                "m.login.application_service",
-                "m.login.sso",
-            ]
+            vec!["m.login.application_service", "m.login.sso"]
         );
     }
 


### PR DESCRIPTION
## Summary
- Stop advertising `m.login.password` from `/login` when delegated auth is enabled; keep appservice and SSO flows.
- Reject direct Matrix password login under delegated auth before Palpo checks local password hashes.
- Reject `/login/get_token` under delegated auth so password UIAA cannot mint a local login token/access token.
- Reject local user registration and local password changes under delegated auth, and report `m.change_password.enabled = false` in `/capabilities`.
- Keep appservice login/registration available because it is an admin/server-side integration path for bridges and services, not a normal user credential path.

## Why
When delegated auth/OIDC is enabled, the external auth service should be the credential authority for login and local credential management. Palpo's existing password login path still verified against `user_passwords`, which creates a second password store and makes Pasion-provisioned users fail with local `Wrong username or password` errors.

Appservice auth remains limited to admin-configured integrations. Ordinary users should use OIDC/SSO or a delegated access token issued by the auth provider.

This PR intentionally scopes the password-UIAA change to `/login/get_token`, because globally rejecting password UIAA would strand existing UIAA-only operations such as device deletion and account deactivation until they have delegated-auth alternatives.

## Note on password-compatible proxying
I checked the Pasion token endpoint and it currently handles `authorization_code`, `refresh_token`, `client_credentials`, and `device_code`, but not `grant_type=password`. Without a Pasion endpoint that validates username/password, provisions the Matrix device, and returns a delegated token, Palpo cannot correctly proxy Matrix password login to Pasion in this repository alone.

This PR therefore removes the unsafe local login fallback. If Pasion later adds a password exchange endpoint, Palpo can wire `m.login.password` to that endpoint instead of re-enabling local password login.

## Checks
- `rustfmt --edition 2024 --check --config skip_children=true crates/server/src/routing/client/session.rs crates/server/src/routing/client.rs crates/server/src/routing/client/register.rs crates/server/src/routing/client/account/password.rs crates/server/src/config/delegated_auth.rs`
- `cargo test -p palpo delegated_auth -- --nocapture`
- `cargo test -p palpo legacy_auth_keeps_existing_login_flows -- --nocapture`

Note: full `cargo fmt --check` currently reports pre-existing formatting diffs across unrelated files, so I used a touched-file rustfmt check for this PR.