### PR TITLE
Bound the sending wakeup queue

### DIFF
--- a/crates/server/src/sending.rs
+++ b/crates/server/src/sending.rs
@@ -11,7 +11,7 @@ use reqwest_retry::RetryTransientMiddleware;
 use reqwest_retry::policies::ExponentialBackoff;
 use serde::Deserialize;
 use serde_json::value::to_raw_value;
-use tokio::sync::{Mutex, Semaphore, mpsc};
+use tokio::sync::{Semaphore, mpsc};
 
 use crate::core::appservice::Registration;
 use crate::core::appservice::event::{PushEventsReqBody, push_events_request};
@@ -68,39 +68,32 @@ pub(crate) const WAKEUP_QUEUE_CAPACITY: usize = 4096;
 type WakeupMessage = (OutgoingKind, SendingEventType, i64);
 
 pub static MPSC_SENDER: OnceLock<mpsc::Sender<WakeupMessage>> = OnceLock::new();
-pub static MPSC_RECEIVER: OnceLock<Mutex<mpsc::Receiver<WakeupMessage>>> = OnceLock::new();
 
-enum NotifyOutcome {
-    Queued,
-    DroppedFull,
-    Closed,
-}
-
-fn try_notify(sender: &mpsc::Sender<WakeupMessage>, message: WakeupMessage) -> NotifyOutcome {
+fn notify_sender(sender: &mpsc::Sender<WakeupMessage>, message: WakeupMessage) -> AppResult<()> {
     use tokio::sync::mpsc::error::TrySendError;
 
     match sender.try_send(message) {
-        Ok(()) => NotifyOutcome::Queued,
-        Err(TrySendError::Full(_)) => NotifyOutcome::DroppedFull,
-        Err(TrySendError::Closed(_)) => NotifyOutcome::Closed,
+        Ok(()) => Ok(()),
+        Err(TrySendError::Full(_)) => {
+            warn_wakeup_queue_full();
+            Ok(())
+        }
+        Err(TrySendError::Closed(_)) => Err(AppError::internal("sending wakeup queue is closed")),
     }
 }
 
 /// Wake the sending guard for a request that was just persisted.
 ///
-/// Dropping the wakeup is safe: the request row already exists in the
-/// database, and the guard's periodic sweep starts transactions for
-/// destinations whose wakeups were lost.
-fn notify(outgoing_kind: OutgoingKind, event: SendingEventType, id: i64) {
-    let Some(sender) = MPSC_SENDER.get() else {
-        error!("sending wakeup queue is not initialized");
-        return;
-    };
-    match try_notify(sender, (outgoing_kind, event, id)) {
-        NotifyOutcome::Queued => {}
-        NotifyOutcome::DroppedFull => warn_wakeup_queue_full(),
-        NotifyOutcome::Closed => error!("sending wakeup queue is closed"),
-    }
+/// Dropping a wakeup because the queue is full is safe: the request row
+/// already exists in the database, and the guard's periodic sweep starts
+/// transactions for destinations whose wakeups were lost. A missing or closed
+/// queue means there is no guard to perform that recovery, so it is returned
+/// to the caller as an error.
+fn notify(outgoing_kind: OutgoingKind, event: SendingEventType, id: i64) -> AppResult<()> {
+    let sender = MPSC_SENDER
+        .get()
+        .ok_or_else(|| AppError::internal("sending wakeup queue is not initialized"))?;
+    notify_sender(sender, (outgoing_kind, event, id))
 }
 
 /// Warn about a full wakeup queue at most once per second, since the queue
@@ -250,7 +243,7 @@ pub async fn send_push_pdu(pdu_id: &EventId, user: &UserId, pushkey: String) -> 
     let event = SendingEventType::Pdu(pdu_id.to_owned());
     let keys = queue_requests(&[(&outgoing_kind, event.clone())]).await?;
     if let Some(key) = keys.into_iter().next() {
-        notify(outgoing_kind, event, key);
+        notify(outgoing_kind, event, key)?;
     }
 
     Ok(())
@@ -312,7 +305,7 @@ pub async fn send_pdu_servers<S: Iterator<Item = OwnedServerName>>(
     )
     .await?;
     for ((outgoing_kind, event_type), key) in requests.into_iter().zip(keys) {
-        notify(outgoing_kind, event_type, key);
+        notify(outgoing_kind, event_type, key)?;
     }
 
     Ok(())
@@ -363,7 +356,7 @@ pub async fn send_edu_servers<S: Iterator<Item = OwnedServerName>>(
     )
     .await?;
     for ((outgoing_kind, event), key) in requests.into_iter().zip(keys) {
-        notify(outgoing_kind, event, key);
+        notify(outgoing_kind, event, key)?;
     }
 
     Ok(())
@@ -389,7 +382,7 @@ pub async fn send_edu_server(server: &ServerName, edu: &Edu) -> AppResult<()> {
     let outgoing_kind = OutgoingKind::Normal(server.to_owned());
     let event = SendingEventType::Edu(serialized.to_owned());
     let key = queue_request(&outgoing_kind, &event).await?;
-    notify(outgoing_kind, event, key);
+    notify(outgoing_kind, event, key)?;
 
     Ok(())
 }
@@ -416,7 +409,7 @@ pub async fn send_reliable_edu(server: &ServerName, edu: &Edu, id: &str) -> AppR
     let event = SendingEventType::Edu(serialized);
     let keys = queue_requests(&[(&outgoing_kind, event.clone())]).await?;
     if let Some(key) = keys.into_iter().next() {
-        notify(outgoing_kind, event, key);
+        notify(outgoing_kind, event, key)?;
     }
 
     Ok(())
@@ -428,7 +421,7 @@ pub async fn send_pdu_appservice(appservice_id: String, pdu_id: &EventId) -> App
     let event = SendingEventType::Pdu(pdu_id.to_owned());
     let keys = queue_requests(&[(&outgoing_kind, event.clone())]).await?;
     if let Some(key) = keys.into_iter().next() {
-        notify(outgoing_kind, event, key);
+        notify(outgoing_kind, event, key)?;
     }
 
     Ok(())
@@ -1098,31 +1091,19 @@ mod tests {
     use crate::config::FederationConfig;
 
     #[tokio::test]
-    async fn full_wakeup_queue_drops_wakeups_without_failing() {
+    async fn full_wakeup_queue_drops_wakeups_but_closed_queue_fails() {
         let (sender, mut receiver) = mpsc::channel(1);
         let kind = OutgoingKind::Appservice("test".to_owned());
         let event = SendingEventType::Flush;
 
-        assert!(matches!(
-            try_notify(&sender, (kind.clone(), event.clone(), 1)),
-            NotifyOutcome::Queued
-        ));
-        assert!(matches!(
-            try_notify(&sender, (kind.clone(), event.clone(), 2)),
-            NotifyOutcome::DroppedFull
-        ));
+        notify_sender(&sender, (kind.clone(), event.clone(), 1)).unwrap();
+        notify_sender(&sender, (kind.clone(), event.clone(), 2)).unwrap();
 
         receiver.recv().await.expect("first wakeup stays queued");
-        assert!(matches!(
-            try_notify(&sender, (kind.clone(), event.clone(), 3)),
-            NotifyOutcome::Queued
-        ));
+        notify_sender(&sender, (kind.clone(), event.clone(), 3)).unwrap();
 
         drop(receiver);
-        assert!(matches!(
-            try_notify(&sender, (kind, event, 4)),
-            NotifyOutcome::Closed
-        ));
+        assert!(notify_sender(&sender, (kind, event, 4)).is_err());
     }
 
     #[test]

--- a/crates/server/src/sending.rs
+++ b/crates/server/src/sending.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 use base64::Engine as _;
 use base64::engine::general_purpose;
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncConnection, RunQueryDsl};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::RetryTransientMiddleware;
 use reqwest_retry::policies::ExponentialBackoff;
@@ -65,7 +65,7 @@ pub const EDU_LIMIT: usize = 100;
 /// guard's periodic sweep picks the request up from the database instead.
 pub(crate) const WAKEUP_QUEUE_CAPACITY: usize = 4096;
 
-type WakeupMessage = (OutgoingKind, SendingEventType, i64);
+type WakeupMessage = OutgoingKind;
 
 pub static MPSC_SENDER: OnceLock<mpsc::Sender<WakeupMessage>> = OnceLock::new();
 
@@ -89,11 +89,11 @@ fn notify_sender(sender: &mpsc::Sender<WakeupMessage>, message: WakeupMessage) -
 /// transactions for destinations whose wakeups were lost. A missing or closed
 /// queue means there is no guard to perform that recovery, so it is returned
 /// to the caller as an error.
-fn notify(outgoing_kind: OutgoingKind, event: SendingEventType, id: i64) -> AppResult<()> {
+fn notify(outgoing_kind: OutgoingKind) -> AppResult<()> {
     let sender = MPSC_SENDER
         .get()
         .ok_or_else(|| AppError::internal("sending wakeup queue is not initialized"))?;
-    notify_sender(sender, (outgoing_kind, event, id))
+    notify_sender(sender, outgoing_kind)
 }
 
 /// Warn about a full wakeup queue at most once per second, since the queue
@@ -242,8 +242,8 @@ pub async fn send_push_pdu(pdu_id: &EventId, user: &UserId, pushkey: String) -> 
     let outgoing_kind = OutgoingKind::Push(user.to_owned(), pushkey);
     let event = SendingEventType::Pdu(pdu_id.to_owned());
     let keys = queue_requests(&[(&outgoing_kind, event.clone())]).await?;
-    if let Some(key) = keys.into_iter().next() {
-        notify(outgoing_kind, event, key)?;
+    if keys.into_iter().next().is_some() {
+        notify(outgoing_kind)?;
     }
 
     Ok(())
@@ -304,8 +304,8 @@ pub async fn send_pdu_servers<S: Iterator<Item = OwnedServerName>>(
             .collect::<Vec<_>>(),
     )
     .await?;
-    for ((outgoing_kind, event_type), key) in requests.into_iter().zip(keys) {
-        notify(outgoing_kind, event_type, key)?;
+    for ((outgoing_kind, _), _) in requests.into_iter().zip(keys) {
+        notify(outgoing_kind)?;
     }
 
     Ok(())
@@ -355,8 +355,8 @@ pub async fn send_edu_servers<S: Iterator<Item = OwnedServerName>>(
             .collect::<Vec<_>>(),
     )
     .await?;
-    for ((outgoing_kind, event), key) in requests.into_iter().zip(keys) {
-        notify(outgoing_kind, event, key)?;
+    for ((outgoing_kind, _), _) in requests.into_iter().zip(keys) {
+        notify(outgoing_kind)?;
     }
 
     Ok(())
@@ -381,8 +381,8 @@ pub async fn send_edu_server(server: &ServerName, edu: &Edu) -> AppResult<()> {
 
     let outgoing_kind = OutgoingKind::Normal(server.to_owned());
     let event = SendingEventType::Edu(serialized.to_owned());
-    let key = queue_request(&outgoing_kind, &event).await?;
-    notify(outgoing_kind, event, key)?;
+    queue_request(&outgoing_kind, &event).await?;
+    notify(outgoing_kind)?;
 
     Ok(())
 }
@@ -408,8 +408,8 @@ pub async fn send_reliable_edu(server: &ServerName, edu: &Edu, id: &str) -> AppR
     let outgoing_kind = OutgoingKind::Normal(server.to_owned());
     let event = SendingEventType::Edu(serialized);
     let keys = queue_requests(&[(&outgoing_kind, event.clone())]).await?;
-    if let Some(key) = keys.into_iter().next() {
-        notify(outgoing_kind, event, key)?;
+    if keys.into_iter().next().is_some() {
+        notify(outgoing_kind)?;
     }
 
     Ok(())
@@ -420,8 +420,8 @@ pub async fn send_pdu_appservice(appservice_id: String, pdu_id: &EventId) -> App
     let outgoing_kind = OutgoingKind::Appservice(appservice_id);
     let event = SendingEventType::Pdu(pdu_id.to_owned());
     let keys = queue_requests(&[(&outgoing_kind, event.clone())]).await?;
-    if let Some(key) = keys.into_iter().next() {
-        notify(outgoing_kind, event, key)?;
+    if keys.into_iter().next().is_some() {
+        notify(outgoing_kind)?;
     }
 
     Ok(())
@@ -981,23 +981,43 @@ async fn queued_requests(
         })
         .collect())
 }
-async fn mark_as_active(events: &[(i64, SendingEventType)]) -> AppResult<()> {
-    for (id, e) in events {
-        let value = if let SendingEventType::Edu(value) = &e {
-            &**value
-        } else {
-            &[]
-        };
-        diesel::update(outgoing_requests::table.find(id))
-            .set((
-                outgoing_requests::data.eq(value),
-                outgoing_requests::state.eq("pending"),
-            ))
-            .execute(&mut connect().await?)
-            .await?;
-    }
+/// Atomically claim queued requests for one sending transaction.
+///
+/// A request may be claimed or deleted after it is selected. Only return
+/// events whose queued row still existed and transitioned to `pending`, so
+/// concurrent recovery cannot send an already-completed request.
+async fn claim_queued_requests(
+    events: &[(i64, SendingEventType)],
+) -> AppResult<Vec<SendingEventType>> {
+    connect()
+        .await?
+        .transaction::<_, AppError, _>(async |conn| {
+            let mut claimed = Vec::with_capacity(events.len());
+            for (id, event) in events {
+                let value = if let SendingEventType::Edu(value) = event {
+                    &**value
+                } else {
+                    &[]
+                };
+                let updated = diesel::update(
+                    outgoing_requests::table
+                        .find(id)
+                        .filter(outgoing_requests::state.ne("pending")),
+                )
+                .set((
+                    outgoing_requests::data.eq(value),
+                    outgoing_requests::state.eq("pending"),
+                ))
+                .execute(conn)
+                .await?;
+                if updated == 1 {
+                    claimed.push(event.clone());
+                }
+            }
 
-    Ok(())
+            Ok(claimed)
+        })
+        .await
 }
 
 /// This does not return a full `Pdu` it is only to satisfy palpo's types.
@@ -1094,16 +1114,18 @@ mod tests {
     async fn full_wakeup_queue_drops_wakeups_but_closed_queue_fails() {
         let (sender, mut receiver) = mpsc::channel(1);
         let kind = OutgoingKind::Appservice("test".to_owned());
-        let event = SendingEventType::Flush;
 
-        notify_sender(&sender, (kind.clone(), event.clone(), 1)).unwrap();
-        notify_sender(&sender, (kind.clone(), event.clone(), 2)).unwrap();
+        notify_sender(&sender, kind.clone()).unwrap();
+        notify_sender(&sender, kind.clone()).unwrap();
 
-        receiver.recv().await.expect("first wakeup stays queued");
-        notify_sender(&sender, (kind.clone(), event.clone(), 3)).unwrap();
+        assert_eq!(
+            receiver.recv().await.expect("first wakeup stays queued"),
+            kind
+        );
+        notify_sender(&sender, kind.clone()).unwrap();
 
         drop(receiver);
-        assert!(notify_sender(&sender, (kind, event, 4)).is_err());
+        assert!(notify_sender(&sender, kind).is_err());
     }
 
     #[test]

--- a/crates/server/src/sending.rs
+++ b/crates/server/src/sending.rs
@@ -53,14 +53,69 @@ pub const EDU_LIMIT: usize = 100;
 // pub(super) type SendingItem = (Key, SendingEvent);
 // pub(super) type QueueItem = (Key, SendingEvent);
 // pub(super) type Key = Vec<u8>;
-pub static MPSC_SENDER: OnceLock<mpsc::UnboundedSender<(OutgoingKind, SendingEventType, i64)>> =
-    OnceLock::new();
-pub static MPSC_RECEIVER: OnceLock<
-    Mutex<mpsc::UnboundedReceiver<(OutgoingKind, SendingEventType, i64)>>,
-> = OnceLock::new();
 
-pub fn sender() -> mpsc::UnboundedSender<(OutgoingKind, SendingEventType, i64)> {
-    MPSC_SENDER.get().expect("sender should set").clone()
+/// Capacity of the in-memory wakeup queue between the enqueue paths and the
+/// sending guard. Requests are persisted in `outgoing_requests` before a
+/// wakeup is queued, so when this queue is full the wakeup is dropped and the
+/// guard's periodic sweep picks the request up from the database instead.
+pub(crate) const WAKEUP_QUEUE_CAPACITY: usize = 4096;
+
+type WakeupMessage = (OutgoingKind, SendingEventType, i64);
+
+pub static MPSC_SENDER: OnceLock<mpsc::Sender<WakeupMessage>> = OnceLock::new();
+pub static MPSC_RECEIVER: OnceLock<Mutex<mpsc::Receiver<WakeupMessage>>> = OnceLock::new();
+
+enum NotifyOutcome {
+    Queued,
+    DroppedFull,
+    Closed,
+}
+
+fn try_notify(sender: &mpsc::Sender<WakeupMessage>, message: WakeupMessage) -> NotifyOutcome {
+    use tokio::sync::mpsc::error::TrySendError;
+
+    match sender.try_send(message) {
+        Ok(()) => NotifyOutcome::Queued,
+        Err(TrySendError::Full(_)) => NotifyOutcome::DroppedFull,
+        Err(TrySendError::Closed(_)) => NotifyOutcome::Closed,
+    }
+}
+
+/// Wake the sending guard for a request that was just persisted.
+///
+/// Dropping the wakeup is safe: the request row already exists in the
+/// database, and the guard's periodic sweep starts transactions for
+/// destinations whose wakeups were lost.
+fn notify(outgoing_kind: OutgoingKind, event: SendingEventType, id: i64) {
+    let Some(sender) = MPSC_SENDER.get() else {
+        error!("sending wakeup queue is not initialized");
+        return;
+    };
+    match try_notify(sender, (outgoing_kind, event, id)) {
+        NotifyOutcome::Queued => {}
+        NotifyOutcome::DroppedFull => warn_wakeup_queue_full(),
+        NotifyOutcome::Closed => error!("sending wakeup queue is closed"),
+    }
+}
+
+/// Warn about a full wakeup queue at most once per second, since the queue
+/// only fills up during bursts of thousands of events.
+fn warn_wakeup_queue_full() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static LAST_WARN_SECS: AtomicU64 = AtomicU64::new(0);
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    // fetch_max returns the previous value, so exactly the caller that moves
+    // the timestamp forward emits the warning for this second.
+    if LAST_WARN_SECS.fetch_max(now, Ordering::Relaxed) < now {
+        warn!(
+            "sending wakeup queue is full; queued requests will be recovered by the periodic sweep"
+        );
+    }
 }
 
 fn should_send_federation_target(
@@ -190,9 +245,7 @@ pub async fn send_push_pdu(pdu_id: &EventId, user: &UserId, pushkey: String) -> 
     let event = SendingEventType::Pdu(pdu_id.to_owned());
     let keys = queue_requests(&[(&outgoing_kind, event.clone())]).await?;
     if let Some(key) = keys.into_iter().next() {
-        sender()
-            .send((outgoing_kind, event, key))
-            .map_err(|e| AppError::internal(format!("failed to send push pdu: {e}")))?;
+        notify(outgoing_kind, event, key);
     }
 
     Ok(())
@@ -254,9 +307,7 @@ pub async fn send_pdu_servers<S: Iterator<Item = OwnedServerName>>(
     )
     .await?;
     for ((outgoing_kind, event_type), key) in requests.into_iter().zip(keys) {
-        if let Err(e) = sender().send((outgoing_kind.to_owned(), event_type, key)) {
-            error!("failed to send pdu: {}", e);
-        }
+        notify(outgoing_kind, event_type, key);
     }
 
     Ok(())
@@ -307,9 +358,7 @@ pub async fn send_edu_servers<S: Iterator<Item = OwnedServerName>>(
     )
     .await?;
     for ((outgoing_kind, event), key) in requests.into_iter().zip(keys) {
-        sender()
-            .send((outgoing_kind.to_owned(), event, key))
-            .map_err(|e| AppError::internal(e.to_string()))?;
+        notify(outgoing_kind, event, key);
     }
 
     Ok(())
@@ -335,9 +384,7 @@ pub async fn send_edu_server(server: &ServerName, edu: &Edu) -> AppResult<()> {
     let outgoing_kind = OutgoingKind::Normal(server.to_owned());
     let event = SendingEventType::Edu(serialized.to_owned());
     let key = queue_request(&outgoing_kind, &event).await?;
-    sender()
-        .send((outgoing_kind, event, key))
-        .map_err(|e| AppError::internal(e.to_string()))?;
+    notify(outgoing_kind, event, key);
 
     Ok(())
 }
@@ -364,9 +411,7 @@ pub async fn send_reliable_edu(server: &ServerName, edu: &Edu, id: &str) -> AppR
     let event = SendingEventType::Edu(serialized);
     let keys = queue_requests(&[(&outgoing_kind, event.clone())]).await?;
     if let Some(key) = keys.into_iter().next() {
-        sender()
-            .send((outgoing_kind, event, key))
-            .map_err(|e| AppError::internal(format!("failed to send reliable edu: {e}")))?;
+        notify(outgoing_kind, event, key);
     }
 
     Ok(())
@@ -378,9 +423,7 @@ pub async fn send_pdu_appservice(appservice_id: String, pdu_id: &EventId) -> App
     let event = SendingEventType::Pdu(pdu_id.to_owned());
     let keys = queue_requests(&[(&outgoing_kind, event.clone())]).await?;
     if let Some(key) = keys.into_iter().next() {
-        sender()
-            .send((outgoing_kind, event, key))
-            .map_err(|e| AppError::internal(format!("failed to send pdu to appservice: {e}")))?;
+        notify(outgoing_kind, event, key);
     }
 
     Ok(())
@@ -855,6 +898,46 @@ async fn active_requests_for(
     Ok(list)
 }
 
+/// Distinct destinations that still have queued (not yet active) requests.
+///
+/// The periodic sweep in the sending guard uses this to recover requests
+/// whose wakeup was dropped because the wakeup queue was full, as well as
+/// requests left queued by a previous process.
+async fn queued_kinds() -> AppResult<Vec<OutgoingKind>> {
+    type Row = (
+        String,
+        Option<String>,
+        Option<OwnedUserId>,
+        Option<String>,
+        Option<OwnedServerName>,
+    );
+    let rows = outgoing_requests::table
+        .filter(outgoing_requests::state.ne("pending"))
+        .select((
+            outgoing_requests::kind,
+            outgoing_requests::appservice_id,
+            outgoing_requests::user_id,
+            outgoing_requests::pushkey,
+            outgoing_requests::server_id,
+        ))
+        .distinct()
+        .load::<Row>(&mut connect().await?)
+        .await?;
+    Ok(rows
+        .into_iter()
+        .filter_map(
+            |(kind, appservice_id, user_id, pushkey, server_id)| match kind.as_str() {
+                "appservice" => appservice_id.map(OutgoingKind::Appservice),
+                "push" => user_id
+                    .zip(pushkey)
+                    .map(|(user_id, pushkey)| OutgoingKind::Push(user_id, pushkey)),
+                "normal" => server_id.map(OutgoingKind::Normal),
+                _ => None,
+            },
+        )
+        .collect())
+}
+
 async fn queued_requests(outgoing_kind: &OutgoingKind) -> AppResult<Vec<(i64, SendingEventType)>> {
     let mut query = outgoing_requests::table
         .filter(outgoing_requests::kind.eq(outgoing_kind.name()))
@@ -1000,6 +1083,34 @@ fn reqwest_client_builder(config: &ServerConfig) -> AppResult<reqwest::ClientBui
 mod tests {
     use super::*;
     use crate::config::FederationConfig;
+
+    #[tokio::test]
+    async fn full_wakeup_queue_drops_wakeups_without_failing() {
+        let (sender, mut receiver) = mpsc::channel(1);
+        let kind = OutgoingKind::Appservice("test".to_owned());
+        let event = SendingEventType::Flush;
+
+        assert!(matches!(
+            try_notify(&sender, (kind.clone(), event.clone(), 1)),
+            NotifyOutcome::Queued
+        ));
+        assert!(matches!(
+            try_notify(&sender, (kind.clone(), event.clone(), 2)),
+            NotifyOutcome::DroppedFull
+        ));
+
+        receiver.recv().await.expect("first wakeup stays queued");
+        assert!(matches!(
+            try_notify(&sender, (kind.clone(), event.clone(), 3)),
+            NotifyOutcome::Queued
+        ));
+
+        drop(receiver);
+        assert!(matches!(
+            try_notify(&sender, (kind, event, 4)),
+            NotifyOutcome::Closed
+        ));
+    }
 
     #[test]
     fn outbound_federation_target_respects_self_allow_and_deny_rules() {

--- a/crates/server/src/sending.rs
+++ b/crates/server/src/sending.rs
@@ -40,6 +40,11 @@ const SELECT_RECEIPT_LIMIT: usize = 256;
 const SELECT_EDU_LIMIT: usize = EDU_LIMIT - 2;
 const DEQUEUE_LIMIT: usize = 48;
 
+/// Maximum number of queued requests pulled into one transaction per
+/// destination. Bounds the per-destination memory the sending guard can use
+/// when draining a backlog.
+const QUEUED_REQUEST_LIMIT: usize = 30;
+
 const EDU_BUF_CAP: usize = 128;
 const EDU_VEC_CAP: usize = 1;
 
@@ -938,11 +943,19 @@ async fn queued_kinds() -> AppResult<Vec<OutgoingKind>> {
         .collect())
 }
 
-async fn queued_requests(outgoing_kind: &OutgoingKind) -> AppResult<Vec<(i64, SendingEventType)>> {
+/// Load up to `limit` queued (not yet active) requests for a destination,
+/// oldest first. The limit is applied in SQL so a large backlog for one
+/// destination is never fully materialized into memory.
+async fn queued_requests(
+    outgoing_kind: &OutgoingKind,
+    limit: usize,
+) -> AppResult<Vec<(i64, SendingEventType)>> {
     let mut query = outgoing_requests::table
         .filter(outgoing_requests::kind.eq(outgoing_kind.name()))
         // Exclude already active requests (state="pending" means being processed)
         .filter(outgoing_requests::state.ne("pending"))
+        .order_by(outgoing_requests::id.asc())
+        .limit(limit as i64)
         .into_boxed();
 
     // Add specific filters based on OutgoingKind

--- a/crates/server/src/sending/guard.rs
+++ b/crates/server/src/sending/guard.rs
@@ -4,11 +4,11 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use futures_util::stream::{FuturesUnordered, StreamExt};
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::mpsc;
 
 use super::{
-    EduBuf, EduVec, MPSC_RECEIVER, MPSC_SENDER, OutgoingKind, SELECT_EDU_LIMIT,
-    SELECT_PRESENCE_LIMIT, SELECT_RECEIPT_LIMIT, SendingEventType, TransactionStatus,
+    EduBuf, EduVec, MPSC_SENDER, OutgoingKind, SELECT_EDU_LIMIT, SELECT_PRESENCE_LIMIT,
+    SELECT_RECEIPT_LIMIT, SendingEventType, TransactionStatus,
 };
 use crate::core::device::DeviceListUpdateContent;
 use crate::core::events::receipt::{ReceiptContent, ReceiptData, ReceiptMap, ReceiptType};
@@ -27,19 +27,18 @@ const SWEEP_INTERVAL: Duration = Duration::from_secs(30);
 
 pub fn start() {
     let (sender, receiver) = mpsc::channel(super::WAKEUP_QUEUE_CAPACITY);
-    let _ = MPSC_SENDER.set(sender);
-    let _ = MPSC_RECEIVER.set(Mutex::new(receiver));
+    if MPSC_SENDER.set(sender).is_err() {
+        error!("sending guard is already started");
+        return;
+    }
     tokio::spawn(async move {
-        process().await.unwrap();
+        if let Err(error) = process(receiver).await {
+            error!(?error, "sending guard stopped");
+        }
     });
 }
 
-async fn process() -> AppResult<()> {
-    let mut receiver = MPSC_RECEIVER
-        .get()
-        .expect("receiver should exist")
-        .lock()
-        .await;
+async fn process(mut receiver: mpsc::Receiver<super::WakeupMessage>) -> AppResult<()> {
     let mut futures = FuturesUnordered::new();
     let mut current_transaction_status = HashMap::<OutgoingKind, TransactionStatus>::new();
     // EDU selection windows of in-flight transactions; persisted as the

--- a/crates/server/src/sending/guard.rs
+++ b/crates/server/src/sending/guard.rs
@@ -20,8 +20,13 @@ use crate::exts::*;
 use crate::room::state;
 use crate::{AppResult, data, room};
 
+/// How often the guard scans the database for queued requests whose wakeup
+/// was dropped (full wakeup queue) or that were left over by a previous
+/// process.
+const SWEEP_INTERVAL: Duration = Duration::from_secs(30);
+
 pub fn start() {
-    let (sender, receiver) = mpsc::unbounded_channel();
+    let (sender, receiver) = mpsc::channel(super::WAKEUP_QUEUE_CAPACITY);
     let _ = MPSC_SENDER.set(sender);
     let _ = MPSC_RECEIVER.set(Mutex::new(receiver));
     tokio::spawn(async move {
@@ -67,6 +72,9 @@ async fn process() -> AppResult<()> {
         current_transaction_status.insert(outgoing_kind.clone(), TransactionStatus::Running);
         futures.push(super::send_events(outgoing_kind.clone(), events));
     }
+
+    let mut sweep = tokio::time::interval(SWEEP_INTERVAL);
+    sweep.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
     loop {
         let retry_delay = next_retry_delay(&current_transaction_status);
@@ -152,6 +160,43 @@ async fn process() -> AppResult<()> {
                     &mut pending_edu_cursors,
                 ).await {
                     futures.push(super::send_events(outgoing_kind, events));
+                }
+            }
+            _ = sweep.tick() => {
+                // Recover destinations whose wakeup was dropped because the
+                // wakeup queue was full, and requests left queued by a
+                // previous process.
+                let kinds = match super::queued_kinds().await {
+                    Ok(kinds) => kinds,
+                    Err(e) => {
+                        error!(error = ?e, "failed to load queued destinations for sweep");
+                        continue;
+                    }
+                };
+                for outgoing_kind in kinds {
+                    if current_transaction_status.contains_key(&outgoing_kind) {
+                        // Running, retrying, or backing off: the existing flow
+                        // picks queued requests up when the transaction settles.
+                        continue;
+                    }
+                    let new_events = match super::queued_requests(&outgoing_kind).await {
+                        Ok(events) => events.into_iter().take(30).collect::<Vec<_>>(),
+                        Err(e) => {
+                            error!(?outgoing_kind, error = ?e, "failed to load queued requests for sweep");
+                            continue;
+                        }
+                    };
+                    if new_events.is_empty() {
+                        continue;
+                    }
+                    if let Ok(Some(events)) = select_events(
+                        &outgoing_kind,
+                        new_events,
+                        &mut current_transaction_status,
+                        &mut pending_edu_cursors,
+                    ).await {
+                        futures.push(super::send_events(outgoing_kind, events));
+                    }
                 }
             }
             _ = async {

--- a/crates/server/src/sending/guard.rs
+++ b/crates/server/src/sending/guard.rs
@@ -96,11 +96,16 @@ async fn process(mut receiver: mpsc::Receiver<super::WakeupMessage>) -> AppResul
                         // Find events that have been added since starting the last request
                         let new_events = super::queued_requests(&outgoing_kind, super::QUEUED_REQUEST_LIMIT).await.unwrap_or_default();
 
-                        if !new_events.is_empty() {
-                            // Insert pdus we found
-                            super::mark_as_active(&new_events).await?;
+                        let mut events = if new_events.is_empty() {
+                            Vec::new()
+                        } else {
+                            // Claim only rows that are still queued. Another
+                            // process may have claimed or completed them since
+                            // the select above.
+                            super::claim_queued_requests(&new_events).await?
+                        };
 
-                            let mut events = new_events.into_iter().map(|(_, event)| event).collect::<Vec<_>>();
+                        if !events.is_empty() {
                             // Piggyback EDUs that accumulated while the previous
                             // transaction was in flight, so a busy destination
                             // does not starve presence/receipt/device-list updates.
@@ -151,14 +156,39 @@ async fn process(mut receiver: mpsc::Receiver<super::WakeupMessage>) -> AppResul
                     }
                 };
             },
-            Some((outgoing_kind, event, id)) = receiver.recv() => {
-                if let Ok(Some(events)) = select_events(
+            Some(outgoing_kind) = receiver.recv() => {
+                if current_transaction_status.contains_key(&outgoing_kind) {
+                    // A running or backing-off transaction will load queued
+                    // rows when it settles or retries.
+                    continue;
+                }
+                let new_events = match super::queued_requests(
                     &outgoing_kind,
-                    vec![(id, event)],
+                    super::QUEUED_REQUEST_LIMIT,
+                ).await {
+                    Ok(events) => events,
+                    Err(e) => {
+                        error!(?outgoing_kind, error = ?e, "failed to load queued requests for wakeup");
+                        continue;
+                    }
+                };
+                if new_events.is_empty() {
+                    // The periodic sweep already handled this wakeup.
+                    continue;
+                }
+                match select_events(
+                    &outgoing_kind,
+                    new_events,
                     &mut current_transaction_status,
                     &mut pending_edu_cursors,
                 ).await {
-                    futures.push(super::send_events(outgoing_kind, events));
+                    Ok(Some(events)) => {
+                        futures.push(super::send_events(outgoing_kind, events));
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        error!(?outgoing_kind, error = ?e, "failed to select queued requests for wakeup");
+                    }
                 }
             }
             _ = sweep.tick() => {
@@ -188,13 +218,19 @@ async fn process(mut receiver: mpsc::Receiver<super::WakeupMessage>) -> AppResul
                     if new_events.is_empty() {
                         continue;
                     }
-                    if let Ok(Some(events)) = select_events(
+                    match select_events(
                         &outgoing_kind,
                         new_events,
                         &mut current_transaction_status,
                         &mut pending_edu_cursors,
                     ).await {
-                        futures.push(super::send_events(outgoing_kind, events));
+                        Ok(Some(events)) => {
+                            futures.push(super::send_events(outgoing_kind, events));
+                        }
+                        Ok(None) => {}
+                        Err(e) => {
+                            error!(?outgoing_kind, error = ?e, "failed to select queued requests for sweep");
+                        }
                     }
                 }
             }
@@ -326,9 +362,19 @@ async fn select_events(
             events.push(e);
         }
     } else {
-        super::mark_as_active(&new_events).await?;
-        for (_, e) in new_events {
-            events.push(e);
+        events = match super::claim_queued_requests(&new_events).await {
+            Ok(events) => events,
+            Err(error) => {
+                current_transaction_status.remove(outgoing_kind);
+                return Err(error);
+            }
+        };
+        if events.is_empty() {
+            // The wakeup was stale: its row was already claimed or deleted by
+            // the periodic sweep (or another process). Undo the Running state
+            // inserted above and do not start an empty transaction.
+            current_transaction_status.remove(outgoing_kind);
+            return Ok(None);
         }
     }
 

--- a/crates/server/src/sending/guard.rs
+++ b/crates/server/src/sending/guard.rs
@@ -95,7 +95,7 @@ async fn process() -> AppResult<()> {
                         }
 
                         // Find events that have been added since starting the last request
-                        let new_events = super::queued_requests(&outgoing_kind).await.unwrap_or_default().into_iter().take(30).collect::<Vec<_>>();
+                        let new_events = super::queued_requests(&outgoing_kind, super::QUEUED_REQUEST_LIMIT).await.unwrap_or_default();
 
                         if !new_events.is_empty() {
                             // Insert pdus we found
@@ -179,8 +179,8 @@ async fn process() -> AppResult<()> {
                         // picks queued requests up when the transaction settles.
                         continue;
                     }
-                    let new_events = match super::queued_requests(&outgoing_kind).await {
-                        Ok(events) => events.into_iter().take(30).collect::<Vec<_>>(),
+                    let new_events = match super::queued_requests(&outgoing_kind, super::QUEUED_REQUEST_LIMIT).await {
+                        Ok(events) => events,
                         Err(e) => {
                             error!(?outgoing_kind, error = ?e, "failed to load queued requests for sweep");
                             continue;


### PR DESCRIPTION
## Summary

Bound the in-memory sending wakeup queue while preserving durable delivery and preventing stale wakeups from duplicating federation, appservice, or push requests.

## Root cause

Outgoing requests are persisted in `outgoing_requests`, but enqueue paths also used an unbounded in-memory channel. A burst could therefore grow process memory without limit.

Dropping wakeups on a bounded full queue requires database recovery. The initial recovery implementation exposed three additional correctness requirements:

- the database query must apply its row limit before materializing EDU payloads;
- a closed receiver is not recoverable by the sweep and must return an error;
- a buffered wakeup may outlive a request already processed by the sweep, so it must never carry an authoritative event payload that can be resent after its row is gone.

## Design

- Use a bounded wakeup channel with capacity 4096 and non-blocking `try_send`.
- Store only the destination in wakeup messages; the guard reloads current queued rows from the database.
- Atomically claim still-queued rows in one database transaction and send only successfully claimed events.
- Push the per-destination request limit into SQL.
- Return an error when the wakeup receiver is missing or closed.
- Periodically sweep distinct idle destinations to recover dropped wakeups and rows left queued by a previous process.
- Log selection failures and roll back in-memory `Running` state instead of silently stalling a destination.

## Validation

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p palpo --all-targets -- -D warnings`
- `cargo test -p palpo --no-fail-fast` (88 passed)
- targeted bounded/full/closed wakeup queue regression test passed