### PR TITLE
Stabilize image pack event types

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -30,7 +30,6 @@ unstable-extensible-events = [
 ]
 unstable-msc1767 = []
 unstable-msc2448 = []
-unstable-msc2545 = []
 unstable-msc2654 = []
 unstable-msc2666 = []
 unstable-msc2747 = []

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -137,7 +137,6 @@ pub mod identity_server;
 pub mod ignored_user_list;
 #[cfg(feature = "unstable-msc3552")]
 pub mod image;
-#[cfg(feature = "unstable-msc2545")]
 pub mod image_pack;
 pub mod invite_permission_config;
 pub mod key;

--- a/crates/core/src/events/enums.rs
+++ b/crates/core/src/events/enums.rs
@@ -56,12 +56,10 @@ event_enum! {
         #[cfg(feature = "unstable-msc4278")]
         #[palpo_enum(ident = UnstableMediaPreviewConfig)]
         "io.element.msc4278.media_preview_config" => super::media_preview_config,
-        #[cfg(feature = "unstable-msc2545")]
-        #[palpo_enum(ident = AccountImagePack, alias = "m.image_pack")]
+        #[palpo_enum(ident = AccountImagePack)]
         "im.ponies.user_emotes" => super::image_pack,
-        #[cfg(feature = "unstable-msc2545")]
-        #[palpo_enum(ident = ImagePackRooms, alias = "m.image_pack.rooms")]
-        "im.ponies.emote_rooms" => super::image_pack,
+        #[palpo_enum(alias = "im.ponies.emote_rooms")]
+        "m.image_pack.rooms" => super::image_pack,
     }
 
     /// Any room account data event.
@@ -192,9 +190,8 @@ event_enum! {
         "m.room.topic" => super::room::topic,
         "m.space.child" => super::space::child,
         "m.space.parent" => super::space::parent,
-        #[cfg(feature = "unstable-msc2545")]
-        #[palpo_enum(ident = RoomImagePack, alias = "m.image_pack")]
-        "im.ponies.room_emotes" => super::image_pack,
+        #[palpo_enum(alias = "m.image_pack", alias = "im.ponies.room_emotes")]
+        "m.room.image_pack" => super::image_pack,
         #[cfg(feature = "unstable-msc3489")]
         #[palpo_enum(alias = "m.beacon_info")]
         "org.matrix.msc3672.beacon_info" => super::beacon_info,

--- a/crates/core/src/events/enums.rs
+++ b/crates/core/src/events/enums.rs
@@ -56,7 +56,7 @@ event_enum! {
         #[cfg(feature = "unstable-msc4278")]
         #[palpo_enum(ident = UnstableMediaPreviewConfig)]
         "io.element.msc4278.media_preview_config" => super::media_preview_config,
-        #[palpo_enum(ident = AccountImagePack)]
+        #[palpo_enum(ident = AccountImagePack, alias = "m.image_pack")]
         "im.ponies.user_emotes" => super::image_pack,
         #[palpo_enum(alias = "im.ponies.emote_rooms")]
         "m.image_pack.rooms" => super::image_pack,

--- a/crates/core/src/events/image_pack.rs
+++ b/crates/core/src/events/image_pack.rs
@@ -12,56 +12,69 @@ use crate::macros::EventContent;
 use crate::serde::StringEnum;
 use crate::{OwnedMxcUri, OwnedRoomId, PrivOwnedStr};
 
-/// The content of an `im.ponies.room_emotes` event,
-/// the unstable version of `m.image_pack` in room state events.
+/// The content of an `m.room.image_pack` event.
 ///
-/// State key is the identifier for the image pack in
+/// The state key is the identifier for the image pack in
 /// [ImagePackRoomsEventContent].
 #[derive(ToSchema, Clone, Debug, Default, Deserialize, Serialize, EventContent)]
-#[palpo_event(type = "im.ponies.room_emotes", kind = State, state_key_type = String)]
+#[palpo_event(
+    type = "m.room.image_pack",
+    kind = State,
+    state_key_type = String,
+    alias = "m.image_pack",
+    alias = "im.ponies.room_emotes"
+)]
 pub struct RoomImagePackEventContent {
     /// A list of images available in this image pack.
     ///
     /// Keys in the map are shortcodes for the images.
-    pub images: BTreeMap<String, PackImage>,
+    pub images: BTreeMap<String, ImagePackImage>,
 
-    /// Image pack info.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pack: Option<PackInfo>,
+    /// Metadata about the image pack as a whole.
+    #[serde(default, skip_serializing_if = "ImagePackMeta::is_empty")]
+    pub pack: ImagePackMeta,
 }
 
 impl RoomImagePackEventContent {
     /// Creates a new `RoomImagePackEventContent` with a list of images.
-    pub fn new(images: BTreeMap<String, PackImage>) -> Self {
-        Self { images, pack: None }
+    pub fn new(images: BTreeMap<String, ImagePackImage>) -> Self {
+        Self {
+            images,
+            pack: ImagePackMeta::default(),
+        }
     }
 }
 
-/// The content of an `im.ponies.user_emotes` event,
-/// the unstable version of `m.image_pack` in account data events.
+/// The legacy content of an `im.ponies.user_emotes` account data event.
+///
+/// MSC2545 no longer defines a stable personal image-pack account data event,
+/// but this type remains available so existing stored events can still be read.
 #[derive(ToSchema, Clone, Debug, Default, Deserialize, Serialize, EventContent)]
 #[palpo_event(type = "im.ponies.user_emotes", kind = GlobalAccountData)]
 pub struct AccountImagePackEventContent {
     /// A list of images available in this image pack.
     ///
     /// Keys in the map are shortcodes for the images.
-    pub images: BTreeMap<String, PackImage>,
+    pub images: BTreeMap<String, ImagePackImage>,
 
-    /// Image pack info.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pack: Option<PackInfo>,
+    /// Image pack metadata.
+    #[serde(default, skip_serializing_if = "ImagePackMeta::is_empty")]
+    pub pack: ImagePackMeta,
 }
 
 impl AccountImagePackEventContent {
     /// Creates a new `AccountImagePackEventContent` with a list of images.
-    pub fn new(images: BTreeMap<String, PackImage>) -> Self {
-        Self { images, pack: None }
+    pub fn new(images: BTreeMap<String, ImagePackImage>) -> Self {
+        Self {
+            images,
+            pack: ImagePackMeta::default(),
+        }
     }
 }
 
-/// An image object in a image pack.
+/// An image object in an image pack.
 #[derive(ToSchema, Clone, Debug, Deserialize, Serialize)]
-pub struct PackImage {
+pub struct ImagePackImage {
     /// The MXC URI to the media file.
     pub url: OwnedMxcUri,
 
@@ -75,27 +88,26 @@ pub struct PackImage {
     /// The [ImageInfo] object used for the `info` block of `m.sticker` events.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub info: Option<ImageInfo>,
-
-    /// The usages for the image.
-    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
-    pub usage: BTreeSet<PackUsage>,
 }
 
-impl PackImage {
-    /// Creates a new `PackImage` with the given MXC URI to the media file.
+impl ImagePackImage {
+    /// Creates a new `ImagePackImage` with the given MXC URI to the media file.
     pub fn new(url: OwnedMxcUri) -> Self {
         Self {
             url,
             body: None,
             info: None,
-            usage: BTreeSet::new(),
         }
     }
 }
 
-/// A description for the pack.
+/// Deprecated name for [`ImagePackImage`].
+#[deprecated = "use ImagePackImage"]
+pub type PackImage = ImagePackImage;
+
+/// Metadata about an image pack.
 #[derive(ToSchema, Clone, Debug, Default, Deserialize, Serialize)]
-pub struct PackInfo {
+pub struct ImagePackMeta {
     /// A display name for the pack.
     /// This does not have to be unique from other packs in a room.
     ///
@@ -119,12 +131,23 @@ pub struct PackInfo {
     pub attribution: Option<String>,
 }
 
-impl PackInfo {
-    /// Creates a new empty `PackInfo`.
+impl ImagePackMeta {
+    /// Creates empty image-pack metadata.
     pub fn new() -> Self {
         Self::default()
     }
+
+    fn is_empty(&self) -> bool {
+        self.display_name.is_none()
+            && self.avatar_url.is_none()
+            && self.usage.is_empty()
+            && self.attribution.is_none()
+    }
 }
+
+/// Deprecated name for [`ImagePackMeta`].
+#[deprecated = "use ImagePackMeta"]
+pub type PackInfo = ImagePackMeta;
 
 /// Usages for either an image pack or an individual image.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
@@ -142,30 +165,91 @@ pub enum PackUsage {
     _Custom(PrivOwnedStr),
 }
 
-/// The content of an `im.ponies.emote_rooms` event,
-/// the unstable version of `m.image_pack.rooms`.
+/// The content of an `m.image_pack.rooms` account data event.
 #[derive(ToSchema, Clone, Debug, Default, Deserialize, Serialize, EventContent)]
-#[palpo_event(type = "im.ponies.emote_rooms", kind = GlobalAccountData)]
+#[palpo_event(
+    type = "m.image_pack.rooms",
+    kind = GlobalAccountData,
+    alias = "im.ponies.emote_rooms"
+)]
 pub struct ImagePackRoomsEventContent {
-    /// A map of enabled image packs in each room.
-    pub rooms: BTreeMap<OwnedRoomId, BTreeMap<String, ImagePackRoomContent>>,
+    /// A map of room IDs to state keys for globally enabled image packs.
+    pub rooms: BTreeMap<OwnedRoomId, BTreeMap<String, RoomImagePackMeta>>,
 }
 
 impl ImagePackRoomsEventContent {
-    /// Creates a new `ImagePackRoomsEventContent`
-    /// with a map of enabled image packs in each room.
-    pub fn new(rooms: BTreeMap<OwnedRoomId, BTreeMap<String, ImagePackRoomContent>>) -> Self {
+    /// Creates a new `ImagePackRoomsEventContent`.
+    pub fn new(rooms: BTreeMap<OwnedRoomId, BTreeMap<String, RoomImagePackMeta>>) -> Self {
         Self { rooms }
     }
 }
 
-/// Additional metadatas for a enabled room image pack.
+/// Additional metadata for a globally enabled room image pack.
+///
+/// This is currently empty.
 #[derive(ToSchema, Clone, Debug, Default, Deserialize, Serialize)]
-pub struct ImagePackRoomContent {}
+pub struct RoomImagePackMeta {}
 
-impl ImagePackRoomContent {
-    /// Creates a new empty `ImagePackRoomContent`.
+impl RoomImagePackMeta {
+    /// Creates empty room image-pack metadata.
     pub fn new() -> Self {
         Self {}
+    }
+}
+
+/// Deprecated name for [`RoomImagePackMeta`].
+#[deprecated = "use RoomImagePackMeta"]
+pub type ImagePackRoomContent = RoomImagePackMeta;
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use serde_json::{json, to_value as to_json_value};
+
+    use super::RoomImagePackEventContent;
+    use crate::events::{GlobalAccountDataEventType, StateEventType};
+
+    #[test]
+    fn room_image_pack_aliases_serialize_to_stable_type() {
+        for event_type in ["m.room.image_pack", "m.image_pack", "im.ponies.room_emotes"] {
+            assert_eq!(
+                StateEventType::from(event_type),
+                StateEventType::RoomImagePack
+            );
+            assert_eq!(
+                StateEventType::from(event_type).to_string(),
+                "m.room.image_pack"
+            );
+        }
+    }
+
+    #[test]
+    fn image_pack_rooms_alias_serializes_to_stable_type() {
+        for event_type in ["m.image_pack.rooms", "im.ponies.emote_rooms"] {
+            assert_eq!(
+                GlobalAccountDataEventType::from(event_type),
+                GlobalAccountDataEventType::ImagePackRooms
+            );
+            assert_eq!(
+                GlobalAccountDataEventType::from(event_type).to_string(),
+                "m.image_pack.rooms"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_pack_metadata_is_omitted() {
+        let content = RoomImagePackEventContent::new(BTreeMap::new());
+
+        assert_eq!(to_json_value(content).unwrap(), json!({ "images": {} }));
+    }
+
+    #[test]
+    fn legacy_personal_pack_remains_readable() {
+        assert_eq!(
+            GlobalAccountDataEventType::from("im.ponies.user_emotes"),
+            GlobalAccountDataEventType::AccountImagePack
+        );
     }
 }

--- a/crates/core/src/events/image_pack.rs
+++ b/crates/core/src/events/image_pack.rs
@@ -1,5 +1,6 @@
-//! Types for image packs in Matrix ([MSC2545]).
+//! Types for [image packs], stabilized from [MSC2545] in Matrix 1.19.
 //!
+//! [image packs]: https://spec.matrix.org/v1.19/client-server-api/#image-packs
 //! [MSC2545]: https://github.com/matrix-org/matrix-spec-proposals/pull/2545
 
 use std::collections::{BTreeMap, BTreeSet};
@@ -9,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::events::room::ImageInfo;
 use crate::macros::EventContent;
-use crate::serde::StringEnum;
+use crate::serde::{JsonValue, StringEnum};
 use crate::{OwnedMxcUri, OwnedRoomId, PrivOwnedStr};
 
 /// The content of an `m.room.image_pack` event.
@@ -137,7 +138,8 @@ impl ImagePackMeta {
         Self::default()
     }
 
-    fn is_empty(&self) -> bool {
+    /// Whether none of the metadata fields are set.
+    pub fn is_empty(&self) -> bool {
         self.display_name.is_none()
             && self.avatar_url.is_none()
             && self.usage.is_empty()
@@ -149,16 +151,16 @@ impl ImagePackMeta {
 #[deprecated = "use ImagePackMeta"]
 pub type PackInfo = ImagePackMeta;
 
-/// Usages for either an image pack or an individual image.
+/// The intended usages for an image pack.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
 #[derive(ToSchema, Clone, StringEnum)]
 #[palpo_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum PackUsage {
-    /// Pack or image is usable as a emoticon.
+    /// The pack is usable as a source of emoticons.
     Emoticon,
 
-    /// Pack or image is usable as a sticker.
+    /// The pack is usable as a source of stickers.
     Sticker,
 
     #[doc(hidden)]
@@ -186,14 +188,21 @@ impl ImagePackRoomsEventContent {
 
 /// Additional metadata for a globally enabled room image pack.
 ///
-/// This is currently empty.
+/// The spec defines no fields yet and reserves this object for future use. Unrecognised
+/// properties are captured so they survive a deserialize/serialize round-trip, as the spec
+/// requires them to be preserved when the event is modified.
 #[derive(ToSchema, Clone, Debug, Default, Deserialize, Serialize)]
-pub struct RoomImagePackMeta {}
+pub struct RoomImagePackMeta {
+    /// Properties not defined by the current spec version.
+    #[serde(flatten)]
+    #[salvo(schema(value_type = Object, additional_properties = true))]
+    pub extra: BTreeMap<String, JsonValue>,
+}
 
 impl RoomImagePackMeta {
     /// Creates empty room image-pack metadata.
     pub fn new() -> Self {
-        Self {}
+        Self::default()
     }
 }
 
@@ -205,9 +214,9 @@ pub type ImagePackRoomContent = RoomImagePackMeta;
 mod tests {
     use std::collections::BTreeMap;
 
-    use serde_json::{json, to_value as to_json_value};
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
-    use super::RoomImagePackEventContent;
+    use super::{ImagePackRoomsEventContent, RoomImagePackEventContent};
     use crate::events::{GlobalAccountDataEventType, StateEventType};
 
     #[test]
@@ -251,5 +260,22 @@ mod tests {
             GlobalAccountDataEventType::from("im.ponies.user_emotes"),
             GlobalAccountDataEventType::AccountImagePack
         );
+    }
+
+    /// The bottom-level object is reserved for future use and unrecognised properties MUST
+    /// survive a modification of the event.
+    #[test]
+    fn enabled_pack_metadata_preserves_unknown_properties() {
+        let json = json!({
+            "rooms": {
+                "!someroom:example.org": {
+                    "": { "com.example.future": { "nested": true } }
+                }
+            }
+        });
+
+        let content: ImagePackRoomsEventContent = from_json_value(json.clone()).unwrap();
+
+        assert_eq!(to_json_value(content).unwrap(), json);
     }
 }

--- a/crates/core/src/events/image_pack.rs
+++ b/crates/core/src/events/image_pack.rs
@@ -50,8 +50,14 @@ impl RoomImagePackEventContent {
 ///
 /// MSC2545 no longer defines a stable personal image-pack account data event,
 /// but this type remains available so existing stored events can still be read.
+/// `m.image_pack` is accepted on ingress because it was the personal pack's
+/// identifier in an earlier revision of the proposal; it is never serialized.
 #[derive(ToSchema, Clone, Debug, Default, Deserialize, Serialize, EventContent)]
-#[palpo_event(type = "im.ponies.user_emotes", kind = GlobalAccountData)]
+#[palpo_event(
+    type = "im.ponies.user_emotes",
+    kind = GlobalAccountData,
+    alias = "m.image_pack"
+)]
 pub struct AccountImagePackEventContent {
     /// A list of images available in this image pack.
     ///
@@ -89,6 +95,15 @@ pub struct ImagePackImage {
     /// The [ImageInfo] object used for the `info` block of `m.sticker` events.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub info: Option<ImageInfo>,
+
+    /// The usages for this individual image.
+    ///
+    /// Removed before MSC2545 stabilized: usage is a pack-level field in Matrix 1.19 and this
+    /// is empty for spec-conformant packs. It is kept so that a legacy `im.ponies.*` pack that
+    /// still carries per-image usages survives a deserialize/serialize round-trip instead of
+    /// silently losing whether an image was sticker-only or emoticon-only.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub usage: BTreeSet<PackUsage>,
 }
 
 impl ImagePackImage {
@@ -98,6 +113,7 @@ impl ImagePackImage {
             url,
             body: None,
             info: None,
+            usage: BTreeSet::new(),
         }
     }
 }
@@ -260,6 +276,36 @@ mod tests {
             GlobalAccountDataEventType::from("im.ponies.user_emotes"),
             GlobalAccountDataEventType::AccountImagePack
         );
+    }
+
+    #[test]
+    fn legacy_personal_pack_alias_remains_readable() {
+        assert_eq!(
+            GlobalAccountDataEventType::from("m.image_pack"),
+            GlobalAccountDataEventType::AccountImagePack
+        );
+        assert_eq!(
+            GlobalAccountDataEventType::from("m.image_pack").to_string(),
+            "im.ponies.user_emotes"
+        );
+    }
+
+    /// Per-image `usage` predates stabilization, so it must survive a round-trip of a legacy
+    /// pack rather than being silently dropped.
+    #[test]
+    fn legacy_per_image_usage_round_trips() {
+        let json = json!({
+            "images": {
+                "mysticker": {
+                    "url": "mxc://example.org/sticker",
+                    "usage": ["sticker"]
+                }
+            }
+        });
+
+        let content: RoomImagePackEventContent = from_json_value(json.clone()).unwrap();
+
+        assert_eq!(to_json_value(content).unwrap(), json);
     }
 
     /// The bottom-level object is reserved for future use and unrecognised properties MUST

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -78,7 +78,6 @@ palpo-core = { workspace = true, features = [
     "unstable-extensible-events",
     "unstable-msc1767",
     "unstable-msc2448",
-    "unstable-msc2545",
     "unstable-msc2654",
     "unstable-msc2666",
     "unstable-msc2747",


### PR DESCRIPTION
## Summary

- make `m.room.image_pack` and `m.image_pack.rooms` the canonical serialized image-pack event types
- accept the earlier `m.image_pack` and `im.ponies.*` identifiers as ingress aliases
- align the stable room image-pack content model and remove the obsolete `unstable-msc2545` gate
- retain the legacy personal `im.ponies.user_emotes` type so existing stored account data remains readable

## Why

Upstream stabilization settled on `m.room.image_pack` for room state and removed the proposed stable personal account-data event. Palpo still emitted the old `im.ponies.*` identifiers, which could rewrite stable input back to an unstable name.

This intentionally corrects the older `m.image_pack` room-state wording in #323 while preserving it as a compatibility alias.

Closes #323

## Checks

- `cargo test -p palpo-core image_pack::tests -- --nocapture`
- `cargo check -p palpo`