### PR TITLE
Enforce rustfmt and clippy in CI; fix dropped futures

### DIFF
--- a/.github/workflows/quality-control.yml
+++ b/.github/workflows/quality-control.yml
@@ -24,12 +24,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - name: Typos check with custom config file
+        uses: crate-ci/typos@master
+
+  lint:
+    name: Rustfmt and Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # rustfmt.toml enables unstable options (unstable_features = true),
+      # which only nightly rustfmt honors.
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: rustfmt
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          components: rustfmt, clippy
-      - name: Typos check with custom config file
-        uses: crate-ci/typos@master
+          components: clippy
+
+      - name: Install dependencies
+        run: "sudo apt update && sudo apt install -y --no-install-recommends libclang-dev libpq-dev cmake"
+
+      - name: Check formatting
+        run: cargo +nightly fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
   test:
     strategy:

--- a/crates/core/src/client/dehydrated_device.rs
+++ b/crates/core/src/client/dehydrated_device.rs
@@ -5,10 +5,9 @@ use std::collections::BTreeMap;
 use salvo::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::PrivOwnedStr;
 use crate::encryption::{DeviceKeys, OneTimeKey};
 use crate::serde::StringEnum;
-use crate::{OwnedDeviceId, OwnedDeviceKeyId};
+use crate::{OwnedDeviceId, OwnedDeviceKeyId, PrivOwnedStr};
 
 /// Data for a dehydrated device.
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/core/src/error/kind.rs
+++ b/crates/core/src/error/kind.rs
@@ -396,8 +396,8 @@ pub enum ErrorKind {
     /// their allocated storage quota, reached a maximum number of allowed rooms, devices, or other
     /// account-scoped resources, or exceeded usage limits for specific features.
     UserLimitExceeded {
-        /// A URI that the client can present to the user to provide more context on the encountered
-        /// limit and, if applicable, guidance on how to increase the limit.
+        /// A URI that the client can present to the user to provide more context on the
+        /// encountered limit and, if applicable, guidance on how to increase the limit.
         ///
         /// The homeserver MAY return different values depending on the type of limit reached.
         info_uri: String,

--- a/crates/core/src/error/kind_serde.rs
+++ b/crates/core/src/error/kind_serde.rs
@@ -731,10 +731,10 @@ impl Serialize for ErrorKind {
             Self::ResourceLimitExceeded { admin_contact } => {
                 st.serialize_entry("admin_contact", admin_contact)?;
             }
-            Self::SenderIgnored { sender } => {
-                if let Some(sender) = sender {
-                    st.serialize_entry("sender", sender)?;
-                }
+            Self::SenderIgnored {
+                sender: Some(sender),
+            } => {
+                st.serialize_entry("sender", sender)?;
             }
             Self::UserLimitExceeded {
                 info_uri,

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -267,23 +267,6 @@ pub struct Mentions {
     pub room: bool,
 }
 
-#[cfg(test)]
-mod tests {
-    use serde_json::value::to_raw_value;
-
-    use super::{AnyMessageLikeEventContent, EventContentFromType, MessageLikeEventContent};
-
-    #[test]
-    fn custom_message_like_event_content_keeps_event_type() {
-        let raw = to_raw_value(&serde_json::json!({ "body": "custom" })).unwrap();
-
-        let content = AnyMessageLikeEventContent::from_parts("com.example.custom", &raw).unwrap();
-
-        assert!(matches!(content, AnyMessageLikeEventContent::_Custom(_)));
-        assert_eq!(content.event_type().to_string(), "com.example.custom");
-    }
-}
-
 impl Mentions {
     /// Create a `Mentions` with the default values.
     pub fn new() -> Self {
@@ -309,5 +292,22 @@ impl Mentions {
     fn add(&mut self, mentions: Self) {
         self.user_ids.extend(mentions.user_ids);
         self.room |= mentions.room;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::value::to_raw_value;
+
+    use super::{AnyMessageLikeEventContent, EventContentFromType, MessageLikeEventContent};
+
+    #[test]
+    fn custom_message_like_event_content_keeps_event_type() {
+        let raw = to_raw_value(&serde_json::json!({ "body": "custom" })).unwrap();
+
+        let content = AnyMessageLikeEventContent::from_parts("com.example.custom", &raw).unwrap();
+
+        assert!(matches!(content, AnyMessageLikeEventContent::_Custom(_)));
+        assert_eq!(content.event_type().to_string(), "com.example.custom");
     }
 }

--- a/crates/core/src/events/room.rs
+++ b/crates/core/src/events/room.rs
@@ -2,20 +2,16 @@
 //!
 //! This module also contains types shared by events in its child namespaces.
 
-use std::{
-    collections::{BTreeMap, btree_map},
-    fmt,
-    ops::Deref,
-};
+use std::collections::{BTreeMap, btree_map};
+use std::fmt;
+use std::ops::Deref;
 
 use as_variant::as_variant;
 use salvo::oapi::ToSchema;
 use serde::{Deserialize, Serialize, de};
 
-use crate::serde::{
-    Base64, JsonObject, StringEnum,
-    base64::{Standard, UrlSafe},
-};
+use crate::serde::base64::{Standard, UrlSafe};
+use crate::serde::{Base64, JsonObject, StringEnum};
 use crate::{OwnedMxcUri, PrivOwnedStr};
 
 pub mod aliases;

--- a/crates/core/src/events/room/encrypted_file_serde.rs
+++ b/crates/core/src/events/room/encrypted_file_serde.rs
@@ -1,6 +1,8 @@
-use std::{borrow::Cow, collections::BTreeMap};
+use std::borrow::Cow;
+use std::collections::BTreeMap;
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer, de, ser::SerializeMap};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
 use super::{
     CustomEncryptedFileHash, EncryptedFileHash, EncryptedFileHashAlgorithm, EncryptedFileHashes,

--- a/crates/core/src/federation/backfill.rs
+++ b/crates/core/src/federation/backfill.rs
@@ -26,7 +26,7 @@ use crate::{OwnedEventId, OwnedRoomId, OwnedServerName, UnixMillis};
 pub fn backfill_request(origin: &str, args: BackfillReqArgs) -> SendResult<SendRequest> {
     let mut url = Url::parse(&format!(
         "{origin}/_matrix/federation/v1/backfill/{}",
-        &args.room_id,
+        args.room_id,
     ))?;
     url.query_pairs_mut()
         .append_pair("limit", &args.limit.to_string());

--- a/crates/core/src/federation/membership.rs
+++ b/crates/core/src/federation/membership.rs
@@ -365,7 +365,7 @@ pub fn send_join_request(
 ) -> SendResult<SendRequest> {
     let url = Url::parse(&format!(
         "{origin}/_matrix/federation/v2/send_join/{}/{}?omit_members={}",
-        &args.room_id, &args.event_id, args.omit_members
+        args.room_id, args.event_id, args.omit_members
     ))?;
     crate::sending::put(url).stuff(body)
 }

--- a/crates/core/src/federation/peek.rs
+++ b/crates/core/src/federation/peek.rs
@@ -21,7 +21,10 @@ use crate::serde::RawJsonValue;
 
 /// Build the outgoing request for a federated room peek.
 pub fn peek_request(origin: &str, args: PeekReqArgs) -> SendResult<SendRequest> {
-    let mut url = Url::parse(&format!("{origin}/_matrix/federation/v1/peek/{}", args.room_id))?;
+    let mut url = Url::parse(&format!(
+        "{origin}/_matrix/federation/v1/peek/{}",
+        args.room_id
+    ))?;
     url.query_pairs_mut()
         .append_pair("limit", &args.limit.to_string());
     Ok(crate::sending::get(url))
@@ -143,4 +146,3 @@ pub struct PeekStartResBody {
     /// resident server will drop the subscription.
     pub renewal_interval: u64,
 }
-

--- a/crates/core/src/identifiers/room_alias_id.rs
+++ b/crates/core/src/identifiers/room_alias_id.rs
@@ -52,11 +52,7 @@ impl RoomAliasId {
     ///
     /// If `join` is `true`, a click on the URI should join the room.
     pub fn matrix_uri(&self, join: bool) -> MatrixUri {
-        MatrixUri::new(
-            self.into(),
-            Vec::new(),
-            Some(UriAction::Join).filter(|_| join),
-        )
+        MatrixUri::new(self.into(), Vec::new(), join.then_some(UriAction::Join))
     }
 
     /// Create a `matrix:` URI for an event scoped under this room alias ID.

--- a/crates/core/src/identifiers/room_id.rs
+++ b/crates/core/src/identifiers/room_id.rs
@@ -183,7 +183,7 @@ impl RoomId {
     /// );
     /// ```
     pub fn matrix_uri(&self, join: bool) -> MatrixUri {
-        MatrixUri::new(self.into(), vec![], Some(UriAction::Join).filter(|_| join))
+        MatrixUri::new(self.into(), vec![], join.then_some(UriAction::Join))
     }
 
     /// Create a `matrix:` URI for this room ID with a list of servers that
@@ -225,7 +225,7 @@ impl RoomId {
         MatrixUri::new(
             self.into(),
             via.into_iter().map(Into::into).collect(),
-            Some(UriAction::Join).filter(|_| join),
+            join.then_some(UriAction::Join),
         )
     }
 

--- a/crates/core/src/identifiers/user_id.rs
+++ b/crates/core/src/identifiers/user_id.rs
@@ -160,11 +160,7 @@ impl UserId {
     /// );
     /// ```
     pub fn matrix_uri(&self, chat: bool) -> MatrixUri {
-        MatrixUri::new(
-            self.into(),
-            Vec::new(),
-            Some(UriAction::Chat).filter(|_| chat),
-        )
+        MatrixUri::new(self.into(), Vec::new(), chat.then_some(UriAction::Chat))
     }
 
     fn colon_idx(&self) -> usize {

--- a/crates/core/src/profile.rs
+++ b/crates/core/src/profile.rs
@@ -2,9 +2,8 @@ use std::borrow::Cow;
 use std::fmt;
 
 use salvo::prelude::*;
-use serde::de;
 use serde::ser::SerializeMap;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer, de};
 use serde_json::{from_value as from_json_value, to_value as to_json_value};
 
 use crate::serde::{JsonValue, StringEnum};

--- a/crates/core/src/push/action.rs
+++ b/crates/core/src/push/action.rs
@@ -2,7 +2,8 @@ use std::borrow::Cow;
 
 use as_variant::as_variant;
 use salvo::prelude::*;
-use serde::{Deserialize, Deserializer, Serialize, Serializer, de, ser::SerializeStruct};
+use serde::ser::SerializeStruct;
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
 use crate::PrivOwnedStr;
 use crate::macros::StringEnum;
@@ -198,9 +199,10 @@ impl Tweak {
 
         match self {
             Tweak::Sound(s) => Some(Cow::Owned(serialize(s))),
-            Tweak::Highlight(h) => {
-                Some(Cow::Owned(serialize(&matches!(h, HighlightTweakValue::Yes))))
-            }
+            Tweak::Highlight(h) => Some(Cow::Owned(serialize(&matches!(
+                h,
+                HighlightTweakValue::Yes
+            )))),
             Tweak::_Custom(c) => c.value.as_deref().map(Cow::Borrowed),
         }
     }

--- a/crates/core/src/push/condition.rs
+++ b/crates/core/src/push/condition.rs
@@ -612,51 +612,6 @@ impl PushConditionPowerLevelsCtx {
     }
 }
 
-#[cfg(test)]
-mod serde_tests {
-    use serde_json::{
-        Value as JsonValue, from_value as from_json_value, json, to_value as to_json_value,
-    };
-
-    use super::{EventMatchConditionData, PushCondition};
-
-    #[test]
-    fn known_push_condition_roundtrips() {
-        let condition = PushCondition::EventMatch(EventMatchConditionData::new(
-            "type".into(),
-            "m.room.message".into(),
-        ));
-        let json = json!({
-            "kind": "event_match",
-            "key": "type",
-            "pattern": "m.room.message",
-        });
-
-        assert_eq!(to_json_value(&condition).unwrap(), json);
-        assert_eq!(
-            from_json_value::<PushCondition>(json).unwrap().kind(),
-            "event_match"
-        );
-    }
-
-    #[test]
-    fn custom_push_condition_roundtrips() {
-        let json = json!({
-            "kind": "dev.palpo.custom",
-            "field": "value",
-        });
-
-        let condition = from_json_value::<PushCondition>(json.clone()).unwrap();
-
-        assert_eq!(condition.kind(), "dev.palpo.custom");
-        assert_eq!(
-            condition.data().get("field"),
-            Some(&JsonValue::String("value".to_owned()))
-        );
-        assert_eq!(to_json_value(condition).unwrap(), json);
-    }
-}
-
 /// Additional functions for character matching.
 trait CharExt {
     /// Whether or not this char can be part of a word.
@@ -857,6 +812,51 @@ type HasThreadSubscriptionFuture<'a> = Pin<Box<dyn Future<Output = bool> + 'a>>;
 #[cfg(not(target_family = "wasm"))]
 type HasThreadSubscriptionFn =
     dyn for<'a> Fn(&'a EventId) -> HasThreadSubscriptionFuture<'a> + Send + Sync;
+
+#[cfg(test)]
+mod serde_tests {
+    use serde_json::{
+        Value as JsonValue, from_value as from_json_value, json, to_value as to_json_value,
+    };
+
+    use super::{EventMatchConditionData, PushCondition};
+
+    #[test]
+    fn known_push_condition_roundtrips() {
+        let condition = PushCondition::EventMatch(EventMatchConditionData::new(
+            "type".into(),
+            "m.room.message".into(),
+        ));
+        let json = json!({
+            "kind": "event_match",
+            "key": "type",
+            "pattern": "m.room.message",
+        });
+
+        assert_eq!(to_json_value(&condition).unwrap(), json);
+        assert_eq!(
+            from_json_value::<PushCondition>(json).unwrap().kind(),
+            "event_match"
+        );
+    }
+
+    #[test]
+    fn custom_push_condition_roundtrips() {
+        let json = json!({
+            "kind": "dev.palpo.custom",
+            "field": "value",
+        });
+
+        let condition = from_json_value::<PushCondition>(json.clone()).unwrap();
+
+        assert_eq!(condition.kind(), "dev.palpo.custom");
+        assert_eq!(
+            condition.data().get("field"),
+            Some(&JsonValue::String("value".to_owned()))
+        );
+        assert_eq!(to_json_value(condition).unwrap(), json);
+    }
+}
 
 #[cfg(target_family = "wasm")]
 type HasThreadSubscriptionFn = dyn for<'a> Fn(&'a EventId) -> HasThreadSubscriptionFuture<'a>;

--- a/crates/core/src/push/condition/condition_serde.rs
+++ b/crates/core/src/push/condition/condition_serde.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Deserializer};
 use serde_json::value::RawValue as RawJsonValue;
 
-use super::{PushCondition, _CustomPushCondition};
+use super::{_CustomPushCondition, PushCondition};
 use crate::serde::{JsonObject, from_raw_json_value};
 
 impl<'de> Deserialize<'de> for PushCondition {

--- a/crates/core/src/room.rs
+++ b/crates/core/src/room.rs
@@ -401,7 +401,10 @@ impl<'de> Deserialize<'de> for AllowRule {
                 )
                 .expect("type was already deserialized as a string");
 
-                Ok(Self::_Custom(Box::new(CustomAllowRule { rule_type, extra })))
+                Ok(Self::_Custom(Box::new(CustomAllowRule {
+                    rule_type,
+                    extra,
+                })))
             }
         }
     }

--- a/crates/core/src/serde/canonical_json.rs
+++ b/crates/core/src/serde/canonical_json.rs
@@ -136,10 +136,10 @@ pub fn validate_canonical_json(json: &CanonicalJsonObject) -> Result<(), Canonic
                     }
                 }
             }
-            CanonicalJsonValue::Integer(value) => {
-                if *value < CANONICALJSON_MIN_INT || *value > CANONICALJSON_MAX_INT {
-                    return Err(CanonicalJsonError::IntegerOutOfRange);
-                }
+            CanonicalJsonValue::Integer(value)
+                if (*value < CANONICALJSON_MIN_INT || *value > CANONICALJSON_MAX_INT) =>
+            {
+                return Err(CanonicalJsonError::IntegerOutOfRange);
             }
             _ => {}
         }

--- a/crates/core/src/serde/canonical_json/redaction.rs
+++ b/crates/core/src/serde/canonical_json/redaction.rs
@@ -1,9 +1,8 @@
 use std::{fmt, mem};
 
+use super::{CanonicalJsonObject, CanonicalJsonValue};
 use crate::room_version_rules::RedactionRules;
 use crate::serde::RawJson;
-
-use super::{CanonicalJsonObject, CanonicalJsonValue};
 
 /// Errors that can happen in redaction.
 #[derive(Debug)]

--- a/crates/core/src/signatures/functions.rs
+++ b/crates/core/src/signatures/functions.rs
@@ -165,8 +165,7 @@ where
 /// }"#;
 ///
 /// let object = serde_json::from_str(input).unwrap();
-/// let canonical =
-///     palpo_core::signatures::to_canonical_json_string_for_signing(&object).unwrap();
+/// let canonical = palpo_core::signatures::to_canonical_json_string_for_signing(&object).unwrap();
 ///
 /// assert_eq!(canonical, r#"{"日":1,"本":2}"#);
 /// ```

--- a/crates/core/src/signatures/functions/tests.rs
+++ b/crates/core/src/signatures/functions/tests.rs
@@ -17,7 +17,7 @@ use crate::{ServerSigningKeyId, SigningKeyAlgorithm, server_name};
 fn generate_key_pair(name: &str) -> Ed25519KeyPair {
     let key_content = Ed25519KeyPair::generate().unwrap();
     Ed25519KeyPair::from_der(&key_content, name.to_owned())
-        .unwrap_or_else(|_| panic!("{:?}", &key_content))
+        .unwrap_or_else(|_| panic!("{:?}", key_content))
 }
 
 fn add_key_to_map(public_key_map: &mut PublicKeyMap, name: &str, pair: &Ed25519KeyPair) {

--- a/crates/core/src/signatures/keys.rs
+++ b/crates/core/src/signatures/keys.rs
@@ -185,7 +185,7 @@ impl Ed25519KeyPair {
             .map_err(Error::DerParse)?;
         let private_key_info = PrivateKeyInfoRef {
             algorithm: ED25519_ALGORITHM_ID,
-            private_key: &private_key,
+            private_key,
             public_key: Some(public_key),
         };
         let encoded = SecretDocument::try_from(&private_key_info).map_err(Error::DerParse)?;

--- a/crates/core/src/third_party.rs
+++ b/crates/core/src/third_party.rs
@@ -378,8 +378,8 @@ mod tests {
         let third_party_id = ThirdPartyIdentifier {
             address: "monkey@banana.island".into(),
             medium: Medium::Email,
-            validated_at: UnixMillis(1_535_176_800_000_u64.try_into().unwrap()),
-            added_at: UnixMillis(1_535_336_848_756_u64.try_into().unwrap()),
+            validated_at: UnixMillis(1_535_176_800_000_u64),
+            added_at: UnixMillis(1_535_336_848_756_u64),
         };
 
         let third_party_id_serialized = json!({

--- a/crates/data/src/full_text_search.rs
+++ b/crates/data/src/full_text_search.rs
@@ -154,7 +154,7 @@ pub mod configuration {
         DB: Backend,
     {
         fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
-            out.push_sql(&format!("'{}'", &self.0));
+            out.push_sql(&format!("'{}'", self.0));
             Ok(())
         }
     }

--- a/crates/data/src/lib.rs
+++ b/crates/data/src/lib.rs
@@ -57,7 +57,12 @@ pub fn migrate(config: &DbConfig) {
 }
 
 pub async fn connect() -> Result<PgPooledConnection, PoolError> {
-    match DIESEL_POOL.get().expect("diesel pool should set").get().await {
+    match DIESEL_POOL
+        .get()
+        .expect("diesel pool should set")
+        .get()
+        .await
+    {
         Ok(conn) => Ok(conn),
         Err(e) => {
             tracing::error!("db connect error: {e}");

--- a/crates/data/src/room.rs
+++ b/crates/data/src/room.rs
@@ -693,10 +693,7 @@ pub async fn get_state_field_id(event_ty: &StateEventType, state_key: &str) -> D
 }
 
 /// Id of the `(event_ty, state_key)` state field, creating it if missing.
-pub async fn ensure_state_field_id(
-    event_ty: &StateEventType,
-    state_key: &str,
-) -> DataResult<i64> {
+pub async fn ensure_state_field_id(event_ty: &StateEventType, state_key: &str) -> DataResult<i64> {
     let id = diesel::insert_into(room_state_fields::table)
         .values((
             room_state_fields::event_ty.eq(event_ty),

--- a/crates/data/src/room/peek.rs
+++ b/crates/data/src/room/peek.rs
@@ -1,16 +1,16 @@
 //! Persistence for MSC2444 federated peeking.
 //!
 //! Two independent concerns:
-//! - `room_peeking_servers`: remote servers peeking one of *our* rooms (resident
-//!   side). New events are delivered to them until their peek expires/cancels.
-//! - `room_peeks`: outbound peeks *we* hold on remote rooms (peeking side),
-//!   renewed before `renew_at`.
+//! - `room_peeking_servers`: remote servers peeking one of *our* rooms (resident side). New events
+//!   are delivered to them until their peek expires/cancels.
+//! - `room_peeks`: outbound peeks *we* hold on remote rooms (peeking side), renewed before
+//!   `renew_at`.
 
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
-use crate::core::identifiers::*;
 use crate::core::UnixMillis;
+use crate::core::identifiers::*;
 use crate::schema::*;
 use crate::{DataResult, connect};
 

--- a/crates/data/src/room/timeline.rs
+++ b/crates/data/src/room/timeline.rs
@@ -76,61 +76,55 @@ pub async fn purge_room_history(room_id: &RoomId, before_ts: i64) -> DataResult<
     conn.transaction::<_, DieselError, _>(async |conn| {
         // Delete from related tables (no foreign key constraints, order doesn't matter)
         for chunk in event_ids.chunks(500) {
-                diesel::delete(event_datas::table.filter(event_datas::event_id.eq_any(chunk)))
-                    .execute(conn)
-                    .await?;
-                diesel::delete(event_edges::table.filter(event_edges::event_id.eq_any(chunk)))
-                    .execute(conn)
-                    .await?;
-                diesel::delete(
-                    event_forward_extremities::table
-                        .filter(event_forward_extremities::event_id.eq_any(chunk)),
-                )
+            diesel::delete(event_datas::table.filter(event_datas::event_id.eq_any(chunk)))
                 .execute(conn)
                 .await?;
-                diesel::delete(
-                    event_backward_extremities::table
-                        .filter(event_backward_extremities::event_id.eq_any(chunk)),
-                )
+            diesel::delete(event_edges::table.filter(event_edges::event_id.eq_any(chunk)))
                 .execute(conn)
                 .await?;
-                diesel::delete(
-                    event_relations::table.filter(event_relations::event_id.eq_any(chunk)),
-                )
+            diesel::delete(
+                event_forward_extremities::table
+                    .filter(event_forward_extremities::event_id.eq_any(chunk)),
+            )
+            .execute(conn)
+            .await?;
+            diesel::delete(
+                event_backward_extremities::table
+                    .filter(event_backward_extremities::event_id.eq_any(chunk)),
+            )
+            .execute(conn)
+            .await?;
+            diesel::delete(event_relations::table.filter(event_relations::event_id.eq_any(chunk)))
                 .execute(conn)
                 .await?;
-                diesel::delete(
-                    event_receipts::table.filter(event_receipts::event_id.eq_any(chunk)),
-                )
+            diesel::delete(event_receipts::table.filter(event_receipts::event_id.eq_any(chunk)))
                 .execute(conn)
                 .await?;
-                diesel::delete(
-                    event_searches::table.filter(event_searches::event_id.eq_any(chunk)),
-                )
+            diesel::delete(event_searches::table.filter(event_searches::event_id.eq_any(chunk)))
                 .execute(conn)
                 .await?;
-                diesel::delete(
-                    event_push_actions::table.filter(event_push_actions::event_id.eq_any(chunk)),
-                )
+            diesel::delete(
+                event_push_actions::table.filter(event_push_actions::event_id.eq_any(chunk)),
+            )
+            .execute(conn)
+            .await?;
+            diesel::delete(event_points::table.filter(event_points::event_id.eq_any(chunk)))
                 .execute(conn)
                 .await?;
-                diesel::delete(event_points::table.filter(event_points::event_id.eq_any(chunk)))
-                    .execute(conn)
-                    .await?;
-                diesel::delete(event_missings::table.filter(event_missings::event_id.eq_any(chunk)))
-                    .execute(conn)
-                    .await?;
-                diesel::delete(threads::table.filter(threads::event_id.eq_any(chunk)))
-                    .execute(conn)
-                    .await?;
-                diesel::delete(timeline_gaps::table.filter(timeline_gaps::event_id.eq_any(chunk)))
-                    .execute(conn)
-                    .await?;
-                // Delete the events themselves
-                diesel::delete(events::table.filter(events::id.eq_any(chunk)))
-                    .execute(conn)
-                    .await?;
-            }
+            diesel::delete(event_missings::table.filter(event_missings::event_id.eq_any(chunk)))
+                .execute(conn)
+                .await?;
+            diesel::delete(threads::table.filter(threads::event_id.eq_any(chunk)))
+                .execute(conn)
+                .await?;
+            diesel::delete(timeline_gaps::table.filter(timeline_gaps::event_id.eq_any(chunk)))
+                .execute(conn)
+                .await?;
+            // Delete the events themselves
+            diesel::delete(events::table.filter(events::id.eq_any(chunk)))
+                .execute(conn)
+                .await?;
+        }
         Ok(())
     })
     .await?;

--- a/crates/data/src/sending.rs
+++ b/crates/data/src/sending.rs
@@ -3,9 +3,9 @@ use std::fmt::Debug;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
+use crate::core::UnixMillis;
 use crate::core::identifiers::*;
 pub use crate::core::sending::*;
-use crate::core::UnixMillis;
 use crate::schema::*;
 use crate::{DataResult, connect};
 
@@ -14,7 +14,10 @@ use crate::{DataResult, connect};
 pub enum OutgoingDestination<'a> {
     Normal(&'a ServerName),
     Appservice(&'a str),
-    Push { user_id: &'a UserId, pushkey: &'a str },
+    Push {
+        user_id: &'a UserId,
+        pushkey: &'a str,
+    },
 }
 
 #[derive(Identifiable, Queryable, Insertable, Debug, Clone)]
@@ -78,10 +81,7 @@ pub async fn get_destination_rooms(server: &ServerName) -> DataResult<Vec<OwnedR
 
 /// Persist retry state for the active outgoing requests of a destination so
 /// other instances can respect the same backoff window.
-pub async fn persist_retry_state(
-    dest: OutgoingDestination<'_>,
-    tries: u32,
-) -> DataResult<()> {
+pub async fn persist_retry_state(dest: OutgoingDestination<'_>, tries: u32) -> DataResult<()> {
     let now = UnixMillis::now().get() as i64;
     match dest {
         OutgoingDestination::Normal(server_name) => {

--- a/crates/data/src/user.rs
+++ b/crates/data/src/user.rs
@@ -723,7 +723,11 @@ pub async fn set_user_type(user_id: &UserId, user_type: Option<&str>) -> DataRes
 }
 
 /// Set locked status for a user
-pub async fn set_locked(user_id: &UserId, locked: bool, locker_id: Option<&UserId>) -> DataResult<()> {
+pub async fn set_locked(
+    user_id: &UserId,
+    locked: bool,
+    locker_id: Option<&UserId>,
+) -> DataResult<()> {
     // Evict before changing account usability so cached user state cannot
     // authenticate after the update commits but before the post-update scan runs.
     access_token::invalidate_user(user_id);
@@ -836,7 +840,10 @@ pub async fn list_users(filter: &ListUsersFilter) -> DataResult<(Vec<DbUser>, i6
     }
 
     // Get total count with filters applied
-    let total: i64 = count_query.count().get_result(&mut connect().await?).await?;
+    let total: i64 = count_query
+        .count()
+        .get_result(&mut connect().await?)
+        .await?;
 
     // Apply ordering
     let dir_asc = filter.dir.as_ref().map(|d| d == "f").unwrap_or(true);

--- a/crates/data/src/user/access_token.rs
+++ b/crates/data/src/user/access_token.rs
@@ -153,10 +153,7 @@ pub fn invalidate_user(user_id: &UserId) {
 ///
 /// Returns `Ok(None)` when `token` is not a known user access token, so the
 /// caller can fall through to other schemes (e.g. appservice tokens).
-pub async fn authenticate_token(
-    token: &str,
-    cache_ttl: Duration,
-) -> DataResult<Option<TokenAuth>> {
+pub async fn authenticate_token(token: &str, cache_ttl: Duration) -> DataResult<Option<TokenAuth>> {
     let caching = !cache_ttl.is_zero();
     if caching && let Some(hit) = cache_get(token, cache_ttl) {
         return Ok(Some(hit));

--- a/crates/data/src/user/external_id.rs
+++ b/crates/data/src/user/external_id.rs
@@ -62,7 +62,8 @@ pub async fn record_external_id(
             user_id: user_id.to_owned(),
             created_at: UnixMillis::now(),
         })
-        .execute(&mut connect().await?).await?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
@@ -75,7 +76,8 @@ pub async fn replace_external_ids(
 
     // Delete existing external IDs for this user
     diesel::delete(user_external_ids::table.filter(user_external_ids::user_id.eq(user_id)))
-        .execute(&mut conn).await?;
+        .execute(&mut conn)
+        .await?;
 
     // Insert new external IDs
     let now = UnixMillis::now();
@@ -87,7 +89,8 @@ pub async fn replace_external_ids(
                 user_id: user_id.to_owned(),
                 created_at: now,
             })
-            .execute(&mut conn).await?;
+            .execute(&mut conn)
+            .await?;
     }
 
     Ok(())
@@ -100,6 +103,7 @@ pub async fn delete_external_id(auth_provider: &str, external_id: &str) -> DataR
             .filter(user_external_ids::auth_provider.eq(auth_provider))
             .filter(user_external_ids::external_id.eq(external_id)),
     )
-    .execute(&mut connect().await?).await?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }

--- a/crates/data/src/user/key.rs
+++ b/crates/data/src/user/key.rs
@@ -148,7 +148,8 @@ pub async fn count_one_time_keys(
         .filter(e2e_one_time_keys::device_id.eq(device_id))
         .group_by(e2e_one_time_keys::algorithm)
         .select((e2e_one_time_keys::algorithm, diesel::dsl::count_star()))
-        .load::<(String, i64)>(&mut connect().await?).await?;
+        .load::<(String, i64)>(&mut connect().await?)
+        .await?;
     Ok(BTreeMap::from_iter(
         list.into_iter()
             .map(|(k, v)| (DeviceKeyAlgorithm::from(k), v as u64)),
@@ -173,11 +174,15 @@ pub async fn add_device_keys(
         .on_conflict((e2e_device_keys::user_id, e2e_device_keys::device_id))
         .do_update()
         .set(&new_device_key)
-        .execute(&mut connect().await?).await?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
-pub async fn get_device_keys(user_id: &UserId, device_id: &DeviceId) -> DataResult<Option<DeviceKeys>> {
+pub async fn get_device_keys(
+    user_id: &UserId,
+    device_id: &DeviceId,
+) -> DataResult<Option<DeviceKeys>> {
     e2e_device_keys::table
         .filter(e2e_device_keys::user_id.eq(user_id))
         .filter(e2e_device_keys::device_id.eq(device_id))
@@ -209,7 +214,8 @@ pub async fn get_device_keys_and_sigs(
         .filter(e2e_cross_signing_sigs::origin_user_id.eq(user_id))
         .filter(e2e_cross_signing_sigs::target_user_id.eq(user_id))
         .filter(e2e_cross_signing_sigs::target_device_id.eq(device_id))
-        .load::<DbCrossSignature>(&mut connect().await?).await?;
+        .load::<DbCrossSignature>(&mut connect().await?)
+        .await?;
     for DbCrossSignature {
         origin_key_id,
         signature,
@@ -334,12 +340,16 @@ pub async fn has_master_cross_signing_key(user_id: &UserId) -> DataResult<bool> 
         .filter(e2e_cross_signing_keys::user_id.eq(user_id))
         .filter(e2e_cross_signing_keys::key_type.eq("master"))
         .count()
-        .get_result::<i64>(&mut connect().await?).await?;
+        .get_result::<i64>(&mut connect().await?)
+        .await?;
     Ok(count > 0)
 }
 
 /// Set the timestamp until which cross-signing key replacement is allowed without UIA
-pub async fn set_cross_signing_replacement_allowed(user_id: &UserId, expires_ts: i64) -> DataResult<()> {
+pub async fn set_cross_signing_replacement_allowed(
+    user_id: &UserId,
+    expires_ts: i64,
+) -> DataResult<()> {
     diesel::insert_into(e2e_cross_signing_uia_bypass::table)
         .values((
             e2e_cross_signing_uia_bypass::user_id.eq(user_id),
@@ -348,7 +358,8 @@ pub async fn set_cross_signing_replacement_allowed(user_id: &UserId, expires_ts:
         .on_conflict(e2e_cross_signing_uia_bypass::user_id)
         .do_update()
         .set(e2e_cross_signing_uia_bypass::updatable_before_ts.eq(expires_ts))
-        .execute(&mut connect().await?).await?;
+        .execute(&mut connect().await?)
+        .await?;
     Ok(())
 }
 
@@ -532,7 +543,10 @@ pub async fn claim_one_time_key(
         diesel::delete(e2e_one_time_keys::table.find(id))
             .execute(&mut connect().await?)
             .await?;
-        Ok(Some((key_id, serde_json::from_value::<OneTimeKey>(key_data)?)))
+        Ok(Some((
+            key_id,
+            serde_json::from_value::<OneTimeKey>(key_data)?,
+        )))
     } else if let Some(DbFallbackKey {
         id,
         key_id,

--- a/crates/data/src/user/key_backup.rs
+++ b/crates/data/src/user/key_backup.rs
@@ -116,7 +116,8 @@ pub async fn update_backup(
         e2e_room_keys_versions::algorithm.eq(serde_json::to_value(algorithm)?),
         e2e_room_keys_versions::etag.eq(UnixMillis::now().get() as i64),
     ))
-    .execute(&mut connect().await?).await?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(affected > 0)
 }
 
@@ -145,7 +146,9 @@ pub async fn get_room_key(
         .map_err(Into::into)
 }
 
-pub async fn get_latest_room_keys_version(user_id: &UserId) -> DataResult<Option<DbRoomKeysVersion>> {
+pub async fn get_latest_room_keys_version(
+    user_id: &UserId,
+) -> DataResult<Option<DbRoomKeysVersion>> {
     e2e_room_keys_versions::table
         .filter(e2e_room_keys_versions::user_id.eq(user_id))
         .filter(e2e_room_keys_versions::is_trashed.eq(false))
@@ -213,7 +216,8 @@ pub async fn add_key(
             ))
             .do_update()
             .set(&new_key)
-            .execute(&mut connect().await?).await?;
+            .execute(&mut connect().await?)
+            .await?;
     }
     Ok(())
 }
@@ -264,7 +268,8 @@ pub async fn delete_backup(user_id: &UserId, version: i64) -> DataResult<()> {
             .filter(e2e_room_keys_versions::version.eq(version)),
     )
     .set(e2e_room_keys_versions::is_trashed.eq(true))
-    .execute(&mut connect().await?).await?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }
 
@@ -274,7 +279,8 @@ pub async fn delete_all_keys(user_id: &UserId, version: i64) -> DataResult<()> {
             .filter(e2e_room_keys::user_id.eq(user_id))
             .filter(e2e_room_keys::version.eq(version)),
     )
-    .execute(&mut connect().await?).await?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }
 
@@ -285,7 +291,8 @@ pub async fn delete_room_keys(user_id: &UserId, version: i64, room_id: &RoomId) 
             .filter(e2e_room_keys::version.eq(version))
             .filter(e2e_room_keys::room_id.eq(room_id)),
     )
-    .execute(&mut connect().await?).await?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }
 
@@ -302,6 +309,7 @@ pub async fn delete_room_key(
             .filter(e2e_room_keys::room_id.eq(room_id))
             .filter(e2e_room_keys::session_id.eq(session_id)),
     )
-    .execute(&mut connect().await?).await?;
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }

--- a/crates/data/src/user/profile.rs
+++ b/crates/data/src/user/profile.rs
@@ -41,7 +41,10 @@ pub async fn create_profile(profile: &NewDbProfile) -> DataResult<()> {
     Ok(())
 }
 
-pub async fn get_profile(user_id: &UserId, room_id: Option<&RoomId>) -> DataResult<Option<DbProfile>> {
+pub async fn get_profile(
+    user_id: &UserId,
+    room_id: Option<&RoomId>,
+) -> DataResult<Option<DbProfile>> {
     let profile = if let Some(room_id) = room_id {
         user_profiles::table
             .filter(user_profiles::user_id.eq(user_id.as_str()))

--- a/crates/data/src/user/registration_token.rs
+++ b/crates/data/src/user/registration_token.rs
@@ -70,7 +70,9 @@ impl From<DbRegistrationToken> for RegistrationTokenInfo {
 /// and have uses remaining) are returned.
 /// If `valid` is Some(false), only invalid tokens are returned.
 /// If `valid` is None, all tokens are returned.
-pub async fn list_registration_tokens(valid: Option<bool>) -> DataResult<Vec<RegistrationTokenInfo>> {
+pub async fn list_registration_tokens(
+    valid: Option<bool>,
+) -> DataResult<Vec<RegistrationTokenInfo>> {
     let mut query = user_registration_tokens::table.into_boxed();
 
     if let Some(is_valid) = valid {
@@ -108,7 +110,8 @@ pub async fn list_registration_tokens(valid: Option<bool>) -> DataResult<Vec<Reg
 
     let tokens = query
         .order(user_registration_tokens::created_at.desc())
-        .load::<DbRegistrationToken>(&mut connect().await?).await?;
+        .load::<DbRegistrationToken>(&mut connect().await?)
+        .await?;
 
     Ok(tokens.into_iter().map(Into::into).collect())
 }
@@ -138,7 +141,8 @@ pub async fn create_registration_token(
         .values(&new_token)
         .on_conflict(user_registration_tokens::token)
         .do_nothing()
-        .execute(&mut connect().await?).await?;
+        .execute(&mut connect().await?)
+        .await?;
 
     Ok(result > 0)
 }
@@ -170,7 +174,8 @@ pub async fn update_registration_token(
             user_registration_tokens::table.filter(user_registration_tokens::token.eq(token)),
         )
         .set(user_registration_tokens::uses_allowed.eq(new_uses_allowed))
-        .execute(&mut conn).await?;
+        .execute(&mut conn)
+        .await?;
     }
 
     if let Some(new_expires_at) = expires_at {
@@ -178,7 +183,8 @@ pub async fn update_registration_token(
             user_registration_tokens::table.filter(user_registration_tokens::token.eq(token)),
         )
         .set(user_registration_tokens::expires_at.eq(new_expires_at))
-        .execute(&mut conn).await?;
+        .execute(&mut conn)
+        .await?;
     }
 
     // Release the connection before the nested read below, which checks out its
@@ -196,7 +202,8 @@ pub async fn delete_registration_token(token: &str) -> DataResult<bool> {
     let result = diesel::delete(
         user_registration_tokens::table.filter(user_registration_tokens::token.eq(token)),
     )
-    .execute(&mut connect().await?).await?;
+    .execute(&mut connect().await?)
+    .await?;
 
     Ok(result > 0)
 }
@@ -267,7 +274,8 @@ pub async fn increment_pending(token: &str) -> DataResult<bool> {
         user_registration_tokens::table.filter(user_registration_tokens::token.eq(token)),
     )
     .set(user_registration_tokens::pending.eq(user_registration_tokens::pending + 1))
-    .execute(&mut connect().await?).await?;
+    .execute(&mut connect().await?)
+    .await?;
 
     Ok(result > 0)
 }
@@ -293,7 +301,8 @@ pub async fn complete_registration(token: &str) -> DataResult<bool> {
         user_registration_tokens::pending.eq(new_pending),
         user_registration_tokens::completed.eq(user_registration_tokens::completed + 1),
     ))
-    .execute(&mut conn).await?;
+    .execute(&mut conn)
+    .await?;
 
     Ok(result > 0)
 }
@@ -316,7 +325,8 @@ pub async fn cancel_registration(token: &str) -> DataResult<bool> {
         user_registration_tokens::table.filter(user_registration_tokens::token.eq(token)),
     )
     .set(user_registration_tokens::pending.eq(new_pending))
-    .execute(&mut conn).await?;
+    .execute(&mut conn)
+    .await?;
 
     Ok(result > 0)
 }

--- a/crates/server/src/admin/console.rs
+++ b/crates/server/src/admin/console.rs
@@ -240,13 +240,12 @@ fn configure_output_err(mut output: MadSkin) -> MadSkin {
     use termimad::crossterm::style::Color;
     use termimad::{Alignment, CompoundStyle, LineStyle};
 
-    let code_style = CompoundStyle::with_fgbg(Color::AnsiValue(196), Color::AnsiValue(234));
-    output.inline_code = code_style.clone();
+    output.inline_code = CompoundStyle::with_fgbg(Color::AnsiValue(196), Color::AnsiValue(234));
     output.code_block = LineStyle {
         left_margin: 0,
         right_margin: 0,
         align: Alignment::Left,
-        compound_style: code_style,
+        compound_style: CompoundStyle::with_fgbg(Color::AnsiValue(196), Color::AnsiValue(234)),
     };
 
     output
@@ -256,13 +255,12 @@ fn configure_output(mut output: MadSkin) -> MadSkin {
     use termimad::crossterm::style::Color;
     use termimad::{Alignment, CompoundStyle, LineStyle};
 
-    let code_style = CompoundStyle::with_fgbg(Color::AnsiValue(40), Color::AnsiValue(234));
-    output.inline_code = code_style.clone();
+    output.inline_code = CompoundStyle::with_fgbg(Color::AnsiValue(40), Color::AnsiValue(234));
     output.code_block = LineStyle {
         left_margin: 0,
         right_margin: 0,
         align: Alignment::Left,
-        compound_style: code_style,
+        compound_style: CompoundStyle::with_fgbg(Color::AnsiValue(40), Color::AnsiValue(234)),
     };
 
     let table_style = CompoundStyle::default();

--- a/crates/server/src/admin/executor.rs
+++ b/crates/server/src/admin/executor.rs
@@ -228,7 +228,10 @@ async fn respond_to_room(
     room_id: &RoomId,
     user_id: &UserId,
 ) -> AppResult<()> {
-    assert!(crate::room::is_admin_room(room_id).await?, "sender is not admin");
+    assert!(
+        crate::room::is_admin_room(room_id).await?,
+        "sender is not admin"
+    );
 
     let state_lock = crate::room::lock_state(room_id).await;
 

--- a/crates/server/src/admin/room/alias.rs
+++ b/crates/server/src/admin/room/alias.rs
@@ -66,7 +66,8 @@ pub(super) async fn process(command: RoomAliasCommand, context: &Context<'_>) ->
                 RoomAliasCommand::Set { force, room_id, .. } => {
                     match (force, crate::room::resolve_local_alias(&room_alias).await) {
                         (true, Ok(id)) => {
-                            match crate::room::set_alias(&room_id, &room_alias, &server_user.id).await
+                            match crate::room::set_alias(&room_id, &room_alias, &server_user.id)
+                                .await
                             {
                                 Err(err) => {
                                     Err(AppError::public(format!("Failed to remove alias: {err}")))
@@ -85,7 +86,8 @@ pub(super) async fn process(command: RoomAliasCommand, context: &Context<'_>) ->
 							 overwrite"
                         ))),
                         (_, Err(_)) => {
-                            match crate::room::set_alias(&room_id, &room_alias, &server_user.id).await
+                            match crate::room::set_alias(&room_id, &room_alias, &server_user.id)
+                                .await
                             {
                                 Err(err) => {
                                     Err(AppError::public(format!("Failed to remove alias: {err}")))

--- a/crates/server/src/admin/room/moderation.rs
+++ b/crates/server/src/admin/room/moderation.rs
@@ -216,8 +216,9 @@ async fn ban_list_of_rooms(ctx: &Context<'_>) -> AppResult<()> {
                 if room_alias_or_id.is_room_alias_id() {
                     match RoomAliasId::parse(room_alias_or_id) {
                         Ok(room_alias) => {
-                            let room_id =
-                                match crate::room::alias::resolve_local_alias(&room_alias).await {
+                            let room_id = match crate::room::alias::resolve_local_alias(&room_alias)
+                                .await
+                            {
                                 Ok(room_id) => room_id,
                                 _ => {
                                     debug!(

--- a/crates/server/src/admin/user/cmd.rs
+++ b/crates/server/src/admin/user/cmd.rs
@@ -585,11 +585,12 @@ pub(super) async fn force_demote(
     let state_lock = crate::room::lock_state(&room_id).await;
     let room_power_levels = crate::room::get_power_levels(&room_id).await.ok();
 
-    let user_can_demote_self = room_power_levels.as_ref().is_some_and(|power_levels| {
-        power_levels.user_can_change_user_power_level(&user_id, &user_id)
-    }) || crate::room::get_state(&room_id, &StateEventType::RoomCreate, "", None)
-        .await
-        .is_ok_and(|event| event.sender == user_id);
+    let user_can_demote_self =
+        room_power_levels.as_ref().is_some_and(|power_levels| {
+            power_levels.user_can_change_user_power_level(&user_id, &user_id)
+        }) || crate::room::get_state(&room_id, &StateEventType::RoomCreate, "", None)
+            .await
+            .is_ok_and(|event| event.sender == user_id);
 
     if !user_can_demote_self {
         return Err(AppError::public(

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -235,7 +235,9 @@ pub fn server_user_id() -> &'static UserId {
 }
 
 pub async fn server_user() -> crate::data::user::DbUser {
-    crate::data::user::get_user(server_user_id()).await.expect("server user should exist in the database")
+    crate::data::user::get_user(server_user_id())
+        .await
+        .expect("server user should exist in the database")
 }
 
 pub fn server_name() -> &'static ServerName {

--- a/crates/server/src/directory.rs
+++ b/crates/server/src/directory.rs
@@ -78,10 +78,12 @@ async fn get_local_public_rooms(
             let chunk = PublicRoomsChunk {
                 canonical_alias: room::get_canonical_alias(&room_id).await.ok().flatten(),
                 name: room::get_name(&room_id).await.ok(),
-                num_joined_members: room::joined_member_count(&room_id).await.unwrap_or_else(|_| {
-                    warn!("Room {} has no member count", room_id);
-                    0
-                }),
+                num_joined_members: room::joined_member_count(&room_id).await.unwrap_or_else(
+                    |_| {
+                        warn!("Room {} has no member count", room_id);
+                        0
+                    },
+                ),
                 topic: room::get_topic(&room_id).await.ok(),
                 world_readable: room::is_world_readable(&room_id).await,
                 guest_can_join: room::guest_can_join(&room_id).await,
@@ -92,7 +94,8 @@ async fn get_local_public_rooms(
                     "",
                     None,
                 )
-                .await.map(|c| match c.join_rule {
+                .await
+                .map(|c| match c.join_rule {
                     JoinRule::Public => Some(PublicRoomJoinRule::Public),
                     JoinRule::Knock => Some(PublicRoomJoinRule::Knock),
                     JoinRule::KnockRestricted(..) => Some(PublicRoomJoinRule::KnockRestricted),
@@ -120,12 +123,15 @@ async fn get_local_public_rooms(
             {
                 true
             } else {
-                chunk.canonical_alias.as_ref().is_some_and(|canonical_alias| {
-                    canonical_alias
-                        .as_str()
-                        .to_lowercase()
-                        .contains(search_term)
-                })
+                chunk
+                    .canonical_alias
+                    .as_ref()
+                    .is_some_and(|canonical_alias| {
+                        canonical_alias
+                            .as_str()
+                            .to_lowercase()
+                            .contains(search_term)
+                    })
             }
         } else {
             // No search term
@@ -138,7 +144,7 @@ async fn get_local_public_rooms(
         }
     }
 
-    all_rooms.sort_by(|l, r| r.num_joined_members.cmp(&l.num_joined_members));
+    all_rooms.sort_by_key(|r| std::cmp::Reverse(r.num_joined_members));
 
     let total_room_count_estimate = (all_rooms.len() as u32).into();
 

--- a/crates/server/src/event.rs
+++ b/crates/server/src/event.rs
@@ -272,9 +272,7 @@ pub fn parse_fetched_pdu(
         Err(e) => {
             // Event could not be converted to canonical json
             error!(value = ?value, "error generating event id for fetched pdu: {:?}", e);
-            return Err(
-                MatrixError::bad_json("could not convert event to canonical json").into(),
-            );
+            return Err(MatrixError::bad_json("could not convert event to canonical json").into());
         }
     };
     Ok((event_id, value))

--- a/crates/server/src/event/batch_token.rs
+++ b/crates/server/src/event/batch_token.rs
@@ -117,39 +117,6 @@ impl FromStr for BatchToken {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parses_live_and_historic_tokens() {
-        assert_eq!(
-            "s2633508".parse::<BatchToken>().unwrap(),
-            BatchToken::Live { stream_ordering: 2633508 }
-        );
-        assert_eq!(
-            "t426-2633508".parse::<BatchToken>().unwrap(),
-            BatchToken::Historic { stream_ordering: 2633508, topological_ordering: 426 }
-        );
-    }
-
-    #[test]
-    fn accepts_bare_numeric_token_for_backward_compat() {
-        // Tokens minted by pre-#69 builds (and replayed from client storage)
-        // have no 's' prefix; they must still resolve to a live token.
-        assert_eq!(
-            "128".parse::<BatchToken>().unwrap(),
-            BatchToken::Live { stream_ordering: 128 }
-        );
-    }
-
-    #[test]
-    fn rejects_non_numeric_garbage() {
-        assert!("garbage".parse::<BatchToken>().is_err());
-        assert!("".parse::<BatchToken>().is_err());
-    }
-}
-
 impl std::fmt::Display for BatchToken {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -159,5 +126,45 @@ impl std::fmt::Display for BatchToken {
                 topological_ordering,
             } => write!(f, "t{}-{}", topological_ordering, stream_ordering),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_live_and_historic_tokens() {
+        assert_eq!(
+            "s2633508".parse::<BatchToken>().unwrap(),
+            BatchToken::Live {
+                stream_ordering: 2633508
+            }
+        );
+        assert_eq!(
+            "t426-2633508".parse::<BatchToken>().unwrap(),
+            BatchToken::Historic {
+                stream_ordering: 2633508,
+                topological_ordering: 426
+            }
+        );
+    }
+
+    #[test]
+    fn accepts_bare_numeric_token_for_backward_compat() {
+        // Tokens minted by pre-#69 builds (and replayed from client storage)
+        // have no 's' prefix; they must still resolve to a live token.
+        assert_eq!(
+            "128".parse::<BatchToken>().unwrap(),
+            BatchToken::Live {
+                stream_ordering: 128
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_non_numeric_garbage() {
+        assert!("garbage".parse::<BatchToken>().is_err());
+        assert!("".parse::<BatchToken>().is_err());
     }
 }

--- a/crates/server/src/event/fetching.rs
+++ b/crates/server/src/event/fetching.rs
@@ -202,7 +202,7 @@ pub(super) async fn fetch_and_process_missing_state_by_ids(
 
     let mut desired_events = pdu_ids;
     desired_events.push(event_id.to_owned());
-    desired_events.extend(auth_chain_ids.into_iter());
+    desired_events.extend(auth_chain_ids);
 
     let desired_count = desired_events.len();
     let mut failed_missing_events = Vec::new();

--- a/crates/server/src/event/handler.rs
+++ b/crates/server/src/event/handler.rs
@@ -686,11 +686,10 @@ pub async fn process_to_timeline_pdu(
         // Now we calculate the set of extremities this room has after the incoming event has been
         // applied. We start with the previous extremities (aka leaves)
         debug!("calculating extremities");
-        let mut extremities: BTreeSet<_> =
-            state::get_forward_extremities(&incoming_pdu.room_id)
-                .await?
-                .into_iter()
-                .collect();
+        let mut extremities: BTreeSet<_> = state::get_forward_extremities(&incoming_pdu.room_id)
+            .await?
+            .into_iter()
+            .collect();
 
         // Remove any forward extremities that are referenced by this incoming event's prev_events
         extremities.retain(|event_id| !incoming_pdu.prev_events.contains(event_id));

--- a/crates/server/src/event/pdu.rs
+++ b/crates/server/src/event/pdu.rs
@@ -159,7 +159,8 @@ impl SnPduEvent {
             self.get_content::<ExtractMemebership>()
                 .map(|m| m.membership)
                 .ok()
-        } else if let Ok(frame_id) = crate::event::get_frame_id(&self.room_id, self.event_sn).await {
+        } else if let Ok(frame_id) = crate::event::get_frame_id(&self.room_id, self.event_sn).await
+        {
             state::user_membership(frame_id, user_id)
                 .await
                 .ok()

--- a/crates/server/src/event/resolver.rs
+++ b/crates/server/src/event/resolver.rs
@@ -115,7 +115,8 @@ pub async fn resolve_state(
     let mut new_room_state = BTreeSet::new();
     let mut guards = Vec::new();
     for ((event_type, state_key), event_id) in state {
-        let state_key_id = state::ensure_field_id(&event_type.to_string().into(), &state_key).await?;
+        let state_key_id =
+            state::ensure_field_id(&event_type.to_string().into(), &state_key).await?;
         let (event_sn, guard) = crate::event::ensure_event_sn(room_id, &event_id).await?;
         if let Some(guard) = guard {
             guards.push(guard);

--- a/crates/server/src/exts/url.rs
+++ b/crates/server/src/exts/url.rs
@@ -377,14 +377,19 @@ async fn query_given_srv_record(record: &str) -> Option<(FedDest, Instant)> {
                 .iter()
                 .find_map(|record| record.try_borrow::<SRV>())
                 .map(|result| {
-                (
-                    FedDest::Named(
-                        result.data().target.to_string().trim_end_matches('.').to_owned(),
-                        format!(":{}", result.data().port),
-                    ),
-                    srv.valid_until(),
-                )
-            })
+                    (
+                        FedDest::Named(
+                            result
+                                .data()
+                                .target
+                                .to_string()
+                                .trim_end_matches('.')
+                                .to_owned(),
+                            format!(":{}", result.data().port),
+                        ),
+                        srv.valid_until(),
+                    )
+                })
         })
         .unwrap_or(None)
 }

--- a/crates/server/src/federation.rs
+++ b/crates/server/src/federation.rs
@@ -164,12 +164,18 @@ pub(crate) async fn user_can_perform_restricted_join(
         return Ok(false);
     }
 
-    if room::user::is_joined(user_id, room_id).await.unwrap_or(false) {
+    if room::user::is_joined(user_id, room_id)
+        .await
+        .unwrap_or(false)
+    {
         // joining user is already joined, there is nothing we need to do
         return Ok(false);
     }
 
-    if room::user::is_invited(user_id, room_id).await.unwrap_or(false) {
+    if room::user::is_invited(user_id, room_id)
+        .await
+        .unwrap_or(false)
+    {
         return Ok(true);
     }
 
@@ -201,8 +207,12 @@ pub(crate) async fn user_can_perform_restricted_join(
             None
         }
     }) {
-        if room::is_server_joined(&config::get().server_name, &m.room_id).await.unwrap_or(false)
-            && room::user::is_joined(user_id, &m.room_id).await.unwrap_or(false)
+        if room::is_server_joined(&config::get().server_name, &m.room_id)
+            .await
+            .unwrap_or(false)
+            && room::user::is_joined(user_id, &m.room_id)
+                .await
+                .unwrap_or(false)
         {
             authorized = true;
             break;

--- a/crates/server/src/federation/membership/join.rs
+++ b/crates/server/src/federation/membership/join.rs
@@ -193,7 +193,8 @@ pub async fn send_join_v1(
         }
     }
 
-    if let Err(e) = sending::send_pdu_room(room_id, &event_id, &[], &[origin.to_owned()]).await {
+    let ignore_servers = [origin.to_owned()];
+    if let Err(e) = sending::send_pdu_room(room_id, &event_id, &[], &ignore_servers).await {
         error!("failed to notify user joined to servers: {e}");
     }
 

--- a/crates/server/src/federation/peek.rs
+++ b/crates/server/src/federation/peek.rs
@@ -18,9 +18,7 @@ use crate::event::handler::process_incoming_pdu;
 use crate::event::parse_fetched_pdu;
 use crate::room::state::{CompressedEvent, DeltaInfo};
 use crate::room::{state, timeline};
-use crate::{
-    AppError, AppResult, GetUrlOrigin, OptionalExtension, config, data, room, sending,
-};
+use crate::{AppError, AppResult, GetUrlOrigin, OptionalExtension, config, data, room, sending};
 
 /// How long a peek subscription is valid before the peeking server must renew.
 /// Returned to peers as `renewal_interval`.
@@ -301,8 +299,15 @@ pub async fn run_maintenance() {
     // peeker was dropped during sync because the room stopped being
     // world-readable, or all users unpeeked). Prevents ownerless subscriptions
     // from being renewed forever.
-    for room_id in data::room::peek::peeked_room_ids().await.unwrap_or_default() {
-        if data::room::peek::room_peeker_count(&room_id).await.unwrap_or(1) == 0 {
+    for room_id in data::room::peek::peeked_room_ids()
+        .await
+        .unwrap_or_default()
+    {
+        if data::room::peek::room_peeker_count(&room_id)
+            .await
+            .unwrap_or(1)
+            == 0
+        {
             let _ = stop_peek(&room_id).await;
         }
     }

--- a/crates/server/src/global.rs
+++ b/crates/server/src/global.rs
@@ -115,151 +115,153 @@ pub fn dns_resolver() -> &'static HickoryResolver<TokioRuntimeProvider> {
 pub async fn appservices() -> &'static Vec<Registration> {
     use figment::Figment;
     use figment::providers::{Format, Toml, Yaml};
-    static APPSERVICES: tokio::sync::OnceCell<Vec<Registration>> = tokio::sync::OnceCell::const_new();
+    static APPSERVICES: tokio::sync::OnceCell<Vec<Registration>> =
+        tokio::sync::OnceCell::const_new();
 
-    APPSERVICES.get_or_init(|| async {
-        let mut appservices = vec![];
-        let Some(registration_dir) = crate::config::appservice_registration_dir() else {
-            return appservices;
-        };
-        tracing::info!("Appservice registration dir: {}", registration_dir);
-        let mut exist_ids = HashSet::new();
-        let Ok(entries) = std::fs::read_dir(registration_dir) else {
-            return appservices;
-        };
-
-        for entry in entries {
-            let Ok(entry) = entry else {
-                continue;
+    APPSERVICES
+        .get_or_init(|| async {
+            let mut appservices = vec![];
+            let Some(registration_dir) = crate::config::appservice_registration_dir() else {
+                return appservices;
             };
-            let path = entry.path();
-
-            if path.is_dir() {
-                continue;
-            }
-            let Some(ext) = path.extension() else {
-                continue;
+            tracing::info!("Appservice registration dir: {}", registration_dir);
+            let mut exist_ids = HashSet::new();
+            let Ok(entries) = std::fs::read_dir(registration_dir) else {
+                return appservices;
             };
-            let registration = match ext.to_str() {
-                Some("yaml") | Some("yml") => match Figment::new()
-                    .merge(Yaml::file(&path))
-                    .extract::<Registration>()
-                {
-                    Ok(registration) => registration,
-                    Err(e) => {
-                        tracing::error!(
-                            "It looks like your config `{}` is invalid. Error occurred: {e}",
-                            path.display()
-                        );
-                        continue;
-                    }
-                },
-                Some("toml") => match Figment::new()
-                    .merge(Toml::file(&path))
-                    .extract::<Registration>()
-                {
-                    Ok(registration) => registration,
-                    Err(e) => {
-                        tracing::error!(
-                            "It looks like your config `{}` is invalid. Error occurred: {e}",
-                            path.display()
-                        );
-                        continue;
-                    }
-                },
-                _ => {
+
+            for entry in entries {
+                let Ok(entry) = entry else {
+                    continue;
+                };
+                let path = entry.path();
+
+                if path.is_dir() {
                     continue;
                 }
-            };
+                let Some(ext) = path.extension() else {
+                    continue;
+                };
+                let registration = match ext.to_str() {
+                    Some("yaml") | Some("yml") => match Figment::new()
+                        .merge(Yaml::file(&path))
+                        .extract::<Registration>()
+                    {
+                        Ok(registration) => registration,
+                        Err(e) => {
+                            tracing::error!(
+                                "It looks like your config `{}` is invalid. Error occurred: {e}",
+                                path.display()
+                            );
+                            continue;
+                        }
+                    },
+                    Some("toml") => match Figment::new()
+                        .merge(Toml::file(&path))
+                        .extract::<Registration>()
+                    {
+                        Ok(registration) => registration,
+                        Err(e) => {
+                            tracing::error!(
+                                "It looks like your config `{}` is invalid. Error occurred: {e}",
+                                path.display()
+                            );
+                            continue;
+                        }
+                    },
+                    _ => {
+                        continue;
+                    }
+                };
 
-            if exist_ids.contains(&registration.id) {
-                tracing::error!("Duplicate appservice registration id: {}", registration.id);
-                continue;
-            }
-            exist_ids.insert(registration.id.clone());
-            appservices.push(registration.clone());
+                if exist_ids.contains(&registration.id) {
+                    tracing::error!("Duplicate appservice registration id: {}", registration.id);
+                    continue;
+                }
+                exist_ids.insert(registration.id.clone());
+                appservices.push(registration.clone());
 
-            // Ensure the appservice registration is in the database so that
-            // event forwarding (via appservice::all()) can find it.
-            let db_registration: DbRegistration = registration.clone().into();
-            let mut conn = connect().await.expect("db connect failed");
-            if let Err(e) = diesel::insert_into(appservice_registrations::table)
-                .values(&db_registration)
-                .on_conflict(appservice_registrations::id)
-                .do_update()
-                .set((
-                    appservice_registrations::url.eq(&db_registration.url),
-                    appservice_registrations::as_token.eq(&db_registration.as_token),
-                    appservice_registrations::hs_token.eq(&db_registration.hs_token),
-                    appservice_registrations::sender_localpart
-                        .eq(&db_registration.sender_localpart),
-                    appservice_registrations::namespaces.eq(&db_registration.namespaces),
-                    appservice_registrations::rate_limited.eq(&db_registration.rate_limited),
-                    appservice_registrations::protocols.eq(&db_registration.protocols),
-                    appservice_registrations::receive_ephemeral
-                        .eq(&db_registration.receive_ephemeral),
-                    appservice_registrations::device_management
-                        .eq(&db_registration.device_management),
+                // Ensure the appservice registration is in the database so that
+                // event forwarding (via appservice::all()) can find it.
+                let db_registration: DbRegistration = registration.clone().into();
+                let mut conn = connect().await.expect("db connect failed");
+                if let Err(e) = diesel::insert_into(appservice_registrations::table)
+                    .values(&db_registration)
+                    .on_conflict(appservice_registrations::id)
+                    .do_update()
+                    .set((
+                        appservice_registrations::url.eq(&db_registration.url),
+                        appservice_registrations::as_token.eq(&db_registration.as_token),
+                        appservice_registrations::hs_token.eq(&db_registration.hs_token),
+                        appservice_registrations::sender_localpart
+                            .eq(&db_registration.sender_localpart),
+                        appservice_registrations::namespaces.eq(&db_registration.namespaces),
+                        appservice_registrations::rate_limited.eq(&db_registration.rate_limited),
+                        appservice_registrations::protocols.eq(&db_registration.protocols),
+                        appservice_registrations::receive_ephemeral
+                            .eq(&db_registration.receive_ephemeral),
+                        appservice_registrations::device_management
+                            .eq(&db_registration.device_management),
+                    ))
+                    .execute(&mut conn)
+                    .await
+                {
+                    tracing::error!("Failed to save appservice registration to database: {e}");
+                }
+                drop(conn);
+
+                let user_id = OwnedUserId::try_from(format!(
+                    "@{}:{}",
+                    registration.sender_localpart,
+                    crate::config::get().server_name
                 ))
-                .execute(&mut conn)
-                .await
-            {
-                tracing::error!("Failed to save appservice registration to database: {e}");
-            }
-            drop(conn);
+                .unwrap();
+                let mut conn = connect().await.expect("db connect failed");
+                if !diesel_exists!(users::table.filter(users::id.eq(&user_id)), &mut conn)
+                    .expect("db query failed")
+                {
+                    diesel::insert_into(users::table)
+                        .values(NewDbUser {
+                            id: user_id.to_owned(),
+                            ty: None,
+                            is_admin: false,
+                            is_guest: false,
+                            is_local: true,
+                            localpart: user_id.localpart().to_owned(),
+                            server_name: user_id.server_name().to_owned(),
+                            appservice_id: Some(registration.id.clone()),
+                            created_at: UnixMillis::now(),
+                        })
+                        .execute(&mut conn)
+                        .await
+                        .expect("db query failed");
+                }
 
-            let user_id = OwnedUserId::try_from(format!(
-                "@{}:{}",
-                registration.sender_localpart,
-                crate::config::get().server_name
-            ))
-            .unwrap();
-            let mut conn = connect().await.expect("db connect failed");
-            if !diesel_exists!(users::table.filter(users::id.eq(&user_id)), &mut conn)
+                if !diesel_exists!(
+                    user_devices::table.filter(user_devices::user_id.eq(&user_id)),
+                    &mut conn
+                )
                 .expect("db query failed")
-            {
-                diesel::insert_into(users::table)
-                    .values(NewDbUser {
-                        id: user_id.to_owned(),
-                        ty: None,
-                        is_admin: false,
-                        is_guest: false,
-                        is_local: true,
-                        localpart: user_id.localpart().to_owned(),
-                        server_name: user_id.server_name().to_owned(),
-                        appservice_id: Some(registration.id.clone()),
-                        created_at: UnixMillis::now(),
-                    })
-                    .execute(&mut conn)
-                    .await
-                    .expect("db query failed");
+                {
+                    diesel::insert_into(user_devices::table)
+                        .values(NewDbUserDevice {
+                            user_id,
+                            device_id: OwnedDeviceId::from("_"),
+                            display_name: Some("[Default]".to_string()),
+                            user_agent: None,
+                            is_hidden: true,
+                            last_seen_ip: None,
+                            last_seen_at: None,
+                            created_at: UnixMillis::now(),
+                        })
+                        .execute(&mut conn)
+                        .await
+                        .expect("db query failed");
+                }
             }
-
-            if !diesel_exists!(
-                user_devices::table.filter(user_devices::user_id.eq(&user_id)),
-                &mut conn
-            )
-            .expect("db query failed")
-            {
-                diesel::insert_into(user_devices::table)
-                    .values(NewDbUserDevice {
-                        user_id,
-                        device_id: OwnedDeviceId::from("_"),
-                        display_name: Some("[Default]".to_string()),
-                        user_agent: None,
-                        is_hidden: true,
-                        last_seen_ip: None,
-                        last_seen_at: None,
-                        created_at: UnixMillis::now(),
-                    })
-                    .execute(&mut conn)
-                    .await
-                    .expect("db query failed");
-            }
-        }
-        appservices
-    })
-    .await
+            appservices
+        })
+        .await
 }
 
 pub async fn add_signing_key_from_trusted_server(

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -207,7 +207,7 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     crate::storage::init(&conf.storage).expect("Failed to initialize storage backend");
     // Force-load appservice registrations during startup so database rows
     // are up-to-date with the configured registration directory.
-    let _ = crate::appservices();
+    let _ = crate::appservices().await;
 
     if args.console {
         tracing::info!("starting admin console...");

--- a/crates/server/src/membership.rs
+++ b/crates/server/src/membership.rs
@@ -115,8 +115,7 @@ pub async fn update_membership(
 ) -> AppResult<()> {
     let conf = crate::config::get();
     // Keep track what remote users exist by adding them as "deactivated" users
-    if user_id.server_name() != conf.server_name
-        && !crate::data::user::user_exists(user_id).await?
+    if user_id.server_name() != conf.server_name && !crate::data::user::user_exists(user_id).await?
     {
         crate::user::create_user(user_id, None).await?;
         // TODO: display_name, avatar url
@@ -257,11 +256,11 @@ pub async fn update_membership(
             if let Some(last_state) = &last_state {
                 for event in last_state {
                     if let Ok(event) = event.deserialize() {
-                        let _ = ensure_field(&event.event_type(), event.state_key());
+                        let _ = ensure_field(&event.event_type(), event.state_key()).await;
                     }
                 }
             }
-            let _ = ensure_field(&StateEventType::RoomMember, user_id.as_str());
+            let _ = ensure_field(&StateEventType::RoomMember, user_id.as_str()).await;
             connect()
                 .await?
                 .transaction::<_, AppError, _>(async |conn| {

--- a/crates/server/src/membership/invite.rs
+++ b/crates/server/src/membership/invite.rs
@@ -49,7 +49,8 @@ pub async fn invite_user(
                     inviter_id,
                     room_id,
                     crate::room::get_version(room_id)
-                        .await.as_ref()
+                        .await
+                        .as_ref()
                         .unwrap_or(&conf.default_room_version),
                     &state_lock,
                 )
@@ -70,7 +71,8 @@ pub async fn invite_user(
             MembershipState::Invite,
             inviter_id,
             Some(invite_room_state.clone()),
-        ).await?;
+        )
+        .await?;
 
         let invite_request = crate::core::federation::membership::invite_user_request_v2(
             &invitee_id.server_name().origin().await,
@@ -144,7 +146,8 @@ pub async fn invite_user(
             &event_id,
             &[invitee_id.server_name().to_owned()],
             &[],
-        ).await;
+        )
+        .await;
     }
 
     timeline::build_and_append_pdu(

--- a/crates/server/src/membership/join.rs
+++ b/crates/server/src/membership/join.rs
@@ -223,9 +223,8 @@ pub async fn join_room(
     // up the room version — this room isn't in our DB yet during a federation join.
     let mut outgoing = join_event.clone();
     maybe_strip_event_id(&mut outgoing, &room_version);
-    let body = SendJoinReqBody(
-        crate::sending::convert_to_outgoing_federation_event(outgoing).await,
-    );
+    let body =
+        SendJoinReqBody(crate::sending::convert_to_outgoing_federation_event(outgoing).await);
     info!("asking {remote_server} for send_join");
     let send_join_request = crate::core::federation::membership::send_join_request(
         &remote_server.origin().await,
@@ -612,7 +611,9 @@ async fn make_join_request(
     room_id: &RoomId,
     servers: &[OwnedServerName],
 ) -> AppResult<(MakeJoinResBody, OwnedServerName)> {
-    let invited_locally = room::user::is_invited(user_id, room_id).await.unwrap_or(false);
+    let invited_locally = room::user::is_invited(user_id, room_id)
+        .await
+        .unwrap_or(false);
     let mut last_join_error = Err(StatusError::bad_request()
         .brief("no server available to assist in joining")
         .into());

--- a/crates/server/src/membership/knock.rs
+++ b/crates/server/src/membership/knock.rs
@@ -58,7 +58,10 @@ pub async fn knock_room(
     }
 
     let conf = config::get();
-    if room::is_server_joined(&conf.server_name, room_id).await.unwrap_or(false) {
+    if room::is_server_joined(&conf.server_name, room_id)
+        .await
+        .unwrap_or(false)
+    {
         use RoomVersionId::*;
         info!("we can knock locally");
         let room_version = room::get_version(room_id).await?;
@@ -79,8 +82,14 @@ pub async fn knock_room(
         }
 
         let content = RoomMemberEventContent {
-            display_name: crate::data::user::display_name(sender_id).await.ok().flatten(),
-            avatar_url: crate::data::user::avatar_url(sender_id).await.ok().flatten(),
+            display_name: crate::data::user::display_name(sender_id)
+                .await
+                .ok()
+                .flatten(),
+            avatar_url: crate::data::user::avatar_url(sender_id)
+                .await
+                .ok()
+                .flatten(),
             blurhash: crate::data::user::blurhash(sender_id).await.ok().flatten(),
             reason: reason.clone(),
             ..RoomMemberEventContent::new(MembershipState::Knock)
@@ -102,7 +111,9 @@ pub async fn knock_room(
                     &pdu.event_id,
                     &[sender_id.server_name().to_owned()],
                     &[],
-                ).await {
+                )
+                .await
+                {
                     error!("failed to notify banned user server: {e}");
                 }
                 return Ok(Some(pdu));
@@ -145,8 +156,14 @@ pub async fn knock_room(
     knock_event_stub.insert(
         "content".to_owned(),
         to_canonical_value(RoomMemberEventContent {
-            display_name: crate::data::user::display_name(sender_id).await.ok().flatten(),
-            avatar_url: crate::data::user::avatar_url(sender_id).await.ok().flatten(),
+            display_name: crate::data::user::display_name(sender_id)
+                .await
+                .ok()
+                .flatten(),
+            avatar_url: crate::data::user::avatar_url(sender_id)
+                .await
+                .ok()
+                .flatten(),
             blurhash: crate::data::user::blurhash(sender_id).await.ok().flatten(),
             reason,
             ..RoomMemberEventContent::new(MembershipState::Knock)
@@ -177,9 +194,9 @@ pub async fn knock_room(
             room_id: room_id.to_owned(),
             event_id: event_id.to_owned(),
         },
-        SendKnockReqBody::new(crate::sending::convert_to_outgoing_federation_event(
-            knock_event.clone(),
-        ).await),
+        SendKnockReqBody::new(
+            crate::sending::convert_to_outgoing_federation_event(knock_event.clone()).await,
+        ),
     )?
     .into_inner();
 
@@ -221,7 +238,8 @@ pub async fn knock_room(
         is_rejected: false,
         rejection_reason: None,
     }
-    .save().await?;
+    .save()
+    .await?;
     let knock_pdu = SnPduEvent {
         pdu: parsed_knock_pdu,
         event_sn,

--- a/crates/server/src/membership/leave.rs
+++ b/crates/server/src/membership/leave.rs
@@ -18,10 +18,12 @@ use crate::{
 
 // Make a user leave all their joined rooms
 pub async fn leave_all_rooms(user_id: &UserId) -> AppResult<()> {
-    let all_room_ids = data::user::joined_rooms(user_id).await?
+    let all_room_ids = data::user::joined_rooms(user_id)
+        .await?
         .into_iter()
         .chain(
-            data::user::invited_rooms(user_id, 0).await?
+            data::user::invited_rooms(user_id, 0)
+                .await?
                 .into_iter()
                 .map(|t| t.0),
         )
@@ -61,7 +63,8 @@ pub async fn leave_room(
                 MembershipState::Leave,
                 user_id,
                 last_state,
-            ).await?;
+            )
+            .await?;
             Ok(())
         }
         Err(e) => {
@@ -105,15 +108,18 @@ async fn leave_room_local(
         &room::lock_state(room_id).await,
     )
     .await?;
-    if just_invited && member_event.sender.server_name() != config::server_name() {
-        let _ = crate::sending::send_pdu_room(
-            room_id,
+    // `build_and_append_pdu` already delivered the leave event to all
+    // participating servers. For a rejected invite the inviting server may
+    // not be among them (e.g. an out-of-band invite), so notify it explicitly.
+    if just_invited
+        && member_event.sender.server_name() != config::server_name()
+        && let Err(e) = crate::sending::send_pdu_servers(
+            std::iter::once(member_event.sender.server_name().to_owned()),
             &pdu.event_id,
-            &[member_event.sender.server_name().to_owned()],
-            &[],
-        );
-    } else {
-        let _ = crate::sending::send_pdu_room(room_id, &pdu.event_id, &[], &[]);
+        )
+        .await
+    {
+        warn!("failed to send leave event to inviting server: {e}");
     }
     Ok((pdu.event_id.clone(), pdu.event_sn))
 }
@@ -124,7 +130,8 @@ async fn leave_room_remote(
 ) -> AppResult<(OwnedEventId, Seqnum)> {
     let mut make_leave_response_and_server =
         Err(AppError::public("no server available to assist in leaving"));
-    let invite_state = state::get_user_state(user_id, room_id).await?
+    let invite_state = state::get_user_state(user_id, room_id)
+        .await?
         .ok_or(MatrixError::bad_state("user is not invited"))?;
 
     let servers: HashSet<_> = invite_state
@@ -224,7 +231,8 @@ async fn leave_room_remote(
         is_rejected: false,
         rejection_reason: None,
     }
-    .save().await?;
+    .save()
+    .await?;
 
     DbEventData {
         event_id: event_id.clone(),
@@ -234,7 +242,8 @@ async fn leave_room_remote(
         json_data: serde_json::to_value(&leave_event_stub)?,
         format_version: None,
     }
-    .save().await?;
+    .save()
+    .await?;
     let parsed_leave_pdu =
         PduEvent::from_canonical_object(room_id, &event_id, leave_event_stub.clone()).map_err(
             |e| {
@@ -265,9 +274,9 @@ async fn leave_room_remote(
             room_id: room_id.to_owned(),
             event_id: event_id.clone(),
         },
-        SendLeaveReqBody(crate::sending::convert_to_outgoing_federation_event(
-            leave_event.clone(),
-        ).await),
+        SendLeaveReqBody(
+            crate::sending::convert_to_outgoing_federation_event(leave_event.clone()).await,
+        ),
     )?
     .into_inner();
     crate::sending::send_federation_request(&remote_server, request, None).await?;

--- a/crates/server/src/room.rs
+++ b/crates/server/src/room.rs
@@ -68,10 +68,7 @@ pub async fn create_room(new_room: NewDbRoom) -> AppResult<OwnedRoomId> {
     Ok(new_room.id)
 }
 
-pub async fn ensure_room(
-    id: &RoomId,
-    room_version_id: &RoomVersionId,
-) -> AppResult<OwnedRoomId> {
+pub async fn ensure_room(id: &RoomId, room_version_id: &RoomVersionId) -> AppResult<OwnedRoomId> {
     if room_exists(id).await? {
         Ok(id.to_owned())
     } else {
@@ -89,8 +86,11 @@ pub async fn ensure_room(
 
 /// Checks if a room exists.
 pub async fn room_exists(room_id: &RoomId) -> AppResult<bool> {
-    diesel_exists!(rooms::table.filter(rooms::id.eq(room_id)), &mut connect().await?)
-        .map_err(Into::into)
+    diesel_exists!(
+        rooms::table.filter(rooms::id.eq(room_id)),
+        &mut connect().await?
+    )
+    .map_err(Into::into)
 }
 
 pub async fn get_room_sn(room_id: &RoomId) -> AppResult<Seqnum> {
@@ -113,12 +113,9 @@ pub async fn get_version(room_id: &RoomId) -> AppResult<RoomVersionId> {
     {
         return Ok(RoomVersionId::try_from(&*room_version)?);
     }
-    let create_event_content = get_state_content::<RoomCreateEventContent>(
-        room_id,
-        &StateEventType::RoomCreate,
-        "",
-        None,
-    ).await?;
+    let create_event_content =
+        get_state_content::<RoomCreateEventContent>(room_id, &StateEventType::RoomCreate, "", None)
+            .await?;
     Ok(create_event_content.room_version)
 }
 
@@ -413,16 +410,10 @@ pub async fn invited_member_count(room_id: &RoomId) -> AppResult<u64> {
         .map_err(Into::into)
 }
 
-pub async fn joined_users(
-    room_id: &RoomId,
-    until_sn: Option<i64>,
-) -> AppResult<Vec<OwnedUserId>> {
+pub async fn joined_users(room_id: &RoomId, until_sn: Option<i64>) -> AppResult<Vec<OwnedUserId>> {
     get_state_users(room_id, &MembershipState::Join, until_sn).await
 }
-pub async fn invited_users(
-    room_id: &RoomId,
-    until_sn: Option<i64>,
-) -> AppResult<Vec<OwnedUserId>> {
+pub async fn invited_users(room_id: &RoomId, until_sn: Option<i64>) -> AppResult<Vec<OwnedUserId>> {
     get_state_users(room_id, &MembershipState::Invite, until_sn).await
 }
 pub async fn active_local_users_in_room(room_id: &RoomId) -> AppResult<Vec<OwnedUserId>> {

--- a/crates/server/src/room/alias.rs
+++ b/crates/server/src/room/alias.rs
@@ -140,7 +140,7 @@ pub async fn is_admin_room(room_id: &RoomId) -> bool {
 
 pub async fn admin_room_id() -> AppResult<OwnedRoomId> {
     crate::room::resolve_local_alias(
-        <&RoomAliasId>::try_from(format!("#admins:{}", &config::get().server_name).as_str())
+        <&RoomAliasId>::try_from(format!("#admins:{}", config::get().server_name).as_str())
             .expect("#admins:server_name is a valid room alias"),
     )
     .await
@@ -266,7 +266,9 @@ async fn user_can_remove_alias(alias_id: &RoomAliasId, user: &DbUser) -> AppResu
     } else if let Ok(power_levels) = super::get_power_levels(&room_id).await {
         Ok(power_levels.user_can_send_state(&user.id, StateEventType::RoomCanonicalAlias))
     // If there is no power levels event, only the room creator can change canonical aliases
-    } else if let Ok(event) = super::get_state(&room_id, &StateEventType::RoomCreate, "", None).await {
+    } else if let Ok(event) =
+        super::get_state(&room_id, &StateEventType::RoomCreate, "", None).await
+    {
         Ok(event.sender == user.id)
     } else {
         error!("Room {} has no m.room.create event (VERY BAD)!", room_id);

--- a/crates/server/src/room/current.rs
+++ b/crates/server/src/room/current.rs
@@ -1,7 +1,6 @@
-use crate::AppResult;
 use crate::core::identifiers::*;
-use crate::data;
 use crate::data::room::DbRoomCurrent;
+use crate::{AppResult, data};
 
 #[tracing::instrument]
 pub async fn get_current(room_id: &RoomId) -> AppResult<Option<DbRoomCurrent>> {
@@ -10,10 +9,14 @@ pub async fn get_current(room_id: &RoomId) -> AppResult<Option<DbRoomCurrent>> {
 
 #[tracing::instrument]
 pub async fn invite_count(room_id: &RoomId, user_id: &UserId) -> AppResult<Option<u64>> {
-    Ok(data::room::invited_members_count(room_id).await?.map(|c| c as u64))
+    Ok(data::room::invited_members_count(room_id)
+        .await?
+        .map(|c| c as u64))
 }
 
 #[tracing::instrument]
 pub async fn left_count(room_id: &RoomId, user_id: &UserId) -> AppResult<Option<u64>> {
-    Ok(data::room::left_members_count(room_id).await?.map(|c| c as u64))
+    Ok(data::room::left_members_count(room_id)
+        .await?
+        .map(|c| c as u64))
 }

--- a/crates/server/src/room/directory.rs
+++ b/crates/server/src/room/directory.rs
@@ -1,7 +1,6 @@
-use crate::AppResult;
 use crate::core::RoomId;
 use crate::core::room::Visibility;
-use crate::data;
+use crate::{AppResult, data};
 
 #[tracing::instrument]
 pub async fn set_public(room_id: &RoomId, value: bool) -> AppResult<()> {

--- a/crates/server/src/room/lazy_loading.rs
+++ b/crates/server/src/room/lazy_loading.rs
@@ -2,9 +2,8 @@ use std::collections::HashSet;
 
 use palpo_core::Seqnum;
 
-use crate::AppResult;
 use crate::core::{DeviceId, OwnedUserId, RoomId, UserId};
-use crate::data;
+use crate::{AppResult, data};
 
 #[tracing::instrument]
 pub async fn lazy_load_was_sent_before(
@@ -13,7 +12,10 @@ pub async fn lazy_load_was_sent_before(
     room_id: &RoomId,
     confirmed_user_id: &UserId,
 ) -> AppResult<bool> {
-    Ok(data::room::lazy_loading::was_sent_before(user_id, device_id, room_id, confirmed_user_id).await?)
+    Ok(
+        data::room::lazy_loading::was_sent_before(user_id, device_id, room_id, confirmed_user_id)
+            .await?,
+    )
 }
 
 /// Marks lazy load entries as sent by writing directly to the database.
@@ -26,7 +28,8 @@ pub async fn lazy_load_mark_sent(
     lazy_load: HashSet<OwnedUserId>,
     _until_sn: Seqnum,
 ) {
-    if let Err(e) = data::room::lazy_loading::mark_sent(user_id, device_id, room_id, lazy_load).await
+    if let Err(e) =
+        data::room::lazy_loading::mark_sent(user_id, device_id, room_id, lazy_load).await
     {
         warn!("failed to mark lazy-load deliveries as sent: {e}");
     }

--- a/crates/server/src/room/pdu_metadata.rs
+++ b/crates/server/src/room/pdu_metadata.rs
@@ -1,16 +1,15 @@
 use palpo_core::Seqnum;
 use serde::Deserialize;
 
-use crate::AppResult;
 use crate::core::Direction;
 use crate::core::client::relation::RelationEventsResBody;
 use crate::core::events::TimelineEventType;
 use crate::core::events::relation::RelationType;
 use crate::core::identifiers::*;
-use crate::data;
 use crate::data::room::NewDbEventRelation;
 use crate::event::{BatchToken, SnPduEvent};
 use crate::room::timeline;
+use crate::{AppResult, data};
 
 #[derive(Clone, Debug, Deserialize)]
 struct ExtractRelType {

--- a/crates/server/src/room/space.rs
+++ b/crates/server/src/room/space.rs
@@ -232,7 +232,8 @@ async fn get_room_summary(
         "",
         None,
     )
-    .await.map_or(JoinRule::Invite, |c: RoomJoinRulesEventContent| c.join_rule);
+    .await
+    .map_or(JoinRule::Invite, |c: RoomJoinRulesEventContent| c.join_rule);
 
     let allowed_room_ids = state::allowed_room_ids(join_rule.clone());
 
@@ -300,8 +301,11 @@ pub async fn get_room_hierarchy(
     let room_sns = pagination_token.map(|p| p.room_sns).unwrap_or_default();
     let room_id = &args.room_id;
     let suggested_only = args.suggested_only;
-    let mut queue: RoomDeque =
-        [(room_id.to_owned(), vec![crate::room::server_name(room_id).await?])].into();
+    let mut queue: RoomDeque = [(
+        room_id.to_owned(),
+        vec![crate::room::server_name(room_id).await?],
+    )]
+    .into();
 
     let mut rooms = Vec::with_capacity(limit);
     let mut parents = BTreeSet::new();
@@ -414,8 +418,12 @@ async fn is_accessible_child(
     }
 
     if let Identifier::UserId(user_id) = identifier
-        && (crate::room::user::is_joined(user_id, current_room).await.unwrap_or(false)
-            || crate::room::user::is_invited(user_id, current_room).await.unwrap_or(false))
+        && (crate::room::user::is_joined(user_id, current_room)
+            .await
+            .unwrap_or(false)
+            || crate::room::user::is_invited(user_id, current_room)
+                .await
+                .unwrap_or(false))
     {
         return true;
     }
@@ -427,12 +435,12 @@ async fn is_accessible_child(
         SpaceRoomJoinRule::Restricted => {
             for room in allowed_room_ids.iter() {
                 let accessible = match identifier {
-                    Identifier::UserId(user) => {
-                        crate::room::user::is_joined(user, room).await.unwrap_or(false)
-                    }
-                    Identifier::ServerName(server) => {
-                        crate::room::is_server_joined(server, room).await.unwrap_or(false)
-                    }
+                    Identifier::UserId(user) => crate::room::user::is_joined(user, room)
+                        .await
+                        .unwrap_or(false),
+                    Identifier::ServerName(server) => crate::room::is_server_joined(server, room)
+                        .await
+                        .unwrap_or(false),
                 };
                 if accessible {
                     return true;

--- a/crates/server/src/room/state.rs
+++ b/crates/server/src/room/state.rs
@@ -247,9 +247,7 @@ pub async fn append_to_state(new_pdu: &SnPduEvent) -> AppResult<i64> {
     }
 }
 
-pub async fn summary_stripped(
-    event: &PduEvent,
-) -> AppResult<Vec<RawJson<AnyStrippedStateEvent>>> {
+pub async fn summary_stripped(event: &PduEvent) -> AppResult<Vec<RawJson<AnyStrippedStateEvent>>> {
     let cells: [(&StateEventType, &str); 8] = [
         (&StateEventType::RoomCreate, ""),
         (&StateEventType::RoomJoinRules, ""),
@@ -776,13 +774,13 @@ pub async fn save_state(
 
     let hash_data = utils::hash_keys(new_compressed_events.iter().map(|bytes| &bytes[..]));
 
-    let (new_frame_id, frame_existed) = if let Ok(frame_id) = get_frame_id(room_id, &hash_data).await
-    {
-        (frame_id, true)
-    } else {
-        let frame_id = ensure_frame(room_id, hash_data).await?;
-        (frame_id, false)
-    };
+    let (new_frame_id, frame_existed) =
+        if let Ok(frame_id) = get_frame_id(room_id, &hash_data).await {
+            (frame_id, true)
+        } else {
+            let frame_id = ensure_frame(room_id, hash_data).await?;
+            (frame_id, false)
+        };
 
     if Some(new_frame_id) == prev_frame_id {
         return Ok(DeltaInfo {
@@ -863,7 +861,8 @@ pub async fn get_user_state(
 /// See <https://spec.matrix.org/latest/appendices/#routing>
 #[tracing::instrument(level = "trace")]
 pub async fn servers_route_via(room_id: &RoomId) -> AppResult<Vec<OwnedServerName>> {
-    let Ok(pdu) = super::get_state(room_id, &StateEventType::RoomPowerLevels, "", None).await else {
+    let Ok(pdu) = super::get_state(room_id, &StateEventType::RoomPowerLevels, "", None).await
+    else {
         return Ok(Vec::new());
     };
 

--- a/crates/server/src/room/state/diff.rs
+++ b/crates/server/src/room/state/diff.rs
@@ -5,9 +5,8 @@ use std::sync::Arc;
 
 use super::FrameInfo;
 use crate::core::{OwnedEventId, RoomId, Seqnum};
-use crate::data;
 use crate::data::room::DbRoomStateDelta;
-use crate::{AppResult, utils};
+use crate::{AppResult, data, utils};
 
 pub struct StateDiff {
     pub parent_id: Option<i64>,

--- a/crates/server/src/room/state/field.rs
+++ b/crates/server/src/room/state/field.rs
@@ -1,7 +1,6 @@
-use crate::AppResult;
 use crate::core::events::StateEventType;
-use crate::data;
 pub use crate::data::room::DbRoomStateField;
+use crate::{AppResult, data};
 
 pub async fn get_field(field_id: i64) -> AppResult<DbRoomStateField> {
     Ok(data::room::get_state_field(field_id).await?)

--- a/crates/server/src/room/timeline.rs
+++ b/crates/server/src/room/timeline.rs
@@ -510,7 +510,7 @@ pub async fn append_pdu(
 
             if let Some(body) = content.body
                 && let Ok(admin_room) = super::resolve_local_alias(
-                    <&RoomAliasId>::try_from(format!("#admins:{}", &conf.server_name).as_str())
+                    <&RoomAliasId>::try_from(format!("#admins:{}", conf.server_name).as_str())
                         .expect("#admins:server_name is a valid room alias"),
                 )
                 .await
@@ -697,12 +697,11 @@ pub async fn append_pdu(
                 allowed.push(server);
             }
         }
-        if !allowed.is_empty() {
-            if let Err(e) =
+        if !allowed.is_empty()
+            && let Err(e) =
                 crate::sending::send_pdu_servers(allowed.into_iter(), &pdu.event_id).await
-            {
-                error!("failed to forward pdu to peeking servers: {e}");
-            }
+        {
+            error!("failed to forward pdu to peeking servers: {e}");
         }
     }
 
@@ -809,7 +808,8 @@ pub async fn build_and_append_pdu(
             &pdu_builder.event_type.to_string().into(),
             state_key,
             None,
-        ).await
+        )
+        .await
         && curr_state.content.get() == pdu_builder.content.get()
     {
         return Ok(curr_state);
@@ -889,10 +889,9 @@ mod tests {
     use serde_json::value::RawValue;
     use tracing_test::traced_test;
 
+    use super::canonicalize_prev_content;
     use crate::core::identifiers::{EventId, OwnedEventId, OwnedRoomId, RoomId};
     use crate::core::serde::to_canonical_object;
-
-    use super::canonicalize_prev_content;
 
     fn ids() -> (OwnedEventId, OwnedRoomId, OwnedEventId) {
         (

--- a/crates/server/src/routing/admin.rs
+++ b/crates/server/src/routing/admin.rs
@@ -46,8 +46,8 @@ pub async fn auth_by_mas_secret(aa: crate::AuthArgs) -> AppResult<()> {
     // information about how many leading bytes of the secret matched.
     let token_bytes = token.as_bytes();
     let secret_bytes = mas_secret.as_bytes();
-    let matches: bool = token_bytes.len() == secret_bytes.len()
-        && token_bytes.ct_eq(secret_bytes).into();
+    let matches: bool =
+        token_bytes.len() == secret_bytes.len() && token_bytes.ct_eq(secret_bytes).into();
     if !matches {
         return Err(MatrixError::forbidden("Invalid MAS secret", None).into());
     }

--- a/crates/server/src/routing/admin/debug.rs
+++ b/crates/server/src/routing/admin/debug.rs
@@ -69,7 +69,7 @@ pub struct TimeResponse {
 pub fn time() -> JsonResult<TimeResponse> {
     json_ok(TimeResponse {
         time: utils::time::format(SystemTime::now(), "%+"),
-        unix_millis: UnixMillis::now().get().into(),
+        unix_millis: UnixMillis::now().get(),
     })
 }
 
@@ -109,11 +109,7 @@ pub fn list_dependencies(names_only: QueryParam<bool, false>) -> JsonResult<Depe
             version: dep
                 .try_req()
                 .map_or_else(|_| "*".to_owned(), |req| req.to_string()),
-            features: dep
-                .req_features()
-                .into_iter()
-                .map(ToOwned::to_owned)
-                .collect(),
+            features: dep.req_features().iter().map(ToOwned::to_owned).collect(),
         })
         .collect();
 
@@ -387,12 +383,14 @@ pub struct PingResponse {
 pub async fn ping(server_name: PathParam<OwnedServerName>) -> JsonResult<PingResponse> {
     let server_name = server_name.into_inner();
     if config::get().enabled_federation().is_none() {
-        return Err(AppError::public("Federation is disabled on this homeserver").into());
+        return Err(AppError::public(
+            "Federation is disabled on this homeserver",
+        ));
     }
     if server_name == config::server_name() {
-        return Err(
-            AppError::public("Not allowed to send federation requests to ourselves").into(),
-        );
+        return Err(AppError::public(
+            "Not allowed to send federation requests to ourselves",
+        ));
     }
     reject_ip_literal(&server_name)?;
 
@@ -531,7 +529,8 @@ pub async fn force_device_list_updates() -> JsonResult<ForceDeviceListUpdatesRes
             let devices = crate::data::user::all_device_ids(user_id).await?;
             devices_seen = devices_seen.saturating_add(devices.len());
 
-            if let Some(device_id) = devices.get(0) {
+            // `as_slice()` avoids resolving to diesel's `RunQueryDsl::first`.
+            if let Some(device_id) = devices.as_slice().first() {
                 crate::user::mark_device_key_update(user_id, device_id).await
             } else {
                 crate::user::mark_signing_key_update(user_id).await

--- a/crates/server/src/routing/admin/event.rs
+++ b/crates/server/src/routing/admin/event.rs
@@ -26,8 +26,9 @@ pub struct FetchEventResponse {
 pub async fn fetch_event(event_id: PathParam<OwnedEventId>) -> JsonResult<FetchEventResponse> {
     let event_id = event_id.into_inner();
 
-    let pdu =
-        timeline::get_pdu(&event_id).await.map_err(|_| MatrixError::not_found("Event not found"))?;
+    let pdu = timeline::get_pdu(&event_id)
+        .await
+        .map_err(|_| MatrixError::not_found("Event not found"))?;
 
     let event = serde_json::to_value(&pdu).unwrap_or_default();
 

--- a/crates/server/src/routing/admin/federation.rs
+++ b/crates/server/src/routing/admin/federation.rs
@@ -105,7 +105,9 @@ pub async fn list_destinations(
 ///
 /// Get details of a specific destination
 #[endpoint]
-pub async fn get_destination(destination: PathParam<OwnedServerName>) -> JsonResult<DestinationInfo> {
+pub async fn get_destination(
+    destination: PathParam<OwnedServerName>,
+) -> JsonResult<DestinationInfo> {
     let destination = destination.into_inner();
 
     // Check if destination is known

--- a/crates/server/src/routing/admin/media.rs
+++ b/crates/server/src/routing/admin/media.rs
@@ -147,7 +147,8 @@ pub async fn delete_media(
         .await?
         .ok_or_else(|| MatrixError::not_found("Unknown media"))?;
 
-    let (deleted_media, total) = data::media::delete_media_by_ids(&server_name, &[media_id]).await?;
+    let (deleted_media, total) =
+        data::media::delete_media_by_ids(&server_name, &[media_id]).await?;
 
     json_ok(DeleteMediaResponse {
         deleted_media,

--- a/crates/server/src/routing/admin/room.rs
+++ b/crates/server/src/routing/admin/room.rs
@@ -169,7 +169,10 @@ async fn get_detailed_room_info(room_id: &RoomId) -> RoomInfoResponse {
         .flatten()
         .map(|a| a.to_string());
 
-    let encryption = room::get_encryption(room_id).await.ok().map(|e| e.to_string());
+    let encryption = room::get_encryption(room_id)
+        .await
+        .ok()
+        .map(|e| e.to_string());
 
     let join_rules = room::get_join_rule(room_id)
         .await
@@ -438,7 +441,9 @@ pub async fn get_room_messages(
 #[endpoint]
 pub async fn get_room_block(room_id: PathParam<OwnedRoomId>) -> JsonResult<RoomBlockStatus> {
     let room_id = room_id.into_inner();
-    let blocked = crate::data::room::is_banned(&room_id).await.unwrap_or(false);
+    let blocked = crate::data::room::is_banned(&room_id)
+        .await
+        .unwrap_or(false);
 
     json_ok(RoomBlockStatus {
         block: blocked,

--- a/crates/server/src/routing/admin/user.rs
+++ b/crates/server/src/routing/admin/user.rs
@@ -109,7 +109,8 @@ pub async fn create_device(
 
     let token = utils::random_string(64);
 
-    data::user::device::create_device(&user_id, &device_id, &token, body.display_name, None).await?;
+    data::user::device::create_device(&user_id, &device_id, &token, body.display_name, None)
+        .await?;
 
     empty_ok()
 }

--- a/crates/server/src/routing/appservice.rs
+++ b/crates/server/src/routing/appservice.rs
@@ -27,7 +27,8 @@ async fn verify_hs_token(aa: &AuthArgs) -> Result<(), crate::AppError> {
     let appservices = crate::appservices();
     // Use constant-time comparison to prevent timing attacks
     if appservices
-        .await.iter()
+        .await
+        .iter()
         .any(|a| a.hs_token.as_bytes().ct_eq(token.as_bytes()).into())
     {
         Ok(())

--- a/crates/server/src/routing/appservice/third_party.rs
+++ b/crates/server/src/routing/appservice/third_party.rs
@@ -26,7 +26,8 @@ async fn verify_hs_token(aa: &AuthArgs) -> Result<(), crate::AppError> {
     let appservices = crate::appservices();
     // Constant-time comparison; mirrors `routing/appservice.rs::verify_hs_token`.
     if appservices
-        .await.iter()
+        .await
+        .iter()
         .any(|a| a.hs_token.as_bytes().ct_eq(token.as_bytes()).into())
     {
         Ok(())

--- a/crates/server/src/routing/client/account.rs
+++ b/crates/server/src/routing/client/account.rs
@@ -156,7 +156,7 @@ pub(super) async fn delete_account_data_msc3391(
 ) -> EmptyResult {
     let authed = depot.authed_info()?;
     let user_id = user_id.into_inner();
-    if &user_id != authed.user_id() {
+    if user_id != authed.user_id() {
         return Err(
             MatrixError::forbidden("Cannot delete account data for another user.", None).into(),
         );

--- a/crates/server/src/routing/client/admin.rs
+++ b/crates/server/src/routing/client/admin.rs
@@ -3,14 +3,13 @@ use std::collections::BTreeMap;
 use salvo::oapi::extract::{JsonBody, PathParam};
 use salvo::prelude::*;
 
-use crate::config;
 use crate::core::client::admin::{
     IsUserLockedResBody, IsUserSuspendedResBody, LockUserReqBody, LockUserResBody,
     SuspendUserReqBody, SuspendUserResBody,
 };
 use crate::core::client::server::{ConnectionInfo, DeviceInfo, SessionInfo, UserInfoResBody};
 use crate::core::identifiers::*;
-use crate::{AppResult, AuthArgs, DepotExt, JsonResult, MatrixError, data, json_ok};
+use crate::{AppResult, AuthArgs, DepotExt, JsonResult, MatrixError, config, data, json_ok};
 
 pub fn authed_router() -> Router {
     Router::new()
@@ -41,7 +40,9 @@ async fn whois(
     let target_user_id = user_id.into_inner();
 
     // Check if the user is an admin or requesting their own info
-    let is_admin = data::user::is_admin(authed.user_id()).await.unwrap_or(false);
+    let is_admin = data::user::is_admin(authed.user_id())
+        .await
+        .unwrap_or(false);
     if !is_admin && authed.user_id() != target_user_id {
         return Err(MatrixError::forbidden(
             "Only admins can query other users' information.",

--- a/crates/server/src/routing/client/directory/room.rs
+++ b/crates/server/src/routing/client/directory/room.rs
@@ -52,10 +52,7 @@ pub(super) async fn set_visibility(
         .await?;
 
     let visibility_is_public = body.visibility == Visibility::Public;
-    if visibility_is_public
-        && config::get().lockdown_public_room_directory
-        && !authed.is_admin()
-    {
+    if visibility_is_public && config::get().lockdown_public_room_directory && !authed.is_admin() {
         return Err(MatrixError::forbidden(
             "Only server admins can publish rooms to the room directory.",
             None,

--- a/crates/server/src/routing/client/key/device_signing.rs
+++ b/crates/server/src/routing/client/key/device_signing.rs
@@ -51,37 +51,36 @@ pub(super) async fn upload(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) 
     // When this request is authenticated by a delegated OIDC token, UIA is not
     // used. Local password/appservice sessions still follow the legacy UIA
     // path even when delegated auth is enabled globally.
-    let uia_required = if config::get().enabled_delegated_auth().is_some()
-        && authed.is_delegated_auth()
-    {
-        false
-    } else if let Ok(body) = &body {
-        let exist_master_key = crate::user::key::get_master_key(sender_id).await?;
-        let exist_self_signing_key = crate::user::key::get_self_signing_key(sender_id).await?;
-        let exist_user_signing_key = crate::user::key::get_user_signing_key(sender_id).await?;
-        if exist_master_key.is_none()
-            && exist_self_signing_key.is_none()
-            && exist_user_signing_key.is_none()
-        {
+    let uia_required =
+        if config::get().enabled_delegated_auth().is_some() && authed.is_delegated_auth() {
             false
-        } else if let Some(expires_ts) =
-            data::user::key::get_cross_signing_replacement_allowed(sender_id).await?
-        {
-            let now_ms = crate::core::UnixMillis::now().get() as i64;
-            // Bypass still valid — skip UIA
-            now_ms >= expires_ts
+        } else if let Ok(body) = &body {
+            let exist_master_key = crate::user::key::get_master_key(sender_id).await?;
+            let exist_self_signing_key = crate::user::key::get_self_signing_key(sender_id).await?;
+            let exist_user_signing_key = crate::user::key::get_user_signing_key(sender_id).await?;
+            if exist_master_key.is_none()
+                && exist_self_signing_key.is_none()
+                && exist_user_signing_key.is_none()
+            {
+                false
+            } else if let Some(expires_ts) =
+                data::user::key::get_cross_signing_replacement_allowed(sender_id).await?
+            {
+                let now_ms = crate::core::UnixMillis::now().get() as i64;
+                // Bypass still valid — skip UIA
+                now_ms >= expires_ts
+            } else {
+                let body = signing_key_payload_for_uia(body, challenged_body.as_ref());
+                signing_key_payload_changed(
+                    body,
+                    exist_master_key.as_ref(),
+                    exist_self_signing_key.as_ref(),
+                    exist_user_signing_key.as_ref(),
+                )
+            }
         } else {
-            let body = signing_key_payload_for_uia(body, challenged_body.as_ref());
-            signing_key_payload_changed(
-                body,
-                exist_master_key.as_ref(),
-                exist_self_signing_key.as_ref(),
-                exist_user_signing_key.as_ref(),
-            )
-        }
-    } else {
-        true
-    };
+            true
+        };
 
     if body.is_err()
         || body

--- a/crates/server/src/routing/client/key/signature.rs
+++ b/crates/server/src/routing/client/key/signature.rs
@@ -108,7 +108,7 @@ async fn validate_target_key(
     key_value: &JsonValue,
 ) -> AppResult<Option<Failure>> {
     if let Ok(device_keys) = serde_json::from_value::<DeviceKeys>(key_value.clone()) {
-        if &device_keys.user_id != target_user_id || device_keys.device_id.as_str() != target_key_id
+        if device_keys.user_id != target_user_id || device_keys.device_id.as_str() != target_key_id
         {
             return Ok(Some(Failure::invalid_signature(
                 "Signed device key does not match the target key.",
@@ -137,7 +137,7 @@ async fn validate_target_key(
     }
 
     if let Ok(cross_signing_key) = serde_json::from_value::<CrossSigningKey>(key_value.clone()) {
-        if &cross_signing_key.user_id != target_user_id
+        if cross_signing_key.user_id != target_user_id
             || !cross_signing_key_contains_key_name(&cross_signing_key, target_key_id)
         {
             return Ok(Some(Failure::invalid_signature(

--- a/crates/server/src/routing/client/media.rs
+++ b/crates/server/src/routing/client/media.rs
@@ -52,7 +52,9 @@ pub async fn get_content(
     _req: &mut Request,
     res: &mut Response,
 ) -> AppResult<()> {
-    if let Some(metadata) = crate::data::media::get_metadata(&args.server_name, &args.media_id).await? {
+    if let Some(metadata) =
+        crate::data::media::get_metadata(&args.server_name, &args.media_id).await?
+    {
         let content_type = metadata
             .content_type
             .as_deref()
@@ -104,7 +106,8 @@ pub async fn get_content_with_filename(
     _req: &mut Request,
     res: &mut Response,
 ) -> AppResult<()> {
-    let Some(metadata) = crate::data::media::get_metadata(&args.server_name, &args.media_id).await?
+    let Some(metadata) =
+        crate::data::media::get_metadata(&args.server_name, &args.media_id).await?
     else {
         return Err(MatrixError::not_yet_uploaded("Media has not been uploaded yet").into());
     };

--- a/crates/server/src/routing/client/profile.rs
+++ b/crates/server/src/routing/client/profile.rs
@@ -6,7 +6,8 @@ use palpo_core::UnixMillis;
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
 use serde::{Deserialize, Serialize};
-use serde_json::{from_value as from_json_value, value::to_raw_value};
+use serde_json::from_value as from_json_value;
+use serde_json::value::to_raw_value;
 
 use crate::core::client::profile::*;
 use crate::core::events::room::member::RoomMemberEventContent;

--- a/crates/server/src/routing/client/room.rs
+++ b/crates/server/src/routing/client/room.rs
@@ -26,7 +26,6 @@ use crate::core::client::room::{
     UpgradeRoomResBody,
 };
 use crate::core::directory::{PublicRoomFilter, PublicRoomsResBody, RoomNetwork};
-use crate::core::federation::peek::{PeekReqArgs, PeekResBody, peek_request};
 use crate::core::events::fully_read::{FullyReadEvent, FullyReadEventContent};
 use crate::core::events::receipt::{
     Receipt, ReceiptEvent, ReceiptEventContent, ReceiptThread, ReceiptType,
@@ -44,6 +43,7 @@ use crate::core::events::room::power_levels::RoomPowerLevelsEventContent;
 use crate::core::events::room::tombstone::RoomTombstoneEventContent;
 use crate::core::events::room::topic::RoomTopicEventContent;
 use crate::core::events::{self, RoomAccountDataEventType, StateEventType, TimelineEventType};
+use crate::core::federation::peek::{PeekReqArgs, PeekResBody, peek_request};
 use crate::core::identifiers::*;
 use crate::core::room::{JoinRule, Visibility};
 use crate::core::room_version_rules::{AuthorizationRules, RoomIdFormatVersion, RoomVersionRules};
@@ -630,8 +630,14 @@ async fn upgrade(
             event_type: TimelineEventType::RoomMember,
             content: to_raw_value(&RoomMemberEventContent {
                 membership: MembershipState::Join,
-                display_name: crate::data::user::display_name(sender_id).await.ok().flatten(),
-                avatar_url: crate::data::user::avatar_url(sender_id).await.ok().flatten(),
+                display_name: crate::data::user::display_name(sender_id)
+                    .await
+                    .ok()
+                    .flatten(),
+                avatar_url: crate::data::user::avatar_url(sender_id)
+                    .await
+                    .ok()
+                    .flatten(),
                 is_direct: None,
                 third_party_invite: None,
                 blurhash: crate::data::user::blurhash(sender_id).await.ok().flatten(),
@@ -846,7 +852,7 @@ pub(super) async fn create_room(
 
     let alias: Option<OwnedRoomAliasId> = if let Some(localpart) = &body.room_alias_name {
         // TODO: Check for invalid characters and maximum length
-        let alias = RoomAliasId::parse(format!("#{}:{}", localpart, &conf.server_name))
+        let alias = RoomAliasId::parse(format!("#{}:{}", localpart, conf.server_name))
             .map_err(|_| MatrixError::invalid_param("Invalid alias."))?;
 
         if room::resolve_local_alias(&alias).await.is_ok() {
@@ -880,8 +886,14 @@ pub(super) async fn create_room(
             event_type: TimelineEventType::RoomMember,
             content: to_raw_value(&RoomMemberEventContent {
                 membership: MembershipState::Join,
-                display_name: crate::data::user::display_name(sender_id).await.ok().flatten(),
-                avatar_url: crate::data::user::avatar_url(sender_id).await.ok().flatten(),
+                display_name: crate::data::user::display_name(sender_id)
+                    .await
+                    .ok()
+                    .flatten(),
+                avatar_url: crate::data::user::avatar_url(sender_id)
+                    .await
+                    .ok()
+                    .flatten(),
                 is_direct: Some(body.is_direct),
                 third_party_invite: None,
                 blurhash: crate::data::user::blurhash(sender_id).await.ok().flatten(),

--- a/crates/server/src/routing/client/room/event.rs
+++ b/crates/server/src/routing/client/room/event.rs
@@ -276,7 +276,9 @@ pub(super) async fn get_context(
             .await
             .unwrap_or_default(),
     };
-    let state_ids = state::get_full_state_ids(frame_id).await.unwrap_or_default();
+    let state_ids = state::get_full_state_ids(frame_id)
+        .await
+        .unwrap_or_default();
     let end_token = events_after
         .last()
         .map(|(_, e)| e.live_token())

--- a/crates/server/src/routing/client/room/membership.rs
+++ b/crates/server/src/routing/client/room/membership.rs
@@ -5,7 +5,8 @@ use diesel_async::RunQueryDsl;
 use palpo_core::Seqnum;
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
-use serde_json::{from_value as from_json_value, value::to_raw_value};
+use serde_json::from_value as from_json_value;
+use serde_json::value::to_raw_value;
 
 use crate::core::client::membership::{
     BanUserReqBody, InvitationRecipient, InviteUserReqBody, JoinRoomReqBody, JoinRoomResBody,
@@ -308,7 +309,11 @@ pub(super) async fn join_room_by_id(
     if let Ok(server) = room_id.server_name() {
         servers.push(server.to_owned());
     } else {
-        servers.extend(crate::room::lookup_servers(&room_id).await.unwrap_or_default());
+        servers.extend(
+            crate::room::lookup_servers(&room_id)
+                .await
+                .unwrap_or_default(),
+        );
     }
     servers.sort_unstable();
     servers.dedup();
@@ -512,7 +517,8 @@ pub(super) async fn ban_user(
         body.user_id.as_ref(),
         None,
     )
-    .await.ok();
+    .await
+    .ok();
 
     let event = if let Some(room_state) = room_state {
         let event = room_state
@@ -602,7 +608,8 @@ pub(super) async fn ban_user(
         &room_id,
         &crate::room::get_version(&room_id).await?,
         &state_lock,
-    ).await?;
+    )
+    .await?;
     if let Err(e) = sending::send_pdu_room(
         &room_id,
         &pdu.event_id,
@@ -694,7 +701,9 @@ pub(super) async fn kick_user(
         &StateEventType::RoomMember,
         body.user_id.as_str(),
         None,
-    ).await else {
+    )
+    .await
+    else {
         return Err(MatrixError::forbidden(
             "users cannot kick users from a room they are not in",
             None,
@@ -776,7 +785,11 @@ pub(crate) async fn knock_room(
             .await?;
 
             let mut servers = body.via.clone();
-            servers.extend(crate::room::lookup_servers(&room_id).await.unwrap_or_default());
+            servers.extend(
+                crate::room::lookup_servers(&room_id)
+                    .await
+                    .unwrap_or_default(),
+            );
             servers.extend(
                 state::get_user_state(sender_id, &room_id)
                     .await

--- a/crates/server/src/routing/client/room/message.rs
+++ b/crates/server/src/routing/client/room/message.rs
@@ -211,7 +211,9 @@ pub(super) async fn get_messages(
             &StateEventType::RoomMember,
             ll_id.as_str(),
             None,
-        ).await {
+        )
+        .await
+        {
             resp.state.push(member_event.to_state_event());
         }
     }

--- a/crates/server/src/routing/client/room/relation.rs
+++ b/crates/server/src/routing/client/room/relation.rs
@@ -51,7 +51,8 @@ pub(super) async fn get_relation_by_rel_type(
         args.limit,
         args.recurse,
         args.dir,
-    ).await?;
+    )
+    .await?;
 
     json_ok(body)
 }
@@ -76,7 +77,8 @@ pub(super) async fn get_relation_by_rel_type_and_event_type(
         args.limit,
         args.recurse,
         args.dir,
-    ).await?;
+    )
+    .await?;
 
     json_ok(body)
 }

--- a/crates/server/src/routing/client/session.rs
+++ b/crates/server/src/routing/client/session.rs
@@ -198,15 +198,15 @@ async fn login(
             };
             if let Err(e) = user::verify_password(&user, password).await {
                 res.status_code(StatusCode::FORBIDDEN); //for complement testing: TestLogin/parallel/POST_/login_wrong_password_is_rejected
-                if let AppError::Matrix(matrix) = e {
-                    if matches!(
+                if let AppError::Matrix(matrix) = e
+                    && matches!(
                         matrix.kind,
                         ErrorKind::UserDeactivated
                             | ErrorKind::UserLocked
                             | ErrorKind::UserSuspended
-                    ) {
-                        return Err(matrix.into());
-                    }
+                    )
+                {
+                    return Err(matrix.into());
                 }
                 return Err(MatrixError::forbidden("Wrong username or password.", None).into());
             }

--- a/crates/server/src/routing/client/to_device.rs
+++ b/crates/server/src/routing/client/to_device.rs
@@ -107,8 +107,8 @@ async fn send_to_device(
 
 #[endpoint]
 pub(super) async fn for_dehydrated(_aa: AuthArgs) -> EmptyResult {
-    Err(MatrixError::unrecognized(
-        "To-device messages for dehydrated devices are not implemented.",
+    Err(
+        MatrixError::unrecognized("To-device messages for dehydrated devices are not implemented.")
+            .into(),
     )
-    .into())
 }

--- a/crates/server/src/routing/client/user/room.rs
+++ b/crates/server/src/routing/client/user/room.rs
@@ -18,7 +18,8 @@ pub(super) async fn get_mutual_rooms(
     let authed = depot.authed_info()?;
 
     // Get the authenticated user's joined rooms
-    let our_rooms: HashSet<_> = data::user::joined_rooms(authed.user_id()).await?
+    let our_rooms: HashSet<_> = data::user::joined_rooms(authed.user_id())
+        .await?
         .into_iter()
         .collect();
 

--- a/crates/server/src/routing/federation/event.rs
+++ b/crates/server/src/routing/federation/event.rs
@@ -41,10 +41,12 @@ async fn get_event(
         return Err(MatrixError::not_found("event not found").into());
     }
 
-    let event_json = timeline::get_pdu_json(&args.event_id).await?.ok_or_else(|| {
-        warn!("event not found, event id: {:?}", &args.event_id);
-        MatrixError::not_found("event not found")
-    })?;
+    let event_json = timeline::get_pdu_json(&args.event_id)
+        .await?
+        .ok_or_else(|| {
+            warn!("event not found, event id: {:?}", &args.event_id);
+            MatrixError::not_found("event not found")
+        })?;
 
     // Look up the room_id from the events table column rather than from the
     // event JSON. v12 events do not include `room_id` in their JSON content
@@ -71,10 +73,12 @@ async fn auth_chain(
     let origin = depot.origin()?;
     crate::federation::access_check(origin, &args.room_id, None).await?;
 
-    let event = timeline::get_pdu_json(&args.event_id).await?.ok_or_else(|| {
-        warn!("event not found, event id: {:?}", &args.event_id);
-        MatrixError::not_found("event not found")
-    })?;
+    let event = timeline::get_pdu_json(&args.event_id)
+        .await?
+        .ok_or_else(|| {
+            warn!("event not found, event id: {:?}", &args.event_id);
+            MatrixError::not_found("event not found")
+        })?;
 
     // For v12 rooms, the event JSON does not contain `room_id`. Fall back to
     // the events table column when the JSON field is missing.

--- a/crates/server/src/routing/federation/media.rs
+++ b/crates/server/src/routing/federation/media.rs
@@ -120,8 +120,9 @@ pub async fn get_thumbnail(
 
     if let Some(DbThumbnail {
         id, content_type, ..
-    }) = crate::data::media::get_thumbnail_by_dimension(server_name, &args.media_id, width, height)
-        .await?
+    }) =
+        crate::data::media::get_thumbnail_by_dimension(server_name, &args.media_id, width, height)
+            .await?
     {
         // Using saved thumbnail
         let key = thumbnail_storage_key(server_name, &args.media_id, id);
@@ -241,7 +242,7 @@ pub async fn get_thumbnail(
 
             // Save to storage backend
             let thumb_key =
-                media_storage_key(server_name, &format!("{}.{width}x{height}", &args.media_id));
+                media_storage_key(server_name, &format!("{}.{width}x{height}", args.media_id));
             storage::write(&thumb_key, &thumbnail_bytes).await?;
 
             let content_disposition = make_content_disposition(

--- a/crates/server/src/routing/federation/query.rs
+++ b/crates/server/src/routing/federation/query.rs
@@ -7,7 +7,9 @@ use salvo::prelude::*;
 use crate::core::federation::query::{EduTypesResBody, ProfileResBody, RoomInfoResBody};
 use crate::core::identifiers::*;
 use crate::core::profile::ProfileFieldValue;
-use crate::{AuthArgs, EmptyResult, IsRemoteOrLocal, JsonResult, MatrixError, config, data, json_ok};
+use crate::{
+    AuthArgs, EmptyResult, IsRemoteOrLocal, JsonResult, MatrixError, config, data, json_ok,
+};
 
 pub fn router() -> Router {
     Router::with_path("query")

--- a/crates/server/src/routing/federation/room.rs
+++ b/crates/server/src/routing/federation/room.rs
@@ -15,9 +15,7 @@ use crate::core::federation::event::{
 use crate::core::federation::knock::{
     MakeKnockReqArgs, MakeKnockResBody, SendKnockReqArgs, SendKnockReqBody, SendKnockResBody,
 };
-use crate::core::federation::peek::{
-    PeekReqArgs, PeekResBody, PeekStartResBody, PeekSubReqArgs,
-};
+use crate::core::federation::peek::{PeekReqArgs, PeekResBody, PeekStartResBody, PeekSubReqArgs};
 use crate::core::identifiers::*;
 use crate::core::serde::{JsonObject, RawJsonValue};
 use crate::event::{gen_event_id_canonical_json, handler};
@@ -68,7 +66,11 @@ async fn peek(_aa: AuthArgs, args: PeekReqArgs, depot: &mut Depot) -> JsonResult
     // Only world-readable rooms may be peeked without membership; otherwise the
     // requesting server has no business reading the state.
     if !room::is_world_readable(room_id).await {
-        return Err(MatrixError::forbidden("Room is not world-readable; peeking is not permitted.", None).into());
+        return Err(MatrixError::forbidden(
+            "Room is not world-readable; peeking is not permitted.",
+            None,
+        )
+        .into());
     }
 
     let room_version = room::get_version(room_id).await?;
@@ -315,8 +317,7 @@ async fn get_state(
     for id in auth_chain_ids.into_iter() {
         match timeline::get_pdu_json(&id).await {
             Ok(Some(json)) => {
-                auth_chain
-                    .push(crate::sending::convert_to_outgoing_federation_event(json).await);
+                auth_chain.push(crate::sending::convert_to_outgoing_federation_event(json).await);
             }
             Ok(None) => {
                 error!("Could not find event json for {id} in db::");

--- a/crates/server/src/routing/federation/user.rs
+++ b/crates/server/src/routing/federation/user.rs
@@ -100,7 +100,9 @@ async fn get_devices(
     // explicitly; otherwise a remote homeserver resyncing this user's device
     // list would drop it and never encrypt to it.
     if let Some((dehydrated_id, _)) = data::user::get_dehydrated_device(&user_id).await?
-        && !devices.iter().any(|device| device.device_id == dehydrated_id)
+        && !devices
+            .iter()
+            .any(|device| device.device_id == dehydrated_id)
         && let Some(keys) = data::user::get_device_keys_and_sigs(&user_id, &dehydrated_id).await?
     {
         let device_display_name = keys.unsigned.device_display_name.clone();

--- a/crates/server/src/sending.rs
+++ b/crates/server/src/sending.rs
@@ -477,16 +477,17 @@ async fn send_events(
                 if pdu.unsigned.contains_key("redacted_because") {
                     continue;
                 }
-                let pusher =
-                    match data::user::pusher::get_pusher(user_id, pushkey).await.map_err(|e| {
+                let pusher = match data::user::pusher::get_pusher(user_id, pushkey)
+                    .await
+                    .map_err(|e| {
                         (
                             OutgoingKind::Push(user_id.clone(), pushkey.clone()),
                             e.into(),
                         )
                     })? {
-                        Some(pusher) => pusher,
-                        None => continue,
-                    };
+                    Some(pusher) => pusher,
+                    None => continue,
+                };
 
                 let rules_for_user = data::user::get_global_data::<PushRulesEventContent>(
                     user_id,
@@ -681,10 +682,8 @@ async fn active_requests() -> AppResult<Vec<(i64, OutgoingKind, SendingEventType
             };
             let event = if let Some(value) = item.edu_json {
                 SendingEventType::Edu(value)
-            } else if let Some(pdu_id) = item.pdu_id {
-                SendingEventType::Pdu(pdu_id)
             } else {
-                return None;
+                SendingEventType::Pdu(item.pdu_id?)
             };
             Some((item.id, kind, event))
         })

--- a/crates/server/src/sending/guard.rs
+++ b/crates/server/src/sending/guard.rs
@@ -256,12 +256,13 @@ async fn select_events(
 /// Persist retry state to the database so other instances can respect backoff.
 async fn persist_retry_state(outgoing_kind: &OutgoingKind, tries: u32) -> AppResult<()> {
     let dest = match outgoing_kind {
-        OutgoingKind::Normal(server_name) => data::sending::OutgoingDestination::Normal(server_name),
+        OutgoingKind::Normal(server_name) => {
+            data::sending::OutgoingDestination::Normal(server_name)
+        }
         OutgoingKind::Appservice(id) => data::sending::OutgoingDestination::Appservice(id),
-        OutgoingKind::Push(user_id, pushkey) => data::sending::OutgoingDestination::Push {
-            user_id,
-            pushkey,
-        },
+        OutgoingKind::Push(user_id, pushkey) => {
+            data::sending::OutgoingDestination::Push { user_id, pushkey }
+        }
     };
     data::sending::persist_retry_state(dest, tries).await?;
     Ok(())

--- a/crates/server/src/server_key/acquire.rs
+++ b/crates/server/src/server_key/acquire.rs
@@ -180,7 +180,7 @@ async fn acquire_origin(
             if let Err(e) = add_signing_keys(server_keys.clone()).await {
                 error!(?origin, "failed to persist fetched signing keys: {e}");
             }
-            key_ids.retain(|key_id| !key_exists(&server_keys, key_id));
+            retain_missing_key_ids(&mut key_ids, &server_keys);
         }
     }
 
@@ -224,11 +224,18 @@ async fn acquire_notary_result(missing: &mut Batch, server_keys: ServerSigningKe
     }
 
     if let Some(key_ids) = missing.get_mut(server) {
-        key_ids.retain(|key_id| key_exists(&server_keys, key_id));
+        retain_missing_key_ids(key_ids, &server_keys);
         if key_ids.is_empty() {
             missing.remove(server);
         }
     }
+}
+
+fn retain_missing_key_ids(
+    key_ids: &mut Vec<OwnedServerSigningKeyId>,
+    server_keys: &ServerSigningKeys,
+) {
+    key_ids.retain(|key_id| !key_exists(server_keys, key_id));
 }
 
 fn keys_count(batch: &Batch) -> usize {
@@ -239,10 +246,10 @@ fn keys_count(batch: &Batch) -> usize {
 mod tests {
     use std::collections::BTreeMap;
 
-    use super::missing_local_key_ids;
-    use crate::core::OwnedServerSigningKeyId;
-    use crate::core::federation::discovery::VerifyKey;
+    use super::{missing_local_key_ids, retain_missing_key_ids};
+    use crate::core::federation::discovery::{ServerSigningKeys, VerifyKey};
     use crate::core::serde::Base64;
+    use crate::core::{OwnedServerSigningKeyId, UnixMillis};
 
     #[test]
     fn acquire_locals_treats_our_configured_signing_key_as_available() {
@@ -263,5 +270,32 @@ mod tests {
             missing.is_empty(),
             "the local configured signing key should not be marked missing"
         );
+    }
+
+    #[test]
+    fn notary_results_remove_keys_that_are_no_longer_missing() {
+        let returned_key_id: OwnedServerSigningKeyId = "ed25519:returned"
+            .try_into()
+            .expect("returned key id should be valid");
+        let still_missing_key_id: OwnedServerSigningKeyId = "ed25519:missing"
+            .try_into()
+            .expect("missing key id should be valid");
+        let mut server_keys = ServerSigningKeys::new(
+            "notary.example.org"
+                .try_into()
+                .expect("server name should be valid"),
+            UnixMillis(0),
+        );
+        server_keys.verify_keys.insert(
+            returned_key_id.clone(),
+            VerifyKey {
+                key: Base64::new(vec![1, 2, 3]),
+            },
+        );
+        let mut missing = vec![returned_key_id, still_missing_key_id.clone()];
+
+        retain_missing_key_ids(&mut missing, &server_keys);
+
+        assert_eq!(missing, vec![still_missing_key_id]);
     }
 }

--- a/crates/server/src/server_key/acquire.rs
+++ b/crates/server/src/server_key/acquire.rs
@@ -177,7 +177,9 @@ async fn acquire_origin(
                 "received server_keys"
             );
 
-            let _ = add_signing_keys(server_keys.clone());
+            if let Err(e) = add_signing_keys(server_keys.clone()).await {
+                error!(?origin, "failed to persist fetched signing keys: {e}");
+            }
             key_ids.retain(|key_id| !key_exists(&server_keys, key_id));
         }
     }
@@ -217,7 +219,9 @@ where
 
 async fn acquire_notary_result(missing: &mut Batch, server_keys: ServerSigningKeys) {
     let server = &server_keys.server_name;
-    let _ = add_signing_keys(server_keys.clone());
+    if let Err(e) = add_signing_keys(server_keys.clone()).await {
+        error!(?server, "failed to persist notary signing keys: {e}");
+    }
 
     if let Some(key_ids) = missing.get_mut(server) {
         key_ids.retain(|key_id| key_exists(&server_keys, key_id));
@@ -228,7 +232,7 @@ async fn acquire_notary_result(missing: &mut Batch, server_keys: ServerSigningKe
 }
 
 fn keys_count(batch: &Batch) -> usize {
-    batch.iter().flat_map(|(_, key_ids)| key_ids.iter()).count()
+    batch.values().flat_map(|key_ids| key_ids.iter()).count()
 }
 
 #[cfg(test)]

--- a/crates/server/src/server_key/request.rs
+++ b/crates/server/src/server_key/request.rs
@@ -105,10 +105,11 @@ pub async fn server_request(target: &ServerName) -> AppResult<ServerSigningKeys>
     // DNS-name targets that resolve to denylisted IPs are blocked at
     // connect time by the federation client's safe DNS resolver.
     if target.is_ip_literal() {
-        return Err(
-            MatrixError::forbidden("federation requests to IP-literal server names are not allowed", None)
-                .into(),
-        );
+        return Err(MatrixError::forbidden(
+            "federation requests to IP-literal server names are not allowed",
+            None,
+        )
+        .into());
     }
 
     let request = server_keys_request(&target.origin().await)?.into_inner();

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -112,7 +112,9 @@ async fn allowed_to_send_state_event(
                         .into());
                     }
 
-                    if !crate::room::resolve_local_alias(&alias).await.is_ok_and(|room| room == room_id)
+                    if !crate::room::resolve_local_alias(&alias)
+                        .await
+                        .is_ok_and(|room| room == room_id)
                     // Make sure it's the right room
                     {
                         return Err(MatrixError::bad_alias(

--- a/crates/server/src/sync_v3.rs
+++ b/crates/server/src/sync_v3.rs
@@ -234,14 +234,10 @@ pub async fn sync_events(
             for other_room_id in
                 room::user::shared_rooms(vec![sender_id.to_owned(), user_id.clone()]).await?
             {
-                let encrypted = room::get_state(
-                    &other_room_id,
-                    &StateEventType::RoomEncryption,
-                    "",
-                    None,
-                )
-                .await
-                .is_ok();
+                let encrypted =
+                    room::get_state(&other_room_id, &StateEventType::RoomEncryption, "", None)
+                        .await
+                        .is_ok();
                 if encrypted {
                     dont_share_encrypted_room = false;
                     break;
@@ -259,14 +255,10 @@ pub async fn sync_events(
         for other_room_id in
             room::user::shared_rooms(vec![sender_id.to_owned(), user_id.clone()]).await?
         {
-            let encrypted = room::get_state(
-                &other_room_id,
-                &StateEventType::RoomEncryption,
-                "",
-                None,
-            )
-            .await
-            .is_ok();
+            let encrypted =
+                room::get_state(&other_room_id, &StateEventType::RoomEncryption, "", None)
+                    .await
+                    .is_ok();
             if encrypted {
                 dont_share_encrypted_room = false;
                 break;
@@ -440,8 +432,9 @@ async fn load_joined_room(
     let Ok(current_frame_id) = room::get_frame_id(room_id, None).await else {
         return Ok((JoinedRoom::default(), None));
     };
-    let since_frame_id =
-        crate::event::get_last_frame_id(room_id, since_tk.map(|t| t.event_sn())).await.ok();
+    let since_frame_id = crate::event::get_last_frame_id(room_id, since_tk.map(|t| t.event_sn()))
+        .await
+        .ok();
 
     let mut timeline = load_timeline(
         sender_id,
@@ -452,7 +445,9 @@ async fn load_joined_room(
     )
     .await?;
 
-    let join_sn = crate::room::user::join_sn(sender_id, room_id).await.unwrap_or_default();
+    let join_sn = crate::room::user::join_sn(sender_id, room_id)
+        .await
+        .unwrap_or_default();
     let joined_since_incremental = since_tk
         .map(|since_tk| join_sn >= since_tk.event_sn())
         .unwrap_or(false);
@@ -572,7 +567,8 @@ async fn load_joined_room(
             let joined_since_last_sync = join_sn >= since_tk.event_sn();
             if since_tk.event_sn() == 0 || joined_since_last_sync {
                 // Probably since = 0, we will do an initial sync
-                let (joined_member_count, invited_member_count, heroes) = calculate_counts().await?;
+                let (joined_member_count, invited_member_count, heroes) =
+                    calculate_counts().await?;
                 let current_state_ids =
                     state::get_full_state_ids(since_frame_id.unwrap_or(current_frame_id)).await?;
                 let mut state_events = Vec::new();
@@ -646,7 +642,10 @@ async fn load_joined_room(
 
                 // && encrypted_room || new_encrypted_room {
                 // If the user is in a new encrypted room, give them all joined users
-                *joined_users = room::joined_users(room_id, None).await?.into_iter().collect();
+                *joined_users = room::joined_users(room_id, None)
+                    .await?
+                    .into_iter()
+                    .collect();
                 // .into_iter()
                 // .filter(|user_id| {
                 //     // Don't send key updates from the sender to the sender
@@ -726,13 +725,16 @@ async fn load_joined_room(
                         device_id,
                         room_id,
                         &event.sender,
-                    ).await? || lazy_load_send_redundant)
+                    )
+                    .await?
+                        || lazy_load_send_redundant)
                         && let Ok(member_event) = room::get_state(
                             room_id,
                             &StateEventType::RoomMember,
                             event.sender.as_str(),
                             None,
-                        ).await
+                        )
+                        .await
                     {
                         lazy_loaded.insert(event.sender.clone());
                         if member_event.can_pass_filter(&filter.room.state) {
@@ -750,9 +752,13 @@ async fn load_joined_room(
                 .await;
 
                 let encrypted_room =
-                    state::get_state(current_frame_id, &StateEventType::RoomEncryption, "").await.is_ok();
+                    state::get_state(current_frame_id, &StateEventType::RoomEncryption, "")
+                        .await
+                        .is_ok();
                 let since_encryption =
-                    state::get_state(since_frame_id, &StateEventType::RoomEncryption, "").await.ok();
+                    state::get_state(since_frame_id, &StateEventType::RoomEncryption, "")
+                        .await
+                        .ok();
                 // Calculations:
                 let _new_encrypted_room = encrypted_room && since_encryption.is_none();
                 let send_member_count = state_events
@@ -786,7 +792,8 @@ async fn load_joined_room(
                                     && !room::user::shared_rooms(vec![
                                         sender_id.to_owned(),
                                         user_id.to_owned(),
-                                    ]).await?
+                                    ])
+                                    .await?
                                     .is_empty()
                                 {
                                     // if user_id.is_local() {
@@ -810,7 +817,8 @@ async fn load_joined_room(
                     // && encrypted_room || new_encrypted_room {
                     // If the user is in a new encrypted room, give them all joined users
                     device_list_updates.extend(
-                        room::joined_users(room_id, None).await?
+                        room::joined_users(room_id, None)
+                            .await?
                             .into_iter()
                             .filter(|user_id| {
                                 // Don't send key updates from the sender to the sender
@@ -843,11 +851,10 @@ async fn load_joined_room(
         };
 
     // Look for device list updates in this room
-    device_list_updates.extend(room::keys_changed_users(
-        room_id,
-        since_tk.event_sn(),
-        until_tk.map(|t| t.event_sn()),
-    ).await?);
+    device_list_updates.extend(
+        room::keys_changed_users(room_id, since_tk.event_sn(), until_tk.map(|t| t.event_sn()))
+            .await?,
+    );
 
     let mut limited = timeline.limited || joined_since_last_sync;
     if let Some((_, first_event)) = timeline.events.first()
@@ -999,7 +1006,8 @@ async fn load_left_room(
         curr_frame_id,
         &StateEventType::RoomMember,
         sender_id.as_str(),
-    ).await?;
+    )
+    .await?;
     let left_frame_id = state::get_pdu_frame_id(&left_event_id).await?;
     let timeline = load_timeline(
         sender_id,
@@ -1022,7 +1030,9 @@ async fn load_left_room(
     }
 
     let mut state_events = Vec::new();
-    let mut left_state_ids = state::get_full_state_ids(left_frame_id).await.unwrap_or_default();
+    let mut left_state_ids = state::get_full_state_ids(left_frame_id)
+        .await
+        .unwrap_or_default();
     let leave_state_key_id =
         state::ensure_field_id(&StateEventType::RoomMember, sender_id.as_str()).await?;
     left_state_ids.insert(leave_state_key_id, left_event_id.clone());
@@ -1174,7 +1184,8 @@ pub(crate) async fn load_timeline(
                 Some(min),
                 filter,
                 limit + 1,
-            ).await?
+            )
+            .await?
         } else {
             timeline::stream::load_pdus_backward(
                 Some(user_id),
@@ -1183,10 +1194,12 @@ pub(crate) async fn load_timeline(
                 Some(since_tk),
                 filter,
                 limit + 1,
-            ).await?
+            )
+            .await?
         }
     } else {
-        timeline::stream::load_pdus_backward(Some(user_id), room_id, None, None, filter, limit + 1).await?
+        timeline::stream::load_pdus_backward(Some(user_id), room_id, None, None, filter, limit + 1)
+            .await?
     };
 
     let mut limited = false;
@@ -1310,10 +1323,10 @@ pub(crate) async fn share_encrypted_room(
     ignore_room: Option<&RoomId>,
 ) -> AppResult<bool> {
     let mut shared_rooms = false;
-    for other_room_id in
-        room::user::shared_rooms(vec![sender_id.to_owned(), user_id.to_owned()]).await?
-            .into_iter()
-            .filter(|room_id| Some(&**room_id) != ignore_room)
+    for other_room_id in room::user::shared_rooms(vec![sender_id.to_owned(), user_id.to_owned()])
+        .await?
+        .into_iter()
+        .filter(|room_id| Some(&**room_id) != ignore_room)
     {
         if room::get_state(&other_room_id, &StateEventType::RoomEncryption, "", None)
             .await

--- a/crates/server/src/sync_v5.rs
+++ b/crates/server/src/sync_v5.rs
@@ -73,17 +73,14 @@ async fn compute_active_rooms<'a>(
     }
 
     // Apply is_encrypted filter
-    match list.filters.as_ref().and_then(|f| f.is_encrypted) {
-        Some(want_encrypted) => {
-            let mut retained: Vec<&'a RoomId> = Vec::with_capacity(active_rooms.len());
-            for r in active_rooms {
-                if room::is_encrypted(r).await == want_encrypted {
-                    retained.push(r);
-                }
+    if let Some(want_encrypted) = list.filters.as_ref().and_then(|f| f.is_encrypted) {
+        let mut retained: Vec<&'a RoomId> = Vec::with_capacity(active_rooms.len());
+        for r in active_rooms {
+            if room::is_encrypted(r).await == want_encrypted {
+                retained.push(r);
             }
-            active_rooms = retained;
         }
-        None => {}
+        active_rooms = retained;
     }
 
     active_rooms
@@ -643,7 +640,9 @@ async fn process_rooms(
 
         let timeline = if all_invited_rooms.contains(&new_room_id) {
             // Invited rooms have empty timeline, only stripped state
-            invite_state = crate::room::user::invite_state(sender_id, room_id).await.ok();
+            invite_state = crate::room::user::invite_state(sender_id, room_id)
+                .await
+                .ok();
             TimelineData {
                 events: Default::default(),
                 limited: false,
@@ -696,7 +695,9 @@ async fn process_rooms(
                     > *room_since_sn;
 
             let private_read_event = if last_private_read_update {
-                crate::room::receipt::last_private_read(sender_id, room_id).await.ok()
+                crate::room::receipt::last_private_read(sender_id, room_id)
+                    .await
+                    .ok()
             } else {
                 None
             };
@@ -751,7 +752,7 @@ async fn process_rooms(
         let room_events: Vec<_> = timeline
             .events
             .iter()
-            .filter(|item| ignored_filter_with_ignored_users(*item, &ignored_users))
+            .filter(|item| ignored_filter_with_ignored_users(*item, ignored_users))
             .map(|(_, pdu)| pdu.to_sync_room_event())
             .collect();
 
@@ -788,13 +789,15 @@ async fn process_rooms(
                             &StateEventType::RoomMember,
                             sender.as_str(),
                             None,
-                        ).await && !is_required_state_send(
-                            sender_id.to_owned(),
-                            device_id.to_owned(),
-                            req_body.conn_id.clone(),
-                            pdu.event_sn,
                         )
                         .await
+                            && !is_required_state_send(
+                                sender_id.to_owned(),
+                                device_id.to_owned(),
+                                req_body.conn_id.clone(),
+                                pdu.event_sn,
+                            )
+                            .await
                         {
                             mark_required_state_sent(
                                 sender_id.to_owned(),
@@ -836,7 +839,8 @@ async fn process_rooms(
                 }
                 // $ME: substitute with the requester's user_id
                 (ref event_type, "$ME") => {
-                    if let Ok(pdu) = room::get_state(room_id, event_type, sender_id.as_str(), None).await
+                    if let Ok(pdu) =
+                        room::get_state(room_id, event_type, sender_id.as_str(), None).await
                         && !is_required_state_send(
                             sender_id.to_owned(),
                             device_id.to_owned(),
@@ -885,7 +889,8 @@ async fn process_rooms(
         let room_name = room::get_name(room_id).await.ok();
         let (heroes, hero_name, heroes_avatar) = if *include_heroes || room_name.is_none() {
             let mut heroes: Vec<sync_events::v5::SyncRoomHero> = Vec::new();
-            for user_id in room::get_members_limit(room_id, 6).await?
+            for user_id in room::get_members_limit(room_id, 6)
+                .await?
                 .into_iter()
                 .filter(|member| *member != sender_id)
                 .take(5)
@@ -958,13 +963,15 @@ async fn process_rooms(
                 limited: timeline.limited,
                 joined_count: Some(
                     crate::room::joined_member_count(room_id)
-                        .await.unwrap_or(0)
+                        .await
+                        .unwrap_or(0)
                         .try_into()
                         .unwrap_or(0),
                 ),
                 invited_count: Some(
                     crate::room::invited_member_count(room_id)
-                        .await.unwrap_or(0)
+                        .await
+                        .unwrap_or(0)
                         .try_into()
                         .unwrap_or(0),
                 ),
@@ -1046,10 +1053,14 @@ async fn collect_e2ee(
             error!("Room {room_id} has no state");
             continue;
         };
-        let since_frame_id = crate::event::get_last_frame_id(room_id, Some(since_sn)).await.ok();
+        let since_frame_id = crate::event::get_last_frame_id(room_id, Some(since_sn))
+            .await
+            .ok();
 
         let encrypted_room =
-            state::get_state(current_frame_id, &StateEventType::RoomEncryption, "").await.is_ok();
+            state::get_state(current_frame_id, &StateEventType::RoomEncryption, "")
+                .await
+                .is_ok();
 
         if let Some(since_frame_id) = since_frame_id {
             // // Skip if there are only timeline changes
@@ -1058,7 +1069,9 @@ async fn collect_e2ee(
             // }
 
             let since_encryption =
-                state::get_state(since_frame_id, &StateEventType::RoomEncryption, "").await.ok();
+                state::get_state(since_frame_id, &StateEventType::RoomEncryption, "")
+                    .await
+                    .ok();
 
             let joined_since_last_sync = room::user::join_sn(sender_id, room_id).await? >= since_sn;
 
@@ -1294,102 +1307,102 @@ pub async fn update_sync_request_with_cache(
         let mut guard = entry.lock().unwrap();
         let cached = &mut *guard;
 
-    for (list_id, list) in &mut req_body.lists {
-        if let Some(cached_list) = cached.lists.get(list_id) {
-            list_or_sticky(
-                &mut list.room_details.required_state,
-                &cached_list.room_details.required_state,
-            );
-            // some_or_sticky(&mut list.include_heroes, cached_list.include_heroes);
+        for (list_id, list) in &mut req_body.lists {
+            if let Some(cached_list) = cached.lists.get(list_id) {
+                list_or_sticky(
+                    &mut list.room_details.required_state,
+                    &cached_list.room_details.required_state,
+                );
+                // some_or_sticky(&mut list.include_heroes, cached_list.include_heroes);
 
-            match (&mut list.filters, cached_list.filters.clone()) {
-                (Some(filters), Some(cached_filters)) => {
-                    some_or_sticky(&mut filters.is_invite, cached_filters.is_invite);
-                    some_or_sticky(&mut filters.is_dm, cached_filters.is_dm);
-                    some_or_sticky(&mut filters.is_encrypted, cached_filters.is_encrypted);
-                    list_or_sticky(&mut filters.room_types, &cached_filters.room_types);
-                    list_or_sticky(&mut filters.not_room_types, &cached_filters.not_room_types);
+                match (&mut list.filters, cached_list.filters.clone()) {
+                    (Some(filters), Some(cached_filters)) => {
+                        some_or_sticky(&mut filters.is_invite, cached_filters.is_invite);
+                        some_or_sticky(&mut filters.is_dm, cached_filters.is_dm);
+                        some_or_sticky(&mut filters.is_encrypted, cached_filters.is_encrypted);
+                        list_or_sticky(&mut filters.room_types, &cached_filters.room_types);
+                        list_or_sticky(&mut filters.not_room_types, &cached_filters.not_room_types);
+                    }
+                    (_, Some(cached_filters)) => list.filters = Some(cached_filters),
+                    (Some(list_filters), _) => list.filters = Some(list_filters.clone()),
+                    (..) => {}
                 }
-                (_, Some(cached_filters)) => list.filters = Some(cached_filters),
-                (Some(list_filters), _) => list.filters = Some(list_filters.clone()),
-                (..) => {}
             }
+            cached.lists.insert(list_id.clone(), list.clone());
         }
-        cached.lists.insert(list_id.clone(), list.clone());
-    }
 
-    // Remove unsubscribed rooms from cache
-    for room_id in &req_body.unsubscribe_rooms {
-        cached.subscriptions.remove(room_id);
-    }
+        // Remove unsubscribed rooms from cache
+        for room_id in &req_body.unsubscribe_rooms {
+            cached.subscriptions.remove(room_id);
+        }
 
-    cached
-        .subscriptions
-        .extend(req_body.room_subscriptions.clone());
-    req_body
-        .room_subscriptions
-        .extend(cached.subscriptions.clone());
+        cached
+            .subscriptions
+            .extend(req_body.room_subscriptions.clone());
+        req_body
+            .room_subscriptions
+            .extend(cached.subscriptions.clone());
 
-    req_body.extensions.e2ee.enabled = req_body
-        .extensions
-        .e2ee
-        .enabled
-        .or(cached.extensions.e2ee.enabled);
+        req_body.extensions.e2ee.enabled = req_body
+            .extensions
+            .e2ee
+            .enabled
+            .or(cached.extensions.e2ee.enabled);
 
-    req_body.extensions.to_device.enabled = req_body
-        .extensions
-        .to_device
-        .enabled
-        .or(cached.extensions.to_device.enabled);
+        req_body.extensions.to_device.enabled = req_body
+            .extensions
+            .to_device
+            .enabled
+            .or(cached.extensions.to_device.enabled);
 
-    req_body.extensions.account_data.enabled = req_body
-        .extensions
-        .account_data
-        .enabled
-        .or(cached.extensions.account_data.enabled);
-    req_body.extensions.account_data.lists = req_body
-        .extensions
-        .account_data
-        .lists
-        .clone()
-        .or(cached.extensions.account_data.lists.clone());
-    req_body.extensions.account_data.rooms = req_body
-        .extensions
-        .account_data
-        .rooms
-        .clone()
-        .or(cached.extensions.account_data.rooms.clone());
+        req_body.extensions.account_data.enabled = req_body
+            .extensions
+            .account_data
+            .enabled
+            .or(cached.extensions.account_data.enabled);
+        req_body.extensions.account_data.lists = req_body
+            .extensions
+            .account_data
+            .lists
+            .clone()
+            .or(cached.extensions.account_data.lists.clone());
+        req_body.extensions.account_data.rooms = req_body
+            .extensions
+            .account_data
+            .rooms
+            .clone()
+            .or(cached.extensions.account_data.rooms.clone());
 
-    some_or_sticky(
-        &mut req_body.extensions.typing.enabled,
-        cached.extensions.typing.enabled,
-    );
-    some_or_sticky(
-        &mut req_body.extensions.typing.rooms,
-        cached.extensions.typing.rooms.clone(),
-    );
-    some_or_sticky(
-        &mut req_body.extensions.typing.lists,
-        cached.extensions.typing.lists.clone(),
-    );
-    some_or_sticky(
-        &mut req_body.extensions.receipts.enabled,
-        cached.extensions.receipts.enabled,
-    );
-    some_or_sticky(
-        &mut req_body.extensions.receipts.rooms,
-        cached.extensions.receipts.rooms.clone(),
-    );
-    some_or_sticky(
-        &mut req_body.extensions.receipts.lists,
-        cached.extensions.receipts.lists.clone(),
-    );
+        some_or_sticky(
+            &mut req_body.extensions.typing.enabled,
+            cached.extensions.typing.enabled,
+        );
+        some_or_sticky(
+            &mut req_body.extensions.typing.rooms,
+            cached.extensions.typing.rooms.clone(),
+        );
+        some_or_sticky(
+            &mut req_body.extensions.typing.lists,
+            cached.extensions.typing.lists.clone(),
+        );
+        some_or_sticky(
+            &mut req_body.extensions.receipts.enabled,
+            cached.extensions.receipts.enabled,
+        );
+        some_or_sticky(
+            &mut req_body.extensions.receipts.rooms,
+            cached.extensions.receipts.rooms.clone(),
+        );
+        some_or_sticky(
+            &mut req_body.extensions.receipts.lists,
+            cached.extensions.receipts.lists.clone(),
+        );
 
-    cached.extensions = req_body.extensions.clone();
-    let known = cached.known_rooms.clone();
-    let list_counts = cached.list_counts.clone();
-    // Persist to DB for cross-instance availability
-    let cache_snapshot = cached.clone();
+        cached.extensions = req_body.extensions.clone();
+        let known = cached.known_rooms.clone();
+        let list_counts = cached.list_counts.clone();
+        // Persist to DB for cross-instance availability
+        let cache_snapshot = cached.clone();
         (known, list_counts, cache_snapshot)
     };
     persist_connection(&user_id, &device_id, &req_body.conn_id, &cache_snapshot).await;
@@ -1518,8 +1531,7 @@ mod tests {
             .collect();
         let dms = HashSet::new();
 
-        let active =
-            compute_active_rooms(&ReqList::default(), &invited, &joined, &all, &dms).await;
+        let active = compute_active_rooms(&ReqList::default(), &invited, &joined, &all, &dms).await;
 
         assert_eq!(active.len(), 3);
     }

--- a/crates/server/src/transaction_id.rs
+++ b/crates/server/src/transaction_id.rs
@@ -1,7 +1,6 @@
-use crate::AppResult;
 use crate::core::identifiers::*;
 use crate::core::{DeviceId, TransactionId, UserId};
-use crate::data;
+use crate::{AppResult, data};
 
 pub async fn add_txn_id(
     txn_id: &TransactionId,

--- a/crates/server/src/user.rs
+++ b/crates/server/src/user.rs
@@ -8,7 +8,8 @@ pub mod presence;
 // mod ldap;
 // pub use ldap::*;
 pub mod session;
-use std::{collections::BTreeSet, mem};
+use std::collections::BTreeSet;
+use std::mem;
 
 pub use presence::*;
 use serde::de::DeserializeOwned;
@@ -19,8 +20,8 @@ use crate::core::events::ignored_user_list::IgnoredUserListEvent;
 use crate::core::events::room::power_levels::RoomPowerLevelsEventContent;
 use crate::core::identifiers::*;
 use crate::core::serde::JsonValue;
-use crate::data::user::{DbUser, DbUserData, NewDbUser};
 use crate::data::DataResult;
+use crate::data::user::{DbUser, DbUserData, NewDbUser};
 use crate::room::timeline;
 use crate::{AppError, AppResult, IsRemoteOrLocal, MatrixError, PduBuilder, config, data, room};
 
@@ -183,7 +184,9 @@ pub async fn full_user_deactivate(
         });
 
         let user_can_demote_self = user_can_change_self
-            || room::get_create(room_id).await.is_ok_and(|event| event.sender == user_id);
+            || room::get_create(room_id)
+                .await
+                .is_ok_and(|event| event.sender == user_id);
 
         if user_can_demote_self {
             let mut power_levels_content: RoomPowerLevelsEventContent = room_power_levels
@@ -280,8 +283,7 @@ pub async fn create_login_token(user_id: &UserId, token: &str) -> AppResult<u64>
 /// Find out which user a login token belongs to.
 /// Removes the token to prevent double-use attacks.
 pub async fn take_login_token(token: &str) -> AppResult<OwnedUserId> {
-    let Some((user_id, expires_at)) = data::user::login_token::get_login_token(token).await?
-    else {
+    let Some((user_id, expires_at)) = data::user::login_token::get_login_token(token).await? else {
         return Err(MatrixError::forbidden("Login token is unrecognised.", None).into());
     };
 

--- a/crates/server/src/user/key.rs
+++ b/crates/server/src/user/key.rs
@@ -56,7 +56,8 @@ pub async fn query_keys<F: Fn(&UserId) -> bool + Send + Sync>(
             }
             if let Some((device_id, _)) = data::user::get_dehydrated_device(user_id).await?
                 && !container.contains_key(&device_id)
-                && let Some(keys) = data::user::get_device_keys_and_sigs(user_id, &device_id).await?
+                && let Some(keys) =
+                    data::user::get_device_keys_and_sigs(user_id, &device_id).await?
             {
                 container.insert(device_id, keys);
             }
@@ -483,7 +484,7 @@ fn validate_cross_signing_key(
     kind: CrossSigningKeyKind,
     key: &CrossSigningKey,
 ) -> AppResult<()> {
-    if &key.user_id != user_id {
+    if key.user_id != user_id {
         return Err(MatrixError::invalid_param(format!(
             "{} key user_id does not match the authenticated user.",
             kind.display_name()

--- a/crates/server/src/user/session.rs
+++ b/crates/server/src/user/session.rs
@@ -109,12 +109,14 @@ mod tests {
         )
         .expect("JWT token should be encoded");
 
-        let mut config = JwtConfig::default();
-        config.secret = "test-secret".to_owned();
-        config.format = "HMAC".to_owned();
-        config.algorithm = "HS256".to_owned();
-        config.validate_exp = true;
-        config.require_exp = true;
+        let config = JwtConfig {
+            secret: "test-secret".to_owned(),
+            format: "HMAC".to_owned(),
+            algorithm: "HS256".to_owned(),
+            validate_exp: true,
+            require_exp: true,
+            ..Default::default()
+        };
 
         let result = validate_jwt_token(&config, &token);
 

--- a/crates/server/src/utils.rs
+++ b/crates/server/src/utils.rs
@@ -17,8 +17,8 @@ pub mod stream;
 pub mod string;
 pub use stream::*;
 pub mod content_disposition;
-pub mod url_guard;
 mod mutex_map;
+pub mod url_guard;
 pub use mutex_map::{MutexMap, MutexMapGuard};
 mod sequm_queue;
 pub use sequm_queue::*;
@@ -84,7 +84,7 @@ pub fn increment(old: Option<&[u8]>) -> Option<Vec<u8>> {
 pub fn generate_keypair() -> Ed25519KeyPair {
     let key_content = Ed25519KeyPair::generate().unwrap();
     Ed25519KeyPair::from_der(&key_content, random_string(8))
-        .unwrap_or_else(|_| panic!("{:?}", &key_content))
+        .unwrap_or_else(|_| panic!("{:?}", key_content))
 }
 
 /// Parses the bytes into an u64.

--- a/crates/server/src/utils/url_guard.rs
+++ b/crates/server/src/utils/url_guard.rs
@@ -2,16 +2,15 @@
 //!
 //! Two layers protect against SSRF:
 //!
-//! 1. The reqwest clients used for user-influenced outbound traffic (push
-//!    gateways, URL preview, federation) install a CIDR-filtering DNS
-//!    resolver (see [`crate::sending::resolver::Resolver::new_with_cidr_denylist`]).
-//!    That resolver filters DNS results against `config::cidr_range_denylist`
-//!    at connect time, which prevents both ordinary hostnames that resolve
-//!    to internal addresses and DNS-rebinding attempts.
+//! 1. The reqwest clients used for user-influenced outbound traffic (push gateways, URL preview,
+//!    federation) install a CIDR-filtering DNS resolver (see
+//!    [`crate::sending::resolver::Resolver::new_with_cidr_denylist`]). That resolver filters DNS
+//!    results against `config::cidr_range_denylist` at connect time, which prevents both ordinary
+//!    hostnames that resolve to internal addresses and DNS-rebinding attempts.
 //!
-//! 2. This module supplies fast pre-flight checks: scheme allowlist and
-//!    rejection of IP-literal hosts that fall inside the denylist (those
-//!    bypass DNS resolution entirely, so the resolver never sees them).
+//! 2. This module supplies fast pre-flight checks: scheme allowlist and rejection of IP-literal
+//!    hosts that fall inside the denylist (those bypass DNS resolution entirely, so the resolver
+//!    never sees them).
 //!
 //! Both layers are needed: the resolver alone misses IP-literal hosts,
 //! and the pre-flight check alone is racy with the actual connect.
@@ -51,11 +50,9 @@ pub fn ensure_ip_literal_host_allowed(url: &Url) -> AppResult<()> {
     if let Ok(ip) = IPAddress::parse(host)
         && !crate::config::valid_cidr_range(&ip)
     {
-        return Err(MatrixError::forbidden(
-            "Requesting from this address is forbidden.",
-            None,
-        )
-        .into());
+        return Err(
+            MatrixError::forbidden("Requesting from this address is forbidden.", None).into(),
+        );
     }
     Ok(())
 }


### PR DESCRIPTION
Addresses the P3 issue "CI 有基础门禁，但没有实际执行 fmt/clippy" from `_report.md`.

## Problem

The quality-control workflow installed the `rustfmt` and `clippy` components but never ran them — only `cargo check` and `cargo test` gate PRs. Formatting drift and lint regressions accumulate silently (the tree had drifted to ~200 rustfmt violations).

## Changes

- New `lint` job in `.github/workflows/quality-control.yml`:
  - `cargo +nightly fmt --all -- --check` — nightly rustfmt because `rustfmt.toml` sets `unstable_features = true` and a number of nightly-only options; stable rustfmt silently ignores them and formats differently.
  - `cargo clippy --workspace --all-targets -- -D warnings` — the workspace `[workspace.lints.clippy]` allowlist (complexity-class lints) still applies.
- Removed the unused `rustfmt, clippy` components from the `typos` job, which never invoked them.
- One-time `cargo +nightly fmt --all` over the tree so the new gate starts green (mechanical reformat only).
- Fixed the clippy findings so `-D warnings` passes.

## Real bugs surfaced by the gate

`clippy::let_underscore_future` found seven `let _ = async_fn(...)` calls that dropped the future without polling it — the intended side effect never ran (separate commit for reviewability):

- `server_key/acquire.rs`: fetched federation signing keys were **never persisted** (both the direct-fetch and notary paths).
- `main.rs`: appservice registrations were not force-loaded at startup despite the comment saying so.
- `membership.rs`: state fields for invite/knock membership were never interned.
- `membership/leave.rs`: the leave PDU was never queued for federation. `build_and_append_pdu` already delivers to all participating servers, so the redundant room-wide send is dropped and only the inviting server (which may not be participating for an out-of-band invite) is notified explicitly.

One clippy suggestion was wrong and is deviated from: `devices.get(0)` → `.first()` resolves to diesel's `RunQueryDsl::first` blanket impl and breaks compilation; `devices.as_slice().first()` is used instead.

## Verification

- `cargo +nightly fmt --all -- --check` passes locally.
- `cargo clippy --workspace --all-targets -- -D warnings` passes locally.
- `cargo check -p palpo --tests` passes after the reformat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
