### PR TITLE
Fix joined appservice member visibility

### DIFF
--- a/crates/server/src/hoops/auth.rs
+++ b/crates/server/src/hoops/auth.rs
@@ -3,7 +3,7 @@ use std::iter::FromIterator;
 use std::time::Duration;
 
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncConnection, RunQueryDsl};
 use salvo::http::headers::HeaderMapExt;
 use salvo::http::headers::authorization::Authorization;
 use salvo::prelude::*;
@@ -16,10 +16,10 @@ use crate::core::serde::CanonicalJsonValue;
 use crate::core::{UnixMillis, signatures};
 use crate::data::connect;
 use crate::data::schema::*;
-use crate::data::user::{DbUser, DbUserDevice, NewDbUser, NewDbUserDevice};
+use crate::data::user::{DbUser, DbUserDevice, NewDbProfile, NewDbUser, NewDbUserDevice};
 use crate::exts::DepotExt;
 use crate::server_key::{PubKeyMap, PubKeys};
-use crate::{AppResult, AuthArgs, AuthedInfo, MatrixError, config};
+use crate::{AppError, AppResult, AuthArgs, AuthedInfo, MatrixError, config};
 
 #[handler]
 pub async fn auth_by_access_token_or_signatures(
@@ -245,27 +245,44 @@ async fn get_or_create_appservice_user(user_id: &UserId, appservice_id: &str) ->
         created_at: UnixMillis::now(),
     };
 
-    let user = diesel::insert_into(users::table)
-        .values(&new_user)
-        .on_conflict(users::id)
-        .do_update()
-        .set(&new_user)
-        .get_result::<DbUser>(&mut connect().await?)
-        .await?;
+    connect()
+        .await?
+        .transaction::<_, AppError, _>(async |conn| {
+            // The upsert locks the user row until this transaction commits. Concurrent
+            // first requests for the same virtual user therefore serialize before the
+            // profile existence check, despite NULL room IDs not being unique in Postgres.
+            let user = diesel::insert_into(users::table)
+                .values(&new_user)
+                .on_conflict(users::id)
+                .do_update()
+                .set(&new_user)
+                .get_result::<DbUser>(conn)
+                .await?;
 
-    // Create a profile for the user, as regular user creation does. Merely updating
-    // the display name would affect zero rows when the profile does not exist.
-    let display_name = user_id.localpart().to_owned();
-    crate::data::user::create_profile(&crate::data::user::NewDbProfile {
-        user_id: user_id.to_owned(),
-        room_id: None,
-        display_name: Some(display_name),
-        avatar_url: None,
-        blurhash: None,
-    })
-    .await?;
+            let profile_exists = user_profiles::table
+                .filter(user_profiles::user_id.eq(user_id))
+                .filter(user_profiles::room_id.is_null())
+                .select(user_profiles::id)
+                .first::<i64>(conn)
+                .await
+                .optional()?
+                .is_some();
+            if !profile_exists {
+                diesel::insert_into(user_profiles::table)
+                    .values(&NewDbProfile {
+                        user_id: user_id.to_owned(),
+                        room_id: None,
+                        display_name: Some(user_id.localpart().to_owned()),
+                        avatar_url: None,
+                        blurhash: None,
+                    })
+                    .execute(conn)
+                    .await?;
+            }
 
-    Ok(user)
+            Ok(user)
+        })
+        .await
 }
 
 /// Get or create a device for an appservice user

--- a/crates/server/src/hoops/auth.rs
+++ b/crates/server/src/hoops/auth.rs
@@ -223,10 +223,11 @@ async fn auth_by_delegated_token(token: &str, aa: &AuthArgs, depot: &mut Depot) 
 /// Get or create a user for an appservice
 async fn get_or_create_appservice_user(user_id: &UserId, appservice_id: &str) -> AppResult<DbUser> {
     // Try to get existing user
-    if let Ok(user) = users::table
+    if let Some(user) = users::table
         .find(user_id)
         .first::<DbUser>(&mut connect().await?)
         .await
+        .optional()?
     {
         return Ok(user);
     }
@@ -252,14 +253,17 @@ async fn get_or_create_appservice_user(user_id: &UserId, appservice_id: &str) ->
         .get_result::<DbUser>(&mut connect().await?)
         .await?;
 
-    // Create a profile for the user
+    // Create a profile for the user, as regular user creation does. Merely updating
+    // the display name would affect zero rows when the profile does not exist.
     let display_name = user_id.localpart().to_owned();
-    if let Err(e) = crate::data::user::set_display_name(user_id, &display_name).await {
-        tracing::warn!(
-            "failed to set profile for appservice user (non-fatal): {}",
-            e
-        );
-    }
+    crate::data::user::create_profile(&crate::data::user::NewDbProfile {
+        user_id: user_id.to_owned(),
+        room_id: None,
+        display_name: Some(display_name),
+        avatar_url: None,
+        blurhash: None,
+    })
+    .await?;
 
     Ok(user)
 }

--- a/crates/server/src/routing/client/room/membership.rs
+++ b/crates/server/src/routing/client/room/membership.rs
@@ -33,6 +33,17 @@ use crate::{
     json_ok, room, sending, utils,
 };
 
+fn insert_joined_member(
+    joined: &mut BTreeMap<OwnedUserId, RoomMember>,
+    user_id: OwnedUserId,
+    profile: Option<DbProfile>,
+) {
+    let member = profile
+        .map(|profile| RoomMember::new(profile.display_name, profile.avatar_url))
+        .unwrap_or_default();
+    joined.insert(user_id, member);
+}
+
 /// #POST /_matrix/client/r0/rooms/{room_id}/members
 /// Lists all joined users in a room.
 ///
@@ -185,17 +196,28 @@ pub(super) async fn joined_members(
 
     let mut joined = BTreeMap::new();
     for user_id in crate::room::joined_users(&room_id, None).await? {
-        if let Some(DbProfile {
-            display_name,
-            avatar_url,
-            ..
-        }) = data::user::get_profile(&user_id, None).await?
-        {
-            joined.insert(user_id, RoomMember::new(display_name, avatar_url));
-        }
+        let profile = data::user::get_profile(&user_id, None).await?;
+        insert_joined_member(&mut joined, user_id, profile);
     }
 
     json_ok(JoinedMembersResBody { joined })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn joined_member_without_profile_is_not_omitted() {
+        let user_id = UserId::parse("@bot:example.org").unwrap();
+        let mut joined = BTreeMap::new();
+
+        insert_joined_member(&mut joined, user_id.clone(), None);
+
+        let member = joined.get(&user_id).expect("joined user must be present");
+        assert_eq!(member.display_name, None);
+        assert_eq!(member.avatar_url, None);
+    }
 }
 
 /// #POST /_matrix/client/r0/joined_rooms
@@ -580,8 +602,7 @@ pub(super) async fn ban_user(
         &room_id,
         &crate::room::get_version(&room_id).await?,
         &state_lock,
-    )
-    .await?;
+    ).await?;
     if let Err(e) = sending::send_pdu_room(
         &room_id,
         &pdu.event_id,
@@ -614,7 +635,8 @@ pub(super) async fn unban_user(
         &StateEventType::RoomMember,
         body.user_id.as_ref(),
         None,
-    ).await?;
+    )
+    .await?;
 
     if event.membership != MembershipState::Ban {
         return Err(MatrixError::bad_state(format!(


### PR DESCRIPTION
## Summary

- include every joined user in the `joined_members` response even when no profile row exists
- create a default profile row when provisioning an application-service virtual user
- propagate database lookup and profile creation failures instead of silently treating them as success
- add regression coverage for joined users without profiles

## Root cause

The endpoint only inserted a joined user into its response when `get_profile` returned `Some`, so profile-less application-service users were silently omitted. Appservice provisioning made that state likely because it attempted to set a display name with an update-only helper before any profile row existed; updating zero rows still returned success.

## Impact

Clients and bots can now reliably use `joined_members` to determine room membership, including rooms containing application-service virtual users.

Fixes #287.

## Validation

- `cargo test -p palpo joined_member_without_profile_is_not_omitted` (1 passed)
- `git diff --check`
