### PR TITLE
Remove unused db pool config fields

### DIFF
--- a/crates/data/src/config.rs
+++ b/crates/data/src/config.rs
@@ -29,9 +29,6 @@ fn default_connection_timeout() -> u64 {
 fn default_statement_timeout() -> u64 {
     30000
 }
-fn default_helper_threads() -> usize {
-    10
-}
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct DbConfig {
@@ -41,7 +38,6 @@ pub struct DbConfig {
     pub url: String,
     #[serde(default = "default_db_pool_size")]
     pub pool_size: u32,
-    pub min_idle: Option<u32>,
 
     /// Number of seconds to wait for unacknowledged TCP packets before treating the connection as
     /// broken. This value will determine how long crates.io stays unavailable in case of full
@@ -60,10 +56,6 @@ pub struct DbConfig {
     /// returning an error.
     #[serde(default = "default_statement_timeout")]
     pub statement_timeout: u64,
-    /// Number of threads to use for asynchronous operations such as connection
-    /// creation.
-    #[serde(default = "default_helper_threads")]
-    pub helper_threads: usize,
     /// Whether to enforce that all the database connections are encrypted with TLS.
     #[serde(default = "default_false")]
     pub enforce_tls: bool,
@@ -75,7 +67,6 @@ impl fmt::Display for DbConfig {
         let lines = [
             ("tcp_timeout", self.tcp_timeout),
             // ("connection_timeout", &self.connection_timeout),
-            // ("helper_threads", &self.helper_threads),
             // ("enforce_tls", self.enforce_tls.to_string()),
         ];
 

--- a/crates/server/src/config/db.rs
+++ b/crates/server/src/config/db.rs
@@ -11,7 +11,6 @@ pub struct DbConfig {
     pub url: String,
     #[serde(default = "default_db_pool_size")]
     pub pool_size: u32,
-    pub min_idle: Option<u32>,
 
     /// Number of seconds to wait for unacknowledged TCP packets before treating the connection as
     /// broken. This value will determine how long crates.io stays unavailable in case of full
@@ -30,10 +29,6 @@ pub struct DbConfig {
     /// returning an error.
     #[serde(default = "default_statement_timeout")]
     pub statement_timeout: u64,
-    /// Number of threads to use for asynchronous operations such as connection
-    /// creation.
-    #[serde(default = "default_helper_threads")]
-    pub helper_threads: usize,
     /// Whether to enforce that all the database connections are encrypted with TLS.
     #[serde(default = "default_false")]
     pub enforce_tls: bool,
@@ -44,21 +39,17 @@ impl DbConfig {
         let Self {
             url,
             pool_size,
-            min_idle,
             tcp_timeout,
             connection_timeout,
             statement_timeout,
-            helper_threads,
             enforce_tls,
         } = self;
         crate::data::DbConfig {
             url: url.clone(),
             pool_size,
-            min_idle,
             tcp_timeout,
             connection_timeout,
             statement_timeout,
-            helper_threads,
             enforce_tls,
         }
     }
@@ -69,11 +60,9 @@ impl Default for DbConfig {
         Self {
             url: default_db_url(),
             pool_size: default_db_pool_size(),
-            min_idle: None,
             tcp_timeout: default_tcp_timeout(),
             connection_timeout: default_connection_timeout(),
             statement_timeout: default_statement_timeout(),
-            helper_threads: default_helper_threads(),
             enforce_tls: default_false(),
         }
     }
@@ -94,7 +83,4 @@ fn default_connection_timeout() -> u64 {
 }
 fn default_statement_timeout() -> u64 {
     30_000
-}
-fn default_helper_threads() -> usize {
-    10
 }

--- a/palpo-example.kdl
+++ b/palpo-example.kdl
@@ -586,11 +586,9 @@
 //     // url "postgres://..."
 //
 //     // pool_size 10
-//     // min_idle 1
 //     // tcp_timeout 10
 //     // connection_timeout 10
 //     // statement_timeout 10
-//     // helper_threads 3
 //     // enforce_tls false
 // }
 

--- a/palpo-example.toml
+++ b/palpo-example.toml
@@ -779,10 +779,6 @@
 #
 # pool_size =
 
-# This item is undocumented. Please contribute documentation for it.
-#
-# min_idle =
-
 # Number of seconds to wait for unacknowledged TCP packets before treating the connection as
 # broken. This value will determine how long crates.io stays unavailable in case of full
 # packet loss between the application and the database: setting it too high will result in an
@@ -802,11 +798,6 @@
 # returning an error.
 #
 # statement_timeout =
-
-# Number of threads to use for asynchronous operations such as connection
-# creation.
-#
-# helper_threads =
 
 # Whether to enforce that all the database connections are encrypted with TLS.
 #


### PR DESCRIPTION
Addresses the P2 issue "数据库连接池配置有字段未使用，文档与行为不一致" from `_report.md`.

## Problem

The `[db]` config section accepted `min_idle` and `helper_threads`, and the generated example configs documented them, but `DieselPool::new` (crates/data/src/pool.rs) never passes them to the deadpool builder — deadpool has no equivalent knobs; both are r2d2-era leftovers. Operators tuning these values for connection pre-warming or connection-creation throughput were silently getting no effect.

## Fix

Remove the two dead fields from `crates/server/src/config/db.rs` and `crates/data/src/config.rs`, and drop their entries from `palpo-example.toml` / `palpo-example.kdl`. All remaining fields (`url`, `pool_size`, `tcp_timeout`, `connection_timeout`, `statement_timeout`, `enforce_tls`) are verified to be wired into the pool builder or connection URL.

Existing config files that still set these keys keep working: unknown keys are ignored during deserialization.

## Verification

- `cargo check -p palpo-data` and `cargo check -p palpo` pass.
- `rg 'min_idle|helper_threads'` over the repo returns no remaining references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
