### PR TITLE
Prevent redacted events from appearing in search

### DIFF
--- a/crates/server/src/event/search.rs
+++ b/crates/server/src/event/search.rs
@@ -19,6 +19,23 @@ use crate::event::BatchToken;
 use crate::room::{state, timeline};
 use crate::{AppResult, MatrixError, SnPduEvent};
 
+fn searchable_events<'a>(
+    room_ids: &'a [OwnedRoomId],
+    search_term: &'a str,
+) -> event_searches::BoxedQuery<'a, diesel::pg::Pg> {
+    event_searches::table
+        .filter(event_searches::room_id.eq_any(room_ids))
+        .filter(
+            event_searches::event_id.eq_any(
+                events::table
+                    .filter(events::is_redacted.eq(false))
+                    .select(events::id),
+            ),
+        )
+        .filter(event_searches::vector.matches(websearch_to_tsquery(search_term)))
+        .into_boxed()
+}
+
 pub async fn search_pdus(
     user_id: &UserId,
     criteria: &Criteria,
@@ -44,10 +61,7 @@ pub async fn search_pdus(
         }
     }
 
-    let base_query = event_searches::table
-        .filter(event_searches::room_id.eq_any(&room_ids))
-        .filter(event_searches::vector.matches(websearch_to_tsquery(&criteria.search_term)));
-    let mut data_query = base_query.clone().into_boxed();
+    let mut data_query = searchable_events(&room_ids, &criteria.search_term);
     if let Some(mut next_batch) = next_batch.map(|nb| nb.split('-')) {
         let server_ts: i64 = next_batch.next().map(str::parse).transpose()?.unwrap_or(0);
         let event_sn: i64 = next_batch.next().map(str::parse).transpose()?.unwrap_or(0);
@@ -83,7 +97,10 @@ pub async fn search_pdus(
     // let _ids: Vec<i64> = event_searches::table
     //     .select(event_searches::id)
     //     .load(&mut connect()?)?;
-    let count: i64 = base_query.count().first(&mut connect().await?).await?;
+    let count: i64 = searchable_events(&room_ids, &criteria.search_term)
+        .count()
+        .first(&mut connect().await?)
+        .await?;
     let next_batch = if items.len() < limit {
         None
     } else if let Some(last) = items.last() {
@@ -212,10 +229,9 @@ pub async fn save_pdu(pdu: &SnPduEvent, pdu_json: &CanonicalJsonObject) -> AppRe
             .get("body")
             .and_then(|v| v.as_str())
             .map(|v| ("content.message", v)),
-        TimelineEventType::RoomRedaction => {
-            // TODO: Redaction
-            return Ok(());
-        }
+        // Redaction events themselves have no searchable content. Applying a
+        // redaction removes the target from the index in `timeline::redact_pdu`.
+        TimelineEventType::RoomRedaction => return Ok(()),
         _ => {
             return Ok(());
         }
@@ -236,4 +252,26 @@ pub async fn save_pdu(pdu: &SnPduEvent, pdu_json: &CanonicalJsonObject) -> AppRe
         .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use diesel::debug_query;
+    use diesel::pg::Pg;
+
+    use super::searchable_events;
+    use crate::core::identifiers::RoomId;
+
+    #[test]
+    fn search_query_excludes_redacted_events() {
+        let room_ids = vec![RoomId::parse("!room:example.org").unwrap().to_owned()];
+        let query = searchable_events(&room_ids, "needle");
+        let sql = debug_query::<Pg, _>(&query).to_string();
+
+        assert!(sql.contains("\"events\".\"is_redacted\" ="), "{sql}");
+        assert!(
+            sql.contains("\"event_searches\".\"event_id\" = ANY(SELECT \"events\".\"id\""),
+            "{sql}"
+        );
+    }
 }

--- a/crates/server/src/room/timeline.rs
+++ b/crates/server/src/room/timeline.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 use std::collections::{BTreeSet, HashSet};
 
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncConnection, RunQueryDsl};
 use serde::Deserialize;
 
 use crate::core::Seqnum;
@@ -856,19 +856,31 @@ pub async fn build_and_append_pdu(
 #[tracing::instrument(skip(reason))]
 pub async fn redact_pdu(event_id: &EventId, reason: &PduEvent) -> AppResult<()> {
     // TODO: Don't reserialize, keep original json
-    if let Ok(mut pdu) = get_pdu(event_id).await {
-        pdu.redact(reason)?;
-        replace_pdu(event_id, &to_canonical_object(&pdu)?).await?;
-        diesel::update(events::table.filter(events::id.eq(event_id)))
-            .set(events::is_redacted.eq(true))
-            .execute(&mut connect().await?)
-            .await?;
-        diesel::delete(event_searches::table.filter(event_searches::event_id.eq(event_id)))
-            .execute(&mut connect().await?)
-            .await?;
-    }
-    // If event does not exist, just noop
-    Ok(())
+    let mut pdu = match get_pdu(event_id).await {
+        Ok(pdu) => pdu,
+        Err(e) if e.is_not_found() => return Ok(()),
+        Err(e) => return Err(e),
+    };
+    pdu.redact(reason)?;
+    let redacted_json = serde_json::to_value(to_canonical_object(&pdu)?)?;
+    connect()
+        .await?
+        .transaction::<_, AppError, _>(async |conn| {
+            diesel::update(event_datas::table.filter(event_datas::event_id.eq(event_id)))
+                .set(event_datas::json_data.eq(&redacted_json))
+                .execute(conn)
+                .await?;
+            diesel::update(events::table.filter(events::id.eq(event_id)))
+                .set(events::is_redacted.eq(true))
+                .execute(conn)
+                .await?;
+            diesel::delete(event_searches::table.filter(event_searches::event_id.eq(event_id)))
+                .execute(conn)
+                .await?;
+
+            Ok(())
+        })
+        .await
 }
 
 pub async fn is_event_next_to_backward_gap(event: &PduEvent) -> AppResult<bool> {


### PR DESCRIPTION
## What changed

- exclude events marked as redacted from both room-event search results and result counts
- atomically replace the stored event with its redacted form, set the redaction marker, and delete its full-text index entry
- keep missing target events idempotent while propagating database and decoding failures
- add a regression test that verifies the production search query filters on `events.is_redacted`

## Why

The normal redaction path deleted the target event's search index, but the stored event update, redaction marker, and index deletion were committed independently. A partial failure or stale index row could therefore leave original terms searchable even though the returned event content was redacted.

The Matrix redaction rules require the stripped event to be served after redaction. Search must not continue matching terms removed by that redaction.

Spec: https://spec.matrix.org/latest/client-server-api/#redactions

## Impact

Redacted content no longer appears as a search hit, including when an old or inconsistent full-text index row remains. Redaction database changes now commit together, and transient failures no longer masquerade as successful no-ops.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --all --all-features --no-fail-fast`
  - server: 104 passed
  - core: 315 passed
  - remaining unit tests and doctests passed

Refs #306