### PR TITLE
Preserve account data deletion sync events

### DIFF
--- a/crates/data/migrations/2026-06-20-042500_user_data_delete_marker/down.sql
+++ b/crates/data/migrations/2026-06-20-042500_user_data_delete_marker/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_datas
+    DROP COLUMN is_deleted;

--- a/crates/data/migrations/2026-06-20-042500_user_data_delete_marker/up.sql
+++ b/crates/data/migrations/2026-06-20-042500_user_data_delete_marker/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_datas
+    ADD COLUMN is_deleted BOOLEAN NOT NULL DEFAULT FALSE;

--- a/crates/data/src/schema.rs
+++ b/crates/data/src/schema.rs
@@ -838,6 +838,7 @@ diesel::table! {
         room_id -> Nullable<Text>,
         data_type -> Text,
         json_data -> Json,
+        is_deleted -> Bool,
         occur_sn -> Int8,
         created_at -> Int8,
     }

--- a/crates/data/src/user/data.rs
+++ b/crates/data/src/user/data.rs
@@ -11,12 +11,6 @@ use crate::core::{Seqnum, UnixMillis};
 use crate::schema::*;
 use crate::{DataResult, connect};
 
-fn is_account_data_tombstone(json_data: &JsonValue) -> bool {
-    json_data
-        .as_object()
-        .is_some_and(|content| content.is_empty())
-}
-
 #[derive(Identifiable, Queryable, Debug, Clone)]
 #[diesel(table_name = user_datas)]
 pub struct DbUserData {
@@ -25,6 +19,7 @@ pub struct DbUserData {
     pub room_id: Option<OwnedRoomId>,
     pub data_type: String,
     pub json_data: JsonValue,
+    pub is_deleted: bool,
     pub occur_sn: i64,
     pub created_at: UnixMillis,
 }
@@ -35,6 +30,7 @@ pub struct NewDbUserData {
     pub room_id: Option<OwnedRoomId>,
     pub data_type: String,
     pub json_data: JsonValue,
+    pub is_deleted: bool,
     pub occur_sn: Option<i64>,
     pub created_at: UnixMillis,
 }
@@ -74,6 +70,7 @@ pub async fn set_data(
     };
 
     if let Some(existing) = &existing
+        && !existing.is_deleted
         && existing.json_data == json_data
     {
         return Ok(existing.clone());
@@ -83,6 +80,7 @@ pub async fn set_data(
         diesel::update(user_datas::table.find(existing.id))
             .set((
                 user_datas::json_data.eq(&json_data),
+                user_datas::is_deleted.eq(false),
                 user_datas::occur_sn.eq(crate::next_sn().await?),
                 user_datas::created_at.eq(UnixMillis::now()),
             ))
@@ -95,6 +93,7 @@ pub async fn set_data(
             room_id: room_id.clone(),
             data_type: event_type.to_owned(),
             json_data,
+            is_deleted: false,
             occur_sn: Some(crate::next_sn().await?),
             created_at: UnixMillis::now(),
         };
@@ -123,7 +122,7 @@ pub async fn get_data<E: DeserializeOwned>(
         .order_by(user_datas::id.desc())
         .first::<DbUserData>(&mut connect().await?)
         .await?;
-    if is_account_data_tombstone(&row.json_data) {
+    if row.is_deleted {
         return Err(diesel::result::Error::NotFound.into());
     }
     Ok(serde_json::from_value(row.json_data)?)
@@ -145,7 +144,7 @@ pub async fn get_room_data<E: DeserializeOwned>(
         .await
         .optional()?;
     if let Some(row) = row {
-        if is_account_data_tombstone(&row.json_data) {
+        if row.is_deleted {
             return Ok(None);
         }
         Ok(Some(serde_json::from_value(row.json_data)?))
@@ -168,7 +167,7 @@ pub async fn get_global_data<E: DeserializeOwned>(
         .await
         .optional()?;
     if let Some(row) = row {
-        if is_account_data_tombstone(&row.json_data) {
+        if row.is_deleted {
             return Ok(None);
         }
         Ok(Some(serde_json::from_value(row.json_data)?))
@@ -202,13 +201,14 @@ pub async fn delete_global_data(user_id: &UserId, kind: &str) -> DataResult<()> 
     .execute(&mut conn)
     .await?;
 
-    if is_account_data_tombstone(&existing.json_data) {
+    if existing.is_deleted {
         return Ok(());
     }
 
     diesel::update(user_datas::table.find(existing.id))
         .set((
             user_datas::json_data.eq(json!({})),
+            user_datas::is_deleted.eq(true),
             user_datas::occur_sn.eq(crate::next_sn().await?),
             user_datas::created_at.eq(UnixMillis::now()),
         ))
@@ -233,12 +233,18 @@ pub async fn get_global_account_data(user_id: &UserId) -> DataResult<HashMap<Str
     user_datas::table
         .filter(user_datas::user_id.eq(user_id))
         .filter(user_datas::room_id.is_null())
-        .select((user_datas::data_type, user_datas::json_data))
-        .load::<(String, JsonValue)>(&mut connect().await?)
+        .select((
+            user_datas::data_type,
+            user_datas::json_data,
+            user_datas::is_deleted,
+        ))
+        .load::<(String, JsonValue, bool)>(&mut connect().await?)
         .await
         .map(|rows| {
             rows.into_iter()
-                .filter(|(_, json_data)| !is_account_data_tombstone(json_data))
+                .filter_map(|(data_type, json_data, is_deleted)| {
+                    (!is_deleted).then_some((data_type, json_data))
+                })
                 .collect()
         })
         .map_err(Into::into)
@@ -255,14 +261,15 @@ pub async fn get_room_account_data(
             user_datas::room_id,
             user_datas::data_type,
             user_datas::json_data,
+            user_datas::is_deleted,
         ))
-        .load::<(Option<OwnedRoomId>, String, JsonValue)>(&mut connect().await?)
+        .load::<(Option<OwnedRoomId>, String, JsonValue, bool)>(&mut connect().await?)
         .await?;
 
     let mut result = HashMap::new();
-    for (room_id, data_type, json_data) in rows {
+    for (room_id, data_type, json_data, is_deleted) in rows {
         if let Some(room_id) = room_id {
-            if is_account_data_tombstone(&json_data) {
+            if is_deleted {
                 continue;
             }
             result
@@ -307,7 +314,7 @@ pub async fn data_changes(
     };
 
     for db_data in db_datas {
-        if since_sn == 0 && is_account_data_tombstone(&db_data.json_data) {
+        if since_sn == 0 && db_data.is_deleted {
             continue;
         }
         let kind = RoomAccountDataEventType::from(&*db_data.data_type);

--- a/crates/data/src/user/data.rs
+++ b/crates/data/src/user/data.rs
@@ -111,17 +111,38 @@ pub async fn get_data<E: DeserializeOwned>(
     room_id: Option<&RoomId>,
     kind: &str,
 ) -> DataResult<E> {
-    let row = user_datas::table
-        .filter(user_datas::user_id.eq(user_id))
-        .filter(
-            user_datas::room_id
-                .eq(room_id)
-                .or(user_datas::room_id.is_null()),
-        )
-        .filter(user_datas::data_type.eq(kind))
-        .order_by(user_datas::id.desc())
-        .first::<DbUserData>(&mut connect().await?)
-        .await?;
+    let mut conn = connect().await?;
+    let row = if let Some(room_id) = room_id {
+        let room_row = user_datas::table
+            .filter(user_datas::user_id.eq(user_id))
+            .filter(user_datas::room_id.eq(room_id))
+            .filter(user_datas::data_type.eq(kind))
+            .order_by(user_datas::id.desc())
+            .first::<DbUserData>(&mut conn)
+            .await
+            .optional()?;
+
+        if let Some(row) = room_row {
+            row
+        } else {
+            user_datas::table
+                .filter(user_datas::user_id.eq(user_id))
+                .filter(user_datas::room_id.is_null())
+                .filter(user_datas::data_type.eq(kind))
+                .order_by(user_datas::id.desc())
+                .first::<DbUserData>(&mut conn)
+                .await?
+        }
+    } else {
+        user_datas::table
+            .filter(user_datas::user_id.eq(user_id))
+            .filter(user_datas::room_id.is_null())
+            .filter(user_datas::data_type.eq(kind))
+            .order_by(user_datas::id.desc())
+            .first::<DbUserData>(&mut conn)
+            .await?
+    };
+
     if row.is_deleted {
         return Err(diesel::result::Error::NotFound.into());
     }

--- a/crates/data/src/user/data.rs
+++ b/crates/data/src/user/data.rs
@@ -11,6 +11,12 @@ use crate::core::{Seqnum, UnixMillis};
 use crate::schema::*;
 use crate::{DataResult, connect};
 
+fn is_account_data_tombstone(json_data: &JsonValue) -> bool {
+    json_data
+        .as_object()
+        .is_some_and(|content| content.is_empty())
+}
+
 #[derive(Identifiable, Queryable, Debug, Clone)]
 #[diesel(table_name = user_datas)]
 pub struct DbUserData {
@@ -117,6 +123,9 @@ pub async fn get_data<E: DeserializeOwned>(
         .order_by(user_datas::id.desc())
         .first::<DbUserData>(&mut connect().await?)
         .await?;
+    if is_account_data_tombstone(&row.json_data) {
+        return Err(diesel::result::Error::NotFound.into());
+    }
     Ok(serde_json::from_value(row.json_data)?)
 }
 
@@ -136,6 +145,9 @@ pub async fn get_room_data<E: DeserializeOwned>(
         .await
         .optional()?;
     if let Some(row) = row {
+        if is_account_data_tombstone(&row.json_data) {
+            return Ok(None);
+        }
         Ok(Some(serde_json::from_value(row.json_data)?))
     } else {
         Ok(None)
@@ -156,6 +168,9 @@ pub async fn get_global_data<E: DeserializeOwned>(
         .await
         .optional()?;
     if let Some(row) = row {
+        if is_account_data_tombstone(&row.json_data) {
+            return Ok(None);
+        }
         Ok(Some(serde_json::from_value(row.json_data)?))
     } else {
         Ok(None)
@@ -163,14 +178,43 @@ pub async fn get_global_data<E: DeserializeOwned>(
 }
 
 pub async fn delete_global_data(user_id: &UserId, kind: &str) -> DataResult<()> {
+    let mut conn = connect().await?;
+    let existing = user_datas::table
+        .filter(user_datas::user_id.eq(user_id))
+        .filter(user_datas::room_id.is_null())
+        .filter(user_datas::data_type.eq(kind))
+        .order_by(user_datas::id.desc())
+        .first::<DbUserData>(&mut conn)
+        .await
+        .optional()?;
+
+    let Some(existing) = existing else {
+        return Ok(());
+    };
+
     diesel::delete(
         user_datas::table
             .filter(user_datas::user_id.eq(user_id))
             .filter(user_datas::room_id.is_null())
-            .filter(user_datas::data_type.eq(kind)),
+            .filter(user_datas::data_type.eq(kind))
+            .filter(user_datas::id.ne(existing.id)),
     )
-    .execute(&mut connect().await?)
+    .execute(&mut conn)
     .await?;
+
+    if is_account_data_tombstone(&existing.json_data) {
+        return Ok(());
+    }
+
+    diesel::update(user_datas::table.find(existing.id))
+        .set((
+            user_datas::json_data.eq(json!({})),
+            user_datas::occur_sn.eq(crate::next_sn().await?),
+            user_datas::created_at.eq(UnixMillis::now()),
+        ))
+        .execute(&mut conn)
+        .await?;
+
     Ok(())
 }
 
@@ -192,7 +236,11 @@ pub async fn get_global_account_data(user_id: &UserId) -> DataResult<HashMap<Str
         .select((user_datas::data_type, user_datas::json_data))
         .load::<(String, JsonValue)>(&mut connect().await?)
         .await
-        .map(|rows| rows.into_iter().collect())
+        .map(|rows| {
+            rows.into_iter()
+                .filter(|(_, json_data)| !is_account_data_tombstone(json_data))
+                .collect()
+        })
         .map_err(Into::into)
 }
 
@@ -214,6 +262,9 @@ pub async fn get_room_account_data(
     let mut result = HashMap::new();
     for (room_id, data_type, json_data) in rows {
         if let Some(room_id) = room_id {
+            if is_account_data_tombstone(&json_data) {
+                continue;
+            }
             result
                 .entry(room_id.to_string())
                 .or_insert_with(HashMap::new)
@@ -256,6 +307,9 @@ pub async fn data_changes(
     };
 
     for db_data in db_datas {
+        if since_sn == 0 && is_account_data_tombstone(&db_data.json_data) {
+            continue;
+        }
         let kind = RoomAccountDataEventType::from(&*db_data.data_type);
         let account_data = json!({
             "type": kind,

--- a/crates/server/src/routing/client/account.rs
+++ b/crates/server/src/routing/client/account.rs
@@ -157,13 +157,16 @@ pub(super) async fn delete_account_data_msc3391(
     let authed = depot.authed_info()?;
     let user_id = user_id.into_inner();
     if &user_id != authed.user_id() {
-        return Err(MatrixError::forbidden(
-            "Cannot delete account data for another user.",
-            None,
-        )
-        .into());
+        return Err(
+            MatrixError::forbidden("Cannot delete account data for another user.", None).into(),
+        );
     }
 
-    data::user::delete_global_data(authed.user_id(), &account_type.into_inner()).await?;
+    let account_type = account_type.into_inner();
+    if account_type == "m.ignored_user_list" {
+        data::user::set_ignored_users(authed.user_id(), &[]).await?;
+    }
+
+    data::user::delete_global_data(authed.user_id(), &account_type).await?;
     empty_ok()
 }

--- a/crates/server/src/routing/client/user/account.rs
+++ b/crates/server/src/routing/client/user/account.rs
@@ -57,7 +57,12 @@ pub(super) async fn set_global_data(
         data::user::set_ignored_users(authed.user_id(), &ignored_ids).await?;
     }
 
-    data::user::set_data(authed.user_id(), None, &event_type, body).await?;
+    if body.as_object().is_some_and(|content| content.is_empty()) {
+        data::user::delete_global_data(authed.user_id(), &event_type).await?;
+    } else {
+        data::user::set_data(authed.user_id(), None, &event_type, body).await?;
+    }
+
     empty_ok()
 }
 


### PR DESCRIPTION
## Summary
- store MSC3391 global account-data deletes as `{}` tombstone updates with fresh stream positions instead of hard-deleting the active row
- treat tombstone account-data rows as absent for direct reads, initial sync, and admin account-data snapshots while still emitting them on incremental sync
- clear the mirrored `user_ignores` rows when deleting `m.ignored_user_list`, and route `PUT {}` through the same delete semantics

## Validation
- `git diff --check`
- `cargo check -p palpo --bin palpo -j 1`

Follow-up for review feedback on #257.