### PR TITLE
Fix stable room summary endpoint

### DIFF
--- a/.github/workflows/complement.yml
+++ b/.github/workflows/complement.yml
@@ -122,11 +122,11 @@ jobs:
           fi
           PASS_RATE=$((PASS_COUNT * 100 / TOTAL))
           echo "Pass rate: ${PASS_RATE}%"
-          if [ "$PASS_RATE" -lt 90 ]; then
-            echo "::error::Pass rate ${PASS_RATE}% is below 90% threshold"
+          if [ "$PASS_RATE" -lt 98 ]; then
+            echo "::error::Pass rate ${PASS_RATE}% is below 98% threshold"
             exit 1
           fi
-          echo "✅ Pass rate ${PASS_RATE}% meets the 90% threshold"
+          echo "✅ Pass rate ${PASS_RATE}% meets the 98% threshold"
 
   mixed-federation:
     name: Mixed federation

--- a/crates/core/src/client/room/summary.rs
+++ b/crates/core/src/client/room/summary.rs
@@ -128,3 +128,160 @@ impl SummaryMsc3266ResBody {
         }
     }
 }
+
+/// Response type for the stable `room_summary` endpoint.
+#[derive(ToSchema, Deserialize, Serialize, Debug)]
+pub struct RoomSummaryResBody {
+    /// ID of the room (useful if it's an alias).
+    pub room_id: OwnedRoomId,
+
+    /// The canonical alias for this room, if set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub canonical_alias: Option<OwnedRoomAliasId>,
+
+    /// Avatar of the room.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avatar_url: Option<OwnedMxcUri>,
+
+    /// Whether guests can join the room.
+    pub guest_can_join: bool,
+
+    /// Name of the room.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// Member count of the room.
+    pub num_joined_members: u64,
+
+    /// Topic of the room.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+
+    /// Whether the room history can be read without joining.
+    pub world_readable: bool,
+
+    /// Join rule of the room.
+    pub join_rule: SpaceRoomJoinRule,
+
+    /// Type of the room, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub room_type: Option<RoomType>,
+
+    /// Version of the room.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub room_version: Option<RoomVersionId>,
+
+    /// The current membership of this user in the room.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub membership: Option<MembershipState>,
+
+    /// If the room is encrypted, the algorithm used for this room.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encryption: Option<EventEncryptionAlgorithm>,
+
+    /// If the room is a restricted room, these are the room IDs which are
+    /// specified by the join rules.
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
+    pub allowed_room_ids: Vec<OwnedRoomId>,
+}
+
+impl From<SummaryMsc3266ResBody> for RoomSummaryResBody {
+    fn from(summary: SummaryMsc3266ResBody) -> Self {
+        Self {
+            room_id: summary.room_id,
+            canonical_alias: summary.canonical_alias,
+            avatar_url: summary.avatar_url,
+            guest_can_join: summary.guest_can_join,
+            name: summary.name,
+            num_joined_members: summary.num_joined_members,
+            topic: summary.topic,
+            world_readable: summary.world_readable,
+            join_rule: summary.join_rule,
+            room_type: summary.room_type,
+            room_version: summary.room_version,
+            membership: summary.membership,
+            encryption: summary.encryption,
+            allowed_room_ids: summary.allowed_room_ids,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, to_value as to_json_value};
+
+    use super::{RoomSummaryResBody, SummaryMsc3266ResBody};
+    use crate::events::room::member::MembershipState;
+    use crate::space::SpaceRoomJoinRule;
+    use crate::{EventEncryptionAlgorithm, owned_room_id, room_version_id};
+
+    #[test]
+    fn stable_room_summary_uses_stable_field_names() {
+        let summary = RoomSummaryResBody {
+            room_id: owned_room_id!("!room:localhost"),
+            canonical_alias: None,
+            avatar_url: None,
+            guest_can_join: false,
+            name: None,
+            num_joined_members: 5,
+            topic: None,
+            world_readable: false,
+            join_rule: SpaceRoomJoinRule::Restricted,
+            room_type: None,
+            room_version: Some(room_version_id!("8")),
+            membership: Some(MembershipState::Join),
+            encryption: Some(EventEncryptionAlgorithm::MegolmV1AesSha2),
+            allowed_room_ids: vec![owned_room_id!("!space:localhost")],
+        };
+
+        assert_eq!(
+            to_json_value(summary).unwrap(),
+            json!({
+                "room_id": "!room:localhost",
+                "guest_can_join": false,
+                "num_joined_members": 5,
+                "world_readable": false,
+                "join_rule": "restricted",
+                "room_version": "8",
+                "membership": "join",
+                "encryption": "m.megolm.v1.aes-sha2",
+                "allowed_room_ids": ["!space:localhost"],
+            })
+        );
+    }
+
+    #[test]
+    fn msc3266_room_summary_keeps_unstable_field_names() {
+        let summary = SummaryMsc3266ResBody {
+            room_id: owned_room_id!("!room:localhost"),
+            canonical_alias: None,
+            avatar_url: None,
+            guest_can_join: false,
+            name: None,
+            num_joined_members: 5,
+            topic: None,
+            world_readable: false,
+            join_rule: SpaceRoomJoinRule::Restricted,
+            room_type: None,
+            room_version: Some(room_version_id!("8")),
+            membership: Some(MembershipState::Join),
+            encryption: Some(EventEncryptionAlgorithm::MegolmV1AesSha2),
+            allowed_room_ids: vec![owned_room_id!("!space:localhost")],
+        };
+
+        assert_eq!(
+            to_json_value(summary).unwrap(),
+            json!({
+                "room_id": "!room:localhost",
+                "guest_can_join": false,
+                "num_joined_members": 5,
+                "world_readable": false,
+                "join_rule": "restricted",
+                "im.nheko.summary.room_version": "8",
+                "membership": "join",
+                "im.nheko.summary.encryption": "m.megolm.v1.aes-sha2",
+                "allowed_room_ids": ["!space:localhost"],
+            })
+        );
+    }
+}

--- a/crates/server/src/routing/client.rs
+++ b/crates/server/src/routing/client.rs
@@ -110,6 +110,14 @@ pub fn router() -> Router {
             )
     }
     client
+        .push(
+            Router::with_path("v1")
+                .hoop(hoops::auth_by_access_token)
+                .push(
+                    Router::with_path("room_summary/{room_id_or_alias}")
+                        .get(room::summary::get_summary),
+                ),
+        )
         .push(Router::with_path("versions").get(supported_versions))
         .push(Router::with_path("v1/auth_metadata").get(unstable::auth_metadata))
         .push(

--- a/crates/server/src/routing/client/room/summary.rs
+++ b/crates/server/src/routing/client/room/summary.rs
@@ -1,7 +1,7 @@
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use salvo::prelude::*;
 
-use crate::core::client::room::{SummaryMsc3266ReqArgs, SummaryMsc3266ResBody};
+use crate::core::client::room::{RoomSummaryResBody, SummaryMsc3266ReqArgs, SummaryMsc3266ResBody};
 use crate::core::events::room::member::MembershipState;
 use crate::core::federation::space::{
     HierarchyReqArgs, HierarchyResBody, SpaceHierarchyParentSummary, hierarchy_request,
@@ -23,6 +23,25 @@ pub async fn get_summary_msc_3266(
     args: SummaryMsc3266ReqArgs,
     depot: &mut Depot,
 ) -> JsonResult<SummaryMsc3266ResBody> {
+    json_ok(room_summary(args, depot).await?)
+}
+
+/// # `GET /_matrix/client/v1/room_summary/{roomIdOrAlias}`
+///
+/// Returns a short description of the state of a room.
+#[handler]
+pub async fn get_summary(
+    _aa: AuthArgs,
+    args: SummaryMsc3266ReqArgs,
+    depot: &mut Depot,
+) -> JsonResult<RoomSummaryResBody> {
+    json_ok(room_summary(args, depot).await?.into())
+}
+
+async fn room_summary(
+    args: SummaryMsc3266ReqArgs,
+    depot: &mut Depot,
+) -> AppResult<SummaryMsc3266ResBody> {
     let authed = depot.authed_info().ok();
     let sender_id = authed.map(|a| a.user_id());
 
@@ -34,12 +53,11 @@ pub async fn get_summary_msc_3266(
     }
 
     if room::is_server_joined(&config::get().server_name, &room_id).await? {
-        let res_body = local_room_summary(&room_id, sender_id).await?;
-        json_ok(res_body)
+        local_room_summary(&room_id, sender_id).await
     } else {
         let room = remote_room_summary_hierarchy(&room_id, &servers, sender_id).await?;
 
-        json_ok(SummaryMsc3266ResBody {
+        Ok(SummaryMsc3266ResBody {
             room_id: room_id.to_owned(),
             canonical_alias: room.canonical_alias,
             avatar_url: room.avatar_url,
@@ -213,7 +231,10 @@ where
             let is_guest = data::user::is_guest(sender_id).await.unwrap_or(false);
             let mut user_in_allowed_restricted_room = false;
             for room in allowed_room_ids {
-                if room::user::is_joined(sender_id, room).await.unwrap_or(false) {
+                if room::user::is_joined(sender_id, room)
+                    .await
+                    .unwrap_or(false)
+                {
                     user_in_allowed_restricted_room = true;
                     break;
                 }


### PR DESCRIPTION
## Summary

- Raise the Complement pass-rate gate from 90% to 98%.
- Add the stable `/_matrix/client/v1/room_summary/{roomIdOrAlias}` endpoint.
- Keep the existing MSC3266 unstable summary response shape while returning stable `room_version` and `encryption` field names from the v1 endpoint.
- Add focused serialization coverage for both stable and unstable summary response shapes.

## Root Cause

Complement was calling the Matrix v1.15 stable room summary endpoint, but Palpo only registered the older unstable `im.nheko.summary` route. Requests to `/_matrix/client/v1/room_summary/...` therefore returned `404 M_UNRECOGNIZED` before the tests could validate `allowed_room_ids`.

## Validation

- `cargo test -p palpo-core room_summary`
- `cargo check -p palpo --bin palpo -j 1`
- `git diff --check origin/main...HEAD`