### PR TITLE
Validate E2EE key signatures

### DIFF
--- a/_improve.md
+++ b/_improve.md
@@ -16,7 +16,7 @@
 ## 仍需专项处理
 
 - [ ] `POST /_matrix/client/*/account/deactivate` 注释声明会离开房间、清设备、清 to-device 等，但当前路由只调用 `data::user::deactivate`，没有接入已有的 `full_user_deactivate` 完整流程。
-- [ ] E2EE cross-signing 仍有未完成校验：`add_cross_signing_key_updates` 标注 `TODO: Check signatures`，`keys/signatures/upload` 也只是持久化签名并固定返回空 `failures`。
+- [x] E2EE cross-signing 仍有未完成校验：`add_cross_signing_key_updates` 标注 `TODO: Check signatures`，`keys/signatures/upload` 也只是持久化签名并固定返回空 `failures`。
 - [ ] MSC3391 account data delete 路由当前返回成功但没有删除数据，属于未实现功能返回假成功。
 - [ ] 多处 Matrix 协议缺口仍以明确错误返回，例如 dehydrated devices、third-party invite exchange、3PID bind 等，需要按协议功能专项补齐。
 - [ ] 本地工作区存在被 `.gitignore` 排除的 `examples/with-*/data` / `space` 运行数据，扫描到 token-like 值。它们不在 Git 跟踪内，但建议开发环境定期清理，避免误打包或手工复制。

--- a/crates/core/src/client/key.rs
+++ b/crates/core/src/client/key.rs
@@ -323,6 +323,15 @@ pub struct Failure {
     /// Human-readable error message.
     error: String,
 }
+impl Failure {
+    /// Creates a signature processing failure.
+    pub fn invalid_signature(error: impl Into<String>) -> Self {
+        Self {
+            errcode: FailureErrorCode::InvalidSignature,
+            error: error.into(),
+        }
+    }
+}
 
 /// Error code for signed key processing failures.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]

--- a/crates/data/src/user.rs
+++ b/crates/data/src/user.rs
@@ -460,7 +460,12 @@ pub fn clean_signatures<F: Fn(&UserId) -> bool>(
         {
             let sid = <&UserId>::try_from(user.as_str())
                 .map_err(|_| DataError::internal("Invalid user ID in database."))?;
-            if sender_id == Some(user_id) || sid == user_id || allowed_signatures(sid) {
+            // Keep a signature only if it was made by the requesting user, by the
+            // target user themselves, or by an otherwise allowed origin. Comparing
+            // against `Some(sid)` (rather than `Some(user_id)`) prevents a self-query
+            // from leaking third-party cross-signing signatures stored over the
+            // target's keys.
+            if sender_id == Some(sid) || sid == user_id || allowed_signatures(sid) {
                 signatures.insert(user, signature);
             }
         }

--- a/crates/data/src/user/key.rs
+++ b/crates/data/src/user/key.rs
@@ -302,10 +302,14 @@ pub async fn get_cross_signing_key(
 }
 
 /// Return the latest cross-signing key of a kind with uploaded signatures attached.
-pub async fn get_cross_signing_key_and_sigs(
+pub async fn get_cross_signing_key_and_sigs<F>(
     user_id: &UserId,
     key_type: &str,
-) -> DataResult<Option<JsonValue>> {
+    allowed_signature_origin: F,
+) -> DataResult<Option<JsonValue>>
+where
+    F: Fn(&UserId) -> bool,
+{
     let Some(key_data) = get_cross_signing_key(user_id, key_type).await? else {
         return Ok(None);
     };
@@ -327,6 +331,9 @@ pub async fn get_cross_signing_key_and_sigs(
             ..
         } in signatures
         {
+            if !allowed_signature_origin(&origin_user_id) {
+                continue;
+            }
             key.signatures
                 .entry(origin_user_id)
                 .or_default()

--- a/crates/data/src/user/key.rs
+++ b/crates/data/src/user/key.rs
@@ -308,7 +308,7 @@ pub async fn get_cross_signing_key(
             .filter(e2e_cross_signing_sigs::target_user_id.eq(user_id))
             .filter(
                 e2e_cross_signing_sigs::target_device_id
-                    .eq(OwnedDeviceId::from(target_key_id.as_str())),
+                    .eq(OwnedDeviceId::from(target_key_id.key_name().as_str())),
             )
             .load::<DbCrossSignature>(&mut connect().await?)
             .await?;

--- a/crates/data/src/user/key.rs
+++ b/crates/data/src/user/key.rs
@@ -290,15 +290,23 @@ pub async fn get_cross_signing_key(
     user_id: &UserId,
     key_type: &str,
 ) -> DataResult<Option<JsonValue>> {
-    let Some(key_data) = e2e_cross_signing_keys::table
+    e2e_cross_signing_keys::table
         .filter(e2e_cross_signing_keys::user_id.eq(user_id))
         .filter(e2e_cross_signing_keys::key_type.eq(key_type))
         .order_by(e2e_cross_signing_keys::id.desc())
         .select(e2e_cross_signing_keys::key_data)
         .first::<JsonValue>(&mut connect().await?)
         .await
-        .optional()?
-    else {
+        .optional()
+        .map_err(Into::into)
+}
+
+/// Return the latest cross-signing key of a kind with uploaded signatures attached.
+pub async fn get_cross_signing_key_and_sigs(
+    user_id: &UserId,
+    key_type: &str,
+) -> DataResult<Option<JsonValue>> {
+    let Some(key_data) = get_cross_signing_key(user_id, key_type).await? else {
         return Ok(None);
     };
 

--- a/crates/data/src/user/key.rs
+++ b/crates/data/src/user/key.rs
@@ -290,15 +290,43 @@ pub async fn get_cross_signing_key(
     user_id: &UserId,
     key_type: &str,
 ) -> DataResult<Option<JsonValue>> {
-    e2e_cross_signing_keys::table
+    let Some(key_data) = e2e_cross_signing_keys::table
         .filter(e2e_cross_signing_keys::user_id.eq(user_id))
         .filter(e2e_cross_signing_keys::key_type.eq(key_type))
         .order_by(e2e_cross_signing_keys::id.desc())
         .select(e2e_cross_signing_keys::key_data)
         .first::<JsonValue>(&mut connect().await?)
         .await
-        .optional()
-        .map_err(Into::into)
+        .optional()?
+    else {
+        return Ok(None);
+    };
+
+    let mut key = serde_json::from_value::<CrossSigningKey>(key_data)?;
+    for target_key_id in key.keys.keys() {
+        let signatures = e2e_cross_signing_sigs::table
+            .filter(e2e_cross_signing_sigs::target_user_id.eq(user_id))
+            .filter(
+                e2e_cross_signing_sigs::target_device_id
+                    .eq(OwnedDeviceId::from(target_key_id.as_str())),
+            )
+            .load::<DbCrossSignature>(&mut connect().await?)
+            .await?;
+        for DbCrossSignature {
+            origin_user_id,
+            origin_key_id,
+            signature,
+            ..
+        } in signatures
+        {
+            key.signatures
+                .entry(origin_user_id)
+                .or_default()
+                .insert(origin_key_id, signature);
+        }
+    }
+
+    serde_json::to_value(key).map(Some).map_err(Into::into)
 }
 
 /// Insert a cross-signing key of the given kind.

--- a/crates/server/src/routing/client/key/signature.rs
+++ b/crates/server/src/routing/client/key/signature.rs
@@ -115,13 +115,22 @@ async fn validate_target_key(
             )));
         }
 
-        if data::user::key::get_device_keys(target_user_id, &device_keys.device_id)
-            .await?
-            .is_none()
-        {
+        let Some(stored_device_keys) =
+            data::user::key::get_device_keys(target_user_id, &device_keys.device_id).await?
+        else {
             return Ok(Some(Failure::invalid_signature(
                 "Unknown target device key.",
             )));
+        };
+
+        match key_matches_stored_key(key_value, &stored_device_keys) {
+            Ok(true) => {}
+            Ok(false) => {
+                return Ok(Some(Failure::invalid_signature(
+                    "Signed device key does not match the stored key.",
+                )));
+            }
+            Err(failure) => return Ok(Some(failure)),
         }
 
         return Ok(None);
@@ -145,14 +154,16 @@ async fn validate_target_key(
             )));
         };
 
-        let Some(existing_key) =
+        let Some(existing_key_value) =
             data::user::key::get_cross_signing_key(target_user_id, key_type).await?
         else {
             return Ok(Some(Failure::invalid_signature(
                 "Unknown target cross-signing key.",
             )));
         };
-        let Ok(existing_key) = serde_json::from_value::<CrossSigningKey>(existing_key) else {
+        let Ok(existing_key) =
+            serde_json::from_value::<CrossSigningKey>(existing_key_value.clone())
+        else {
             return Ok(Some(Failure::invalid_signature(
                 "Stored target cross-signing key is invalid.",
             )));
@@ -168,12 +179,48 @@ async fn validate_target_key(
             )));
         }
 
+        match key_matches_stored_key_value(key_value, &existing_key_value) {
+            Ok(true) => {}
+            Ok(false) => {
+                return Ok(Some(Failure::invalid_signature(
+                    "Signed cross-signing key does not match the stored key.",
+                )));
+            }
+            Err(failure) => return Ok(Some(failure)),
+        }
+
         return Ok(None);
     }
 
     Ok(Some(Failure::invalid_signature(
         "Signed key is neither a device key nor a cross-signing key.",
     )))
+}
+
+fn key_matches_stored_key(
+    uploaded_key_value: &JsonValue,
+    stored_key: &impl serde::Serialize,
+) -> Result<bool, Failure> {
+    let stored_key_value = serde_json::to_value(stored_key)
+        .map_err(|_| Failure::invalid_signature("Stored target key is invalid."))?;
+
+    key_matches_stored_key_value(uploaded_key_value, &stored_key_value)
+}
+
+fn key_matches_stored_key_value(
+    uploaded_key_value: &JsonValue,
+    stored_key_value: &JsonValue,
+) -> Result<bool, Failure> {
+    Ok(canonical_json_for_signing(uploaded_key_value)?
+        == canonical_json_for_signing(stored_key_value)?)
+}
+
+fn canonical_json_for_signing(key_value: &JsonValue) -> Result<String, Failure> {
+    let object = serde_json::from_value::<CanonicalJsonObject>(key_value.clone())
+        .map_err(|_| Failure::invalid_signature("Signed key is not canonical JSON."))?;
+
+    signatures::to_canonical_json_string_for_signing(&object)
+        .map_err(|_| Failure::invalid_signature("Signed key is not canonical JSON."))
 }
 
 fn sender_signature_map<'a>(

--- a/crates/server/src/routing/client/key/signature.rs
+++ b/crates/server/src/routing/client/key/signature.rs
@@ -3,8 +3,12 @@ use std::collections::BTreeMap;
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
 
-use crate::core::client::key::{UploadSignaturesReqBody, UploadSignaturesResBody};
-use crate::{AuthArgs, DepotExt, JsonResult, MatrixError, json_ok};
+use crate::core::client::key::{Failure, UploadSignaturesReqBody, UploadSignaturesResBody};
+use crate::core::encryption::{CrossSigningKey, DeviceKeys, KeyUsage};
+use crate::core::identifiers::*;
+use crate::core::serde::{Base64, CanonicalJsonObject, JsonValue, RawJsonValue};
+use crate::core::signatures::{self, PublicKeyMap, PublicKeySet};
+use crate::{AppResult, AuthArgs, DepotExt, JsonResult, data, json_ok};
 
 /// #POST /_matrix/client/r0/keys/signatures/upload
 /// Uploads end-to-end key signatures from the sender user.
@@ -16,39 +20,282 @@ pub(super) async fn upload(
 ) -> JsonResult<UploadSignaturesResBody> {
     let authed = depot.authed_info()?;
     let body = body.into_inner();
+    let mut failures: BTreeMap<OwnedUserId, BTreeMap<String, Failure>> = BTreeMap::new();
 
     for (user_id, keys) in &body.0 {
-        for (key_id, key) in keys {
-            let key = serde_json::to_value(key)
-                .map_err(|_| MatrixError::invalid_param("Invalid key JSON"))?;
-
-            for signature in key
-                .get("signatures")
-                .ok_or(MatrixError::invalid_param("Missing signatures field."))?
-                .get(authed.user_id().to_string())
-                .ok_or(MatrixError::invalid_param(
-                    "Invalid user in signatures field.",
-                ))?
-                .as_object()
-                .ok_or(MatrixError::invalid_param("Invalid signature."))?
-                .clone()
-                .into_iter()
+        for (key_id, key) in keys.iter() {
+            if let Some(failure) =
+                process_signed_key(authed.user_id(), user_id, key_id, key).await?
             {
-                // Signature validation?
-                let signature = (
-                    signature.0,
-                    signature
-                        .1
-                        .as_str()
-                        .ok_or(MatrixError::invalid_param("Invalid signature value."))?
-                        .to_owned(),
-                );
-                crate::user::sign_key(user_id, key_id, signature, authed.user_id()).await?;
+                failures
+                    .entry(user_id.to_owned())
+                    .or_default()
+                    .insert(key_id.to_owned(), failure);
             }
         }
     }
 
-    json_ok(UploadSignaturesResBody {
-        failures: BTreeMap::new(), // TODO: integrate
-    })
+    json_ok(UploadSignaturesResBody::new(failures))
+}
+
+async fn process_signed_key(
+    sender_id: &UserId,
+    target_user_id: &UserId,
+    target_key_id: &str,
+    key: &RawJsonValue,
+) -> AppResult<Option<Failure>> {
+    let key_value = match serde_json::from_str::<JsonValue>(key.get()) {
+        Ok(value) => value,
+        Err(_) => return Ok(Some(Failure::invalid_signature("Invalid signed key JSON."))),
+    };
+
+    if let Some(failure) = validate_target_key(target_user_id, target_key_id, &key_value).await? {
+        return Ok(Some(failure));
+    }
+
+    let sender_signatures = match sender_signature_map(sender_id, &key_value) {
+        Ok(signatures) => signatures,
+        Err(failure) => return Ok(Some(failure)),
+    };
+
+    if sender_signatures.values().any(|value| !value.is_string()) {
+        return Ok(Some(Failure::invalid_signature(
+            "Signature values must be strings.",
+        )));
+    }
+
+    let signing_key_ids = sender_signatures.keys().cloned().collect::<Vec<_>>();
+    let public_keys = signing_public_keys(sender_id, &signing_key_ids).await?;
+    if public_keys.is_empty() {
+        return Ok(Some(Failure::invalid_signature(
+            "No known signing key for authenticated user.",
+        )));
+    }
+
+    let verification_object =
+        match canonical_object_for_sender_signature(sender_id, &key_value, sender_signatures) {
+            Ok(object) => object,
+            Err(failure) => return Ok(Some(failure)),
+        };
+    let mut public_key_map = PublicKeyMap::new();
+    public_key_map.insert(sender_id.to_string(), public_keys.clone());
+    if signatures::verify_json(&public_key_map, &verification_object).is_err() {
+        return Ok(Some(Failure::invalid_signature(
+            "Signature does not verify against the authenticated user's keys.",
+        )));
+    }
+
+    for (signing_key_id, signature) in sender_signatures {
+        if public_keys.contains_key(signing_key_id)
+            && let Some(signature) = signature.as_str()
+        {
+            crate::user::sign_key(
+                target_user_id,
+                target_key_id,
+                (signing_key_id.to_owned(), signature.to_owned()),
+                sender_id,
+            )
+            .await?;
+        }
+    }
+
+    Ok(None)
+}
+
+async fn validate_target_key(
+    target_user_id: &UserId,
+    target_key_id: &str,
+    key_value: &JsonValue,
+) -> AppResult<Option<Failure>> {
+    if let Ok(device_keys) = serde_json::from_value::<DeviceKeys>(key_value.clone()) {
+        if &device_keys.user_id != target_user_id || device_keys.device_id.as_str() != target_key_id
+        {
+            return Ok(Some(Failure::invalid_signature(
+                "Signed device key does not match the target key.",
+            )));
+        }
+
+        if data::user::key::get_device_keys(target_user_id, &device_keys.device_id)
+            .await?
+            .is_none()
+        {
+            return Ok(Some(Failure::invalid_signature(
+                "Unknown target device key.",
+            )));
+        }
+
+        return Ok(None);
+    }
+
+    if let Ok(cross_signing_key) = serde_json::from_value::<CrossSigningKey>(key_value.clone()) {
+        if &cross_signing_key.user_id != target_user_id
+            || !cross_signing_key
+                .keys
+                .keys()
+                .any(|key_id| key_id.as_str() == target_key_id)
+        {
+            return Ok(Some(Failure::invalid_signature(
+                "Signed cross-signing key does not match the target key.",
+            )));
+        }
+
+        let Some(key_type) = cross_signing_key_type(&cross_signing_key) else {
+            return Ok(Some(Failure::invalid_signature(
+                "Unknown cross-signing key usage.",
+            )));
+        };
+
+        let Some(existing_key) =
+            data::user::key::get_cross_signing_key(target_user_id, key_type).await?
+        else {
+            return Ok(Some(Failure::invalid_signature(
+                "Unknown target cross-signing key.",
+            )));
+        };
+        let Ok(existing_key) = serde_json::from_value::<CrossSigningKey>(existing_key) else {
+            return Ok(Some(Failure::invalid_signature(
+                "Stored target cross-signing key is invalid.",
+            )));
+        };
+
+        if !existing_key
+            .keys
+            .keys()
+            .any(|key_id| key_id.as_str() == target_key_id)
+        {
+            return Ok(Some(Failure::invalid_signature(
+                "Target cross-signing key does not match the stored key.",
+            )));
+        }
+
+        return Ok(None);
+    }
+
+    Ok(Some(Failure::invalid_signature(
+        "Signed key is neither a device key nor a cross-signing key.",
+    )))
+}
+
+fn sender_signature_map<'a>(
+    sender_id: &UserId,
+    key_value: &'a JsonValue,
+) -> Result<&'a serde_json::Map<String, JsonValue>, Failure> {
+    key_value
+        .get("signatures")
+        .and_then(JsonValue::as_object)
+        .and_then(|signatures| signatures.get(sender_id.as_str()))
+        .and_then(JsonValue::as_object)
+        .ok_or_else(|| Failure::invalid_signature("Missing signature from authenticated user."))
+}
+
+fn canonical_object_for_sender_signature(
+    sender_id: &UserId,
+    key_value: &JsonValue,
+    sender_signatures: &serde_json::Map<String, JsonValue>,
+) -> Result<CanonicalJsonObject, Failure> {
+    let mut value = key_value.clone();
+    let Some(object) = value.as_object_mut() else {
+        return Err(Failure::invalid_signature(
+            "Signed key must be a JSON object.",
+        ));
+    };
+
+    let mut signatures = serde_json::Map::new();
+    signatures.insert(
+        sender_id.to_string(),
+        JsonValue::Object(sender_signatures.clone()),
+    );
+    object.insert("signatures".to_owned(), JsonValue::Object(signatures));
+
+    serde_json::from_value(value)
+        .map_err(|_| Failure::invalid_signature("Signed key is not canonical JSON."))
+}
+
+async fn signing_public_keys(
+    sender_id: &UserId,
+    signing_key_ids: &[String],
+) -> AppResult<PublicKeySet> {
+    let mut public_keys = PublicKeySet::new();
+
+    add_cross_signing_public_keys(
+        &mut public_keys,
+        crate::user::get_master_key(sender_id).await?.as_ref(),
+        signing_key_ids,
+    );
+    add_cross_signing_public_keys(
+        &mut public_keys,
+        crate::user::get_self_signing_key(sender_id).await?.as_ref(),
+        signing_key_ids,
+    );
+    add_cross_signing_public_keys(
+        &mut public_keys,
+        crate::user::get_user_signing_key(sender_id).await?.as_ref(),
+        signing_key_ids,
+    );
+
+    for signing_key_id in signing_key_ids {
+        if public_keys.contains_key(signing_key_id) {
+            continue;
+        }
+
+        let Ok(device_key_id) = DeviceKeyId::parse(signing_key_id) else {
+            continue;
+        };
+        let Some(device_keys) =
+            data::user::key::get_device_keys(sender_id, device_key_id.key_name()).await?
+        else {
+            continue;
+        };
+        if let Some(public_key) = device_keys.keys.get(&device_key_id) {
+            add_public_key(&mut public_keys, signing_key_id, public_key);
+        }
+    }
+
+    Ok(public_keys)
+}
+
+fn add_cross_signing_public_keys(
+    public_keys: &mut PublicKeySet,
+    key: Option<&CrossSigningKey>,
+    signing_key_ids: &[String],
+) {
+    let Some(key) = key else {
+        return;
+    };
+
+    for signing_key_id in signing_key_ids {
+        if let Some(public_key) = key.keys.get(signing_key_id.as_str()) {
+            add_public_key(public_keys, signing_key_id, public_key);
+        }
+    }
+}
+
+fn add_public_key(public_keys: &mut PublicKeySet, key_id: &str, public_key: &str) {
+    if let Ok(public_key) = Base64::parse(public_key) {
+        public_keys.insert(key_id.to_owned(), public_key);
+    }
+}
+
+fn cross_signing_key_type(key: &CrossSigningKey) -> Option<&'static str> {
+    if key
+        .usage
+        .iter()
+        .any(|usage| matches!(usage, KeyUsage::Master))
+    {
+        Some("master")
+    } else if key
+        .usage
+        .iter()
+        .any(|usage| matches!(usage, KeyUsage::SelfSigning))
+    {
+        Some("self_signing")
+    } else if key
+        .usage
+        .iter()
+        .any(|usage| matches!(usage, KeyUsage::UserSigning))
+    {
+        Some("user_signing")
+    } else {
+        None
+    }
 }

--- a/crates/server/src/routing/client/key/signature.rs
+++ b/crates/server/src/routing/client/key/signature.rs
@@ -138,10 +138,7 @@ async fn validate_target_key(
 
     if let Ok(cross_signing_key) = serde_json::from_value::<CrossSigningKey>(key_value.clone()) {
         if &cross_signing_key.user_id != target_user_id
-            || !cross_signing_key
-                .keys
-                .keys()
-                .any(|key_id| key_id.as_str() == target_key_id)
+            || !cross_signing_key_contains_key_name(&cross_signing_key, target_key_id)
         {
             return Ok(Some(Failure::invalid_signature(
                 "Signed cross-signing key does not match the target key.",
@@ -169,11 +166,7 @@ async fn validate_target_key(
             )));
         };
 
-        if !existing_key
-            .keys
-            .keys()
-            .any(|key_id| key_id.as_str() == target_key_id)
-        {
+        if !cross_signing_key_contains_key_name(&existing_key, target_key_id) {
             return Ok(Some(Failure::invalid_signature(
                 "Target cross-signing key does not match the stored key.",
             )));
@@ -195,6 +188,12 @@ async fn validate_target_key(
     Ok(Some(Failure::invalid_signature(
         "Signed key is neither a device key nor a cross-signing key.",
     )))
+}
+
+fn cross_signing_key_contains_key_name(key: &CrossSigningKey, key_name: &str) -> bool {
+    key.keys
+        .keys()
+        .any(|key_id| key_id.key_name().as_str() == key_name)
 }
 
 fn key_matches_stored_key(

--- a/crates/server/src/user.rs
+++ b/crates/server/src/user.rs
@@ -106,7 +106,12 @@ pub fn clean_signatures<F: Fn(&UserId) -> bool>(
         {
             let sid = <&UserId>::try_from(user.as_str())
                 .map_err(|_| AppError::internal("Invalid user ID in database."))?;
-            if sender_id == Some(user_id) || sid == user_id || allowed_signatures(sid) {
+            // Keep a signature only if it was made by the requesting user, by the
+            // target user themselves, or by an otherwise allowed origin. Comparing
+            // against `Some(sid)` (rather than `Some(user_id)`) prevents a self-query
+            // from leaking third-party cross-signing signatures stored over the
+            // target's keys.
+            if sender_id == Some(sid) || sid == user_id || allowed_signatures(sid) {
                 signatures.insert(user, signature);
             }
         }

--- a/crates/server/src/user/key.rs
+++ b/crates/server/src/user/key.rs
@@ -138,12 +138,18 @@ pub async fn query_keys<F: Fn(&UserId) -> bool + Send + Sync>(
                     let json = serde_json::to_value(master_key).expect("to_value always works");
                     let raw =
                         serde_json::from_value(json).expect("RawJson::from_value always works");
-                    crate::user::add_cross_signing_keys(
+                    if crate::user::add_cross_signing_keys(
                         &user_id, &raw, &None, &None,
                         false, /* Dont notify. A notification would trigger another key request
                                * resulting in an endless loop */
                     )
-                    .await?;
+                    .await
+                    .is_err()
+                    {
+                        back_off(server.to_owned());
+                        failures.insert(server.to_string(), json!({}));
+                        continue;
+                    }
                     master_keys.insert(user_id.to_owned(), raw);
                 }
 

--- a/crates/server/src/user/key.rs
+++ b/crates/server/src/user/key.rs
@@ -253,7 +253,13 @@ pub async fn get_allowed_master_key(
     user_id: &UserId,
     allowed_signatures: &(dyn Fn(&UserId) -> bool + Send + Sync),
 ) -> AppResult<Option<CrossSigningKey>> {
-    let key_data = data::user::key::get_cross_signing_key_and_sigs(user_id, "master").await?;
+    let key_data =
+        data::user::key::get_cross_signing_key_and_sigs(user_id, "master", |signature_user_id| {
+            sender_id == Some(signature_user_id)
+                || signature_user_id == user_id
+                || allowed_signatures(signature_user_id)
+        })
+        .await?;
     if let Some(mut key_data) = key_data {
         clean_signatures(&mut key_data, sender_id, user_id, allowed_signatures)?;
         Ok(serde_json::from_value(key_data).ok())
@@ -275,7 +281,16 @@ pub async fn get_allowed_self_signing_key(
     user_id: &UserId,
     allowed_signatures: &(dyn Fn(&UserId) -> bool + Send + Sync),
 ) -> AppResult<Option<CrossSigningKey>> {
-    let key_data = data::user::key::get_cross_signing_key_and_sigs(user_id, "self_signing").await?;
+    let key_data = data::user::key::get_cross_signing_key_and_sigs(
+        user_id,
+        "self_signing",
+        |signature_user_id| {
+            sender_id == Some(signature_user_id)
+                || signature_user_id == user_id
+                || allowed_signatures(signature_user_id)
+        },
+    )
+    .await?;
     if let Some(mut key_data) = key_data {
         clean_signatures(&mut key_data, sender_id, user_id, allowed_signatures)?;
         Ok(serde_json::from_value(key_data).ok())

--- a/crates/server/src/user/key.rs
+++ b/crates/server/src/user/key.rs
@@ -155,6 +155,11 @@ pub async fn query_keys<F: Fn(&UserId) -> bool + Send + Sync>(
 
                 self_signing_keys.extend(response.self_signing_keys);
                 for (user_id, devices) in &response.device_keys {
+                    if user_id.server_name() != server {
+                        back_off(server.to_owned());
+                        failures.insert(server.to_string(), json!({}));
+                        continue;
+                    }
                     for (device_id, keys) in devices {
                         if &keys.user_id != user_id || &keys.device_id != device_id {
                             back_off(server.to_owned());

--- a/crates/server/src/user/key.rs
+++ b/crates/server/src/user/key.rs
@@ -349,12 +349,11 @@ pub async fn add_cross_signing_key_updates(
             None
         };
 
+    let master_key_for_signatures = master_key.or(existing_master_key.as_ref());
+
     if let Some(master_key) = master_key {
         validate_cross_signing_key(user_id, CrossSigningKeyKind::Master, master_key)?;
-        add_cross_signing_key(user_id, "master", master_key).await?;
     }
-
-    let master_key_for_signatures = master_key.or(existing_master_key.as_ref());
 
     if let Some(self_signing_key) = self_signing_key {
         validate_cross_signing_key(user_id, CrossSigningKeyKind::SelfSigning, self_signing_key)?;
@@ -364,8 +363,6 @@ pub async fn add_cross_signing_key_updates(
             master_key_for_signatures
                 .ok_or(MatrixError::invalid_param("Missing master signing key."))?,
         )?;
-
-        add_cross_signing_key(user_id, "self_signing", self_signing_key).await?;
     }
 
     if let Some(user_signing_key) = user_signing_key {
@@ -376,7 +373,17 @@ pub async fn add_cross_signing_key_updates(
             master_key_for_signatures
                 .ok_or(MatrixError::invalid_param("Missing master signing key."))?,
         )?;
+    }
 
+    if let Some(master_key) = master_key {
+        add_cross_signing_key(user_id, "master", master_key).await?;
+    }
+
+    if let Some(self_signing_key) = self_signing_key {
+        add_cross_signing_key(user_id, "self_signing", self_signing_key).await?;
+    }
+
+    if let Some(user_signing_key) = user_signing_key {
         add_cross_signing_key(user_id, "user_signing", user_signing_key).await?;
     }
 

--- a/crates/server/src/user/key.rs
+++ b/crates/server/src/user/key.rs
@@ -6,12 +6,14 @@ use serde_json::json;
 
 use crate::core::client::key::ClaimKeysResBody;
 use crate::core::device::DeviceListUpdateContent;
-use crate::core::encryption::{CrossSigningKey, DeviceKeys, OneTimeKey};
+use crate::core::encryption::{CrossSigningKey, DeviceKeys, KeyUsage, OneTimeKey};
 use crate::core::federation::key::{
     QueryKeysReqBody, QueryKeysResBody, claim_keys_request, query_keys_request,
 };
 use crate::core::federation::transaction::{Edu, SigningKeyUpdateContent};
 use crate::core::identifiers::*;
+use crate::core::serde::{Base64, CanonicalJsonObject, JsonValue};
+use crate::core::signatures::{self, PublicKeyMap, PublicKeySet};
 use crate::core::{DeviceKeyAlgorithm, UnixMillis, client, federation};
 use crate::data::user::{NewDbCrossSignature, NewDbKeyChange};
 use crate::exts::*;
@@ -340,47 +342,40 @@ pub async fn add_cross_signing_key_updates(
     user_signing_key: Option<&CrossSigningKey>,
     notify: bool,
 ) -> AppResult<()> {
-    // TODO: Check signatures
+    let existing_master_key =
+        if master_key.is_none() && (self_signing_key.is_some() || user_signing_key.is_some()) {
+            get_master_key(user_id).await?
+        } else {
+            None
+        };
+
     if let Some(master_key) = master_key {
+        validate_cross_signing_key(user_id, CrossSigningKeyKind::Master, master_key)?;
         add_cross_signing_key(user_id, "master", master_key).await?;
     }
 
+    let master_key_for_signatures = master_key.or(existing_master_key.as_ref());
+
     if let Some(self_signing_key) = self_signing_key {
-        let mut self_signing_key_ids = self_signing_key.keys.values();
-
-        let _self_signing_key_id =
-            self_signing_key_ids
-                .next()
-                .ok_or(MatrixError::invalid_param(
-                    "Self signing key contained no key.",
-                ))?;
-
-        if self_signing_key_ids.next().is_some() {
-            return Err(MatrixError::invalid_param(
-                "Self signing key contained more than one key.",
-            )
-            .into());
-        }
+        validate_cross_signing_key(user_id, CrossSigningKeyKind::SelfSigning, self_signing_key)?;
+        verify_cross_signing_key_signature(
+            self_signing_key,
+            user_id,
+            master_key_for_signatures
+                .ok_or(MatrixError::invalid_param("Missing master signing key."))?,
+        )?;
 
         add_cross_signing_key(user_id, "self_signing", self_signing_key).await?;
     }
 
     if let Some(user_signing_key) = user_signing_key {
-        let mut user_signing_key_ids = user_signing_key.keys.values();
-
-        let _user_signing_key_id =
-            user_signing_key_ids
-                .next()
-                .ok_or(MatrixError::invalid_param(
-                    "User signing key contained no key.",
-                ))?;
-
-        if user_signing_key_ids.next().is_some() {
-            return Err(MatrixError::invalid_param(
-                "User signing key contained more than one key.",
-            )
-            .into());
-        }
+        validate_cross_signing_key(user_id, CrossSigningKeyKind::UserSigning, user_signing_key)?;
+        verify_cross_signing_key_signature(
+            user_signing_key,
+            user_id,
+            master_key_for_signatures
+                .ok_or(MatrixError::invalid_param("Missing master signing key."))?,
+        )?;
 
         add_cross_signing_key(user_id, "user_signing", user_signing_key).await?;
     }
@@ -388,6 +383,140 @@ pub async fn add_cross_signing_key_updates(
     if notify {
         mark_signing_key_update(user_id).await?;
     }
+
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum CrossSigningKeyKind {
+    Master,
+    SelfSigning,
+    UserSigning,
+}
+
+impl CrossSigningKeyKind {
+    fn matches_usage(self, usage: &KeyUsage) -> bool {
+        matches!(
+            (self, usage),
+            (Self::Master, KeyUsage::Master)
+                | (Self::SelfSigning, KeyUsage::SelfSigning)
+                | (Self::UserSigning, KeyUsage::UserSigning)
+        )
+    }
+
+    fn display_name(self) -> &'static str {
+        match self {
+            Self::Master => "Master",
+            Self::SelfSigning => "Self signing",
+            Self::UserSigning => "User signing",
+        }
+    }
+}
+
+fn validate_cross_signing_key(
+    user_id: &UserId,
+    kind: CrossSigningKeyKind,
+    key: &CrossSigningKey,
+) -> AppResult<()> {
+    if &key.user_id != user_id {
+        return Err(MatrixError::invalid_param(format!(
+            "{} key user_id does not match the authenticated user.",
+            kind.display_name()
+        ))
+        .into());
+    }
+
+    if key.usage.len() != 1 || !key.usage.iter().any(|usage| kind.matches_usage(usage)) {
+        return Err(MatrixError::invalid_param(format!(
+            "{} key contained invalid usage.",
+            kind.display_name()
+        ))
+        .into());
+    }
+
+    if key.keys.len() != 1 {
+        return Err(MatrixError::invalid_param(format!(
+            "{} key must contain exactly one key.",
+            kind.display_name()
+        ))
+        .into());
+    }
+
+    let (key_id, public_key) = key
+        .keys
+        .iter()
+        .next()
+        .expect("cross-signing key length checked above");
+    if key_id.algorithm() != DeviceKeyAlgorithm::Ed25519 {
+        return Err(MatrixError::invalid_param(format!(
+            "{} key must use ed25519.",
+            kind.display_name()
+        ))
+        .into());
+    }
+    let _: Base64 = Base64::parse(public_key).map_err(|_| {
+        MatrixError::invalid_param(format!(
+            "{} key contained an invalid public key.",
+            kind.display_name()
+        ))
+    })?;
+
+    Ok(())
+}
+
+fn verify_cross_signing_key_signature(
+    signed_key: &CrossSigningKey,
+    signer_user_id: &UserId,
+    signer_key: &CrossSigningKey,
+) -> AppResult<()> {
+    let signer_signatures =
+        signed_key
+            .signatures
+            .get(signer_user_id)
+            .ok_or(MatrixError::invalid_param(
+                "Missing cross-signing key signature.",
+            ))?;
+    let mut public_keys = PublicKeySet::new();
+    for (key_id, public_key) in &signer_key.keys {
+        if signer_signatures.contains_key(key_id) {
+            public_keys.insert(
+                key_id.to_string(),
+                Base64::parse(public_key).map_err(|_| {
+                    MatrixError::invalid_param("Master key contained an invalid public key.")
+                })?,
+            );
+        }
+    }
+    if public_keys.is_empty() {
+        return Err(
+            MatrixError::invalid_param("Missing signature from the user's master key.").into(),
+        );
+    }
+
+    let mut value = serde_json::to_value(signed_key)?;
+    let Some(object) = value.as_object_mut() else {
+        return Err(MatrixError::invalid_param("Invalid cross-signing key.").into());
+    };
+    let mut signatures = serde_json::Map::new();
+    signatures.insert(
+        signer_user_id.to_string(),
+        JsonValue::Object(
+            serde_json::to_value(signer_signatures)?
+                .as_object()
+                .cloned()
+                .ok_or(MatrixError::invalid_param(
+                    "Invalid cross-signing key signatures.",
+                ))?,
+        ),
+    );
+    object.insert("signatures".to_owned(), JsonValue::Object(signatures));
+    let object: CanonicalJsonObject = serde_json::from_value(value)
+        .map_err(|_| MatrixError::invalid_param("Invalid cross-signing key canonical JSON."))?;
+
+    let mut public_key_map = PublicKeyMap::new();
+    public_key_map.insert(signer_user_id.to_string(), public_keys);
+    signatures::verify_json(&public_key_map, &object)
+        .map_err(|_| MatrixError::invalid_param("Invalid cross-signing key signature."))?;
 
     Ok(())
 }

--- a/crates/server/src/user/key.rs
+++ b/crates/server/src/user/key.rs
@@ -154,6 +154,22 @@ pub async fn query_keys<F: Fn(&UserId) -> bool + Send + Sync>(
                 }
 
                 self_signing_keys.extend(response.self_signing_keys);
+                for (user_id, devices) in &response.device_keys {
+                    for (device_id, keys) in devices {
+                        if &keys.user_id != user_id || &keys.device_id != device_id {
+                            back_off(server.to_owned());
+                            failures.insert(server.to_string(), json!({}));
+                            continue;
+                        }
+                        if data::user::key::add_device_keys(user_id, device_id, keys)
+                            .await
+                            .is_err()
+                        {
+                            back_off(server.to_owned());
+                            failures.insert(server.to_string(), json!({}));
+                        }
+                    }
+                }
                 device_keys.extend(response.device_keys);
             }
             _ => {

--- a/crates/server/src/user/key.rs
+++ b/crates/server/src/user/key.rs
@@ -253,7 +253,7 @@ pub async fn get_allowed_master_key(
     user_id: &UserId,
     allowed_signatures: &(dyn Fn(&UserId) -> bool + Send + Sync),
 ) -> AppResult<Option<CrossSigningKey>> {
-    let key_data = data::user::key::get_cross_signing_key(user_id, "master").await?;
+    let key_data = data::user::key::get_cross_signing_key_and_sigs(user_id, "master").await?;
     if let Some(mut key_data) = key_data {
         clean_signatures(&mut key_data, sender_id, user_id, allowed_signatures)?;
         Ok(serde_json::from_value(key_data).ok())
@@ -275,7 +275,7 @@ pub async fn get_allowed_self_signing_key(
     user_id: &UserId,
     allowed_signatures: &(dyn Fn(&UserId) -> bool + Send + Sync),
 ) -> AppResult<Option<CrossSigningKey>> {
-    let key_data = data::user::key::get_cross_signing_key(user_id, "self_signing").await?;
+    let key_data = data::user::key::get_cross_signing_key_and_sigs(user_id, "self_signing").await?;
     if let Some(mut key_data) = key_data {
         clean_signatures(&mut key_data, sender_id, user_id, allowed_signatures)?;
         Ok(serde_json::from_value(key_data).ok())


### PR DESCRIPTION
## Summary
- add a constructor for key-signature upload failures and return per-key failures instead of a fixed empty map
- validate uploaded key signatures against known local signing keys before persisting them
- require self-signing and user-signing key uploads to verify against the user's master key
- include stored cross-signing signatures when returning cross-signing keys
- mark the E2EE cross-signing item in `_improve.md` as handled

## Validation
- `git diff --check`
- `cargo check -p palpo --bin palpo -j 1`