### PR TITLE
Persist per-destination EDU send cursor

### DIFF
--- a/crates/data/migrations/2026-07-12-000001_outgoing_edu_cursors/down.sql
+++ b/crates/data/migrations/2026-07-12-000001_outgoing_edu_cursors/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE outgoing_edu_cursors;

--- a/crates/data/migrations/2026-07-12-000001_outgoing_edu_cursors/up.sql
+++ b/crates/data/migrations/2026-07-12-000001_outgoing_edu_cursors/up.sql
@@ -1,0 +1,11 @@
+-- Per-destination EDU delivery cursor for the federation sender.
+--
+-- Tracks the last sequence number whose presence/read-receipt/device-list
+-- updates were successfully delivered to a remote server, so each transaction
+-- can select exactly the EDUs the destination has not seen yet and the
+-- position survives restarts.
+CREATE TABLE outgoing_edu_cursors (
+    server_id TEXT NOT NULL PRIMARY KEY,
+    edu_sn BIGINT NOT NULL,
+    updated_at BIGINT NOT NULL
+);

--- a/crates/data/src/schema.rs
+++ b/crates/data/src/schema.rs
@@ -504,6 +504,17 @@ diesel::table! {
     use diesel::sql_types::*;
     use crate::full_text_search::*;
 
+    outgoing_edu_cursors (server_id) {
+        server_id -> Text,
+        edu_sn -> Int8,
+        updated_at -> Int8,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use crate::full_text_search::*;
+
     outgoing_requests (id) {
         id -> Int8,
         kind -> Text,
@@ -1180,6 +1191,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     media_metadatas,
     media_thumbnails,
     media_url_previews,
+    outgoing_edu_cursors,
     outgoing_requests,
     room_aliases,
     room_joined_servers,

--- a/crates/data/src/sending.rs
+++ b/crates/data/src/sending.rs
@@ -45,6 +45,42 @@ pub struct NewDbOutgoingRequest {
     pub edu_json: Option<Vec<u8>>,
 }
 
+/// Last sequence number whose EDUs were successfully delivered to `server`,
+/// if a transaction containing EDUs has ever completed for it.
+pub async fn get_edu_cursor(server: &ServerName) -> DataResult<Option<i64>> {
+    outgoing_edu_cursors::table
+        .filter(outgoing_edu_cursors::server_id.eq(server))
+        .select(outgoing_edu_cursors::edu_sn)
+        .first::<i64>(&mut connect().await?)
+        .await
+        .optional()
+        .map_err(Into::into)
+}
+
+/// Record that EDUs up to `edu_sn` have been delivered to `server`. The
+/// cursor never moves backwards, so concurrent instances cannot rewind each
+/// other and cause duplicate selection windows.
+pub async fn advance_edu_cursor(server: &ServerName, edu_sn: i64) -> DataResult<()> {
+    let now = UnixMillis::now().get() as i64;
+    diesel::insert_into(outgoing_edu_cursors::table)
+        .values((
+            outgoing_edu_cursors::server_id.eq(server),
+            outgoing_edu_cursors::edu_sn.eq(edu_sn),
+            outgoing_edu_cursors::updated_at.eq(now),
+        ))
+        .on_conflict(outgoing_edu_cursors::server_id)
+        .do_update()
+        .set((
+            outgoing_edu_cursors::edu_sn.eq(diesel::dsl::sql::<diesel::sql_types::BigInt>(
+                "GREATEST(outgoing_edu_cursors.edu_sn, excluded.edu_sn)",
+            )),
+            outgoing_edu_cursors::updated_at.eq(now),
+        ))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
 /// Get all known federation destinations
 pub async fn get_all_destinations() -> DataResult<Vec<OwnedServerName>> {
     let servers: Vec<OwnedServerName> = outgoing_requests::table

--- a/crates/server/src/sending/guard.rs
+++ b/crates/server/src/sending/guard.rs
@@ -37,6 +37,9 @@ async fn process() -> AppResult<()> {
         .await;
     let mut futures = FuturesUnordered::new();
     let mut current_transaction_status = HashMap::<OutgoingKind, TransactionStatus>::new();
+    // EDU selection windows of in-flight transactions; persisted as the
+    // destination's cursor once the transaction succeeds.
+    let mut pending_edu_cursors = HashMap::<OutgoingKind, Seqnum>::new();
 
     // Retry requests we could not finish yet
     let mut initial_transactions = HashMap::<OutgoingKind, Vec<SendingEventType>>::new();
@@ -74,6 +77,15 @@ async fn process() -> AppResult<()> {
                     Ok(outgoing_kind) => {
                         super::delete_all_active_requests_for(&outgoing_kind).await?;
 
+                        // The transaction reached the destination; persist its EDU
+                        // window so the next selection resumes after it.
+                        if let Some(edu_sn) = pending_edu_cursors.remove(&outgoing_kind)
+                            && let OutgoingKind::Normal(server_name) = &outgoing_kind
+                            && let Err(e) = data::sending::advance_edu_cursor(server_name, edu_sn).await
+                        {
+                            error!(?server_name, error = ?e, "failed to advance edu cursor");
+                        }
+
                         // Find events that have been added since starting the last request
                         let new_events = super::queued_requests(&outgoing_kind).await.unwrap_or_default().into_iter().take(30).collect::<Vec<_>>();
 
@@ -81,18 +93,27 @@ async fn process() -> AppResult<()> {
                             // Insert pdus we found
                             super::mark_as_active(&new_events).await?;
 
-                            futures.push(
-                                super::send_events(
-                                    outgoing_kind.clone(),
-                                    new_events.into_iter().map(|(_, event)| event).collect(),
-                                )
-                            );
+                            let mut events = new_events.into_iter().map(|(_, event)| event).collect::<Vec<_>>();
+                            // Piggyback EDUs that accumulated while the previous
+                            // transaction was in flight, so a busy destination
+                            // does not starve presence/receipt/device-list updates.
+                            if let OutgoingKind::Normal(server_name) = &outgoing_kind
+                                && let Ok((select_edus, last_sn)) = select_edus(server_name).await
+                            {
+                                events.extend(select_edus.into_iter().map(SendingEventType::Edu));
+                                pending_edu_cursors.insert(outgoing_kind.clone(), last_sn);
+                            }
+
+                            futures.push(super::send_events(outgoing_kind.clone(), events));
                         } else {
                             current_transaction_status.remove(&outgoing_kind);
                         }
                     }
                     Err((outgoing_kind, event)) => {
                         error!("failed to send event: {event:?}  outgoing_kind:{outgoing_kind:?}");
+                        // Do not advance the cursor: the same EDU window is
+                        // re-selected once the destination is reachable again.
+                        pending_edu_cursors.remove(&outgoing_kind);
                         current_transaction_status.entry(outgoing_kind.clone()).and_modify(|e| *e = match e {
                             TransactionStatus::Running => {
                                 TransactionStatus::Failed(1, Instant::now())
@@ -117,6 +138,7 @@ async fn process() -> AppResult<()> {
                     &outgoing_kind,
                     vec![(id, event)],
                     &mut current_transaction_status,
+                    &mut pending_edu_cursors,
                 ).await {
                     futures.push(super::send_events(outgoing_kind, events));
                 }
@@ -201,6 +223,7 @@ async fn select_events(
     outgoing_kind: &OutgoingKind,
     new_events: Vec<(i64, SendingEventType)>, // Events we want to send: event and full key
     current_transaction_status: &mut HashMap<OutgoingKind, TransactionStatus>,
+    pending_edu_cursors: &mut HashMap<OutgoingKind, Seqnum>,
 ) -> AppResult<Option<Vec<SendingEventType>>> {
     let mut retry = false;
     let mut allow = true;
@@ -244,9 +267,13 @@ async fn select_events(
         }
 
         if let OutgoingKind::Normal(server_name) = outgoing_kind
-            && let Ok((select_edus, _last_count)) = select_edus(server_name).await
+            && let Ok((select_edus, last_sn)) = select_edus(server_name).await
         {
             events.extend(select_edus.into_iter().map(SendingEventType::Edu));
+            // Remember the window we selected; the cursor is only persisted
+            // once the transaction succeeds, so a failed send re-selects the
+            // same EDUs on the next attempt.
+            pending_edu_cursors.insert(outgoing_kind.clone(), last_sn);
         }
     }
 
@@ -468,12 +495,22 @@ async fn select_edus_presence(
     Ok(Some(buf))
 }
 
+/// The lower bound (inclusive) of the next EDU selection window.
+///
+/// A destination with a persisted cursor resumes right after it; a
+/// destination we have never completed an EDU transaction for starts at the
+/// current sequence number so it is not flooded with historical updates.
+fn edu_since_sn(cursor: Option<Seqnum>, max_edu_sn: Seqnum) -> Seqnum {
+    cursor.map_or(max_edu_sn, |c| c + 1)
+}
+
 #[tracing::instrument(skip(server_name))]
 pub async fn select_edus(server_name: &ServerName) -> AppResult<(EduVec, i64)> {
     let max_edu_sn = data::curr_sn().await?;
     let conf = crate::config::get();
 
-    let since_sn = data::curr_sn().await?;
+    let cursor = data::sending::get_edu_cursor(server_name).await?;
+    let since_sn = edu_since_sn(cursor, max_edu_sn);
 
     let events_len = AtomicUsize::default();
     let device_changes =
@@ -498,6 +535,16 @@ pub async fn select_edus(server_name: &ServerName) -> AppResult<(EduVec, i64)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn edu_selection_resumes_after_cursor_and_starts_fresh_without_one() {
+        // Selection queries are `occur_sn >= since_sn`, so resuming right
+        // after the cursor neither re-sends nor skips updates.
+        assert_eq!(edu_since_sn(Some(41), 100), 42);
+        // No cursor yet: start at the current sequence number instead of
+        // replaying history to a destination we have never sent EDUs to.
+        assert_eq!(edu_since_sn(None, 100), 100);
+    }
 
     #[test]
     fn retry_backoff_grows_quadratically_and_caps_at_one_day() {

--- a/crates/server/src/sending/guard.rs
+++ b/crates/server/src/sending/guard.rs
@@ -105,6 +105,17 @@ async fn process() -> AppResult<()> {
                             }
 
                             futures.push(super::send_events(outgoing_kind.clone(), events));
+                        } else if let OutgoingKind::Normal(server_name) = &outgoing_kind
+                            && let Ok((select_edus, last_sn)) = select_edus(server_name).await
+                            && !select_edus.is_empty()
+                        {
+                            // No queued PDUs, but the EDU window is not empty
+                            // (e.g. a previous send failed and dropped it):
+                            // deliver the EDUs on their own instead of leaving
+                            // them until unrelated traffic shows up.
+                            let events = select_edus.into_iter().map(SendingEventType::Edu).collect::<Vec<_>>();
+                            pending_edu_cursors.insert(outgoing_kind.clone(), last_sn);
+                            futures.push(super::send_events(outgoing_kind.clone(), events));
                         } else {
                             current_transaction_status.remove(&outgoing_kind);
                         }
@@ -179,17 +190,27 @@ async fn process() -> AppResult<()> {
                         }
                     };
 
-                    if active_events.is_empty() {
+                    let mut events = active_events.into_iter().map(|(_, event)| event).collect::<Vec<_>>();
+                    // Also retry the EDU window whose delivery failed: it was
+                    // dropped from pending_edu_cursors without advancing the
+                    // cursor, so it is re-selected here instead of waiting for
+                    // unrelated future traffic to this destination.
+                    if let OutgoingKind::Normal(server_name) = &outgoing_kind
+                        && let Ok((select_edus, last_sn)) = select_edus(server_name).await
+                        && !select_edus.is_empty()
+                    {
+                        events.extend(select_edus.into_iter().map(SendingEventType::Edu));
+                        pending_edu_cursors.insert(outgoing_kind.clone(), last_sn);
+                    }
+
+                    if events.is_empty() {
                         current_transaction_status.remove(&outgoing_kind);
                         continue;
                     }
 
                     current_transaction_status
                         .insert(outgoing_kind.clone(), TransactionStatus::Retrying(tries));
-                    futures.push(super::send_events(
-                        outgoing_kind,
-                        active_events.into_iter().map(|(_, event)| event).collect(),
-                    ));
+                    futures.push(super::send_events(outgoing_kind, events));
                 }
             }
         }
@@ -265,16 +286,16 @@ async fn select_events(
         for (_, e) in new_events {
             events.push(e);
         }
+    }
 
-        if let OutgoingKind::Normal(server_name) = outgoing_kind
-            && let Ok((select_edus, last_sn)) = select_edus(server_name).await
-        {
-            events.extend(select_edus.into_iter().map(SendingEventType::Edu));
-            // Remember the window we selected; the cursor is only persisted
-            // once the transaction succeeds, so a failed send re-selects the
-            // same EDUs on the next attempt.
-            pending_edu_cursors.insert(outgoing_kind.clone(), last_sn);
-        }
+    // Piggyback pending EDUs on fresh and retry transactions alike. The
+    // cursor only advances once a transaction succeeds, so a retry simply
+    // re-selects the same window.
+    if let OutgoingKind::Normal(server_name) = outgoing_kind
+        && let Ok((select_edus, last_sn)) = select_edus(server_name).await
+    {
+        events.extend(select_edus.into_iter().map(SendingEventType::Edu));
+        pending_edu_cursors.insert(outgoing_kind.clone(), last_sn);
     }
 
     Ok(Some(events))


### PR DESCRIPTION
Fixes the P1 issue "EDU 增量发送没有使用持久化游标" from `_report.md`.

## Problem

`select_edus()` used `data::curr_sn()` as **both** the lower bound (`since_sn`) and the upper bound (`max_edu_sn`) of its selection window, and the caller discarded the returned position:

- Presence, read-receipt and device-list updates whose `occur_sn` was below the current sequence number at flush time were silently skipped — in practice almost all pending EDUs were never delivered to remote servers.
- No per-destination position existed at all, so nothing survived restarts and duplicate/miss boundaries were undefined across retries.

## Fix

- New migration `outgoing_edu_cursors` (`server_id` PK, `edu_sn`, `updated_at`): the last EDU stream position successfully delivered to each destination.
- `data::sending::get_edu_cursor` / `advance_edu_cursor`; the upsert uses `GREATEST(...)` so the cursor never moves backwards, keeping concurrent instances from rewinding each other.
- `select_edus()` resumes right after the persisted cursor (`cursor + 1`, matching the `occur_sn >= since_sn` query semantics). A destination with no cursor starts at the current sequence number, so it is not flooded with historical updates.
- The sender loop tracks the selected window per in-flight transaction and only persists it **after the transaction succeeds**; on failure the pending window is dropped and the same EDUs are re-selected on the next attempt (at-least-once delivery).
- Follow-up transactions for a busy destination now also piggyback newly accumulated EDUs, so a continuous PDU stream no longer starves presence/receipt/device-list updates.

## Known limitation

If more than `SELECT_EDU_LIMIT`/`SELECT_PRESENCE_LIMIT`/`SELECT_RECEIPT_LIMIT` updates accumulate in one window, the cursor still advances to the window's upper bound, so updates beyond the cap are skipped. This is bounded and self-correcting for this data (presence and receipts are latest-state; the device-list EDU is a placeholder that forces the remote to resync), and is strictly better than the previous behavior where essentially all EDUs were skipped. Tracking the exact `occur_sn` of capped selections can be a follow-up.

## Verification

- `cargo check -p palpo-data` / `cargo check -p palpo --tests` pass.
- `cargo test -p palpo --bin palpo sending::guard` — 4 tests pass, including a new unit test for the selection-window arithmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
