### PR TITLE
Add policy server signature verification

### DIFF
--- a/crates/core/src/events/room/policy.rs
+++ b/crates/core/src/events/room/policy.rs
@@ -12,6 +12,9 @@ use crate::macros::EventContent;
 use crate::serde::Base64;
 use crate::{OwnedServerName, SigningKeyAlgorithm};
 
+/// The signing key ID used for Ed25519 signatures from Policy Servers.
+pub const POLICY_SERVER_ED25519_SIGNING_KEY_ID: &str = "ed25519:policy_server";
+
 /// The content of an [`m.room.policy`] event.
 ///
 /// A Policy Server configuration.

--- a/crates/core/src/federation/policy/sign_event.rs
+++ b/crates/core/src/federation/policy/sign_event.rs
@@ -5,6 +5,7 @@
 use salvo::prelude::*;
 use serde::{Deserialize, Serialize};
 
+use crate::events::room::policy::POLICY_SERVER_ED25519_SIGNING_KEY_ID;
 use crate::serde::RawJsonValue;
 use crate::{
     OwnedServerName, OwnedServerSigningKeyId, ServerName, ServerSignatures, ServerSigningKeyId,
@@ -35,7 +36,7 @@ pub struct PolicySignEventResBody {
 
 impl PolicySignEventResBody {
     /// The signing key ID that must be used by the Policy Server for the Ed25519 signature.
-    pub const POLICY_SERVER_ED25519_SIGNING_KEY_ID: &str = "ed25519:policy_server";
+    pub const POLICY_SERVER_ED25519_SIGNING_KEY_ID: &str = POLICY_SERVER_ED25519_SIGNING_KEY_ID;
 
     /// Creates a new `PolicySignEventResBody` with the given Policy Server name and signature.
     pub fn new(server_name: OwnedServerName, ed25519_signature: String) -> Self {

--- a/crates/core/src/signatures.rs
+++ b/crates/core/src/signatures.rs
@@ -52,6 +52,7 @@ pub use self::functions::canonical_json;
 pub use self::functions::{
     content_hash, hash_and_sign_event, reference_hash, required_keys, sign_json,
     to_canonical_json_string_for_signing, verify_canonical_json_bytes, verify_event, verify_json,
+    verify_policy_server_signature,
 };
 pub use self::keys::{Ed25519KeyPair, KeyPair, PublicKeyMap, PublicKeySet};
 pub use self::verification::Verified;

--- a/crates/core/src/signatures/functions.rs
+++ b/crates/core/src/signatures/functions.rs
@@ -12,10 +12,8 @@ use sha2::digest::Digest;
 #[cfg(test)]
 mod tests;
 
-use crate::events::{
-    StaticEventContent,
-    room::policy::{POLICY_SERVER_ED25519_SIGNING_KEY_ID, RoomPolicyEventContent},
-};
+use crate::events::StaticEventContent;
+use crate::events::room::policy::{POLICY_SERVER_ED25519_SIGNING_KEY_ID, RoomPolicyEventContent};
 use crate::room_version_rules::{
     EventIdFormatVersion, RedactionRules, RoomVersionRules, SignaturesRules,
 };

--- a/crates/core/src/signatures/functions.rs
+++ b/crates/core/src/signatures/functions.rs
@@ -12,6 +12,10 @@ use sha2::digest::Digest;
 #[cfg(test)]
 mod tests;
 
+use crate::events::{
+    StaticEventContent,
+    room::policy::{POLICY_SERVER_ED25519_SIGNING_KEY_ID, RoomPolicyEventContent},
+};
 use crate::room_version_rules::{
     EventIdFormatVersion, RedactionRules, RoomVersionRules, SignaturesRules,
 };
@@ -732,6 +736,56 @@ pub fn verify_event(
     }
 
     Ok(Verified::Signatures)
+}
+
+/// Verify that an event has a valid signature from the room's Policy Server.
+///
+/// An `m.room.policy` state event with an empty state key is exempt because it configures the
+/// Policy Server whose signature would otherwise be required.
+pub fn verify_policy_server_signature(
+    room_policy: &RoomPolicyEventContent,
+    object: &CanonicalJsonObject,
+    rules: &RoomVersionRules,
+) -> Result<(), Error> {
+    let event_type = match object.get("type") {
+        Some(CanonicalJsonValue::String(event_type)) => event_type,
+        Some(_) => return Err(JsonError::not_of_type("type", JsonType::String)),
+        None => return Err(JsonError::field_missing_from_object("type")),
+    };
+
+    if event_type == RoomPolicyEventContent::TYPE
+        && matches!(object.get("state_key"), Some(CanonicalJsonValue::String(state_key)) if state_key.is_empty())
+    {
+        return Ok(());
+    }
+
+    let redacted = redact(object.clone(), &rules.redaction, None)?;
+    let canonical_json = to_canonical_json_string_for_signing(&redacted)?;
+    let signature_map = match object.get("signatures") {
+        Some(CanonicalJsonValue::Object(signatures)) => signatures,
+        Some(_) => return Err(JsonError::not_of_type("signatures", JsonType::Object)),
+        None => return Err(JsonError::field_missing_from_object("signatures")),
+    };
+
+    let Some(public_key) = room_policy.public_keys.get(&SigningKeyAlgorithm::Ed25519) else {
+        return Err(
+            VerificationError::NoSupportedSignatureForEntity(room_policy.via.to_string()).into(),
+        );
+    };
+    let public_key_map = BTreeMap::from([(
+        room_policy.via.to_string(),
+        BTreeMap::from([(
+            POLICY_SERVER_ED25519_SIGNING_KEY_ID.to_owned(),
+            public_key.clone(),
+        )]),
+    )]);
+
+    verify_canonical_json_for_entity(
+        room_policy.via.as_str(),
+        &public_key_map,
+        signature_map,
+        canonical_json.as_bytes(),
+    )
 }
 
 /// Internal implementation detail of the canonical JSON algorithm.

--- a/crates/core/src/signatures/functions/tests.rs
+++ b/crates/core/src/signatures/functions/tests.rs
@@ -5,14 +5,15 @@ use serde_json::json;
 
 use super::{
     servers_to_check_signatures, sign_json, to_canonical_json_string_for_signing,
-    verify_canonical_json_bytes, verify_event,
+    verify_canonical_json_bytes, verify_event, verify_policy_server_signature,
 };
+use crate::events::room::policy::RoomPolicyEventContent;
 use crate::room_version_rules::{RoomVersionRules, SignaturesRules};
-use crate::serde::{Base64, CanonicalJsonValue};
+use crate::serde::{Base64, CanonicalJsonObject, CanonicalJsonValue};
 use crate::signatures::{
     Ed25519KeyPair, Error, KeyPair, PublicKeyMap, PublicKeySet, VerificationError, Verified,
 };
-use crate::{ServerSigningKeyId, SigningKeyAlgorithm, server_name};
+use crate::{ServerSigningKeyId, SigningKeyAlgorithm, owned_server_name, server_name};
 
 fn generate_key_pair(name: &str) -> Ed25519KeyPair {
     let key_content = Ed25519KeyPair::generate().unwrap();
@@ -785,4 +786,105 @@ fn verify_canonical_json_bytes_wrong_key() {
     )
     .unwrap_err();
     assert_matches!(err, Error::Verification(VerificationError::Signature(_)));
+}
+
+fn policy_signature_test_event() -> CanonicalJsonObject {
+    serde_json::from_str(
+        r#"{
+            "auth_events": [],
+            "content": {},
+            "depth": 3,
+            "hashes": {
+                "sha256": "5jM4wQpv6lnBo7CLIghJuHdW+s2CMBJPUOGOC89ncos"
+            },
+            "origin": "domain",
+            "origin_server_ts": 1000000,
+            "prev_events": [],
+            "room_id": "!x:domain",
+            "sender": "@name:domain-sender",
+            "type": "X",
+            "unsigned": {
+                "age_ts": 1000000
+            }
+        }"#,
+    )
+    .unwrap()
+}
+
+#[test]
+fn verify_policy_server_signature_succeeds_with_policy_server_signature() {
+    let key_pair = generate_key_pair("policy_server");
+    let mut signed_event = policy_signature_test_event();
+    sign_json("domain-policy-server", &key_pair, &mut signed_event).unwrap();
+
+    let room_policy = RoomPolicyEventContent::new(
+        owned_server_name!("domain-policy-server"),
+        Base64::new(key_pair.public_key().to_vec()),
+    );
+
+    assert_matches!(
+        verify_policy_server_signature(&room_policy, &signed_event, &RoomVersionRules::V6),
+        Ok(())
+    );
+}
+
+#[test]
+fn verify_policy_server_signature_fails_with_invalid_policy_server_signature() {
+    let signing_key_pair = generate_key_pair("policy_server");
+    let configured_key_pair = generate_key_pair("policy_server");
+    let mut signed_event = policy_signature_test_event();
+    sign_json("domain-policy-server", &signing_key_pair, &mut signed_event).unwrap();
+
+    let room_policy = RoomPolicyEventContent::new(
+        owned_server_name!("domain-policy-server"),
+        Base64::new(configured_key_pair.public_key().to_vec()),
+    );
+
+    assert_matches!(
+        verify_policy_server_signature(&room_policy, &signed_event, &RoomVersionRules::V6),
+        Err(Error::Verification(VerificationError::Signature(_)))
+    );
+}
+
+#[test]
+fn verify_policy_server_signature_fails_when_signature_is_missing() {
+    let key_pair = generate_key_pair("policy_server");
+    let sender_key_pair = generate_key_pair("1");
+    let mut signed_event = policy_signature_test_event();
+    sign_json("domain-sender", &sender_key_pair, &mut signed_event).unwrap();
+    let room_policy = RoomPolicyEventContent::new(
+        owned_server_name!("domain-policy-server"),
+        Base64::new(key_pair.public_key().to_vec()),
+    );
+
+    let err = verify_policy_server_signature(&room_policy, &signed_event, &RoomVersionRules::V6)
+        .unwrap_err();
+    assert_matches!(
+        err,
+        Error::Verification(VerificationError::NoSignaturesForEntity(entity))
+    );
+    assert_eq!(entity, "domain-policy-server");
+}
+
+#[test]
+fn verify_policy_server_signature_allows_policy_configuration_event() {
+    let key_pair = generate_key_pair("policy_server");
+    let mut event = policy_signature_test_event();
+    event.insert(
+        "type".to_owned(),
+        CanonicalJsonValue::String("m.room.policy".to_owned()),
+    );
+    event.insert(
+        "state_key".to_owned(),
+        CanonicalJsonValue::String(String::new()),
+    );
+    let room_policy = RoomPolicyEventContent::new(
+        owned_server_name!("domain-policy-server"),
+        Base64::new(key_pair.public_key().to_vec()),
+    );
+
+    assert_matches!(
+        verify_policy_server_signature(&room_policy, &event, &RoomVersionRules::V6),
+        Ok(())
+    );
 }


### PR DESCRIPTION
Part of #320

## Summary

- add a reusable verifier for Policy Server signatures on redacted event JSON
- require the fixed `ed25519:policy_server` key and centralize that key ID with the policy event type
- exempt the empty-state-key `m.room.policy` configuration event as required by the specification
- cover valid, invalid, missing, and configuration-event cases

## Scope

This adds the core verification primitive from upstream Ruma. Server-side event production and inbound enforcement remain tracked in #320 and are intentionally not advertised by this PR.

## Testing

- `cargo test -p palpo-core`