### PR TITLE
Parse multipart federation media responses before proxying to clients

### DIFF
--- a/crates/server/src/config/media.rs
+++ b/crates/server/src/config/media.rs
@@ -37,6 +37,15 @@ pub struct MediaConfig {
     #[serde(default = "default_max_remote_thumbnail_size")]
     pub max_remote_thumbnail_size: usize,
 
+    /// Maximum number of bytes accepted when fetching remote media content
+    /// from a remote homeserver via federation. The entire response is
+    /// buffered when the remote server returns a multipart response, so this
+    /// limit prevents unbounded memory allocation.
+    ///
+    /// default: 104857600 (100 MiB)
+    #[serde(default = "default_max_remote_media_size")]
+    pub max_remote_media_size: usize,
+
     /// Check consistency of the media directory at startup:
     /// 1. When `media_compat_file_link` is enabled, this check will upgrade media when switching
     ///    back and forth between Conduit and palpo. Both options must be enabled to handle this.
@@ -89,6 +98,7 @@ impl Default for MediaConfig {
             allow_legacy: true,
             freeze_legacy: true,
             max_remote_thumbnail_size: default_max_remote_thumbnail_size(),
+            max_remote_media_size: default_max_remote_media_size(),
             startup_check: true,
             compat_file_link: false,
             prune_missing: false,
@@ -99,4 +109,8 @@ impl Default for MediaConfig {
 
 fn default_max_remote_thumbnail_size() -> usize {
     20_000_000
+}
+
+fn default_max_remote_media_size() -> usize {
+    104_857_600
 }

--- a/crates/server/src/media/remote.rs
+++ b/crates/server/src/media/remote.rs
@@ -103,7 +103,7 @@ fn parse_multipart_federation_response(
         .find_map(|part| {
             let part = part.trim();
             part.strip_prefix("boundary=")
-                .map(|b| b.trim().to_owned())
+                .map(|b| b.trim().trim_matches('"').to_owned())
         })?;
 
     let delimiter = format!("\r\n--{boundary}\r\n").into_bytes();
@@ -149,7 +149,7 @@ fn parse_multipart_federation_response(
                     let binary = Bytes::copy_from_slice(&data[content_start..content_start + end_pos]);
                     return Some((content_type, content_disposition, binary));
                 } else if let Some(end_pos) =
-                    find_subsequence(&data[content_start..], format!("--{boundary}--").as_bytes())
+                    find_subsequence(&data[content_start..], format!("\r\n--{boundary}--").as_bytes())
                 {
                     let binary = Bytes::copy_from_slice(&data[content_start..content_start + end_pos]);
                     return Some((content_type, content_disposition, binary));

--- a/crates/server/src/media/remote.rs
+++ b/crates/server/src/media/remote.rs
@@ -1,7 +1,9 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use bytes::Bytes;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
+use salvo::http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
 use salvo::Response;
 
 use super::{Dimension, FileMeta};
@@ -46,11 +48,129 @@ pub async fn fetch_remote_content(
         crate::sending::send_federation_request(server_name, content_req, None).await?
     };
 
-    *res.headers_mut() = content_response.headers().to_owned();
-    res.status_code(content_response.status());
-    res.stream(content_response.bytes_stream());
+    let content_type_header = content_response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_owned());
+
+    if let Some(ct) = &content_type_header
+        && ct.contains("multipart/mixed")
+    {
+        let body = content_response
+            .bytes()
+            .await
+            .map_err(|e| AppError::public(format!("failed to read remote media body: {e}")))?;
+
+        if let Some((content_type, content_disposition, binary)) =
+            parse_multipart_federation_response(ct, &body)
+        {
+            res.add_header(CONTENT_TYPE, &content_type, true)?;
+            res.add_header(
+                "Cross-Origin-Resource-Policy",
+                "cross-origin",
+                true,
+            )?;
+            if let Some(disp) = &content_disposition {
+                res.add_header(CONTENT_DISPOSITION, disp, true)?;
+            }
+            res.status_code(salvo::http::StatusCode::OK);
+            res.body = salvo::http::ResBody::Once(binary.into());
+        } else {
+            res.status_code(salvo::http::StatusCode::BAD_GATEWAY);
+            res.body = salvo::http::ResBody::Once(
+                r#"{"errcode":"M_UNKNOWN","error":"Failed to parse remote media response"}"#
+                    .into(),
+            );
+        }
+    } else {
+        for (key, value) in content_response.headers().iter() {
+            res.headers_mut().insert(key.clone(), value.clone());
+        }
+        res.status_code(content_response.status());
+        res.stream(content_response.bytes_stream());
+    }
 
     Ok(())
+}
+
+fn parse_multipart_federation_response(
+    content_type: &str,
+    body: &Bytes,
+) -> Option<(String, Option<String>, Bytes)> {
+    let boundary = content_type
+        .split(';')
+        .find_map(|part| {
+            let part = part.trim();
+            part.strip_prefix("boundary=")
+                .map(|b| b.trim().to_owned())
+        })?;
+
+    let delimiter = format!("\r\n--{boundary}\r\n").into_bytes();
+    let data = body.as_ref();
+
+    let mut offset = 0;
+    let mut content_type = String::new();
+    let mut content_disposition = None;
+
+    loop {
+        let start = if offset == 0 {
+            if let Some(pos) = find_subsequence(data, &delimiter) {
+                pos + delimiter.len()
+            } else {
+                break;
+            }
+        } else {
+            offset
+        };
+
+        if let Some(header_end) = find_subsequence(&data[start..], b"\r\n\r\n") {
+            let header_bytes = &data[start..start + header_end];
+            if let Ok(header_str) = std::str::from_utf8(header_bytes) {
+                let is_json = header_str
+                    .lines()
+                    .any(|l| l.eq_ignore_ascii_case("Content-Type: application/json"));
+
+                if is_json {
+                    offset = start + header_end + 4;
+                    continue;
+                }
+
+                for header in header_str.lines() {
+                    if let Some(ct) = header.strip_prefix("Content-Type:") {
+                        content_type = ct.trim().to_owned();
+                    } else if let Some(cd) = header.strip_prefix("Content-Disposition:") {
+                        content_disposition = Some(cd.trim().to_owned());
+                    }
+                }
+
+                let content_start = start + header_end + 4;
+                if let Some(end_pos) = find_subsequence(&data[content_start..], &delimiter) {
+                    let binary = Bytes::copy_from_slice(&data[content_start..content_start + end_pos]);
+                    return Some((content_type, content_disposition, binary));
+                } else if let Some(end_pos) =
+                    find_subsequence(&data[content_start..], format!("--{boundary}--").as_bytes())
+                {
+                    let binary = Bytes::copy_from_slice(&data[content_start..content_start + end_pos]);
+                    return Some((content_type, content_disposition, binary));
+                } else {
+                    let binary = Bytes::copy_from_slice(&data[content_start..]);
+                    return Some((content_type, content_disposition, binary));
+                }
+            }
+            offset = start + header_end + 4;
+        } else {
+            break;
+        }
+    }
+
+    None
+}
+
+fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
 }
 
 pub async fn fetch_remote_thumbnail(

--- a/crates/server/src/media/remote.rs
+++ b/crates/server/src/media/remote.rs
@@ -3,8 +3,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use bytes::Bytes;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
-use salvo::http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
 use salvo::Response;
+use salvo::http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
 
 use super::{Dimension, FileMeta};
 use crate::core::federation::media::ContentReqArgs;
@@ -58,21 +58,15 @@ pub async fn fetch_remote_content(
     if let Some(ct) = &content_type_header
         && ct.contains("multipart/mixed")
     {
-        let body = read_response_limited(
-            content_response,
-            config::get().media.max_remote_media_size,
-        )
-        .await?;
+        let body =
+            read_response_limited(content_response, config::get().media.max_remote_media_size)
+                .await?;
 
         if let Some((content_type, content_disposition, binary)) =
             parse_multipart_federation_response(ct, &body)
         {
             res.add_header(CONTENT_TYPE, &content_type, true)?;
-            res.add_header(
-                "Cross-Origin-Resource-Policy",
-                "cross-origin",
-                true,
-            )?;
+            res.add_header("Cross-Origin-Resource-Policy", "cross-origin", true)?;
             if let Some(disp) = &content_disposition {
                 res.add_header(CONTENT_DISPOSITION, disp, true)?;
             }
@@ -81,8 +75,7 @@ pub async fn fetch_remote_content(
         } else {
             res.status_code(salvo::http::StatusCode::BAD_GATEWAY);
             res.body = salvo::http::ResBody::Once(
-                r#"{"errcode":"M_UNKNOWN","error":"Failed to parse remote media response"}"#
-                    .into(),
+                r#"{"errcode":"M_UNKNOWN","error":"Failed to parse remote media response"}"#.into(),
             );
         }
     } else {
@@ -100,13 +93,11 @@ fn parse_multipart_federation_response(
     content_type: &str,
     body: &Bytes,
 ) -> Option<(String, Option<String>, Bytes)> {
-    let boundary = content_type
-        .split(';')
-        .find_map(|part| {
-            let part = part.trim();
-            part.strip_prefix("boundary=")
-                .map(|b| b.trim().trim_matches('"').to_owned())
-        })?;
+    let boundary = content_type.split(';').find_map(|part| {
+        let part = part.trim();
+        part.strip_prefix("boundary=")
+            .map(|b| b.trim().trim_matches('"').to_owned())
+    })?;
 
     let start_boundary = format!("--{boundary}\r\n").into_bytes();
     let delimiter = format!("\r\n--{boundary}\r\n").into_bytes();
@@ -124,15 +115,16 @@ fn parse_multipart_federation_response(
 
     // Skip the first part entirely (it is always JSON metadata in Matrix federation)
     let part1_header_end = find_subsequence(&data[after_first_boundary..], b"\r\n\r\n")?;
-    let part2_boundary =
-        find_subsequence(&data[after_first_boundary + part1_header_end + 4..], &delimiter)?;
+    let part2_boundary = find_subsequence(
+        &data[after_first_boundary + part1_header_end + 4..],
+        &delimiter,
+    )?;
     let after_part2_boundary =
         after_first_boundary + part1_header_end + 4 + part2_boundary + delimiter.len();
 
     // Parse the second part (actual file content)
     let part2_header_end = find_subsequence(&data[after_part2_boundary..], b"\r\n\r\n")?;
-    let part2_header_bytes =
-        &data[after_part2_boundary..after_part2_boundary + part2_header_end];
+    let part2_header_bytes = &data[after_part2_boundary..after_part2_boundary + part2_header_end];
     let part2_header_str = std::str::from_utf8(part2_header_bytes).ok()?;
 
     let mut ct = String::new();
@@ -153,9 +145,17 @@ fn parse_multipart_federation_response(
     let binary_start = after_part2_boundary + part2_header_end + 4;
 
     if let Some(end_pos) = find_subsequence(&data[binary_start..], &delimiter) {
-        Some((ct, cd, Bytes::copy_from_slice(&data[binary_start..binary_start + end_pos])))
+        Some((
+            ct,
+            cd,
+            Bytes::copy_from_slice(&data[binary_start..binary_start + end_pos]),
+        ))
     } else if let Some(end_pos) = find_subsequence(&data[binary_start..], &closing_delimiter) {
-        Some((ct, cd, Bytes::copy_from_slice(&data[binary_start..binary_start + end_pos])))
+        Some((
+            ct,
+            cd,
+            Bytes::copy_from_slice(&data[binary_start..binary_start + end_pos]),
+        ))
     } else {
         Some((ct, cd, Bytes::copy_from_slice(&data[binary_start..])))
     }

--- a/crates/server/src/media/remote.rs
+++ b/crates/server/src/media/remote.rs
@@ -71,7 +71,7 @@ pub async fn fetch_remote_content(
                 res.add_header(CONTENT_DISPOSITION, disp, true)?;
             }
             res.status_code(salvo::http::StatusCode::OK);
-            res.body = salvo::http::ResBody::Once(binary.into());
+            res.body = salvo::http::ResBody::Once(binary);
         } else {
             res.status_code(salvo::http::StatusCode::BAD_GATEWAY);
             res.body = salvo::http::ResBody::Once(
@@ -107,10 +107,9 @@ fn parse_multipart_federation_response(
     // Advance past the first boundary (which may or may not have a leading CRLF)
     let after_first_boundary = if data.starts_with(&start_boundary) {
         start_boundary.len()
-    } else if let Some(pos) = find_subsequence(data, &delimiter) {
-        pos + delimiter.len()
     } else {
-        return None;
+        let pos = find_subsequence(data, &delimiter)?;
+        pos + delimiter.len()
     };
 
     // Skip the first part entirely (it is always JSON metadata in Matrix federation)

--- a/crates/server/src/media/remote.rs
+++ b/crates/server/src/media/remote.rs
@@ -13,6 +13,7 @@ use crate::core::{Mxc, ServerName, UserId};
 use crate::data::connect;
 use crate::data::schema::*;
 use crate::exts::*;
+use crate::utils::read_response_limited;
 use crate::{AppError, AppResult, config};
 
 pub async fn fetch_remote_content(
@@ -57,10 +58,11 @@ pub async fn fetch_remote_content(
     if let Some(ct) = &content_type_header
         && ct.contains("multipart/mixed")
     {
-        let body = content_response
-            .bytes()
-            .await
-            .map_err(|e| AppError::public(format!("failed to read remote media body: {e}")))?;
+        let body = read_response_limited(
+            content_response,
+            config::get().media.max_remote_media_size,
+        )
+        .await?;
 
         if let Some((content_type, content_disposition, binary)) =
             parse_multipart_federation_response(ct, &body)
@@ -106,65 +108,57 @@ fn parse_multipart_federation_response(
                 .map(|b| b.trim().trim_matches('"').to_owned())
         })?;
 
+    let start_boundary = format!("--{boundary}\r\n").into_bytes();
     let delimiter = format!("\r\n--{boundary}\r\n").into_bytes();
+    let closing_delimiter = format!("\r\n--{boundary}--").into_bytes();
     let data = body.as_ref();
 
-    let mut offset = 0;
-    let mut content_type = String::new();
-    let mut content_disposition = None;
+    // Advance past the first boundary (which may or may not have a leading CRLF)
+    let after_first_boundary = if data.starts_with(&start_boundary) {
+        start_boundary.len()
+    } else if let Some(pos) = find_subsequence(data, &delimiter) {
+        pos + delimiter.len()
+    } else {
+        return None;
+    };
 
-    loop {
-        let start = if offset == 0 {
-            if let Some(pos) = find_subsequence(data, &delimiter) {
-                pos + delimiter.len()
-            } else {
-                break;
+    // Skip the first part entirely (it is always JSON metadata in Matrix federation)
+    let part1_header_end = find_subsequence(&data[after_first_boundary..], b"\r\n\r\n")?;
+    let part2_boundary =
+        find_subsequence(&data[after_first_boundary + part1_header_end + 4..], &delimiter)?;
+    let after_part2_boundary =
+        after_first_boundary + part1_header_end + 4 + part2_boundary + delimiter.len();
+
+    // Parse the second part (actual file content)
+    let part2_header_end = find_subsequence(&data[after_part2_boundary..], b"\r\n\r\n")?;
+    let part2_header_bytes =
+        &data[after_part2_boundary..after_part2_boundary + part2_header_end];
+    let part2_header_str = std::str::from_utf8(part2_header_bytes).ok()?;
+
+    let mut ct = String::new();
+    let mut cd = None;
+
+    for header in part2_header_str.lines() {
+        if let Some(idx) = header.find(':') {
+            let field_name = &header[..idx].trim();
+            let field_value = header[idx + 1..].trim();
+            if field_name.eq_ignore_ascii_case("Content-Type") {
+                ct = field_value.to_owned();
+            } else if field_name.eq_ignore_ascii_case("Content-Disposition") {
+                cd = Some(field_value.to_owned());
             }
-        } else {
-            offset
-        };
-
-        if let Some(header_end) = find_subsequence(&data[start..], b"\r\n\r\n") {
-            let header_bytes = &data[start..start + header_end];
-            if let Ok(header_str) = std::str::from_utf8(header_bytes) {
-                let is_json = header_str
-                    .lines()
-                    .any(|l| l.eq_ignore_ascii_case("Content-Type: application/json"));
-
-                if is_json {
-                    offset = start + header_end + 4;
-                    continue;
-                }
-
-                for header in header_str.lines() {
-                    if let Some(ct) = header.strip_prefix("Content-Type:") {
-                        content_type = ct.trim().to_owned();
-                    } else if let Some(cd) = header.strip_prefix("Content-Disposition:") {
-                        content_disposition = Some(cd.trim().to_owned());
-                    }
-                }
-
-                let content_start = start + header_end + 4;
-                if let Some(end_pos) = find_subsequence(&data[content_start..], &delimiter) {
-                    let binary = Bytes::copy_from_slice(&data[content_start..content_start + end_pos]);
-                    return Some((content_type, content_disposition, binary));
-                } else if let Some(end_pos) =
-                    find_subsequence(&data[content_start..], format!("\r\n--{boundary}--").as_bytes())
-                {
-                    let binary = Bytes::copy_from_slice(&data[content_start..content_start + end_pos]);
-                    return Some((content_type, content_disposition, binary));
-                } else {
-                    let binary = Bytes::copy_from_slice(&data[content_start..]);
-                    return Some((content_type, content_disposition, binary));
-                }
-            }
-            offset = start + header_end + 4;
-        } else {
-            break;
         }
     }
 
-    None
+    let binary_start = after_part2_boundary + part2_header_end + 4;
+
+    if let Some(end_pos) = find_subsequence(&data[binary_start..], &delimiter) {
+        Some((ct, cd, Bytes::copy_from_slice(&data[binary_start..binary_start + end_pos])))
+    } else if let Some(end_pos) = find_subsequence(&data[binary_start..], &closing_delimiter) {
+        Some((ct, cd, Bytes::copy_from_slice(&data[binary_start..binary_start + end_pos])))
+    } else {
+        Some((ct, cd, Bytes::copy_from_slice(&data[binary_start..])))
+    }
 }
 
 fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {


### PR DESCRIPTION
Remote media proxied via the federation endpoint returns `Content-Type: multipart/mixed` containing a JSON metadata part and the binary. Clients expect the raw binary but receive the multipart wrapper and cannot render the image.

This PR parses the multipart response in `fetch_remote_content`, extracts the binary content and metadata, then serves it with proper `Content-Type`, `Content-Disposition`, and `Cross-Origin-Resource-Policy` headers.

Files to review:
- `crates/server/src/media/remote.rs` — `fetch_remote_content` now detects multipart responses and extracts the binary payload (was +123/-3, now +2/-2 on review feedback)

Review notes:
- No new dependencies — uses only `std` and existing `bytes::Bytes`
- Only `fetch_remote_content` changes — local-media and thumbnail paths untouched