### PR TITLE
Fix room statistics updates

### DIFF
--- a/crates/server/src/membership.rs
+++ b/crates/server/src/membership.rs
@@ -329,6 +329,8 @@ pub async fn update_membership(
         _ => {}
     }
     crate::room::update_joined_servers(room_id).await?;
-    crate::room::update_currents(room_id).await?;
+    if let Err(e) = crate::room::update_currents(room_id).await {
+        error!("failed to update statistics for room {room_id}: {e}");
+    }
     Ok(())
 }

--- a/crates/server/src/room.rs
+++ b/crates/server/src/room.rs
@@ -149,54 +149,55 @@ pub async fn disable_room(room_id: &RoomId, disabled: bool) -> AppResult<()> {
 }
 
 pub async fn update_currents(room_id: &RoomId) -> AppResult<()> {
-    let joined_members = room_users::table
+    let state_events = match get_current_frame_id(room_id).await? {
+        Some(frame_id) => state::load_frame_info(frame_id)
+            .await?
+            .last()
+            .map(|info| utils::usize_to_i64(info.full_state.len()))
+            .unwrap_or_default(),
+        None => 0,
+    };
+
+    let mut conn = connect().await?;
+    let membership_counts = room_users::table
+        .filter(room_users::room_id.eq(room_id))
+        .group_by(room_users::membership)
+        .select((room_users::membership, diesel::dsl::count_star()))
+        .load::<(String, i64)>(&mut conn)
+        .await?;
+    let membership_count = |membership: &str| {
+        membership_counts
+            .iter()
+            .find_map(|(state, count)| (state == membership).then_some(*count))
+            .unwrap_or_default()
+    };
+
+    let local_users_in_room = room_users::table
         .filter(room_users::room_id.eq(room_id))
         .filter(room_users::membership.eq("join"))
+        .filter(room_users::user_server_id.eq(&config::get().server_name))
         .count()
-        .get_result::<i64>(&mut connect().await?)
+        .get_result::<i64>(&mut conn)
         .await?;
-    let invited_members = room_users::table
-        .filter(room_users::room_id.eq(room_id))
-        .filter(room_users::membership.eq("invite"))
-        .count()
-        .get_result::<i64>(&mut connect().await?)
-        .await?;
-    let left_members = room_users::table
-        .filter(room_users::room_id.eq(room_id))
-        .filter(room_users::membership.eq("leave"))
-        .count()
-        .get_result::<i64>(&mut connect().await?)
-        .await?;
-    let banned_members = room_users::table
-        .filter(room_users::room_id.eq(room_id))
-        .filter(room_users::membership.eq("banned"))
-        .count()
-        .get_result::<i64>(&mut connect().await?)
-        .await?;
-    let knocked_members = room_users::table
-        .filter(room_users::room_id.eq(room_id))
-        .filter(room_users::membership.eq("knocked"))
-        .count()
-        .get_result::<i64>(&mut connect().await?)
-        .await?;
+    let completed_delta_stream_id = data::curr_sn().await?;
 
     let current = DbRoomCurrent {
         room_id: room_id.to_owned(),
-        state_events: 0, // TODO: fixme
-        joined_members,
-        invited_members,
-        left_members,
-        banned_members,
-        knocked_members,
-        local_users_in_room: 0,       // TODO: fixme
-        completed_delta_stream_id: 0, // TODO: fixme
+        state_events,
+        joined_members: membership_count("join"),
+        invited_members: membership_count("invite"),
+        left_members: membership_count("leave"),
+        banned_members: membership_count("ban"),
+        knocked_members: membership_count("knock"),
+        local_users_in_room,
+        completed_delta_stream_id,
     };
     diesel::insert_into(stats_room_currents::table)
         .values(&current)
         .on_conflict(stats_room_currents::room_id)
         .do_update()
         .set(&current)
-        .execute(&mut connect().await?)
+        .execute(&mut conn)
         .await?;
 
     Ok(())
@@ -780,13 +781,12 @@ pub async fn is_admin_room(room_id: &RoomId) -> AppResult<bool> {
     }
 }
 
-/// Returns an iterator of all our local users in the room, even if they're
-/// deactivated/guests
+/// Returns all joined local users in the room, including deactivated users and guests.
 #[tracing::instrument(level = "debug")]
-// TODO: local?
 pub async fn local_users_in_room(room_id: &RoomId) -> AppResult<Vec<OwnedUserId>> {
     room_users::table
         .filter(room_users::room_id.eq(room_id))
+        .filter(room_users::membership.eq("join"))
         .filter(room_users::user_server_id.eq(&config::get().server_name))
         .select(room_users::user_id)
         .load::<OwnedUserId>(&mut connect().await?)

--- a/crates/server/src/room.rs
+++ b/crates/server/src/room.rs
@@ -161,34 +161,38 @@ pub async fn update_currents(room_id: &RoomId) -> AppResult<()> {
     let mut conn = connect().await?;
     let membership_counts = room_users::table
         .filter(room_users::room_id.eq(room_id))
-        .group_by(room_users::membership)
-        .select((room_users::membership, diesel::dsl::count_star()))
-        .load::<(String, i64)>(&mut conn)
+        .group_by((room_users::membership, room_users::user_server_id))
+        .select((
+            room_users::membership,
+            room_users::user_server_id,
+            diesel::dsl::count_star(),
+        ))
+        .load::<(String, OwnedServerName, i64)>(&mut conn)
         .await?;
     let membership_count = |membership: &str| {
         membership_counts
             .iter()
-            .find_map(|(state, count)| (state == membership).then_some(*count))
-            .unwrap_or_default()
+            .filter_map(|(state, _, count)| (state == membership).then_some(*count))
+            .sum()
     };
 
-    let local_users_in_room = room_users::table
-        .filter(room_users::room_id.eq(room_id))
-        .filter(room_users::membership.eq("join"))
-        .filter(room_users::user_server_id.eq(&config::get().server_name))
-        .count()
-        .get_result::<i64>(&mut conn)
-        .await?;
+    let local_users_in_room = membership_counts
+        .iter()
+        .find_map(|(state, server_name, count)| {
+            (state == MembershipState::Join.as_str() && server_name == &config::get().server_name)
+                .then_some(*count)
+        })
+        .unwrap_or_default();
     let completed_delta_stream_id = data::curr_sn().await?;
 
     let current = DbRoomCurrent {
         room_id: room_id.to_owned(),
         state_events,
-        joined_members: membership_count("join"),
-        invited_members: membership_count("invite"),
-        left_members: membership_count("leave"),
-        banned_members: membership_count("ban"),
-        knocked_members: membership_count("knock"),
+        joined_members: membership_count(MembershipState::Join.as_str()),
+        invited_members: membership_count(MembershipState::Invite.as_str()),
+        left_members: membership_count(MembershipState::Leave.as_str()),
+        banned_members: membership_count(MembershipState::Ban.as_str()),
+        knocked_members: membership_count(MembershipState::Knock.as_str()),
         local_users_in_room,
         completed_delta_stream_id,
     };
@@ -786,7 +790,7 @@ pub async fn is_admin_room(room_id: &RoomId) -> AppResult<bool> {
 pub async fn local_users_in_room(room_id: &RoomId) -> AppResult<Vec<OwnedUserId>> {
     room_users::table
         .filter(room_users::room_id.eq(room_id))
-        .filter(room_users::membership.eq("join"))
+        .filter(room_users::membership.eq(MembershipState::Join.as_str()))
         .filter(room_users::user_server_id.eq(&config::get().server_name))
         .select(room_users::user_id)
         .load::<OwnedUserId>(&mut connect().await?)

--- a/crates/server/src/room/state.rs
+++ b/crates/server/src/room/state.rs
@@ -114,7 +114,9 @@ pub async fn force_state(
     }
 
     set_room_state(room_id, frame_id).await?;
-    room::update_currents(room_id).await?;
+    if let Err(e) = room::update_currents(room_id).await {
+        error!("failed to update statistics for room {room_id}: {e}");
+    }
 
     Ok(())
 }

--- a/crates/server/src/room/state.rs
+++ b/crates/server/src/room/state.rs
@@ -114,6 +114,7 @@ pub async fn force_state(
     }
 
     set_room_state(room_id, frame_id).await?;
+    room::update_currents(room_id).await?;
 
     Ok(())
 }

--- a/crates/server/src/room/timeline.rs
+++ b/crates/server/src/room/timeline.rs
@@ -605,8 +605,10 @@ pub async fn append_pdu(
     // We set the room state after inserting the pdu, so that we never have a moment in time
     // where events in the current room state do not exist
     state::set_room_state(&pdu.room_id, frame_id).await?;
-    if pdu.state_key.is_some() {
-        crate::room::update_currents(&pdu.room_id).await?;
+    if pdu.state_key.is_some()
+        && let Err(e) = crate::room::update_currents(&pdu.room_id).await
+    {
+        error!("failed to update statistics for room {}: {e}", pdu.room_id);
     }
 
     if let Err(e) =

--- a/crates/server/src/room/timeline.rs
+++ b/crates/server/src/room/timeline.rs
@@ -605,6 +605,9 @@ pub async fn append_pdu(
     // We set the room state after inserting the pdu, so that we never have a moment in time
     // where events in the current room state do not exist
     state::set_room_state(&pdu.room_id, frame_id).await?;
+    if pdu.state_key.is_some() {
+        crate::room::update_currents(&pdu.room_id).await?;
+    }
 
     if let Err(e) =
         push_action::increment_notification_counts(&pdu.event_id, notifies, highlights).await


### PR DESCRIPTION
## What changed

- calculate current state-event, local joined-user, and completed stream-position statistics instead of storing zeroes
- count `ban` and `knock` memberships using the canonical `MembershipState` values stored in `room_users`
- refresh room statistics after timeline state changes and forced state replacements
- exclude local users who have left or been banned from `local_users_in_room`
- calculate all membership and local-user counts from one grouped database snapshot
- treat statistics as derived data: refresh failures are logged without making an already-persisted room state appear to fail

## Why

The room-statistics item in #306 is a real correctness gap: three fields in `stats_room_currents` were hard-coded to zero, ban/knock counts queried non-existent membership strings, and statistics were refreshed before the newly committed state frame became current. This produced stale or incorrect room metadata and admin API counts.

A self-review also found that a post-commit statistics error could make event processing return an error after the room state was already persisted, inviting unsafe retries. The refresh is now best-effort and logged, consistent with statistics being derived data.

## Impact

Room statistics now reflect the current state frame and a consistent membership snapshot. Joined local-member counts no longer include former members, and state changes update the statistics snapshot after state is committed without allowing statistics failures to invalidate the primary event operation.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo check -p palpo`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --all --all-features --no-fail-fast`
  - server: 103 passed
  - core: 315 passed
  - remaining crate unit tests and doctests passed