### PR TITLE
Detect unknown configuration keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,6 +3672,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde-saphyr",
+ "serde_ignored",
  "serde_json",
  "serde_regex",
  "sha1 0.11.0",
@@ -5587,6 +5588,16 @@ dependencies = [
  "itoa",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ secrecy = "0.10.3"
 serde = { version = "1.0.228", features = ["derive"] }
 subtle = "2.6"
 serde_html_form = "0.4.0"
+serde_ignored = "0.1.14"
 serde_json = { version = "1.0.150" }
 serde-saphyr = { version = "0.0.29" }
 serde_regex = { version = "1.2.0" }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -164,6 +164,7 @@ sanitize-filename = { workspace = true }
 scheduled-thread-pool = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
+serde_ignored = { workspace = true }
 serde_json = { workspace = true }
 serde_regex = { workspace = true }
 serde-saphyr = { workspace = true }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -208,7 +208,9 @@ pub fn init(config_path: impl AsRef<Path>) {
         panic!("config file not found: `{}`", config_path.display());
     }
 
-    let raw_conf = figment_from_path(config_path)
+    let file_conf = figment_from_path(config_path);
+    let raw_conf = file_conf
+        .clone()
         .merge(Env::prefixed("PALPO_").global())
         .merge(Env::prefixed("PALPO_").split("__").global());
     let conf = match raw_conf.extract::<ServerConfig>() {
@@ -218,9 +220,37 @@ pub fn init(config_path: impl AsRef<Path>) {
             std::process::exit(1);
         }
     };
+    let unknown_keys = match unknown_config_keys(&file_conf, &raw_conf) {
+        Ok(keys) => keys,
+        Err(e) => {
+            eprintln!("failed to check for unknown configuration keys: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    for key in unknown_keys {
+        eprintln!(
+            "WARNING: unknown configuration key `{key}` in `{}`; this key is ignored",
+            config_path.display()
+        );
+    }
 
     CONFIG.set(conf).expect("config should be set once");
 }
+
+fn unknown_config_keys(file_conf: &Figment, merged_conf: &Figment) -> figment::Result<Vec<String>> {
+    let value = merged_conf.extract::<figment::value::Value>()?;
+    let mut ignored_paths = Vec::new();
+    let _: ServerConfig = serde_ignored::deserialize(&value, |path| {
+        ignored_paths.push(path.to_string());
+    })?;
+
+    ignored_paths.retain(|path| file_conf.find_value(path).is_ok());
+    ignored_paths.sort_unstable();
+    ignored_paths.dedup();
+    Ok(ignored_paths)
+}
+
 pub fn reload(_path: impl AsRef<Path>) -> AppResult<()> {
     Err(AppError::public(
         "configuration reload is not implemented yet.",
@@ -345,10 +375,17 @@ fn supported_stability(stability: &RoomVersionStability) -> bool {
 mod tests {
     use std::path::Path;
 
+    use figment::Figment;
+    use figment::providers::{Format, Json, Serialized, Toml};
     use kdl::KdlDocument;
     use serde_json::json;
 
-    use super::{ServerConfig, figment_from_path, kdl_doc_to_json};
+    use super::{ServerConfig, figment_from_path, kdl_doc_to_json, unknown_config_keys};
+
+    fn unknown_toml_keys(toml: &str) -> Vec<String> {
+        let file_conf = Figment::new().merge(Toml::string(toml));
+        unknown_config_keys(&file_conf, &file_conf).expect("config should deserialize")
+    }
 
     #[test]
     fn empty_kdl_block_is_an_explicit_empty_list() {
@@ -367,5 +404,80 @@ mod tests {
             .expect("Complement TOML should deserialize");
 
         assert!(config.ip_range_denylist.is_empty());
+    }
+
+    #[test]
+    fn detects_unknown_top_level_key() {
+        assert_eq!(
+            unknown_toml_keys("alow_registration = false"),
+            ["alow_registration"]
+        );
+    }
+
+    #[test]
+    fn detects_unknown_kdl_key() {
+        let doc: KdlDocument = "alow_registration #false"
+            .parse()
+            .expect("KDL config should parse");
+        let json = serde_json::to_string(&kdl_doc_to_json(&doc))
+            .expect("KDL config should convert to JSON");
+        let file_conf = Figment::new().merge(Json::string(&json));
+
+        assert_eq!(
+            unknown_config_keys(&file_conf, &file_conf).expect("config should deserialize"),
+            ["alow_registration"]
+        );
+    }
+
+    #[test]
+    fn detects_unknown_key_inside_known_section() {
+        assert_eq!(
+            unknown_toml_keys("[logger]\nlevle = 'debug'"),
+            ["logger.levle"]
+        );
+    }
+
+    #[test]
+    fn detects_misnested_key() {
+        let keys = unknown_toml_keys(
+            "[rc_message]\nper_second = 10.0\nburst = 50\nip_range_denylist = []",
+        );
+
+        assert_eq!(keys, ["rc_message.ip_range_denylist"]);
+    }
+
+    #[test]
+    fn does_not_flag_env_only_key() {
+        let file_conf = Figment::new().merge(Toml::string("allow_registration = false"));
+        let merged_conf = file_conf
+            .clone()
+            .merge(Serialized::default("env_only_key", true));
+
+        assert!(
+            unknown_config_keys(&file_conf, &merged_conf)
+                .expect("config should deserialize")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn permits_free_form_map_keys() {
+        let keys = unknown_toml_keys(
+            r#"
+                [oidc]
+                enable = true
+
+                [oidc.providers.example]
+                issuer = "https://issuer.example"
+                client_id = "client"
+                client_secret = "secret"
+                redirect_uri = "https://palpo.example/callback"
+
+                [oidc.providers.example.additional_params]
+                prompt = "login"
+            "#,
+        );
+
+        assert!(keys.is_empty());
     }
 }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -7,6 +7,7 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD;
 use figment::Figment;
 use figment::providers::{Env, Format, Json, Toml, Yaml};
+use figment::value::Value;
 use ipaddress::IPAddress;
 use kdl::{KdlDocument, KdlNode, KdlValue};
 
@@ -238,14 +239,68 @@ pub fn init(config_path: impl AsRef<Path>) {
     CONFIG.set(conf).expect("config should be set once");
 }
 
+enum IgnoredPathSegment {
+    Map(String),
+    Seq(usize),
+}
+
+fn ignored_path_segments(path: &serde_ignored::Path<'_>) -> Vec<IgnoredPathSegment> {
+    fn collect(path: &serde_ignored::Path<'_>, segments: &mut Vec<IgnoredPathSegment>) {
+        match path {
+            serde_ignored::Path::Root => {}
+            serde_ignored::Path::Seq { parent, index } => {
+                collect(parent, segments);
+                segments.push(IgnoredPathSegment::Seq(*index));
+            }
+            serde_ignored::Path::Map { parent, key } => {
+                collect(parent, segments);
+                segments.push(IgnoredPathSegment::Map(key.clone()));
+            }
+            serde_ignored::Path::Some { parent }
+            | serde_ignored::Path::NewtypeStruct { parent }
+            | serde_ignored::Path::NewtypeVariant { parent } => collect(parent, segments),
+        }
+    }
+
+    let mut segments = Vec::new();
+    collect(path, &mut segments);
+    segments
+}
+
+fn value_contains_path(value: &Value, path: &[IgnoredPathSegment]) -> bool {
+    path.iter()
+        .try_fold(value, |value, segment| match segment {
+            IgnoredPathSegment::Map(key) => value.as_dict()?.get(key),
+            IgnoredPathSegment::Seq(index) => value.as_array()?.get(*index),
+        })
+        .is_some()
+}
+
+fn display_ignored_path(path: &[IgnoredPathSegment]) -> String {
+    let mut display = String::new();
+    for segment in path {
+        if !display.is_empty() {
+            display.push('.');
+        }
+        match segment {
+            IgnoredPathSegment::Map(key) => display.push_str(key),
+            IgnoredPathSegment::Seq(index) => display.push_str(&index.to_string()),
+        }
+    }
+    display
+}
+
 fn unknown_config_keys(file_conf: &Figment, merged_conf: &Figment) -> figment::Result<Vec<String>> {
-    let value = merged_conf.extract::<figment::value::Value>()?;
+    let file_value = file_conf.extract::<Value>()?;
+    let merged_value = merged_conf.extract::<Value>()?;
     let mut ignored_paths = Vec::new();
-    let _: ServerConfig = serde_ignored::deserialize(&value, |path| {
-        ignored_paths.push(path.to_string());
+    let _: ServerConfig = serde_ignored::deserialize(&merged_value, |path| {
+        let segments = ignored_path_segments(&path);
+        if value_contains_path(&file_value, &segments) {
+            ignored_paths.push(display_ignored_path(&segments));
+        }
     })?;
 
-    ignored_paths.retain(|path| file_conf.find_value(path).is_ok());
     ignored_paths.sort_unstable();
     ignored_paths.dedup();
     Ok(ignored_paths)
@@ -438,6 +493,24 @@ mod tests {
     }
 
     #[test]
+    fn detects_unknown_key_inside_array() {
+        assert_eq!(
+            unknown_toml_keys("[[listeners]]\naddres = '127.0.0.1:8008'"),
+            ["listeners.0.addres"]
+        );
+    }
+
+    #[test]
+    fn detects_unknown_key_inside_optional_section() {
+        assert_eq!(
+            unknown_toml_keys(
+                "[[listeners]]\n[listeners.tls]\ncert = 'cert.pem'\nkey = 'key.pem'\ndual_protcol = true"
+            ),
+            ["listeners.0.tls.dual_protcol"]
+        );
+    }
+
+    #[test]
     fn detects_misnested_key() {
         let keys = unknown_toml_keys(
             "[rc_message]\nper_second = 10.0\nburst = 50\nip_range_denylist = []",
@@ -452,6 +525,20 @@ mod tests {
         let merged_conf = file_conf
             .clone()
             .merge(Serialized::default("env_only_key", true));
+
+        assert!(
+            unknown_config_keys(&file_conf, &merged_conf)
+                .expect("config should deserialize")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn does_not_flag_overlay_only_key_inside_array() {
+        let file_conf = Figment::new().merge(Toml::string("allow_registration = false"));
+        let merged_conf = file_conf
+            .clone()
+            .merge(Toml::string("[[listeners]]\naddres = '127.0.0.1:8008'"));
 
         assert!(
             unknown_config_keys(&file_conf, &merged_conf)

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -432,8 +432,8 @@ mod tests {
     #[test]
     fn detects_unknown_key_inside_known_section() {
         assert_eq!(
-            unknown_toml_keys("[logger]\nlevle = 'debug'"),
-            ["logger.levle"]
+            unknown_toml_keys("[logger]\nunknown_level = 'debug'"),
+            ["logger.unknown_level"]
         );
     }
 

--- a/crates/server/src/config/server.rs
+++ b/crates/server/src/config/server.rs
@@ -780,10 +780,10 @@ pub struct ServerConfig {
     // // external structure; separate section
     // #[serde(default)]
     // pub appservice: BTreeMap<String, AppService>,
-    // NOTE: #[serde(flatten)] with a catchall map is intentionally removed because
-    // it causes serde to incorrectly apply default values to fields like
-    // `ip_range_denylist` even when explicitly set in the config file.
-    // Unknown/deprecated key warnings are handled separately.
+    // NOTE: A #[serde(flatten)] catchall map is intentionally not used because it
+    // causes serde to incorrectly apply default values to fields like
+    // `ip_range_denylist` even when explicitly set in the config file. Unknown
+    // keys are detected without modifying this structure in config::init().
 }
 
 impl ServerConfig {
@@ -919,7 +919,6 @@ impl ServerConfig {
         }
 
         self.warn_deprecated();
-        self.warn_unknown_key();
 
         // if self.sentry && self.sentry_endpoint.is_none() {
         //     return Err(AppError::internal(
@@ -1130,14 +1129,6 @@ impl ServerConfig {
     fn warn_deprecated(&self) {
         debug!("Checking for deprecated config keys");
         // No deprecated keys currently defined
-    }
-
-    /// iterates over all the catchall keys (unknown config options) and warns
-    /// if there are any.
-    fn warn_unknown_key(&self) {
-        debug!("Checking for unknown config keys");
-        // Unknown key detection is not available without serde(flatten) catchall.
-        // This is intentional - the catchall caused issues with default values.
     }
 }
 


### PR DESCRIPTION
## Summary

- detect ignored keys while deserializing the merged Figment configuration
- warn with the nested key path and source config file before startup continues
- exclude keys supplied only through `PALPO_*` environment overlays
- preserve free-form map sections and the existing explicit empty denylist behavior

## Root cause

The former `serde(flatten)` catchall was removed because it interfered with defaults, leaving `warn_unknown_key()` as a no-op. As a result, misspelled or mis-nested security-sensitive settings were silently ignored.

## User impact

Operators now receive a prominent startup warning for unknown TOML or KDL keys instead of unknowingly running with a serde default.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p palpo --tests --locked -- -D warnings`
- `cargo test -p palpo config::tests --locked --no-fail-fast` (11 passed)
- `cargo deny check`

Closes #305