### PR TITLE
Limit buffered remote media responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3617,6 +3617,7 @@ dependencies = [
  "globwalk",
  "hickory-resolver",
  "hmac 0.13.0",
+ "http",
  "hyper-util",
  "image",
  "indexmap",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -203,6 +203,7 @@ sha2 = { workspace = true }
 subtle = { workspace = true }
 
 [dev-dependencies]
+http = { workspace = true }
 tracing-test = { workspace = true }
 
 [lints]

--- a/crates/server/src/config/media.rs
+++ b/crates/server/src/config/media.rs
@@ -25,6 +25,14 @@ pub struct MediaConfig {
     #[serde(default = "default_true")]
     pub freeze_legacy: bool,
 
+    /// Maximum number of bytes accepted when fetching a thumbnail from a
+    /// remote homeserver. Both authenticated and legacy thumbnail responses
+    /// are subject to this streamed hard limit.
+    ///
+    /// default: 20000000
+    #[serde(default = "default_max_remote_thumbnail_size")]
+    pub max_remote_thumbnail_size: usize,
+
     /// Check consistency of the media directory at startup:
     /// 1. When `media_compat_file_link` is enabled, this check will upgrade media when switching
     ///    back and forth between Conduit and palpo. Both options must be enabled to handle this.
@@ -76,10 +84,15 @@ impl Default for MediaConfig {
         Self {
             allow_legacy: true,
             freeze_legacy: true,
+            max_remote_thumbnail_size: default_max_remote_thumbnail_size(),
             startup_check: true,
             compat_file_link: false,
             prune_missing: false,
             prevent_downloads_from: Default::default(),
         }
     }
+}
+
+fn default_max_remote_thumbnail_size() -> usize {
+    20_000_000
 }

--- a/crates/server/src/config/url_preview.rs
+++ b/crates/server/src/config/url_preview.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::macros::config_example;
 
 #[config_example(filename = "palpo-example.toml", section = "url_preview")]
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UrlPreviewConfig {
     /// Optional IP address or network interface-name to bind as the source of
     /// URL preview requests. If not set, it will not bind to a specific
@@ -82,6 +82,14 @@ pub struct UrlPreviewConfig {
     #[serde(default = "default_max_spider_size")]
     pub max_spider_size: usize,
 
+    /// Maximum number of bytes accepted for an image fetched while building a
+    /// URL preview. `Content-Length` is checked early and the response stream
+    /// is also counted so chunked responses cannot bypass this limit.
+    ///
+    /// default: 10000000
+    #[serde(default = "default_max_image_size")]
+    pub max_image_size: usize,
+
     /// Option to decide whether you would like to run the domain allowlist
     /// checks (contains and explicit) on the root domain or not. Does not apply
     /// to URL contains allowlist. Defaults to false.
@@ -94,6 +102,21 @@ pub struct UrlPreviewConfig {
     /// subdomains under a root domain.
     #[serde(default)]
     pub check_root_domain: bool,
+}
+
+impl Default for UrlPreviewConfig {
+    fn default() -> Self {
+        Self {
+            bound_interface: None,
+            domain_contains_allowlist: Vec::new(),
+            domain_explicit_allowlist: Vec::new(),
+            domain_explicit_denylist: Vec::new(),
+            url_contains_allowlist: Vec::new(),
+            max_spider_size: default_max_spider_size(),
+            max_image_size: default_max_image_size(),
+            check_root_domain: false,
+        }
+    }
 }
 
 impl UrlPreviewConfig {
@@ -126,4 +149,20 @@ impl UrlPreviewConfig {
 
 fn default_max_spider_size() -> usize {
     256_000 // 256KB
+}
+
+fn default_max_image_size() -> usize {
+    10_000_000
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_size_limits_are_nonzero() {
+        let config = UrlPreviewConfig::default();
+        assert_eq!(config.max_spider_size, 256_000);
+        assert_eq!(config.max_image_size, 10_000_000);
+    }
 }

--- a/crates/server/src/media/preview.rs
+++ b/crates/server/src/media/preview.rs
@@ -335,7 +335,7 @@ async fn download_image(url: &Url) -> AppResult<UrlPreviewData> {
     let content_type = content_type
         .and_then(|ct| ct.to_str().ok())
         .map(|c| c.to_owned());
-    let image = image.bytes().await?;
+    let image = utils::read_response_limited(image, conf.url_preview.max_image_size).await?;
     let mxc = Mxc {
         server_name: &conf.server_name,
         media_id: &utils::random_string(crate::MXC_LENGTH),

--- a/crates/server/src/media/remote.rs
+++ b/crates/server/src/media/remote.rs
@@ -136,7 +136,12 @@ async fn fetch_thumbnail_authenticated(
         .and_then(|s| ContentDisposition::from_str(s).ok());
 
     // Get the file content
-    let file = response.bytes().await?.to_vec();
+    let file = crate::utils::read_response_limited(
+        response,
+        config::get().media.max_remote_thumbnail_size,
+    )
+    .await?
+    .to_vec();
 
     // Save the thumbnail locally for caching
     if !file.is_empty()
@@ -234,7 +239,12 @@ async fn fetch_thumbnail_unauthenticated(
         .and_then(|s| ContentDisposition::from_str(s).ok());
 
     // Get the file content
-    let file = response.bytes().await?.to_vec();
+    let file = crate::utils::read_response_limited(
+        response,
+        config::get().media.max_remote_thumbnail_size,
+    )
+    .await?
+    .to_vec();
 
     // Save the thumbnail locally for caching
     if !file.is_empty()

--- a/crates/server/src/routing/client/media.rs
+++ b/crates/server/src/routing/client/media.rs
@@ -330,7 +330,9 @@ pub async fn get_thumbnail(
         let response =
             crate::sending::send_federation_request(&args.server_name, request, None).await?;
         *res.headers_mut() = response.headers().clone();
-        let bytes = response.bytes().await?;
+        let bytes =
+            utils::read_response_limited(response, config::get().media.max_remote_thumbnail_size)
+                .await?;
 
         // Cache the remote thumbnail via storage backend
         let cache_key = media_storage_key(

--- a/crates/server/src/utils/stream.rs
+++ b/crates/server/src/utils/stream.rs
@@ -1,5 +1,46 @@
+use bytes::Bytes;
 use futures_util::stream::{Stream, TryStream};
 use futures_util::{StreamExt, stream};
+
+use crate::AppResult;
+use crate::core::MatrixError;
+
+fn ensure_response_size(current: usize, additional: usize, max_size: usize) -> AppResult<()> {
+    if additional > max_size.saturating_sub(current) {
+        return Err(MatrixError::too_large(format!(
+            "Remote response exceeds the configured {max_size} byte limit",
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+/// Read an HTTP response into memory without allowing it to exceed `max_size`.
+///
+/// `Content-Length` is used only for an early rejection. The streamed byte
+/// count remains authoritative so chunked and incorrectly sized responses are
+/// bounded as well.
+pub async fn read_response_limited(
+    mut response: reqwest::Response,
+    max_size: usize,
+) -> AppResult<Bytes> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > max_size as u64)
+    {
+        return Err(MatrixError::too_large(format!(
+            "Remote response exceeds the configured {max_size} byte limit",
+        ))
+        .into());
+    }
+
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await? {
+        ensure_response_size(body.len(), chunk.len(), max_size)?;
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body.into())
+}
 
 pub trait IterStream<I: IntoIterator + Send> {
     /// Convert an Iterator into a Stream
@@ -26,5 +67,49 @@ where
         self,
     ) -> impl TryStream<Ok = <I as IntoIterator>::Item, Error = crate::AppError> + Send {
         self.stream().map(Ok)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn response(body: Vec<u8>, content_length: Option<usize>) -> reqwest::Response {
+        let mut builder = http::Response::builder();
+        if let Some(content_length) = content_length {
+            builder = builder.header(http::header::CONTENT_LENGTH, content_length);
+        }
+        builder.body(body).unwrap().into()
+    }
+
+    #[tokio::test]
+    async fn response_reader_accepts_bytes_up_to_limit() {
+        let body = read_response_limited(response(vec![1; 10], None), 10)
+            .await
+            .unwrap();
+        assert_eq!(body.len(), 10);
+    }
+
+    #[tokio::test]
+    async fn response_reader_rejects_oversized_content_length() {
+        assert!(
+            read_response_limited(response(vec![1; 11], Some(11)), 10)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn response_reader_rejects_oversized_stream_without_length() {
+        assert!(
+            read_response_limited(response(vec![1; 11], None), 10)
+                .await
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn response_size_check_handles_overflow() {
+        assert!(ensure_response_size(usize::MAX, 1, usize::MAX).is_err());
     }
 }


### PR DESCRIPTION
## What changed

- add a shared response reader that enforces a hard byte limit while streaming
- reject oversized `Content-Length` values before buffering
- enforce the streamed count even when the response is chunked or declares an incorrect length
- apply the reader to URL preview images and every buffered remote-thumbnail path
- add separate configurable defaults for preview images (10 MB) and remote thumbnails (20 MB)
- restore documented URL-preview size defaults when the whole config section is omitted

## Why

Several attacker-controlled remote responses were consumed with `Response::bytes()`. A remote server could therefore make Palpo buffer and cache an arbitrarily large preview image or thumbnail, causing memory and storage amplification. Checking only `Content-Length` would still allow chunked responses or incorrect headers to bypass the limit.

## Impact

Responses within the configured limits behave as before. Oversized preview images and thumbnails now fail with `M_TOO_LARGE` before being cached. Operators can tune `url_preview.max_image_size` and `media.max_remote_thumbnail_size` independently.

Full remote media downloads are already streamed directly to the client and are not changed by this PR.

## Validation

- `cargo test -p palpo response_ --no-fail-fast` (4 passed)
- `cargo test -p palpo size_ --no-fail-fast` (2 passed)
- `cargo check -p palpo --tests`
- targeted `rustfmt --check` for changed Rust modules
- `git diff --check`

Note: repository-wide `cargo fmt --all -- --check` currently reports pre-existing formatting differences outside this change.
