### PR TITLE
Improve URL preview safety and key queries

### DIFF
--- a/_improve.md
+++ b/_improve.md
@@ -1,29 +1,28 @@
-# Palpo 代码审计与改进记录
+# Palpo 最新代码审计与改进记录
 
-本轮审计聚焦安全风险、未完成实现、死代码、部署示例可用性和配置默认值一致性。所有本报告列出的问题已在本轮收敛。
+基线：`main` 最新提交 `59f3d7e9d0`，本轮分支 `chris/codebase-improvements`。
 
-## 已完成
+本轮审计聚焦安全边界、未完成实现、未接入功能、死代码/假成功路径，以及配置示例中容易被复制到生产环境的风险。
 
-- [x] 修复 `openid_token_ttl` 默认值单位错误。配置文档说明默认值为 3600 秒，但代码返回 `60 * 60_000`，导致默认 OpenID token 有效期约 41 天。
-- [x] 修复 appservice 请求失败日志泄露 `access_token` 的风险。发送给 appservice 的 URL 会携带 `access_token` 查询参数，失败日志原样输出 URL 会泄露 homeserver token。
-- [x] 替换 `examples/*/appservices/*-registration.yaml` 中的固定 appservice token。示例里的固定 token 容易被复制到真实环境。
-- [x] 修正 Docker 部署示例中 Postgres 初始化变量名：`POSTGRES_DATABASE` 不是官方镜像识别的变量，应使用 `POSTGRES_DB`。
-- [x] 收紧基础 Docker Compose 中 Postgres 端口暴露范围，避免默认监听所有宿主机网卡。
-- [x] 修复 Caddy 部署示例中错误的镜像地址 `docker.io/ghcr.io/...`。
-- [x] 修复 HTTP client 连接池/超时配置未接入的问题，并将 `request_idle_per_host` 默认值与文档保持一致。
-- [x] 修复未实现的管理命令返回“成功”的问题。`reload-config`、`reload-mods`、`restart`、`shutdown` 现在会明确返回未实现错误，避免误导管理员。
-- [x] 修复 `config::reload` 空实现却返回 `Ok(())` 的问题。
-- [x] 删除未接入的 `admin/debug` 死代码模块，并移除仍指向 debug 命令的注释和配置示例。
-- [x] 将旧 debug 命令中可安全复用的能力接成 admin-only REST API，供管理界面调试 PDU、房间状态、签名、server key、依赖信息和 federation ping。
-- [x] 为 `PALPO_` 环境变量增加 `__` 嵌套配置支持，例如 `PALPO_DB__URL` 可覆盖 `db.url`。
-- [x] 为 Docker 部署和桥接示例增加 `.env.example`，并让 Compose 通过 `PALPO_POSTGRES_PASSWORD` 和 `PALPO_DB__URL` 使用同一份数据库密码。
-- [x] 替换部署与桥接示例配置中的 `changeme`、`root`、`your_password` 数据库密码为环境变量或明确占位符。
-- [x] 替换本地与桥接配置示例中的 `root` 数据库密码和固定 TURN secret，避免示例凭据被复制到真实环境。
-- [x] 修复多个未实现路由返回 `200 OK` 的问题。federation query fallback、third-party invite exchange、3PID onbind、dehydrated-device 相关占位接口现在返回明确的 `M_UNRECOGNIZED`。
-- [x] 为房间目录可见性变更补基础权限检查：普通用户必须在房间内且具备修改 canonical alias 状态事件的权限；开启 `lockdown_public_room_directory` 时，发布公开房间仅允许服务端管理员。
-- [x] 补跑并通过全量 `cargo check --workspace -j 4`。
-- [x] 使用 `docker compose config` 验证基础 Docker、Caddy、Traefik 和 Telegram 示例的 Compose 文件可解析。
+## 本轮已完成
 
-## 后续专项
+- [x] 修复 URL preview allowlist/denylist 判定顺序。`domain_explicit_denylist` 现在会优先于 `*` allowlist 生效，避免管理员配置了全量 allowlist 后显式 denylist 被绕过。
+- [x] 修复 URL preview `domain_contains_allowlist` 匹配方向错误。配置 `google.com` 现在会按文档匹配包含该片段的 host，而不是反向检查“配置项是否包含 host”。
+- [x] 收紧 URL preview contains 匹配。空字符串不再被当作“匹配所有 URL/host”的 contains 规则。
+- [x] 为 URL preview allowlist/denylist 行为补 3 个单元测试，覆盖 contains 匹配方向、denylist 优先级和空 contains 项。
+- [x] 修复本地 `/keys/query` 指定多个 device id 时只返回最后一个设备的问题。设备结果容器现在在循环外创建，不再被每个 device 覆盖。
+- [x] 替换 `palpo-required.toml`、`palpo-required.kdl` 和 Discord bridge 配置注释中的 `postgres:root` 示例密码，保持与其它示例一致的强占位符。
 
-- Matrix 协议能力缺口仍需按功能专项继续实现，例如完整 dehydrated device 流程、3PID bind 处理、third-party invite exchange、room history visibility 细节、key signature 校验、邮件 pusher 等。本轮已避免未实现路径返回假成功，并关闭了可安全修复的安全/部署/死代码问题。
+## 仍需专项处理
+
+- [ ] `POST /_matrix/client/*/account/deactivate` 注释声明会离开房间、清设备、清 to-device 等，但当前路由只调用 `data::user::deactivate`，没有接入已有的 `full_user_deactivate` 完整流程。
+- [ ] E2EE cross-signing 仍有未完成校验：`add_cross_signing_key_updates` 标注 `TODO: Check signatures`，`keys/signatures/upload` 也只是持久化签名并固定返回空 `failures`。
+- [ ] MSC3391 account data delete 路由当前返回成功但没有删除数据，属于未实现功能返回假成功。
+- [ ] 多处 Matrix 协议缺口仍以明确错误返回，例如 dehydrated devices、third-party invite exchange、3PID bind 等，需要按协议功能专项补齐。
+- [ ] 本地工作区存在被 `.gitignore` 排除的 `examples/with-*/data` / `space` 运行数据，扫描到 token-like 值。它们不在 Git 跟踪内，但建议开发环境定期清理，避免误打包或手工复制。
+
+## 验证
+
+- [x] `cargo check -p palpo --bin palpo -j 1`
+- [x] `cargo test -p palpo media::preview::tests -j 1`
+- [ ] `cargo check --workspace --all-targets -j 4` 本轮曾运行，但 4 分钟超时，未得到完整 workspace/all-targets 结果。

--- a/crates/server/src/media/preview.rs
+++ b/crates/server/src/media/preview.rs
@@ -135,7 +135,17 @@ impl From<DbUrlPreview> for UrlPreviewData {
     }
 }
 
-pub fn url_preview_allowed(url: &Url) -> bool {
+fn contains_wildcard(values: &[String]) -> bool {
+    values.iter().any(|value| value == "*")
+}
+
+fn value_contains_any_non_empty(value: &str, patterns: &[String]) -> bool {
+    patterns
+        .iter()
+        .any(|pattern| !pattern.is_empty() && value.contains(pattern))
+}
+
+pub(crate) fn url_preview_allowed_by_config(url: &Url, conf: &config::UrlPreviewConfig) -> bool {
     if ["http", "https"]
         .iter()
         .all(|&scheme| scheme != url.scheme().to_lowercase())
@@ -155,22 +165,10 @@ pub fn url_preview_allowed(url: &Url) -> bool {
         Some(h) => h.to_owned(),
     };
 
-    let conf = crate::config::get();
-    let allowlist_domain_contains = &conf.url_preview.domain_contains_allowlist;
-    let allowlist_domain_explicit = &conf.url_preview.domain_explicit_allowlist;
-    let denylist_domain_explicit = &conf.url_preview.domain_explicit_denylist;
-    let allowlist_url_contains = &conf.url_preview.url_contains_allowlist;
-
-    if allowlist_domain_contains.contains(&"*".to_owned())
-        || allowlist_domain_explicit.contains(&"*".to_owned())
-        || allowlist_url_contains.contains(&"*".to_owned())
-    {
-        debug!(
-            "Config key contains * which is allowing all URL previews. Allowing URL {}",
-            url
-        );
-        return true;
-    }
+    let allowlist_domain_contains = &conf.domain_contains_allowlist;
+    let allowlist_domain_explicit = &conf.domain_explicit_allowlist;
+    let denylist_domain_explicit = &conf.domain_explicit_denylist;
+    let allowlist_url_contains = &conf.url_contains_allowlist;
 
     if !host.is_empty() {
         if denylist_domain_explicit.contains(&host) {
@@ -181,6 +179,34 @@ pub fn url_preview_allowed(url: &Url) -> bool {
             return false;
         }
 
+        let root_domain = if conf.check_root_domain {
+            debug!("Checking root domain");
+            host.split_once('.').map(|(_, root_domain)| root_domain)
+        } else {
+            None
+        };
+
+        if let Some(root_domain) = root_domain
+            && denylist_domain_explicit.contains(&root_domain.to_owned())
+        {
+            debug!(
+                "Root domain {} is not allowed by url_preview_domain_explicit_denylist",
+                &root_domain
+            );
+            return false;
+        }
+
+        if contains_wildcard(allowlist_domain_contains)
+            || contains_wildcard(allowlist_domain_explicit)
+            || contains_wildcard(allowlist_url_contains)
+        {
+            debug!(
+                "Config key contains * which is allowing all URL previews. Allowing URL {}",
+                url
+            );
+            return true;
+        }
+
         if allowlist_domain_explicit.contains(&host) {
             debug!(
                 "Host {} is allowed by url_preview_domain_explicit_allowlist (check 2/4)",
@@ -189,10 +215,7 @@ pub fn url_preview_allowed(url: &Url) -> bool {
             return true;
         }
 
-        if allowlist_domain_contains
-            .iter()
-            .any(|domain_s| domain_s.contains(&host.clone()))
-        {
+        if value_contains_any_non_empty(&host, allowlist_domain_contains) {
             debug!(
                 "Host {} is allowed by url_preview_domain_contains_allowlist (check 3/4)",
                 &host
@@ -200,10 +223,7 @@ pub fn url_preview_allowed(url: &Url) -> bool {
             return true;
         }
 
-        if allowlist_url_contains
-            .iter()
-            .any(|url_s| url.to_string().contains(url_s))
-        {
+        if value_contains_any_non_empty(url.as_str(), allowlist_url_contains) {
             debug!(
                 "URL {} is allowed by url_preview_url_contains_allowlist (check 4/4)",
                 &host
@@ -212,46 +232,32 @@ pub fn url_preview_allowed(url: &Url) -> bool {
         }
 
         // check root domain if available and if user has root domain checks
-        if conf.url_preview.check_root_domain {
-            debug!("Checking root domain");
-            match host.split_once('.') {
-                None => return false,
-                Some((_, root_domain)) => {
-                    if denylist_domain_explicit.contains(&root_domain.to_owned()) {
-                        debug!(
-                            "Root domain {} is not allowed by \
-    						 url_preview_domain_explicit_denylist (check 1/3)",
-                            &root_domain
-                        );
-                        return false;
-                    }
-
-                    if allowlist_domain_explicit.contains(&root_domain.to_owned()) {
-                        debug!(
-                            "Root domain {} is allowed by url_preview_domain_explicit_allowlist \
+        if let Some(root_domain) = root_domain {
+            if allowlist_domain_explicit.contains(&root_domain.to_owned()) {
+                debug!(
+                    "Root domain {} is allowed by url_preview_domain_explicit_allowlist \
     						 (check 2/3)",
-                            &root_domain
-                        );
-                        return true;
-                    }
+                    &root_domain
+                );
+                return true;
+            }
 
-                    if allowlist_domain_contains
-                        .iter()
-                        .any(|domain_s| domain_s.contains(&root_domain.to_owned()))
-                    {
-                        debug!(
-                            "Root domain {} is allowed by url_preview_domain_contains_allowlist \
+            if value_contains_any_non_empty(root_domain, allowlist_domain_contains) {
+                debug!(
+                    "Root domain {} is allowed by url_preview_domain_contains_allowlist \
     						 (check 3/3)",
-                            &root_domain
-                        );
-                        return true;
-                    }
-                }
+                    &root_domain
+                );
+                return true;
             }
         }
     }
 
     false
+}
+
+pub fn url_preview_allowed(url: &Url) -> bool {
+    url_preview_allowed_by_config(url, &config::get().url_preview)
 }
 
 pub async fn get_url_preview(url: &Url) -> AppResult<UrlPreviewData> {
@@ -311,7 +317,8 @@ async fn request_url_preview(url: &Url) -> AppResult<UrlPreviewData> {
         img if img.starts_with("image/") => download_image(url).await?,
         _ => return Err(MatrixError::unknown("unsupported content-type").into()),
     };
-    crate::data::media::set_url_preview(&data.clone().into_new_db_url_preview(url.as_str())).await?;
+    crate::data::media::set_url_preview(&data.clone().into_new_db_url_preview(url.as_str()))
+        .await?;
 
     Ok(data)
 }
@@ -411,4 +418,51 @@ async fn download_html(url: &Url) -> AppResult<UrlPreviewData> {
     data.og_description = props.get("description").cloned().or(html.description);
 
     Ok(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn allowed(url: &str, preview: config::UrlPreviewConfig) -> bool {
+        url_preview_allowed_by_config(&Url::parse(url).unwrap(), &preview)
+    }
+
+    #[test]
+    fn domain_contains_allowlist_matches_hosts_that_contain_pattern() {
+        let preview = config::UrlPreviewConfig {
+            domain_contains_allowlist: vec!["google.com".to_owned()],
+            ..Default::default()
+        };
+
+        assert!(allowed("https://www.google.com/path", preview.clone()));
+        assert!(allowed(
+            "https://mymaliciousdomainexamplegoogle.com/path",
+            preview.clone()
+        ));
+        assert!(!allowed("https://example.org/path", preview));
+    }
+
+    #[test]
+    fn explicit_denylist_wins_over_wildcard_allowlist() {
+        let preview = config::UrlPreviewConfig {
+            domain_explicit_allowlist: vec!["*".to_owned()],
+            domain_explicit_denylist: vec!["blocked.example".to_owned()],
+            ..Default::default()
+        };
+
+        assert!(!allowed("https://blocked.example/path", preview.clone()));
+        assert!(allowed("https://allowed.example/path", preview));
+    }
+
+    #[test]
+    fn empty_contains_entries_do_not_allow_everything() {
+        let preview = config::UrlPreviewConfig {
+            domain_contains_allowlist: vec![String::new()],
+            url_contains_allowlist: vec![String::new()],
+            ..Default::default()
+        };
+
+        assert!(!allowed("https://example.org/path", preview));
+    }
 }

--- a/crates/server/src/user/key.rs
+++ b/crates/server/src/user/key.rs
@@ -54,15 +54,14 @@ pub async fn query_keys<F: Fn(&UserId) -> bool + Send + Sync>(
             }
             device_keys.insert(user_id.to_owned(), container);
         } else {
+            let mut container = BTreeMap::new();
             for device_id in device_ids {
-                let mut container = BTreeMap::new();
-                if let Some(keys) =
-                    data::user::get_device_keys_and_sigs(user_id, device_id).await?
+                if let Some(keys) = data::user::get_device_keys_and_sigs(user_id, device_id).await?
                 {
                     container.insert(device_id.to_owned(), keys);
                 }
-                device_keys.insert(user_id.to_owned(), container);
             }
+            device_keys.insert(user_id.to_owned(), container);
         }
 
         if let Some(master_key) =

--- a/examples/with-discord/config.example.yaml
+++ b/examples/with-discord/config.example.yaml
@@ -98,7 +98,7 @@ database:
   # WARNING: You will almost certainly be fine with sqlite unless your bridge
   # is in heavy demand and you suffer from IO slowness.
   filename: "/data/discord.db"
-  # conn_string: "postgresql://postgres:root@localhost/discord_bridge"
+  # conn_string: "postgresql://postgres:REPLACE_WITH_STRONG_PASSWORD@localhost/discord_bridge"
   # url: "sqlite:///data/discord.db"
   max_connections: 10
   min_connections: 1

--- a/palpo-required.kdl
+++ b/palpo-required.kdl
@@ -9,7 +9,7 @@ listeners {
 }
 
 db {
-    url "postgres://postgres:root@localhost:5432/palpo_local" // Update with your database URL
+    url "postgres://postgres:REPLACE_WITH_STRONG_PASSWORD@localhost:5432/palpo_local" // Update with your database URL
 }
 
 well_known {

--- a/palpo-required.toml
+++ b/palpo-required.toml
@@ -8,7 +8,7 @@ allow_registration = true
 address = "0.0.0.0:8008"
 
 [db]
-url = "postgres://postgres:root@localhost:5432/palpo_local" # Update with your database URL
+url = "postgres://postgres:REPLACE_WITH_STRONG_PASSWORD@localhost:5432/palpo_local" # Update with your database URL
 
 [well_known]
 # Palpo handles the /.well-known/matrix/* endpoints, making both clients and servers try to access palpo with the host


### PR DESCRIPTION
## Summary

- Add an updated `_improve.md` audit report for the latest `main` baseline.
- Fix URL preview allowlist handling so explicit denylists win over wildcard allowlists, contains rules match in the documented direction, and empty contains entries do not allow every URL.
- Fix local `/keys/query` responses so requesting multiple device IDs for one user returns all requested device keys instead of only the last one.
- Replace remaining `postgres:root` example credentials with strong placeholder values.

## Impact

This tightens URL preview SSRF-adjacent configuration behavior, fixes an E2EE device-key query correctness bug, and reduces the chance of weak example credentials being copied into real deployments.

## Validation

- `cargo check -p palpo --bin palpo -j 1`
- `cargo test -p palpo media::preview::tests -j 1`
- `git diff --check`

Full `cargo check --workspace --all-targets -j 4` was attempted during the audit but timed out after 4 minutes, so it is noted as incomplete in `_improve.md`.