### PR TITLE
Fix default SSRF denylist

### DIFF
--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -139,9 +139,18 @@ fn kdl_node_to_json(node: &KdlNode) -> serde_json::Value {
         .collect();
 
     if let Some(children) = node.children() {
+        // An empty child block is the KDL representation of an explicitly
+        // empty list. This is distinct from omitting the node, which allows
+        // serde defaults to apply.
+        if children.nodes().is_empty() && args.is_empty() && props.is_empty() {
+            return serde_json::Value::Array(Vec::new());
+        }
+
         // Check if all children are dash nodes (KDL array convention)
-        let all_dashes = !children.nodes().is_empty()
-            && children.nodes().iter().all(|n| n.name().to_string() == "-");
+        let all_dashes = children
+            .nodes()
+            .iter()
+            .all(|n| n.name().to_string() == "-");
         if all_dashes {
             let arr: Vec<serde_json::Value> =
                 children.nodes().iter().map(kdl_node_to_json).collect();
@@ -193,6 +202,26 @@ fn kdl_value_to_json(value: &KdlValue) -> serde_json::Value {
         serde_json::Value::Bool(b)
     } else {
         serde_json::Value::Null
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use kdl::KdlDocument;
+    use serde_json::json;
+
+    use super::kdl_doc_to_json;
+
+    #[test]
+    fn empty_kdl_block_is_an_explicit_empty_list() {
+        let doc: KdlDocument = "ip_range_denylist {\n}"
+            .parse()
+            .expect("empty KDL list should parse");
+
+        assert_eq!(
+            kdl_doc_to_json(&doc),
+            json!({ "ip_range_denylist": [] })
+        );
     }
 }
 

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -207,10 +207,12 @@ fn kdl_value_to_json(value: &KdlValue) -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use kdl::KdlDocument;
     use serde_json::json;
 
-    use super::kdl_doc_to_json;
+    use super::{ServerConfig, figment_from_path, kdl_doc_to_json};
 
     #[test]
     fn empty_kdl_block_is_an_explicit_empty_list() {
@@ -222,6 +224,17 @@ mod tests {
             kdl_doc_to_json(&doc),
             json!({ "ip_range_denylist": [] })
         );
+    }
+
+    #[test]
+    fn complement_toml_preserves_empty_denylist_opt_out() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/complement/palpo.toml");
+        let config = figment_from_path(path)
+            .extract::<ServerConfig>()
+            .expect("Complement TOML should deserialize");
+
+        assert!(config.ip_range_denylist.is_empty());
     }
 }
 

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -147,10 +147,7 @@ fn kdl_node_to_json(node: &KdlNode) -> serde_json::Value {
         }
 
         // Check if all children are dash nodes (KDL array convention)
-        let all_dashes = children
-            .nodes()
-            .iter()
-            .all(|n| n.name().to_string() == "-");
+        let all_dashes = children.nodes().iter().all(|n| n.name().to_string() == "-");
         if all_dashes {
             let arr: Vec<serde_json::Value> =
                 children.nodes().iter().map(kdl_node_to_json).collect();
@@ -220,16 +217,12 @@ mod tests {
             .parse()
             .expect("empty KDL list should parse");
 
-        assert_eq!(
-            kdl_doc_to_json(&doc),
-            json!({ "ip_range_denylist": [] })
-        );
+        assert_eq!(kdl_doc_to_json(&doc), json!({ "ip_range_denylist": [] }));
     }
 
     #[test]
     fn complement_toml_preserves_empty_denylist_opt_out() {
-        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../../tests/complement/palpo.toml");
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/complement/palpo.toml");
         let config = figment_from_path(path)
             .extract::<ServerConfig>()
             .expect("Complement TOML should deserialize");

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -202,35 +202,6 @@ fn kdl_value_to_json(value: &KdlValue) -> serde_json::Value {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use std::path::Path;
-
-    use kdl::KdlDocument;
-    use serde_json::json;
-
-    use super::{ServerConfig, figment_from_path, kdl_doc_to_json};
-
-    #[test]
-    fn empty_kdl_block_is_an_explicit_empty_list() {
-        let doc: KdlDocument = "ip_range_denylist {\n}"
-            .parse()
-            .expect("empty KDL list should parse");
-
-        assert_eq!(kdl_doc_to_json(&doc), json!({ "ip_range_denylist": [] }));
-    }
-
-    #[test]
-    fn complement_toml_preserves_empty_denylist_opt_out() {
-        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/complement/palpo.toml");
-        let config = figment_from_path(path)
-            .extract::<ServerConfig>()
-            .expect("Complement TOML should deserialize");
-
-        assert!(config.ip_range_denylist.is_empty());
-    }
-}
-
 pub fn init(config_path: impl AsRef<Path>) {
     let config_path = config_path.as_ref();
     if !config_path.exists() {
@@ -368,4 +339,33 @@ pub fn available_room_versions() -> impl Iterator<Item = RoomVersion> {
 #[inline]
 fn supported_stability(stability: &RoomVersionStability) -> bool {
     get().allow_unstable_room_versions || *stability == RoomVersionStability::Stable
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use kdl::KdlDocument;
+    use serde_json::json;
+
+    use super::{ServerConfig, figment_from_path, kdl_doc_to_json};
+
+    #[test]
+    fn empty_kdl_block_is_an_explicit_empty_list() {
+        let doc: KdlDocument = "ip_range_denylist {\n}"
+            .parse()
+            .expect("empty KDL list should parse");
+
+        assert_eq!(kdl_doc_to_json(&doc), json!({ "ip_range_denylist": [] }));
+    }
+
+    #[test]
+    fn complement_toml_preserves_empty_denylist_opt_out() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/complement/palpo.toml");
+        let config = figment_from_path(path)
+            .extract::<ServerConfig>()
+            .expect("Complement TOML should deserialize");
+
+        assert!(config.ip_range_denylist.is_empty());
+    }
 }

--- a/crates/server/src/config/server.rs
+++ b/crates/server/src/config/server.rs
@@ -585,8 +585,8 @@ pub struct ServerConfig {
     ///
     /// Currently this does not account for proxies in use like Synapse does.
     ///
-    /// To disable, set this to be an empty vector (`[]`) or omit the field.
-    /// If omitted, no IP range filtering is performed (use a firewall instead).
+    /// To disable, set this to be an empty vector (`[]`). If omitted, the
+    /// default denylist below is used.
     ///
     /// A safer recommended set is:
     /// ["127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12",
@@ -594,7 +594,7 @@ pub struct ServerConfig {
     /// "192.88.99.0/24", "198.18.0.0/15", "192.0.2.0/24", "198.51.100.0/24",
     /// "203.0.113.0/24", "224.0.0.0/4", "::1/128", "fe80::/10", "fc00::/7",
     /// "2001:db8::/32", "ff00::/8", "fec0::/10"]
-    #[serde(default)]
+    #[serde(default = "default_ip_range_denylist")]
     pub ip_range_denylist: Vec<String>,
 
     // pub auto_acme: Option<AcmeConfig>,
@@ -1408,7 +1408,9 @@ fn default_rc_message() -> RateLimitConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{default_openid_token_ttl, default_request_idle_per_host};
+    use super::{
+        default_ip_range_denylist, default_openid_token_ttl, default_request_idle_per_host,
+    };
 
     #[test]
     fn openid_token_ttl_default_is_seconds() {
@@ -1418,5 +1420,16 @@ mod tests {
     #[test]
     fn request_idle_per_host_matches_documented_default() {
         assert_eq!(default_request_idle_per_host(), 1);
+    }
+
+    #[test]
+    fn ip_range_denylist_default_blocks_internal_ranges() {
+        let denylist = default_ip_range_denylist();
+
+        assert!(denylist.contains(&"127.0.0.0/8".to_owned()));
+        assert!(denylist.contains(&"10.0.0.0/8".to_owned()));
+        assert!(denylist.contains(&"192.168.0.0/16".to_owned()));
+        assert!(denylist.contains(&"::1/128".to_owned()));
+        assert!(denylist.contains(&"fc00::/7".to_owned()));
     }
 }

--- a/crates/server/src/event/pdu.rs
+++ b/crates/server/src/event/pdu.rs
@@ -962,8 +962,7 @@ impl PduBuilder {
             );
         }
 
-        let temp_event_id =
-            OwnedEventId::try_from(format!("$backfill_{}", Ulid::r#gen())).unwrap();
+        let temp_event_id = OwnedEventId::try_from(format!("$backfill_{}", Ulid::r#gen())).unwrap();
 
         let mut pdu = PduEvent {
             event_id: temp_event_id.clone(),

--- a/tests/complement/palpo.toml
+++ b/tests/complement/palpo.toml
@@ -41,6 +41,9 @@ trusted_servers = []
 
 appservice_registration_dir = "/complement/appservice"
 
+# Complement homeservers communicate over private Docker networks.
+ip_range_denylist = []
+
 # Disable rate limiting for Complement tests
 [rc_login]
 per_second = 9999.0
@@ -57,8 +60,6 @@ burst = 9999
 [rc_message]
 per_second = 9999.0
 burst = 9999
-
-ip_range_denylist = []
 
 [db]
 url = "postgres://postgres:postgres@127.0.0.1:5432/palpo"
@@ -89,4 +90,3 @@ ansi_colors = false
 # [keypair]
 # document = "MFECAQEwBQYDK2VwBCIEIJXK7IX/PTIr/9VrBwkdwJw+aeXjcNSSnAOetAY0Hfl/gSEAELqWFgDu6Ap47RzE1ehee2XCvGamRzu6u0N66lsgOJ0="
 # version = "1"
-


### PR DESCRIPTION
## Summary
- Enable the documented default CIDR denylist for outbound request SSRF protection. The docs claimed Palpo denied internal/loopback/multicast/testnet ranges by default, but `#[serde(default)]` made the actual default empty, silently disabling the resolver and IP-literal SSRF guard.
- Setting `ip_range_denylist = []` explicitly disables the filter; omitting the field now uses the default denylist.
- Fix KDL config parsing so an empty child block (`ip_range_denylist { }`) is treated as an explicit empty list instead of an empty object, so KDL configs can opt out too.
- Fix the Complement config opt-out: `ip_range_denylist = []` in `tests/complement/palpo.toml` was placed inside the `[rc_message]` table, so it never applied — which is why the previous CI run failed (Complement homeservers federate over private Docker networks). It now sits at the top level.

## Validation
- `cargo test -p palpo --bin palpo config` — 10 passed, including new tests for the default denylist contents, the KDL empty-block semantics, and the Complement TOML opt-out.
- `cargo clippy -p palpo --all-targets` — clean.
- `cargo +nightly fmt --all -- --check` — clean for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)