### PR TITLE
Parse multipart federation media responses before proxying to clients

### DIFF
--- a/crates/server/src/media/remote.rs
+++ b/crates/server/src/media/remote.rs
@@ -103,7 +103,7 @@ fn parse_multipart_federation_response(
         .find_map(|part| {
             let part = part.trim();
             part.strip_prefix("boundary=")
-                .map(|b| b.trim().to_owned())
+                .map(|b| b.trim().trim_matches('"').to_owned())
         })?;
 
     let delimiter = format!("\r\n--{boundary}\r\n").into_bytes();
@@ -149,7 +149,7 @@ fn parse_multipart_federation_response(
                     let binary = Bytes::copy_from_slice(&data[content_start..content_start + end_pos]);
                     return Some((content_type, content_disposition, binary));
                 } else if let Some(end_pos) =
-                    find_subsequence(&data[content_start..], format!("--{boundary}--").as_bytes())
+                    find_subsequence(&data[content_start..], format!("\r\n--{boundary}--").as_bytes())
                 {
                     let binary = Bytes::copy_from_slice(&data[content_start..content_start + end_pos]);
                     return Some((content_type, content_disposition, binary));

--- a/crates/server/src/media/remote.rs
+++ b/crates/server/src/media/remote.rs
@@ -1,7 +1,9 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use bytes::Bytes;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
+use salvo::http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
 use salvo::Response;
 
 use super::{Dimension, FileMeta};
@@ -46,11 +48,129 @@ pub async fn fetch_remote_content(
         crate::sending::send_federation_request(server_name, content_req, None).await?
     };
 
-    *res.headers_mut() = content_response.headers().to_owned();
-    res.status_code(content_response.status());
-    res.stream(content_response.bytes_stream());
+    let content_type_header = content_response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_owned());
+
+    if let Some(ct) = &content_type_header
+        && ct.contains("multipart/mixed")
+    {
+        let body = content_response
+            .bytes()
+            .await
+            .map_err(|e| AppError::public(format!("failed to read remote media body: {e}")))?;
+
+        if let Some((content_type, content_disposition, binary)) =
+            parse_multipart_federation_response(ct, &body)
+        {
+            res.add_header(CONTENT_TYPE, &content_type, true)?;
+            res.add_header(
+                "Cross-Origin-Resource-Policy",
+                "cross-origin",
+                true,
+            )?;
+            if let Some(disp) = &content_disposition {
+                res.add_header(CONTENT_DISPOSITION, disp, true)?;
+            }
+            res.status_code(salvo::http::StatusCode::OK);
+            res.body = salvo::http::ResBody::Once(binary.into());
+        } else {
+            res.status_code(salvo::http::StatusCode::BAD_GATEWAY);
+            res.body = salvo::http::ResBody::Once(
+                r#"{"errcode":"M_UNKNOWN","error":"Failed to parse remote media response"}"#
+                    .into(),
+            );
+        }
+    } else {
+        for (key, value) in content_response.headers().iter() {
+            res.headers_mut().insert(key.clone(), value.clone());
+        }
+        res.status_code(content_response.status());
+        res.stream(content_response.bytes_stream());
+    }
 
     Ok(())
+}
+
+fn parse_multipart_federation_response(
+    content_type: &str,
+    body: &Bytes,
+) -> Option<(String, Option<String>, Bytes)> {
+    let boundary = content_type
+        .split(';')
+        .find_map(|part| {
+            let part = part.trim();
+            part.strip_prefix("boundary=")
+                .map(|b| b.trim().to_owned())
+        })?;
+
+    let delimiter = format!("\r\n--{boundary}\r\n").into_bytes();
+    let data = body.as_ref();
+
+    let mut offset = 0;
+    let mut content_type = String::new();
+    let mut content_disposition = None;
+
+    loop {
+        let start = if offset == 0 {
+            if let Some(pos) = find_subsequence(data, &delimiter) {
+                pos + delimiter.len()
+            } else {
+                break;
+            }
+        } else {
+            offset
+        };
+
+        if let Some(header_end) = find_subsequence(&data[start..], b"\r\n\r\n") {
+            let header_bytes = &data[start..start + header_end];
+            if let Ok(header_str) = std::str::from_utf8(header_bytes) {
+                let is_json = header_str
+                    .lines()
+                    .any(|l| l.eq_ignore_ascii_case("Content-Type: application/json"));
+
+                if is_json {
+                    offset = start + header_end + 4;
+                    continue;
+                }
+
+                for header in header_str.lines() {
+                    if let Some(ct) = header.strip_prefix("Content-Type:") {
+                        content_type = ct.trim().to_owned();
+                    } else if let Some(cd) = header.strip_prefix("Content-Disposition:") {
+                        content_disposition = Some(cd.trim().to_owned());
+                    }
+                }
+
+                let content_start = start + header_end + 4;
+                if let Some(end_pos) = find_subsequence(&data[content_start..], &delimiter) {
+                    let binary = Bytes::copy_from_slice(&data[content_start..content_start + end_pos]);
+                    return Some((content_type, content_disposition, binary));
+                } else if let Some(end_pos) =
+                    find_subsequence(&data[content_start..], format!("--{boundary}--").as_bytes())
+                {
+                    let binary = Bytes::copy_from_slice(&data[content_start..content_start + end_pos]);
+                    return Some((content_type, content_disposition, binary));
+                } else {
+                    let binary = Bytes::copy_from_slice(&data[content_start..]);
+                    return Some((content_type, content_disposition, binary));
+                }
+            }
+            offset = start + header_end + 4;
+        } else {
+            break;
+        }
+    }
+
+    None
+}
+
+fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
 }
 
 pub async fn fetch_remote_thumbnail(


### PR DESCRIPTION
## TL;DR

Remote media proxied via the federation endpoint returns `Content-Type: multipart/mixed` instead of the actual binary format — clients (Cinny, Element Web) can't render the image. This PR parses the multipart response and serves the raw binary with proper headers.

**Files to review (1, +123 / -3):**

| File | Why |
|---|---|
| `crates/server/src/media/remote.rs` *(start here)* | `fetch_remote_content` now detects multipart responses and extracts the binary payload. |

## Why

When `fetch_remote_content` falls back to the federation media download endpoint (`/_matrix/federation/v1/media/download/{mediaId}`), that endpoint returns `Content-Type: multipart/mixed` with a JSON metadata part and a binary part. The function streamed the entire multipart response directly to the client:

```
Content-Type: multipart/mixed; boundary=962f...
--962f...
Content-Type: application/json
{}

--962f...
Content-Type: image/png
Content-Disposition: inline

<actual image data>
--962f...--
```

Clients expect `Content-Type: image/png` with the raw binary and break silently on the multipart wrapper.

## How

After receiving the federation response, the new code checks `Content-Type`:
- If `multipart/mixed` — reads the full body, parses the multipart structure, extracts the binary content and metadata, then sets `Content-Type`, `Content-Disposition`, and `Cross-Origin-Resource-Policy: cross-origin` headers before serving the raw binary.
- Otherwise — streams the response as before (unchanged path).

The parse function splits on the boundary, finds the non-JSON part, and extracts its headers and content bytes.

## Reviewer notes

- **Minimal scope.** Only `fetch_remote_content` changes — the local-media path and thumbnail generation are untouched.
- **No new dependencies.** Uses only `std` and existing `bytes::Bytes` — no multipart parser crate added.
