### PR TITLE
Remove abandoned MSC4373 support

### DIFF
--- a/crates/core/src/federation/query.rs
+++ b/crates/core/src/federation/query.rs
@@ -84,60 +84,6 @@ pub fn profile_request(origin: &str, args: ProfileReqArgs) -> SendResult<SendReq
     Ok(crate::sending::get(url))
 }
 
-/// `GET /_matrix/federation/unstable/io.fsky.vel/edutypes`
-///
-/// Determine what types of EDUs a server wishes to receive.
-pub fn edu_types_request(origin: &str) -> SendResult<SendRequest> {
-    let url = Url::parse(&format!(
-        "{origin}/_matrix/federation/unstable/io.fsky.vel/edutypes"
-    ))?;
-    Ok(crate::sending::get(url))
-}
-
-/// Request type for the `edutypes` endpoint.
-#[derive(ToSchema, Clone, Debug, Default, Deserialize, Serialize)]
-pub struct EduTypesReqBody {}
-
-impl EduTypesReqBody {
-    /// Creates a new `EduTypesReqBody`.
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-/// Response type for the `edutypes` endpoint.
-#[derive(ToSchema, Clone, Debug, Deserialize, Serialize)]
-pub struct EduTypesResBody {
-    /// Whether presence EDUs should be sent.
-    #[serde(rename = "m.presence", default = "crate::serde::default_true")]
-    pub presence: bool,
-
-    /// Whether read receipt EDUs should be sent.
-    #[serde(rename = "m.receipt", default = "crate::serde::default_true")]
-    pub receipt: bool,
-
-    /// Whether typing EDUs should be sent.
-    #[serde(rename = "m.typing", default = "crate::serde::default_true")]
-    pub typing: bool,
-}
-
-impl EduTypesResBody {
-    /// Creates a new `EduTypesResBody` with all EDU flags set to `true`.
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-impl Default for EduTypesResBody {
-    fn default() -> Self {
-        Self {
-            presence: true,
-            receipt: true,
-            typing: true,
-        }
-    }
-}
-
 /// Request type for the `get_profile_information` endpoint.
 
 #[derive(ToParameters, Deserialize, Debug)]
@@ -282,39 +228,5 @@ impl CustomResBody {
     /// Creates a new response with the given body.
     pub fn new(body: JsonValue) -> Self {
         Self(body)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
-
-    use super::EduTypesResBody;
-
-    #[test]
-    fn edu_types_default_to_true_when_missing() {
-        let body: EduTypesResBody = from_json_value(json!({})).unwrap();
-
-        assert!(body.presence);
-        assert!(body.receipt);
-        assert!(body.typing);
-    }
-
-    #[test]
-    fn edu_types_use_msc4373_field_names() {
-        let body = EduTypesResBody {
-            presence: true,
-            receipt: false,
-            typing: true,
-        };
-
-        assert_eq!(
-            to_json_value(body).unwrap(),
-            json!({
-                "m.presence": true,
-                "m.receipt": false,
-                "m.typing": true,
-            })
-        );
     }
 }

--- a/crates/server/src/routing.rs
+++ b/crates/server/src/routing.rs
@@ -54,7 +54,6 @@ pub fn root() -> Router {
             Router::with_path("_matrix")
                 .push(client::router())
                 .push(media::router())
-                .push(federation::public_router())
                 .push(federation::router())
                 .push(federation::key::router())
                 .push(policy::router())

--- a/crates/server/src/routing/federation.rs
+++ b/crates/server/src/routing/federation.rs
@@ -59,13 +59,6 @@ pub fn router() -> Router {
         .push(Router::with_path("versions").get(get_versions))
 }
 
-pub fn public_router() -> Router {
-    Router::with_path("federation")
-        .hoop(check_federation_enabled)
-        .oapi_tag("federation")
-        .push(Router::with_path("unstable/io.fsky.vel/edutypes").get(query::get_edu_types))
-}
-
 #[handler]
 async fn check_federation_enabled() -> AppResult<()> {
     let conf = config::get();

--- a/crates/server/src/routing/federation/query.rs
+++ b/crates/server/src/routing/federation/query.rs
@@ -4,7 +4,7 @@ use palpo_core::federation::query::ProfileReqArgs;
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
 
-use crate::core::federation::query::{EduTypesResBody, ProfileResBody, RoomInfoResBody};
+use crate::core::federation::query::{ProfileResBody, RoomInfoResBody};
 use crate::core::identifiers::*;
 use crate::core::profile::ProfileFieldValue;
 use crate::{
@@ -16,19 +16,6 @@ pub fn router() -> Router {
         .push(Router::with_path("profile").get(get_profile))
         .push(Router::with_path("directory").get(get_directory))
         .push(Router::with_path("{query_type}").get(query_by_type))
-}
-
-/// #GET /_matrix/federation/unstable/io.fsky.vel/edutypes
-/// Determine what types of EDUs this server wishes to receive.
-#[endpoint]
-pub async fn get_edu_types() -> JsonResult<EduTypesResBody> {
-    let conf = config::get();
-
-    json_ok(EduTypesResBody {
-        presence: conf.presence.allow_incoming,
-        receipt: conf.read_receipt.allow_incoming,
-        typing: conf.typing.allow_incoming,
-    })
 }
 
 /// #GET /_matrix/federation/v1/query/profile


### PR DESCRIPTION
## Summary

- remove the abandoned MSC4373 EDU discovery request and response types
- remove the unstable `io.fsky.vel/edutypes` server endpoint
- remove the dedicated public federation router registration

## Why

MSC4373 was abandoned upstream, so retaining its unstable API adds unsupported surface area without a path to the Matrix specification.

Closes #327

## Checks

- `cargo check -p palpo-core -p palpo`
- verified no `MSC4373`, `edutypes`, or `edu_types` references remain