### PR TITLE
Implement MSC3391 room account data deletion

### DIFF
--- a/crates/data/src/user/data.rs
+++ b/crates/data/src/user/data.rs
@@ -239,6 +239,50 @@ pub async fn delete_global_data(user_id: &UserId, kind: &str) -> DataResult<()> 
     Ok(())
 }
 
+/// Delete a room-scoped account-data entry, keeping a tombstone row so the
+/// deletion propagates through sync (MSC3391), mirroring `delete_global_data`.
+pub async fn delete_room_data(user_id: &UserId, room_id: &RoomId, kind: &str) -> DataResult<()> {
+    let mut conn = connect().await?;
+    let existing = user_datas::table
+        .filter(user_datas::user_id.eq(user_id))
+        .filter(user_datas::room_id.eq(room_id))
+        .filter(user_datas::data_type.eq(kind))
+        .order_by(user_datas::id.desc())
+        .first::<DbUserData>(&mut conn)
+        .await
+        .optional()?;
+
+    let Some(existing) = existing else {
+        return Ok(());
+    };
+
+    diesel::delete(
+        user_datas::table
+            .filter(user_datas::user_id.eq(user_id))
+            .filter(user_datas::room_id.eq(room_id))
+            .filter(user_datas::data_type.eq(kind))
+            .filter(user_datas::id.ne(existing.id)),
+    )
+    .execute(&mut conn)
+    .await?;
+
+    if existing.is_deleted {
+        return Ok(());
+    }
+
+    diesel::update(user_datas::table.find(existing.id))
+        .set((
+            user_datas::json_data.eq(json!({})),
+            user_datas::is_deleted.eq(true),
+            user_datas::occur_sn.eq(crate::next_sn().await?),
+            user_datas::created_at.eq(UnixMillis::now()),
+        ))
+        .execute(&mut conn)
+        .await?;
+
+    Ok(())
+}
+
 /// Load all global account-data rows for a user.
 pub async fn get_global_datas(user_id: &UserId) -> DataResult<Vec<DbUserData>> {
     user_datas::table

--- a/crates/server/src/routing/client/account.rs
+++ b/crates/server/src/routing/client/account.rs
@@ -170,3 +170,29 @@ pub(super) async fn delete_account_data_msc3391(
     data::user::delete_global_data(authed.user_id(), &account_type).await?;
     empty_ok()
 }
+
+// msc3391
+#[handler]
+pub(super) async fn delete_room_account_data_msc3391(
+    _aa: AuthArgs,
+    user_id: PathParam<OwnedUserId>,
+    room_id: PathParam<OwnedRoomId>,
+    account_type: PathParam<String>,
+    depot: &mut Depot,
+) -> EmptyResult {
+    let authed = depot.authed_info()?;
+    let user_id = user_id.into_inner();
+    if user_id != authed.user_id() {
+        return Err(
+            MatrixError::forbidden("Cannot delete account data for another user.", None).into(),
+        );
+    }
+
+    data::user::delete_room_data(
+        authed.user_id(),
+        &room_id.into_inner(),
+        &account_type.into_inner(),
+    )
+    .await?;
+    empty_ok()
+}

--- a/crates/server/src/routing/client/unstable.rs
+++ b/crates/server/src/routing/client/unstable.rs
@@ -26,6 +26,12 @@ pub(super) fn router() -> Router {
                     .delete(super::account::delete_account_data_msc3391),
                 )
                 .push(
+                    Router::with_path(
+                        "org.matrix.msc3391/user/{user_id}/rooms/{room_id}/account_data/{account_type}",
+                    )
+                    .delete(super::account::delete_room_account_data_msc3391),
+                )
+                .push(
                     Router::with_path("org.matrix.simplified_msc3575/sync")
                         .post(super::sync_msc4186::sync_events_v5),
                 )


### PR DESCRIPTION
## Summary
MSC3391 defines DELETE endpoints for both global and room-scoped account data, but only the global variant (`DELETE /unstable/org.matrix.msc3391/user/{userId}/account_data/{type}`) was mounted. This adds the room-scoped variant.

## Changes
- New route `DELETE /unstable/org.matrix.msc3391/user/{userId}/rooms/{roomId}/account_data/{type}`, with the same ownership check as the global handler.
- New `data::user::delete_room_data` helper mirroring `delete_global_data`: prunes duplicate rows, then marks the latest row `is_deleted` with a fresh `occur_sn` so the deletion propagates through sync as a tombstone.

## Validation
- `cargo clippy -p palpo --all-targets` and `cargo clippy -p palpo-data` — clean.
- `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)