### PR TITLE
Run configured admin commands at startup

### DIFF
--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -21,7 +21,7 @@ use futures_util::io::{AsyncWriteExt, BufWriter};
 use futures_util::lock::Mutex;
 use futures_util::{Future, FutureExt, TryFutureExt};
 use regex::Regex;
-use tokio::sync::mpsc;
+use tokio::sync::{broadcast, mpsc};
 
 use self::appservice::AppserviceCommand;
 use self::federation::FederationCommand;
@@ -160,37 +160,56 @@ pub(super) async fn process(command: AdminCommand, context: &Context<'_>) -> App
 /// Maximum number of commands which can be queued for dispatch.
 const COMMAND_QUEUE_LIMIT: usize = 512;
 
-pub async fn start() -> AppResult<()> {
+pub(crate) struct AdminService {
+    receiver: mpsc::Receiver<CommandInput>,
+    signals: broadcast::Receiver<&'static str>,
+}
+
+/// Initialize admin command processing and run configured startup commands.
+///
+/// Initialization finishes before the HTTP server starts, so a failed startup
+/// command can prevent the server from accepting traffic.
+pub(crate) async fn init(additional_startup_commands: Vec<String>) -> AppResult<AdminService> {
     executor::init().await;
 
     let exec = executor();
-    let mut signals = exec.signal.subscribe();
-    let (sender, mut receiver) = mpsc::channel(COMMAND_QUEUE_LIMIT);
+    let signals = exec.signal.subscribe();
+    let (sender, receiver) = mpsc::channel(COMMAND_QUEUE_LIMIT);
     _ = exec
         .channel
         .write()
         .expect("locked for writing")
         .insert(sender);
 
-    tokio::task::yield_now().await;
-    exec.console.start().await;
+    exec.startup_execute(additional_startup_commands).await?;
 
-    loop {
-        tokio::select! {
-            command = receiver.recv() => match command {
-                Some(command) => exec.handle_command(command).await,
-                None => break,
-            },
-            sig = signals.recv() => match sig {
-                Ok(sig) => exec.handle_signal(sig).await,
-                Err(_) => continue,
-            },
+    Ok(AdminService { receiver, signals })
+}
+
+impl AdminService {
+    pub(crate) async fn run(mut self, console: bool) -> AppResult<()> {
+        let exec = executor();
+        if console {
+            exec.console.start().await;
         }
+
+        loop {
+            tokio::select! {
+                command = self.receiver.recv() => match command {
+                    Some(command) => exec.handle_command(command).await,
+                    None => break,
+                },
+                sig = self.signals.recv() => match sig {
+                    Ok(sig) => exec.handle_signal(sig).await,
+                    Err(_) => continue,
+                },
+            }
+        }
+
+        exec.interrupt().await;
+
+        Ok(())
     }
-
-    exec.interrupt().await;
-
-    Ok(())
 }
 
 // Utility to turn clap's `--help` text to HTML.

--- a/crates/server/src/admin/console.rs
+++ b/crates/server/src/admin/console.rs
@@ -116,7 +116,7 @@ impl Console {
         }
 
         debug!("session ending");
-        // Drop the command channel sender so that admin::start()'s event loop
+        // Drop the command channel sender so that the AdminService event loop
         // will receive None from receiver.recv() and exit.
         if let Ok(mut channel) = crate::admin::executor().channel.write() {
             channel.take();

--- a/crates/server/src/admin/executor.rs
+++ b/crates/server/src/admin/executor.rs
@@ -16,7 +16,7 @@ pub fn executor() -> &'static Executor {
     EXECUTOR.get().expect("executor not initialized")
 }
 
-pub async fn init() {
+pub(super) async fn init() {
     let exec = Executor {
         signal: broadcast::channel::<&'static str>(1).0,
         channel: StdRwLock::new(None),
@@ -56,12 +56,21 @@ impl Executor {
 
     pub(super) async fn signal_execute(&self) -> AppResult<()> {
         let conf = config::get();
-        // List of commands to execute
         let commands = conf.admin.signal_execute.clone();
-
-        // When true, errors are ignored and execution continues.
         let ignore_errors = conf.admin.execute_errors_ignore;
 
+        self.execute_commands(commands, ignore_errors).await
+    }
+
+    pub(super) async fn startup_execute(&self, additional_commands: Vec<String>) -> AppResult<()> {
+        let conf = config::get();
+        let commands = merge_startup_commands(&conf.admin.startup_execute, additional_commands);
+        let ignore_errors = conf.admin.execute_errors_ignore;
+
+        self.execute_commands(commands, ignore_errors).await
+    }
+
+    async fn execute_commands(&self, commands: Vec<String>, ignore_errors: bool) -> AppResult<()> {
         for (i, command) in commands.iter().enumerate() {
             if let Err(e) = self.execute_command(i, command.clone()).await
                 && !ignore_errors
@@ -180,6 +189,14 @@ impl Executor {
     }
 }
 
+fn merge_startup_commands(configured: &[String], additional_commands: Vec<String>) -> Vec<String> {
+    configured
+        .iter()
+        .cloned()
+        .chain(additional_commands)
+        .collect()
+}
+
 /// Sends markdown notice to the admin room as the admin user.
 pub async fn send_notice(body: &str) -> AppResult<()> {
     send_message(RoomMessageEventContent::notice_markdown(body)).await
@@ -272,4 +289,66 @@ async fn handle_response_error(
     .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    static COMMAND_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    fn failing_processor(_command: CommandInput) -> crate::admin::ProcessorFuture {
+        COMMAND_CALLS.fetch_add(1, Ordering::Relaxed);
+        Box::pin(async {
+            Err(RoomMessageEventContent::text_plain(
+                "intentional test failure",
+            ))
+        })
+    }
+
+    fn test_executor(processor: Processor) -> Executor {
+        Executor {
+            signal: broadcast::channel(1).0,
+            channel: StdRwLock::new(None),
+            handle: RwLock::new(Some(processor)),
+            complete: StdRwLock::new(None),
+            console: Console::new(),
+        }
+    }
+
+    #[test]
+    fn startup_commands_keep_config_then_cli_order() {
+        let configured = vec!["server show-version".to_owned()];
+        let cli = vec!["server show-config".to_owned(), "user list".to_owned()];
+
+        assert_eq!(
+            merge_startup_commands(&configured, cli),
+            ["server show-version", "server show-config", "user list"]
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_command_execution_honors_error_policy() {
+        COMMAND_CALLS.store(0, Ordering::Relaxed);
+        let executor = test_executor(failing_processor);
+
+        let result = executor
+            .execute_commands(vec!["first".to_owned(), "second".to_owned()], false)
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(COMMAND_CALLS.load(Ordering::Relaxed), 1);
+
+        COMMAND_CALLS.store(0, Ordering::Relaxed);
+        let executor = test_executor(failing_processor);
+
+        let result = executor
+            .execute_commands(vec!["first".to_owned(), "second".to_owned()], true)
+            .await;
+
+        assert!(result.is_ok());
+        assert_eq!(COMMAND_CALLS.load(Ordering::Relaxed), 2);
+    }
 }

--- a/crates/server/src/config/admin.rs
+++ b/crates/server/src/config/admin.rs
@@ -37,7 +37,7 @@ pub struct AdminConfig {
     /// For example: `./palpo --execute "server admin-notice palpo has
     /// started up at $(date)"`
     ///
-    /// example: admin_execute = ["server admin-notice palpo started"]`
+    /// example: startup_execute = ["server admin-notice palpo started"]`
     ///
     /// default: []
     #[serde(default)]
@@ -46,7 +46,7 @@ pub struct AdminConfig {
     /// Ignore errors in startup commands.
     ///
     /// If false, palpo will error and fail to start if an admin execute
-    /// command (`--execute` / `admin_execute`) fails.
+    /// command (`--execute` / `startup_execute`) fails.
     #[serde(default)]
     pub execute_errors_ignore: bool,
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -213,9 +213,10 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // are up-to-date with the configured registration directory.
     let _ = crate::appservices().await;
 
-    // Startup admin commands can enqueue federation, appservice, or push work.
-    // Initialize the sending worker before executing them.
-    crate::sending::guard::start();
+    // Startup admin commands can enqueue federation, appservice, or push work,
+    // so prepare the wakeup queue for those durable requests before executing
+    // them. The network worker starts only after the no-server exit below.
+    let sending_guard = crate::sending::guard::init();
 
     let console = args.console || conf.admin.console_automatic;
     let admin = crate::admin::init(args.execute).await?;
@@ -233,6 +234,8 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         }
         return Ok(());
     }
+
+    sending_guard.start();
 
     tokio::spawn(async move {
         if let Err(error) = admin.run(console).await {

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -163,6 +163,10 @@ pub(crate) struct Args {
     #[arg(long, num_args(0))]
     pub(crate) console: bool,
 
+    /// Admin command to execute during startup. May be specified repeatedly.
+    #[arg(long, value_name = "COMMAND")]
+    pub(crate) execute: Vec<String>,
+
     #[arg(long, short, num_args(1), default_value_t = true)]
     pub(crate) server: bool,
 }
@@ -209,31 +213,40 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // are up-to-date with the configured registration directory.
     let _ = crate::appservices().await;
 
-    if args.console {
-        tracing::info!("starting admin console...");
+    // Startup admin commands can enqueue federation, appservice, or push work.
+    // Initialize the sending worker before executing them.
+    crate::sending::guard::start();
 
-        if !args.server {
-            crate::admin::start()
-                .await
-                .expect("admin console failed to start");
-            tracing::info!("admin console stopped");
-            return Ok(());
-        } else {
-            tokio::spawn(async move {
-                crate::admin::start()
-                    .await
-                    .expect("admin console failed to start");
-                tracing::info!("admin console stopped, shutting down...");
-                std::process::exit(0);
-            });
-        }
+    let console = args.console || conf.admin.console_automatic;
+    let admin = crate::admin::init(args.execute).await?;
+
+    if console {
+        tracing::info!("starting admin console...");
     }
+
     if !args.server {
-        tracing::info!("server is not started, exiting...");
+        if console {
+            admin.run(true).await?;
+            tracing::info!("admin console stopped");
+        } else {
+            tracing::info!("server is not started, exiting...");
+        }
         return Ok(());
     }
 
-    crate::sending::guard::start();
+    tokio::spawn(async move {
+        if let Err(error) = admin.run(console).await {
+            tracing::error!(?error, "admin command processor stopped");
+            if console {
+                std::process::exit(1);
+            }
+        } else if console {
+            tracing::info!("admin console stopped, shutting down...");
+            std::process::exit(0);
+        } else {
+            tracing::error!("admin command processor stopped");
+        }
+    });
 
     // MSC2444: periodically renew our outbound room peeks and drop lapsed inbound
     // peekers.
@@ -321,6 +334,20 @@ mod tests {
     use salvo::test::TestClient;
 
     use super::*;
+
+    #[test]
+    fn execute_cli_argument_can_be_repeated() {
+        let args = Args::try_parse_from([
+            "palpo",
+            "--execute",
+            "server show-version",
+            "--execute",
+            "user list",
+        ])
+        .unwrap();
+
+        assert_eq!(args.execute, ["server show-version", "user list"]);
+    }
 
     #[handler]
     async fn test_handler(res: &mut Response) {

--- a/crates/server/src/sending.rs
+++ b/crates/server/src/sending.rs
@@ -11,7 +11,7 @@ use reqwest_retry::RetryTransientMiddleware;
 use reqwest_retry::policies::ExponentialBackoff;
 use serde::Deserialize;
 use serde_json::value::to_raw_value;
-use tokio::sync::{Mutex, Semaphore, mpsc};
+use tokio::sync::{Semaphore, mpsc};
 
 use crate::core::appservice::Registration;
 use crate::core::appservice::event::{PushEventsReqBody, push_events_request};
@@ -55,9 +55,6 @@ pub const EDU_LIMIT: usize = 100;
 // pub(super) type Key = Vec<u8>;
 pub static MPSC_SENDER: OnceLock<mpsc::UnboundedSender<(OutgoingKind, SendingEventType, i64)>> =
     OnceLock::new();
-pub static MPSC_RECEIVER: OnceLock<
-    Mutex<mpsc::UnboundedReceiver<(OutgoingKind, SendingEventType, i64)>>,
-> = OnceLock::new();
 
 pub fn sender() -> mpsc::UnboundedSender<(OutgoingKind, SendingEventType, i64)> {
     MPSC_SENDER.get().expect("sender should set").clone()

--- a/crates/server/src/sending/guard.rs
+++ b/crates/server/src/sending/guard.rs
@@ -4,11 +4,11 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use futures_util::stream::{FuturesUnordered, StreamExt};
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::mpsc;
 
 use super::{
-    EduBuf, EduVec, MPSC_RECEIVER, MPSC_SENDER, OutgoingKind, SELECT_EDU_LIMIT,
-    SELECT_PRESENCE_LIMIT, SELECT_RECEIPT_LIMIT, SendingEventType, TransactionStatus,
+    EduBuf, EduVec, MPSC_SENDER, OutgoingKind, SELECT_EDU_LIMIT, SELECT_PRESENCE_LIMIT,
+    SELECT_RECEIPT_LIMIT, SendingEventType, TransactionStatus,
 };
 use crate::core::device::DeviceListUpdateContent;
 use crate::core::events::receipt::{ReceiptContent, ReceiptData, ReceiptMap, ReceiptType};
@@ -20,21 +20,38 @@ use crate::exts::*;
 use crate::room::state;
 use crate::{AppResult, data, room};
 
-pub fn start() {
-    let (sender, receiver) = mpsc::unbounded_channel();
-    let _ = MPSC_SENDER.set(sender);
-    let _ = MPSC_RECEIVER.set(Mutex::new(receiver));
-    tokio::spawn(async move {
-        process().await.unwrap();
-    });
+/// A configured sending guard whose worker has not been started yet.
+///
+/// Keeping initialization separate from `start` lets startup admin commands
+/// enqueue durable requests without dispatching network traffic in
+/// `--server false` mode.
+#[must_use = "call Guard::start when the server is enabled"]
+pub struct Guard {
+    receiver: mpsc::UnboundedReceiver<(OutgoingKind, SendingEventType, i64)>,
 }
 
-async fn process() -> AppResult<()> {
-    let mut receiver = MPSC_RECEIVER
-        .get()
-        .expect("receiver should exist")
-        .lock()
-        .await;
+pub fn init() -> Guard {
+    let (sender, receiver) = mpsc::unbounded_channel();
+    assert!(
+        MPSC_SENDER.set(sender).is_ok(),
+        "sending guard is already initialized"
+    );
+    Guard { receiver }
+}
+
+impl Guard {
+    pub fn start(self) {
+        tokio::spawn(async move {
+            if let Err(error) = process(self.receiver).await {
+                error!(?error, "sending guard stopped");
+            }
+        });
+    }
+}
+
+async fn process(
+    mut receiver: mpsc::UnboundedReceiver<(OutgoingKind, SendingEventType, i64)>,
+) -> AppResult<()> {
     let mut futures = FuturesUnordered::new();
     let mut current_transaction_status = HashMap::<OutgoingKind, TransactionStatus>::new();
     // EDU selection windows of in-flight transactions; persisted as the

--- a/palpo-example.toml
+++ b/palpo-example.toml
@@ -622,14 +622,14 @@
 # For example: `./palpo --execute "server admin-notice palpo has
 # started up at $(date)"`
 #
-# example: admin_execute = ["server admin-notice palpo started"]`
+# example: startup_execute = ["server admin-notice palpo started"]`
 #
 # startup_execute = []
 
 # Ignore errors in startup commands.
 #
 # If false, palpo will error and fail to start if an admin execute
-# command (`--execute` / `admin_execute`) fails.
+# command (`--execute` / `startup_execute`) fails.
 #
 # execute_errors_ignore = false
 


### PR DESCRIPTION
## Summary

- initialize the admin command processor during normal startup
- execute configured `startup_execute` and repeatable `--execute` commands before HTTP listening
- honor `execute_errors_ignore` and `console_automatic`
- prepare outbound wakeups for startup commands without dispatching traffic in `--server false` mode

## Root cause

`startup_execute` and `console_automatic` were deserialized but never consumed, and the admin executor was only initialized when `--console` was passed.

The first implementation also exposed a lifecycle coupling in the sending guard: creating its queue immediately spawned the outbound worker. Startup commands need the queue to exist, but a maintenance invocation with `--server false` must not start federation, appservice, or push delivery.

## Design

The sending guard now has two explicit phases:

1. `init()` creates the wakeup queue before startup commands run, so commands may durably enqueue outbound requests.
2. `start()` consumes the prepared guard and starts the network worker only after the no-server exit.

This keeps startup command execution available in headless and no-server modes without introducing outbound network side effects when the server is disabled.

## Validation

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p palpo --all-targets -- -D warnings`
- `cargo test -p palpo --no-fail-fast` (90 passed)
- `cargo run -p palpo -- --help` (verified repeatable `--execute <COMMAND>`)

Fixes #311