### PR TITLE
Update Salvo to 0.94.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5148,8 +5148,8 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "salvo"
-version = "0.93.0"
-source = "git+https://github.com/salvo-rs/salvo.git?branch=main#41e57e035b0264761e4df1ba496f49a93bd6fa81"
+version = "0.94.0"
+source = "git+https://github.com/salvo-rs/salvo.git?branch=main#4d3106152404aac332fbeae2ba1cd642aee0df49"
 dependencies = [
  "salvo-compression",
  "salvo-cors",
@@ -5163,8 +5163,8 @@ dependencies = [
 
 [[package]]
 name = "salvo-compression"
-version = "0.93.0"
-source = "git+https://github.com/salvo-rs/salvo.git?branch=main#41e57e035b0264761e4df1ba496f49a93bd6fa81"
+version = "0.94.0"
+source = "git+https://github.com/salvo-rs/salvo.git?branch=main#4d3106152404aac332fbeae2ba1cd642aee0df49"
 dependencies = [
  "brotli",
  "bytes",
@@ -5172,6 +5172,7 @@ dependencies = [
  "futures-util",
  "indexmap",
  "salvo_core",
+ "smallvec",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5180,8 +5181,8 @@ dependencies = [
 
 [[package]]
 name = "salvo-cors"
-version = "0.93.0"
-source = "git+https://github.com/salvo-rs/salvo.git?branch=main#41e57e035b0264761e4df1ba496f49a93bd6fa81"
+version = "0.94.0"
+source = "git+https://github.com/salvo-rs/salvo.git?branch=main#4d3106152404aac332fbeae2ba1cd642aee0df49"
 dependencies = [
  "bytes",
  "salvo_core",
@@ -5190,8 +5191,8 @@ dependencies = [
 
 [[package]]
 name = "salvo-jwt-auth"
-version = "0.93.0"
-source = "git+https://github.com/salvo-rs/salvo.git?branch=main#41e57e035b0264761e4df1ba496f49a93bd6fa81"
+version = "0.94.0"
+source = "git+https://github.com/salvo-rs/salvo.git?branch=main#4d3106152404aac332fbeae2ba1cd642aee0df49"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5209,8 +5210,8 @@ dependencies = [
 
 [[package]]
 name = "salvo-oapi"
-version = "0.93.0"
-source = "git+https://github.com/salvo-rs/salvo.git?branch=main#41e57e035b0264761e4df1ba496f49a93bd6fa81"
+version = "0.94.0"
+source = "git+https://github.com/salvo-rs/salvo.git?branch=main#4d3106152404aac332fbeae2ba1cd642aee0df49"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5243,22 +5244,22 @@ dependencies = [
 
 [[package]]
 name = "salvo-oapi-macros"
-version = "0.93.0"
-source = "git+https://github.com/salvo-rs/salvo.git?branch=main#41e57e035b0264761e4df1ba496f49a93bd6fa81"
+version = "0.94.0"
+source = "git+https://github.com/salvo-rs/salvo.git?branch=main#4d3106152404aac332fbeae2ba1cd642aee0df49"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "regex",
  "salvo-serde-util",
+ "salvo_core",
  "syn 2.0.118",
 ]
 
 [[package]]
 name = "salvo-proxy"
-version = "0.93.0"
-source = "git+https://github.com/salvo-rs/salvo.git?branch=main#41e57e035b0264761e4df1ba496f49a93bd6fa81"
+version = "0.94.0"
+source = "git+https://github.com/salvo-rs/salvo.git?branch=main#4d3106152404aac332fbeae2ba1cd642aee0df49"
 dependencies = [
  "fastrand",
  "futures-util",
@@ -5274,8 +5275,8 @@ dependencies = [
 
 [[package]]
 name = "salvo-serde-util"
-version = "0.93.0"
-source = "git+https://github.com/salvo-rs/salvo.git?branch=main#41e57e035b0264761e4df1ba496f49a93bd6fa81"
+version = "0.94.0"
+source = "git+https://github.com/salvo-rs/salvo.git?branch=main#4d3106152404aac332fbeae2ba1cd642aee0df49"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5284,8 +5285,8 @@ dependencies = [
 
 [[package]]
 name = "salvo-serve-static"
-version = "0.93.0"
-source = "git+https://github.com/salvo-rs/salvo.git?branch=main#41e57e035b0264761e4df1ba496f49a93bd6fa81"
+version = "0.94.0"
+source = "git+https://github.com/salvo-rs/salvo.git?branch=main#4d3106152404aac332fbeae2ba1cd642aee0df49"
 dependencies = [
  "hex",
  "mime",
@@ -5303,8 +5304,8 @@ dependencies = [
 
 [[package]]
 name = "salvo_core"
-version = "0.93.0"
-source = "git+https://github.com/salvo-rs/salvo.git?branch=main#41e57e035b0264761e4df1ba496f49a93bd6fa81"
+version = "0.94.0"
+source = "git+https://github.com/salvo-rs/salvo.git?branch=main#4d3106152404aac332fbeae2ba1cd642aee0df49"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5354,8 +5355,8 @@ dependencies = [
 
 [[package]]
 name = "salvo_extra"
-version = "0.93.0"
-source = "git+https://github.com/salvo-rs/salvo.git?branch=main#41e57e035b0264761e4df1ba496f49a93bd6fa81"
+version = "0.94.0"
+source = "git+https://github.com/salvo-rs/salvo.git?branch=main#4d3106152404aac332fbeae2ba1cd642aee0df49"
 dependencies = [
  "base64 0.22.1",
  "etag",
@@ -5375,13 +5376,12 @@ dependencies = [
 
 [[package]]
 name = "salvo_macros"
-version = "0.93.0"
-source = "git+https://github.com/salvo-rs/salvo.git?branch=main#41e57e035b0264761e4df1ba496f49a93bd6fa81"
+version = "0.94.0"
+source = "git+https://github.com/salvo-rs/salvo.git?branch=main#4d3106152404aac332fbeae2ba1cd642aee0df49"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "regex",
  "salvo-serde-util",
  "syn 2.0.118",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 version = "0.4.0"
 authors = ["Chrislearn Young <chris@acroidea.com>"]
 edition = "2024"
-rust-version = "1.93"
+rust-version = "1.94"
 description = """
 Matrix server implementation
 """
@@ -99,7 +99,7 @@ rustyline-async = { version = "0.4.9" }
 regex = "1.12.3"
 reqwest = { version = "0.13.4", features = ["json", "form"] }
 ring = "0.17.14"
-salvo = { version = "0.93.0", features = ["rustls"]}
+salvo = { version = "0.94.0", features = ["rustls"]}
 sanitize-filename = "0.6.0"
 scheduled-thread-pool = "0.2.7"
 secrecy = "0.10.3"

--- a/crates/server/src/exts.rs
+++ b/crates/server/src/exts.rs
@@ -14,7 +14,7 @@ pub trait DepotExt {
 }
 impl DepotExt for Depot {
     fn authed_info(&self) -> AppResult<&AuthedInfo> {
-        self.obtain::<AuthedInfo>()
+        self.get_typed::<AuthedInfo>()
             .map_err(|_| StatusError::unauthorized().into())
     }
     fn set_origin(&mut self, origin: OwnedServerName) {
@@ -25,7 +25,7 @@ impl DepotExt for Depot {
             .map_err(|_| StatusError::unauthorized().into())
     }
     fn take_authed_info(&mut self) -> AppResult<AuthedInfo> {
-        self.scrape::<AuthedInfo>()
+        self.remove_typed::<AuthedInfo>()
             .map_err(|_| StatusError::unauthorized().into())
     }
 }

--- a/crates/server/src/hoops/auth.rs
+++ b/crates/server/src/hoops/auth.rs
@@ -87,7 +87,7 @@ async fn auth_by_local_token(token: &str, aa: &AuthArgs, depot: &mut Depot) -> A
     }) = token_auth
     {
         crate::user::ensure_account_usable(&user)?;
-        depot.inject(AuthedInfo {
+        depot.insert_typed(AuthedInfo {
             user,
             user_device: device,
             access_token_id: Some(access_token_id),
@@ -139,7 +139,7 @@ async fn auth_by_local_token(token: &str, aa: &AuthArgs, depot: &mut Depot) -> A
                 };
 
                 crate::user::ensure_account_usable(&user)?;
-                depot.inject(AuthedInfo {
+                depot.insert_typed(AuthedInfo {
                     user,
                     user_device,
                     access_token_id: None,
@@ -211,7 +211,7 @@ async fn auth_by_delegated_token(token: &str, aa: &AuthArgs, depot: &mut Depot) 
             .map_err(|_| MatrixError::unknown_token("No device found for user", true))?
     };
 
-    depot.inject(AuthedInfo {
+    depot.insert_typed(AuthedInfo {
         user,
         user_device,
         access_token_id: None,


### PR DESCRIPTION
## Summary

- Bump the workspace Salvo dependency from `0.93.0` to `0.94.0` and refresh the Salvo lockfile entries.
- Update the workspace Rust version to `1.94` because Salvo `0.94.0` requires Rust `1.94`.
- Replace deprecated Salvo depot calls with the typed API (`insert_typed`, `get_typed`, `remove_typed`).

## Impact

This keeps Palpo on the newer Salvo release while preserving the existing authentication depot behavior. Consumers and CI need a Rust toolchain at `1.94` or newer.

## Validation

- `cargo check --workspace`