### PR TITLE
Honor configured CORS origins

### DIFF
--- a/crates/server/src/config/server.rs
+++ b/crates/server/src/config/server.rs
@@ -1051,6 +1051,19 @@ impl ServerConfig {
             );
         }
 
+        for origin in &self.allowed_origins {
+            if origin == "*" {
+                return Err(AppError::internal(
+                    "allowed_origins must be empty to allow every CORS origin; '*' cannot be mixed with an origin list",
+                ));
+            }
+            if origin.is_empty() || origin.parse::<HeaderValue>().is_err() {
+                return Err(AppError::internal(format!(
+                    "Invalid CORS origin in allowed_origins: {origin:?}",
+                )));
+            }
+        }
+
         // check if user specified valid IP CIDR ranges on startup
         for cidr in &self.ip_range_denylist {
             if let Err(_e) = ipaddress::IPAddress::parse(cidr) {

--- a/crates/server/src/hoops.rs
+++ b/crates/server/src/hoops.rs
@@ -50,61 +50,6 @@ pub async fn limit_size(
     limiter.handle(req, depot, res, ctrl).await;
 }
 
-#[handler]
-async fn access_control(
-    req: &mut Request,
-    depot: &mut Depot,
-    res: &mut Response,
-    ctrl: &mut FlowCtrl,
-) {
-    let headers = res.headers_mut();
-    let origin = req
-        .headers()
-        .get("origin")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("*");
-    let allowed_origins = &crate::config::get().allowed_origins;
-    let allow_origin = if allowed_origins.is_empty() || allowed_origins.iter().any(|o| o == origin)
-    {
-        origin.to_owned()
-    } else {
-        // If origin is not in the allowed list, don't set credentials
-        "*".to_owned()
-    };
-    headers.insert(
-        "Access-Control-Allow-Origin",
-        allow_origin
-            .parse()
-            .unwrap_or_else(|_| "*".parse().unwrap()),
-    );
-    headers.insert(
-        "Access-Control-Allow-Methods",
-        "GET,POST,PUT,DELETE,PATCH,OPTIONS".parse().unwrap(),
-    );
-    headers.insert(
-        "Access-Control-Allow-Headers",
-        "Accept,Content-Type,Authorization,Range".parse().unwrap(),
-    );
-    headers.insert(
-        "Access-Control-Expose-Headers",
-        "Access-Token,Response-Status,Content-Length,Content-Range"
-            .parse()
-            .unwrap(),
-    );
-    // Only set Allow-Credentials when origin is not wildcard
-    if allow_origin != "*" {
-        headers.insert("Access-Control-Allow-Credentials", "true".parse().unwrap());
-    }
-    headers.insert(
-        "Content-Security-Policy",
-        "frame-ancestors 'self'".parse().unwrap(),
-    );
-    headers.insert("X-Content-Type-Options", "nosniff".parse().unwrap());
-    ctrl.call_next(req, depot, res).await;
-    // headers.insert("Cross-Origin-Embedder-Policy", "require-corp".parse().unwrap());
-    // headers.insert("Cross-Origin-Opener-Policy", "same-origin".parse().unwrap());
-}
-
 /// Token-bucket rate limiter: maps IP → (available_tokens, last_check_time)
 struct RateLimiter {
     buckets: Mutex<HashMap<String, (f64, Instant)>>,

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -71,7 +71,7 @@ use salvo::catcher::Catcher;
 use salvo::compression::{Compression, CompressionLevel};
 use salvo::conn::rustls::{Keycert, RustlsConfig};
 use salvo::conn::tcp::DynTcpAcceptors;
-use salvo::cors::{self, AllowHeaders, Cors};
+use salvo::cors::{AllowHeaders, AllowOrigin, Cors, CorsHandler};
 use salvo::http::Method;
 use salvo::logging::Logger;
 use salvo::prelude::*;
@@ -93,6 +93,36 @@ pub fn cjson_ok<T>(data: T) -> CjsonResult<T> {
 }
 pub fn empty_ok() -> JsonResult<EmptyObject> {
     Ok(Json(EmptyObject {}))
+}
+
+fn cors_handler(allowed_origins: &[String]) -> CorsHandler {
+    let allow_origin = if allowed_origins.is_empty() {
+        AllowOrigin::any()
+    } else {
+        AllowOrigin::list(
+            allowed_origins
+                .iter()
+                .map(|origin| origin.parse().expect("allowed CORS origin was validated")),
+        )
+    };
+
+    Cors::new()
+        .allow_origin(allow_origin)
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
+        .allow_headers(AllowHeaders::list([
+            salvo::http::header::ACCEPT,
+            salvo::http::header::CONTENT_TYPE,
+            salvo::http::header::AUTHORIZATION,
+            salvo::http::header::RANGE,
+        ]))
+        .max_age(Duration::from_secs(86400))
+        .into_handler()
 }
 
 pub trait OptionalExtension<T> {
@@ -230,25 +260,7 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .catcher(catcher)
         .hoop(hoops::default_accept_json)
         .hoop(Logger::new())
-        .hoop(
-            Cors::new()
-                .allow_origin(cors::Any)
-                .allow_methods([
-                    Method::GET,
-                    Method::POST,
-                    Method::PUT,
-                    Method::DELETE,
-                    Method::OPTIONS,
-                ])
-                .allow_headers(AllowHeaders::list([
-                    salvo::http::header::ACCEPT,
-                    salvo::http::header::CONTENT_TYPE,
-                    salvo::http::header::AUTHORIZATION,
-                    salvo::http::header::RANGE,
-                ]))
-                .max_age(Duration::from_secs(86400))
-                .into_handler(),
-        )
+        .hoop(cors_handler(&conf.allowed_origins))
         .hoop(hoops::remove_json_utf8);
     let service = if conf.compression.is_enabled() {
         let mut compression = Compression::new();
@@ -301,4 +313,60 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .instrument(tracing::info_span!("server.serve"))
         .await;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use salvo::http::header::{ACCESS_CONTROL_ALLOW_ORIGIN, ORIGIN};
+    use salvo::test::TestClient;
+
+    use super::*;
+
+    #[handler]
+    async fn test_handler(res: &mut Response) {
+        res.render(Text::Plain("ok"));
+    }
+
+    fn service(allowed_origins: &[String]) -> Service {
+        Service::new(Router::new().get(test_handler)).hoop(cors_handler(allowed_origins))
+    }
+
+    #[tokio::test]
+    async fn cors_allows_any_origin_when_list_is_empty() {
+        let response = TestClient::get("http://localhost/")
+            .add_header(ORIGIN, "https://client.example", true)
+            .send(&service(&[]))
+            .await;
+
+        assert_eq!(
+            response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN).unwrap(),
+            "*"
+        );
+    }
+
+    #[tokio::test]
+    async fn cors_only_echoes_configured_origins() {
+        let allowed_origins = vec!["https://client.example".to_owned()];
+        let service = service(&allowed_origins);
+
+        let allowed = TestClient::get("http://localhost/")
+            .add_header(ORIGIN, "https://client.example", true)
+            .send(&service)
+            .await;
+        assert_eq!(
+            allowed.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN).unwrap(),
+            "https://client.example"
+        );
+
+        let rejected = TestClient::get("http://localhost/")
+            .add_header(ORIGIN, "https://other.example", true)
+            .send(&service)
+            .await;
+        assert!(
+            rejected
+                .headers()
+                .get(ACCESS_CONTROL_ALLOW_ORIGIN)
+                .is_none()
+        );
+    }
 }


### PR DESCRIPTION
## What changed

- build the Salvo CORS middleware from `allowed_origins`
- preserve wildcard behavior when the list is empty
- omit `Access-Control-Allow-Origin` for origins outside a configured allowlist
- validate configured origin header values during startup
- remove the unused custom CORS handler

## Why

The server previously hard-coded `Access-Control-Allow-Origin: *`, so `allowed_origins` did not affect responses. Deployments that configured an allowlist therefore remained open to every browser origin.

## Impact

Empty `allowed_origins` keeps the existing permissive behavior. A non-empty list now restricts browser origins as documented. Invalid values and a literal `*` fail configuration validation; operators should use an empty list when all origins are intended.

## Validation

- `cargo test -p palpo cors_ --no-fail-fast`
- `cargo check -p palpo --tests`
- `rustfmt --edition 2024 --config skip_children=true --check crates/server/src/main.rs crates/server/src/config/server.rs crates/server/src/hoops.rs`
- `git diff --check`

Note: repository-wide `cargo fmt --all -- --check` currently reports pre-existing formatting differences outside this change.
