### PR TITLE
Send full PDUs in federation invite state

### DIFF
--- a/crates/core/src/federation/membership.rs
+++ b/crates/core/src/federation/membership.rs
@@ -52,9 +52,12 @@ pub struct InviteUserReqBodyV2 {
     #[salvo(schema(value_type = Object, additional_properties = true))]
     pub event: Box<RawJsonValue>,
 
-    /// An optional list of simplified events to help the receiver of the invite
-    /// identify the room.
-    pub invite_room_state: Vec<RawJson<AnyStrippedStateEvent>>,
+    /// State events to help the receiver of the invite identify the room.
+    ///
+    /// Since Matrix v1.16 these are full PDUs, formatted according to the room
+    /// version, rather than stripped state events.
+    #[salvo(schema(value_type = Vec<Object>))]
+    pub invite_room_state: Vec<Box<RawJsonValue>>,
 
     /// An optional list of servers the invited homeserver should attempt to
     /// join or leave via, according to [MSC4125](https://github.com/matrix-org/matrix-spec-proposals/pull/4125).

--- a/crates/server/src/membership/invite.rs
+++ b/crates/server/src/membership/invite.rs
@@ -28,7 +28,7 @@ pub async fn invite_user(
 
     let conf = crate::config::get();
     if invitee_id.server_name().is_remote() {
-        let (pdu, pdu_json, invite_room_state) = {
+        let (pdu, pdu_json, invite_room_state, federation_invite_room_state) = {
             let content = RoomMemberEventContent {
                 avatar_url: None,
                 display_name: None,
@@ -58,8 +58,14 @@ pub async fn invite_user(
             drop(state_lock);
 
             let invite_room_state = state::summary_stripped(&pdu).await?;
+            let federation_invite_room_state = state::summary_pdus(&pdu).await?;
 
-            (pdu, pdu_json, invite_room_state)
+            (
+                pdu,
+                pdu_json,
+                invite_room_state,
+                federation_invite_room_state,
+            )
         };
         let room_version_id = room::get_version(room_id).await?;
 
@@ -83,7 +89,7 @@ pub async fn invite_user(
             InviteUserReqBodyV2 {
                 room_version: room_version_id.clone(),
                 event: sending::convert_to_outgoing_federation_event(pdu_json.clone()).await,
-                invite_room_state,
+                invite_room_state: federation_invite_room_state,
                 via: state::servers_route_via(room_id).await.ok(),
             },
         )?

--- a/crates/server/src/room/state.rs
+++ b/crates/server/src/room/state.rs
@@ -24,7 +24,7 @@ use crate::core::events::{AnyStrippedStateEvent, StateEventType, TimelineEventTy
 use crate::core::identifiers::*;
 use crate::core::room::{AllowRule, JoinRule, RoomMembership};
 use crate::core::room_version_rules::AuthorizationRules;
-use crate::core::serde::{JsonValue, RawJson};
+use crate::core::serde::{JsonValue, RawJson, RawJsonValue};
 use crate::core::state::StateMap;
 use crate::core::{EventId, OwnedEventId, RoomId, UserId};
 use crate::data::connect;
@@ -33,7 +33,7 @@ use crate::data::schema::*;
 use crate::event::{PduEvent, update_frame_id, update_frame_id_by_sn};
 use crate::room::timeline;
 use crate::{
-    AppError, AppResult, MatrixError, RoomMutexGuard, SnPduEvent, membership, room, utils,
+    AppError, AppResult, MatrixError, RoomMutexGuard, SnPduEvent, membership, room, sending, utils,
 };
 
 pub static SERVER_VISIBILITY_CACHE: LazyLock<Mutex<LruCache<(OwnedServerName, i64), bool>>> =
@@ -269,6 +269,55 @@ pub async fn summary_stripped(event: &PduEvent) -> AppResult<Vec<RawJson<AnyStri
 
     state.push(event.to_stripped_state_event().await);
     Ok(state)
+}
+
+/// Build the room-state summary used by federation invites.
+///
+/// Matrix v1.16 requires every entry to be a full PDU in the room version's
+/// wire format and requires the room's create event to be present.
+pub async fn summary_pdus(event: &PduEvent) -> AppResult<Vec<Box<RawJsonValue>>> {
+    let cells: [(&StateEventType, &str); 8] = [
+        (&StateEventType::RoomCreate, ""),
+        (&StateEventType::RoomJoinRules, ""),
+        (&StateEventType::RoomCanonicalAlias, ""),
+        (&StateEventType::RoomName, ""),
+        (&StateEventType::RoomAvatar, ""),
+        (&StateEventType::RoomMember, event.sender.as_str()),
+        (&StateEventType::RoomEncryption, ""),
+        (&StateEventType::RoomTopic, ""),
+    ];
+
+    let create = super::get_state(&event.room_id, &StateEventType::RoomCreate, "", None)
+        .await
+        .map_err(|_| AppError::internal("room create event is missing from invite state"))?;
+
+    let mut events = vec![create];
+    for (event_type, state_key) in cells.into_iter().skip(1) {
+        if let Ok(state_event) = super::get_state(&event.room_id, event_type, state_key, None).await
+        {
+            events.push(state_event);
+        }
+    }
+
+    let mut pdus = Vec::with_capacity(events.len() + 1);
+    for state_event in events {
+        let json = timeline::get_pdu_json(&state_event.event_id)
+            .await?
+            .ok_or_else(|| {
+                AppError::internal(format!(
+                    "state event {} is missing its JSON data",
+                    state_event.event_id
+                ))
+            })?;
+        pdus.push(sending::convert_to_outgoing_federation_event(json).await);
+    }
+
+    let invite_json = timeline::get_pdu_json(&event.event_id)
+        .await?
+        .ok_or_else(|| AppError::internal("invite event is missing its JSON data"))?;
+    pdus.push(sending::convert_to_outgoing_federation_event(invite_json).await);
+
+    Ok(pdus)
 }
 
 pub async fn get_forward_extremities(room_id: &RoomId) -> AppResult<Vec<OwnedEventId>> {

--- a/crates/server/src/routing/federation/membership.rs
+++ b/crates/server/src/routing/federation/membership.rs
@@ -7,11 +7,13 @@ use serde_json::value::to_raw_value;
 
 use crate::core::UnixMillis;
 use crate::core::events::room::member::{MembershipState, RoomMemberEventContent};
-use crate::core::events::{StateEventType, TimelineEventType};
+use crate::core::events::{AnyStrippedStateEvent, StateEventType, TimelineEventType};
 use crate::core::federation::membership::*;
 use crate::core::identifiers::*;
 use crate::core::room::{JoinRule, RoomEventReqArgs};
-use crate::core::serde::{CanonicalJsonObject, CanonicalJsonValue, to_canonical_object};
+use crate::core::serde::{
+    CanonicalJsonObject, CanonicalJsonValue, JsonValue, RawJson, RawJsonValue, to_canonical_object,
+};
 use crate::data::connect;
 use crate::data::room::NewDbEvent;
 use crate::data::schema::*;
@@ -202,7 +204,11 @@ async fn invite_user(
         return Err(MatrixError::forbidden("this server does not allow room invites", None).into());
     }
 
-    let mut invite_state = body.invite_room_state.clone();
+    let mut invite_state = body
+        .invite_room_state
+        .iter()
+        .map(|event| stripped_invite_state_event(event))
+        .collect::<Result<Vec<_>, _>>()?;
 
     // If we are active in the room, the remote server will notify us about the join via /send.
     // If we are not in the room, we need to manually
@@ -284,6 +290,35 @@ async fn invite_user(
     json_ok(InviteUserResBodyV2 {
         event: crate::sending::convert_to_outgoing_federation_event(signed_event).await,
     })
+}
+
+/// Convert federation invite state to the stripped form exposed to clients.
+///
+/// Current senders provide full PDUs, while pre-v1.16 senders may still send
+/// stripped state. Both forms contain these four common fields.
+fn stripped_invite_state_event(
+    event: &RawJsonValue,
+) -> Result<RawJson<AnyStrippedStateEvent>, MatrixError> {
+    let event: JsonValue = serde_json::from_str(event.get())
+        .map_err(|_| MatrixError::invalid_param("invite state event is invalid JSON"))?;
+    let event = event
+        .as_object()
+        .ok_or_else(|| MatrixError::invalid_param("invite state event is not an object"))?;
+
+    let field = |name| {
+        event.get(name).cloned().ok_or_else(|| {
+            MatrixError::invalid_param(format!("invite state event is missing {name}"))
+        })
+    };
+    let stripped = json!({
+        "content": field("content")?,
+        "sender": field("sender")?,
+        "state_key": field("state_key")?,
+        "type": field("type")?,
+    });
+
+    RawJson::from_value(&stripped)
+        .map_err(|_| MatrixError::invalid_param("invite state event is invalid"))
 }
 
 /// # `GET /_matrix/federation/v1/make_leave/{roomId}/userId}`
@@ -478,4 +513,67 @@ async fn send_leave(
         error!("failed to notify leave event: {e}");
     }
     empty_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::value::to_raw_value;
+    use serde_json::{Value, json};
+
+    use super::stripped_invite_state_event;
+
+    #[test]
+    fn strips_full_federation_pdu_for_client_state() {
+        let pdu = to_raw_value(&json!({
+            "auth_events": ["$auth"],
+            "content": { "name": "Federated room" },
+            "depth": 7,
+            "hashes": { "sha256": "hash" },
+            "origin_server_ts": 1,
+            "prev_events": ["$prev"],
+            "room_id": "!room:example.org",
+            "sender": "@alice:example.org",
+            "signatures": { "example.org": { "ed25519:key": "sig" } },
+            "state_key": "",
+            "type": "m.room.name"
+        }))
+        .unwrap();
+
+        let stripped = stripped_invite_state_event(&pdu).unwrap();
+        let value: Value = serde_json::from_str(stripped.as_str()).unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "content": { "name": "Federated room" },
+                "sender": "@alice:example.org",
+                "state_key": "",
+                "type": "m.room.name"
+            })
+        );
+    }
+
+    #[test]
+    fn accepts_legacy_stripped_invite_state() {
+        let event = to_raw_value(&json!({
+            "content": { "join_rule": "invite" },
+            "sender": "@alice:example.org",
+            "state_key": "",
+            "type": "m.room.join_rules"
+        }))
+        .unwrap();
+
+        assert!(stripped_invite_state_event(&event).is_ok());
+    }
+
+    #[test]
+    fn rejects_invite_state_without_required_common_fields() {
+        let event = to_raw_value(&json!({
+            "content": {},
+            "type": "m.room.name"
+        }))
+        .unwrap();
+
+        assert!(stripped_invite_state_event(&event).is_err());
+    }
 }


### PR DESCRIPTION
## Summary

- send full room-version PDUs in federation `invite_room_state`
- require and include `m.room.create`
- keep local/client invite state stripped while accepting legacy inbound stripped state

## Root cause

The v2 federation invite request reused the client-facing stripped-state summary. Matrix v1.16 changed this field to full PDUs, so strict servers reject Palpo invites with `M_INVALID_PARAM`.

## Impact

Restores outbound federation invites to spec-current homeservers without changing the stripped invite state exposed to clients.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p palpo --all-targets -- -D warnings`
- `cargo test -p palpo --no-fail-fast` (90 passed)
- `cargo test -p palpo-core --no-fail-fast` (288 tests and 38 doctests passed)

Fixes #310
