### PR TITLE
Implement MSC3391 account data deletion

### DIFF
--- a/_improve.md
+++ b/_improve.md
@@ -17,7 +17,7 @@
 
 - [ ] `POST /_matrix/client/*/account/deactivate` 注释声明会离开房间、清设备、清 to-device 等，但当前路由只调用 `data::user::deactivate`，没有接入已有的 `full_user_deactivate` 完整流程。
 - [ ] E2EE cross-signing 仍有未完成校验：`add_cross_signing_key_updates` 标注 `TODO: Check signatures`，`keys/signatures/upload` 也只是持久化签名并固定返回空 `failures`。
-- [ ] MSC3391 account data delete 路由当前返回成功但没有删除数据，属于未实现功能返回假成功。
+- [x] MSC3391 account data delete 路由当前返回成功但没有删除数据，属于未实现功能返回假成功。
 - [ ] 多处 Matrix 协议缺口仍以明确错误返回，例如 dehydrated devices、third-party invite exchange、3PID bind 等，需要按协议功能专项补齐。
 - [ ] 本地工作区存在被 `.gitignore` 排除的 `examples/with-*/data` / `space` 运行数据，扫描到 token-like 值。它们不在 Git 跟踪内，但建议开发环境定期清理，避免误打包或手工复制。
 

--- a/crates/data/src/user/data.rs
+++ b/crates/data/src/user/data.rs
@@ -162,6 +162,18 @@ pub async fn get_global_data<E: DeserializeOwned>(
     }
 }
 
+pub async fn delete_global_data(user_id: &UserId, kind: &str) -> DataResult<()> {
+    diesel::delete(
+        user_datas::table
+            .filter(user_datas::user_id.eq(user_id))
+            .filter(user_datas::room_id.is_null())
+            .filter(user_datas::data_type.eq(kind)),
+    )
+    .execute(&mut connect().await?)
+    .await?;
+    Ok(())
+}
+
 /// Load all global account-data rows for a user.
 pub async fn get_global_datas(user_id: &UserId) -> DataResult<Vec<DbUserData>> {
     user_datas::table

--- a/crates/server/src/routing/client/account.rs
+++ b/crates/server/src/routing/client/account.rs
@@ -8,8 +8,9 @@ use crate::core::client::account::{
     DeactivateReqBody, DeactivateResBody, ThirdPartyIdRemovalStatus, WhoamiResBody,
 };
 use crate::core::client::uiaa::{AuthFlow, AuthType, UiaaInfo};
+use crate::core::identifiers::*;
 use crate::exts::*;
-use crate::{AuthArgs, EmptyResult, JsonResult, MatrixError, data, hoops, json_ok};
+use crate::{AuthArgs, EmptyResult, JsonResult, MatrixError, data, empty_ok, hoops, json_ok};
 
 pub fn public_router() -> Router {
     Router::with_path("account")
@@ -147,9 +148,22 @@ async fn deactivate(
 
 // msc3391
 #[handler]
-pub(super) fn delete_account_data_msc3391(
-    _req: &mut Request,
-    _res: &mut Response,
-) -> JsonResult<()> {
-    json_ok(())
+pub(super) async fn delete_account_data_msc3391(
+    _aa: AuthArgs,
+    user_id: PathParam<OwnedUserId>,
+    account_type: PathParam<String>,
+    depot: &mut Depot,
+) -> EmptyResult {
+    let authed = depot.authed_info()?;
+    let user_id = user_id.into_inner();
+    if &user_id != authed.user_id() {
+        return Err(MatrixError::forbidden(
+            "Cannot delete account data for another user.",
+            None,
+        )
+        .into());
+    }
+
+    data::user::delete_global_data(authed.user_id(), &account_type.into_inner()).await?;
+    empty_ok()
 }


### PR DESCRIPTION
## Summary
- implement MSC3391 global account data deletion instead of returning a fake success
- forbid deleting another user's account data via the path parameter
- mark the corresponding `_improve.md` item as handled

## Validation
- `git diff --check`
- `cargo check -p palpo --bin palpo -j 1`