### PR TITLE
Implement MSC4140 delayed events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,128 +19,170 @@ keywords = ["http", "async", "web", "framework", "server"]
 license = "Apache-2.0"
 
 [workspace.dependencies]
+
+# ----- Workspace crates -----
 palpo-core = { version = "0.4.0", path = "crates/core" }
 palpo-core-macros = { version = "0.4.0", path = "crates/core-macros" }
 palpo-data = { version = "0.4.0", path = "crates/data" }
 palpo-identifiers-validation = { version = "0.4.0", path = "crates/identifiers-validation" }
 palpo-server-macros = { version = "0.4.0", path = "crates/server-macros" }
 
-rust-argon2 = "3.0.0"
-ctor = "1.0.7"
-dtor = "1.0.5"
+# ----- Error handling -----
 anyhow = "1.0.102"
-assert_matches2 = "0.1.2"
+thiserror = "2.0.18"
+
+# ----- Async runtime & concurrency -----
 async-trait = "0.1.89"
-as_variant = "1.3.0"
-base64 = "0.23"
-bcrypt = "0.19.1"
-blurhash = "0.2"
-bytes = "1.11.1"
-byteorder = "1.5.0"
-cargo_toml = "1.0.0"
-chksum = "0.4.0"
-chrono = { version = "0.4.45", features = ["serde"] }
-clap = { version = "4.6.1", default-features = false }
-config = "0.15.23"
+futures-util = { version = "0.3.32", features = ["io"] }
+scheduled-thread-pool = "0.2.7"
+tokio = { version = "1.52.3", features = [
+    "macros",
+    "parking_lot",
+    "process",
+    "rt-multi-thread",
+] }
+tokio-stream = { version = "0.1.18", features = ["sync"] }
+tokio-util = { version = "0.7.18", features = ["io"] }
+
+# ----- Web framework & HTTP -----
 cookie = "0.18.1"
-core_affinity = "0.8.3"
-cyborgtime = "2.1.1"
-data-encoding = "2.11.0"
-date_header = "1.0.5"
+form_urlencoded = "1"
+http = "1.4.1"
+http-auth = { version = "0.1.10", default-features = false }
+hyper-util = "0.1.20"
+mime = "0.3.17"
+mime-infer = "4.0.1"
+percent-encoding = "2"
+reqwest = { version = "0.13.4", features = ["json", "form"] }
+reqwest-middleware = "0.5.2"
+reqwest-retry = "0.9.1"
+salvo = { version = "0.95.0", features = ["rustls"] }
+tower-service = "0.3.3"
+url = { version = "2.5.8", default-features = false, features = ["serde"] }
+webpage = { version = "2.0.1", default-features = false }
+
+# ----- Networking -----
+hickory-resolver = "0.26.1"
+ipaddress = "0.1.3"
+# ldap3 = { git = "https://github.com/palpo-im/ldap3", branch = "main", default-features = false, features = ["sync", "tls-rustls"] }
+
+# ----- Database -----
 deadpool = { version = "0.13" }
 diesel = { version = "2.3.10" }
 diesel-async = { version = "0.9.1" }
 # diesel_full_text_search = { version = "2.2.0" }
 diesel_migrations = "2.3.2"
-dotenvy = "0.15.7"
-ed25519-dalek = "3.0.0"
-either = { version = "1.16.0", default-features = false }
-fast32 = "1.0.3"
-figment = "0.10.19"
-kdl = "6.5.0"
-futures-util = { version = "0.3.32", features = ["io"] }
-form_urlencoded = "1"
-globwalk = "0.9.1"
-ipaddress = "0.1.3"
-hickory-resolver = "0.26.1"
-hyper-util = "0.1.20"
-hmac = "0.13.0"
-http-auth = { version = "0.1.10", default-features = false }
-html5ever = "0.39.0"
-http = "1.4.1"
-image = "0.25.10"
-opendal = { version = "0.58.0", default-features = false }
-indexmap = "2.14.0"
-itertools = "0.15.0"
-jsonwebtoken = { version = "10.4.0", default-features = false, features = [
-    "use_pem",
-] }
-js_option = "0.2.0"
-konst = "0.4.3"
-# ldap3 = { git = "https://github.com/palpo-im/ldap3", branch = "main", default-features = false, features = ["sync", "tls-rustls"] }
-language-tags = { version = "0.3.2", features = ["serde"] }
-lru-cache = "0.1.2"
-maplit = "1.0.2"
-mime = "0.3.17"
-mime-infer = "4.0.1"
-# nix = "0.26.1"
-path-slash = "0.2.1"
-percent-encoding = "2"
-phf = { version = "0.14.0", features = ["macros"] }
-pkcs8 = "0.11.0"
-proc-macro-crate = "3.5.0"
-proc-macro2 = "1.0.106"
-pulldown-cmark = { version = "0.13.4", default-features = false }
-quote = "1.0.45"
-rand = "0.10"
-reqwest-middleware = "0.5.2"
-reqwest-retry = "0.9.1"
-rustyline-async = { version = "0.4.9" }
-regex = "1.12.3"
-reqwest = { version = "0.13.4", features = ["json", "form"] }
-ring = "0.17.14"
-salvo = { version = "0.95.0", features = ["rustls"]}
-sanitize-filename = "0.6.0"
-scheduled-thread-pool = "0.2.7"
-secrecy = "0.10.3"
+
+# ----- Serialization & data formats -----
 serde = { version = "1.0.228", features = ["derive"] }
-subtle = "2.6"
+serde-saphyr = { version = "0.0.29" }
 serde_html_form = "0.4.0"
 serde_ignored = "0.1.14"
 serde_json = { version = "1.0.150" }
-serde-saphyr = { version = "0.0.29" }
 serde_regex = { version = "1.2.0" }
-smallvec = { version = "1.15.1" }
-sha2 = "0.11.0"
-sha1 = "0.11.0"
-strum = "0.28.0"
-strum_macros = "0.28.0"
-subslice = "0.2.3"
-syn = "3.0.0"
-tempfile = "3.27.0"
-termimad = { version = "0.35.1", default-features = false }
-textnonce = "1.0.0"
-thiserror = "2.0.18"
-tokio = { version = "1.52.3", features = ["macros", "parking_lot", "process", "rt-multi-thread"] }
-tokio-stream = { version = "0.1.18", features = ["sync"] }
-tokio-util = { version = "0.7.18", features = ["io"] }
 toml = { version = "1.1.2", default-features = false }
-tower-service = "0.3.3"
+
+# ----- Configuration -----
+cargo_toml = "1.0.0"
+config = "0.15.23"
+dotenvy = "0.15.7"
+figment = "0.10.19"
+kdl = "6.5.0"
+
+# ----- Cryptography & security -----
+base64 = "0.23"
+bcrypt = "0.19.1"
+data-encoding = "2.11.0"
+ed25519-dalek = "3.0.0"
+hmac = "0.13.0"
+jsonwebtoken = { version = "10.4.0", default-features = false, features = [
+    "use_pem",
+] }
+pkcs8 = "0.11.0"
+rand = "0.10"
+ring = "0.17.14"
+rust-argon2 = "3.0.0"
+secrecy = "0.10.3"
+sha1 = "0.11.0"
+sha2 = "0.11.0"
+subtle = "2.6"
+
+# ----- Identifiers & encoding -----
+fast32 = "1.0.3"
+textnonce = "1.0.0"
+ulid = "3.0.0"
+uuid = { version = "1.23.2", features = ["v4"] }
+
+# ----- Text, markup & i18n -----
+html5ever = "0.39.0"
+language-tags = { version = "0.3.2", features = ["serde"] }
+pulldown-cmark = { version = "0.13.4", default-features = false }
+regex = "1.12.3"
+wildmatch = "2.6.1"
+
+# ----- Media & files -----
+blurhash = "0.2"
+chksum = "0.4.0"
+globwalk = "0.9.1"
+image = "0.25.10"
+opendal = { version = "0.58.0", default-features = false }
+path-slash = "0.2.1"
+sanitize-filename = "0.6.0"
+tempfile = "3.27.0"
+
+# ----- Date & time -----
+chrono = { version = "0.4.45", features = ["serde"] }
+cyborgtime = "2.1.1"
+date_header = "1.0.5"
+web-time = "1.1.0"
+
+# ----- Collections & general utilities -----
+as_variant = "1.3.0"
+bytes = "1.11.1"
+byteorder = "1.5.0"
+either = { version = "1.16.0", default-features = false }
+indexmap = "2.14.0"
+itertools = "0.15.0"
+js_option = "0.2.0"
+konst = "0.4.3"
+lru-cache = "0.1.2"
+maplit = "1.0.2"
+phf = { version = "0.14.0", features = ["macros"] }
+smallvec = { version = "1.15.1" }
+subslice = "0.2.3"
+
+# ----- Logging & tracing -----
 tracing = { version = "0.1.44", features = [
-    "release_max_level_debug",
     "attributes",
     "max_level_debug",
+    "release_max_level_debug",
 ] }
 tracing-core = { version = "0.1.36" }
 tracing-futures = "0.2.5"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
+
+# ----- Macros & codegen -----
+ctor = "1.0.7"
+dtor = "1.0.5"
+proc-macro-crate = "3.5.0"
+proc-macro2 = "1.0.106"
+quote = "1.0.45"
+strum = "0.28.0"
+strum_macros = "0.28.0"
+syn = "3.0.0"
+
+# ----- CLI & terminal -----
+clap = { version = "4.6.1", default-features = false }
+rustyline-async = { version = "0.4.9" }
+termimad = { version = "0.35.1", default-features = false }
+
+# ----- System & process -----
+core_affinity = "0.8.3"
+# nix = "0.26.1"
+
+# ----- Testing -----
+assert_matches2 = "0.1.2"
 tracing-test = "0.2.6"
-url = { version = "2.5.8", default-features = false, features = ["serde"] }
-uuid = { version = "1.23.2", features = ["v4"] }
-ulid = "3.0.0"
-web-time = "1.1.0"
-webpage = { version = "2.0.1", default-features = false }
-wildmatch = "2.6.1"
 
 [workspace.lints.clippy]
 result_large_err = "allow"

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -3,6 +3,8 @@ pub mod admin;
 pub mod appservice;
 pub mod backup;
 pub mod dehydrated_device;
+#[cfg(feature = "unstable-msc4140")]
+pub mod delayed_events;
 pub mod device;
 pub mod directory;
 pub mod discovery;

--- a/crates/core/src/client/delayed_events.rs
+++ b/crates/core/src/client/delayed_events.rs
@@ -1,0 +1,428 @@
+//! Endpoints for sending and interacting with delayed events.
+//!
+//! Delayed events are an unstable feature added by [MSC4140].
+//!
+//! [MSC4140]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
+
+use std::time::Duration;
+
+use salvo::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::events::TimelineEventType;
+use crate::serde::{JsonValue, StringEnum};
+use crate::{OwnedEventId, OwnedRoomId, OwnedTransactionId, PrivOwnedStr, UnixMillis};
+
+/// The standard error response body stored for a delayed event that failed to
+/// be sent.
+#[derive(ToSchema, Clone, Debug, Serialize, Deserialize)]
+pub struct DelayedEventError {
+    /// The Matrix error code of the failure, e.g. `M_FORBIDDEN`.
+    pub errcode: String,
+
+    /// A human-readable description of the failure.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// The structure of the data for returning a delayed event from a GET endpoint.
+#[derive(ToSchema, Clone, Debug, Serialize, Deserialize)]
+pub struct DelayedEventData {
+    /// The ID of the delayed event.
+    pub delay_id: String,
+
+    /// The ID of the room that the delayed event was scheduled to be sent in.
+    pub room_id: OwnedRoomId,
+
+    /// The event type of the delayed event.
+    #[serde(rename = "type")]
+    pub event_type: TimelineEventType,
+
+    /// The state key if the event is a state event, nothing otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_key: Option<String>,
+
+    /// The event content to send.
+    ///
+    /// This is the content that was submitted to the send endpoint, not the
+    /// content of the final event.
+    #[salvo(schema(value_type = Object, additional_properties = true))]
+    pub content: JsonValue,
+
+    /// The duration that the server should wait before sending this event.
+    #[serde(with = "crate::serde::duration::ms")]
+    #[salvo(schema(value_type = u64))]
+    pub delay: Duration,
+
+    /// The timestamp when the delayed event was scheduled or last restarted.
+    pub running_since: UnixMillis,
+
+    /// The error that prevented the delayed event from being sent.
+    ///
+    /// Present only for finalized events that were cancelled due to an error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<DelayedEventError>,
+
+    /// The `event_id` this event got when it was sent.
+    ///
+    /// Present only for events that were sent successfully.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_id: Option<OwnedEventId>,
+
+    /// The timestamp when the event was finalized.
+    ///
+    /// Present only for events that were finalized (sent, failed to send, or
+    /// cancelled).
+    #[serde(
+        rename = "finalised_ts",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub finalized_ts: Option<UnixMillis>,
+}
+
+impl DelayedEventData {
+    /// Returns the status indicated by this delayed event data.
+    pub fn status(&self) -> DelayedEventStatus {
+        if self.finalized_ts.is_none() {
+            DelayedEventStatus::Scheduled
+        } else if self.event_id.is_some() {
+            DelayedEventStatus::Send
+        } else if self.error.is_some() {
+            DelayedEventStatus::Error
+        } else {
+            DelayedEventStatus::Cancel
+        }
+    }
+}
+
+/// The status that a delayed event stored on the server can have.
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
+#[derive(ToSchema, Clone, StringEnum)]
+#[palpo_enum(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum DelayedEventStatus {
+    /// The event is currently scheduled to be submitted at a later date.
+    /// It may be restarted, sent or cancelled via the management endpoint.
+    Scheduled,
+
+    /// The event has been sent successfully.
+    Send,
+
+    /// The event has been cancelled.
+    Cancel,
+
+    /// The event has encountered an error when trying to send.
+    Error,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+/// The possible update actions for updating a delayed event.
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
+#[derive(ToSchema, Clone, StringEnum)]
+#[palpo_enum(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum UpdateAction {
+    /// Restart the delayed event timeout. (heartbeat ping)
+    Restart,
+
+    /// Send the delayed event immediately independent of the timeout state.
+    /// (deletes all timers)
+    Send,
+
+    /// Delete the delayed event and never send it. (deletes all timers)
+    Cancel,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+// /// `PUT /_matrix/client/unstable/org.matrix.msc4140/rooms/{room_id}/delayed_event/{event_type}/
+// {txn_id}` ///
+// /// Send a delayed event (a scheduled message) to a room.
+// const METADATA: Metadata = metadata! {
+//     method: PUT,
+//     rate_limited: true,
+//     authentication: AccessToken,
+//     history: {
+//         unstable("org.matrix.msc4140") =>
+// "/_matrix/client/unstable/org.matrix.msc4140/rooms/{room_id}/delayed_event/{event_type}/{txn_id}"
+// ,     }
+// };
+
+/// Request args for the `send_delayed_event` endpoint.
+#[derive(ToParameters, Deserialize, Debug)]
+pub struct SendDelayedEventReqArgs {
+    /// The room to send the event to.
+    #[salvo(parameter(parameter_in = Path))]
+    pub room_id: OwnedRoomId,
+
+    /// The type of event to send.
+    #[salvo(parameter(parameter_in = Path))]
+    pub event_type: TimelineEventType,
+
+    /// The transaction ID for this event.
+    ///
+    /// Clients should generate a unique ID across requests within the
+    /// same session. It will be used by the server to ensure idempotency of
+    /// requests.
+    #[salvo(parameter(parameter_in = Path))]
+    pub txn_id: OwnedTransactionId,
+
+    /// Timestamp to use for the `origin_server_ts` of the event when it is
+    /// sent.
+    ///
+    /// This is called [timestamp massaging] and can only be used by
+    /// Appservices.
+    ///
+    /// [timestamp massaging]: https://spec.matrix.org/latest/application-service-api/#timestamp-massaging
+    #[salvo(parameter(parameter_in = Query))]
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "ts")]
+    pub timestamp: Option<UnixMillis>,
+}
+
+/// Request body for the `send_delayed_event` endpoint.
+#[derive(ToSchema, Serialize, Deserialize, Debug)]
+pub struct SendDelayedEventReqBody {
+    /// The duration that the server should wait before sending this event.
+    #[serde(with = "crate::serde::duration::ms")]
+    #[salvo(schema(value_type = u64))]
+    pub delay: Duration,
+
+    /// The state key if the event is a state event, nothing otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_key: Option<String>,
+
+    /// The event content to send.
+    #[salvo(schema(value_type = Object, additional_properties = true))]
+    pub content: JsonValue,
+}
+
+/// Response type for the `send_delayed_event` endpoint.
+#[derive(ToSchema, Serialize, Deserialize, Debug)]
+pub struct SendDelayedEventResBody {
+    /// The `delay_id` generated for this delayed event. Used to interact with
+    /// delayed events.
+    pub delay_id: String,
+}
+
+impl SendDelayedEventResBody {
+    /// Creates a new `SendDelayedEventResBody` with the given delay id.
+    pub fn new(delay_id: String) -> Self {
+        Self { delay_id }
+    }
+}
+
+// /// `GET /_matrix/client/unstable/org.matrix.msc4140/delayed_events`
+// ///
+// /// Get all of the user's scheduled delayed events.
+// const METADATA: Metadata = metadata! {
+//     method: GET,
+//     rate_limited: true,
+//     authentication: AccessToken,
+//     history: {
+//         unstable("org.matrix.msc4140") =>
+// "/_matrix/client/unstable/org.matrix.msc4140/delayed_events",     }
+// };
+
+/// Response type for the `get_all_delayed_events` endpoint.
+#[derive(ToSchema, Serialize, Deserialize, Debug)]
+pub struct DelayedEventsResBody {
+    /// An array of objects describing scheduled delayed events owned by the
+    /// requesting user.
+    pub delayed_events: Vec<DelayedEventData>,
+}
+
+impl DelayedEventsResBody {
+    /// Creates a new `DelayedEventsResBody` with the given delayed events.
+    pub fn new(delayed_events: Vec<DelayedEventData>) -> Self {
+        Self { delayed_events }
+    }
+}
+
+// /// `GET /_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}`
+// ///
+// /// Get the information about a delayed event. The response body is a single
+// /// `DelayedEventData` object.
+// const METADATA: Metadata = metadata! {
+//     method: GET,
+//     rate_limited: true,
+//     authentication: AccessToken,
+//     history: {
+//         unstable("org.matrix.msc4140") =>
+// "/_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}",     }
+// };
+
+// /// `POST /_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}/{action}`
+// ///
+// /// Update a delayed event: restart its timeout, send it immediately, or
+// /// cancel it.
+// const METADATA: Metadata = metadata! {
+//     method: POST,
+//     rate_limited: true,
+//     authentication: AccessToken,
+//     history: {
+//         unstable("org.matrix.msc4140") =>
+// "/_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}/{action}",     }
+// };
+
+/// Request args for the `update_delayed_event` endpoint.
+#[derive(ToParameters, Deserialize, Debug)]
+pub struct UpdateDelayedEventReqArgs {
+    /// The delay id that we want to update.
+    #[salvo(parameter(parameter_in = Path))]
+    pub delay_id: String,
+
+    /// Which kind of update we want to request for the delayed event.
+    #[salvo(parameter(parameter_in = Path))]
+    pub action: UpdateAction,
+}
+
+/// Request body for the deprecated body-action variant of the
+/// `update_delayed_event` endpoint
+/// (`POST /_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}`).
+#[derive(ToSchema, Serialize, Deserialize, Debug)]
+pub struct UpdateDelayedEventReqBody {
+    /// Which kind of update we want to request for the delayed event.
+    pub action: UpdateAction,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use serde_json::{Value as JsonValue, json};
+
+    use super::*;
+
+    #[test]
+    fn deserialize_send_delayed_event_req_body() {
+        let body: SendDelayedEventReqBody = serde_json::from_value(json!({
+            "delay": 103,
+            "content": {"msgtype": "m.text", "body": "test"},
+        }))
+        .unwrap();
+
+        assert_eq!(body.delay, Duration::from_millis(103));
+        assert_eq!(body.state_key, None);
+        assert_eq!(body.content, json!({"msgtype": "m.text", "body": "test"}));
+    }
+
+    #[test]
+    fn deserialize_send_delayed_state_event_req_body() {
+        let body: SendDelayedEventReqBody = serde_json::from_value(json!({
+            "delay": 9000,
+            "state_key": "a_state_key",
+            "content": {"topic": "test topic"},
+        }))
+        .unwrap();
+
+        assert_eq!(body.delay, Duration::from_millis(9000));
+        assert_eq!(body.state_key.as_deref(), Some("a_state_key"));
+    }
+
+    #[test]
+    fn serialize_delayed_event_data() {
+        let event = DelayedEventData {
+            delay_id: "a_delay_id".to_owned(),
+            room_id: "!roomid:example.org".try_into().unwrap(),
+            event_type: "m.room.topic".into(),
+            state_key: Some("a_state_key".to_owned()),
+            content: json!({"topic": "test topic"}),
+            delay: Duration::from_millis(103),
+            running_since: crate::UnixMillis(70000),
+            error: None,
+            event_id: Some("$event:example.org".try_into().unwrap()),
+            finalized_ts: Some(crate::UnixMillis(70103)),
+        };
+        assert_eq!(event.status(), DelayedEventStatus::Send);
+
+        assert_eq!(
+            serde_json::to_value(&event).unwrap(),
+            json!({
+                "content": {"topic": "test topic"},
+                "delay": 103,
+                "delay_id": "a_delay_id",
+                "event_id": "$event:example.org",
+                "finalised_ts": 70103,
+                "room_id": "!roomid:example.org",
+                "running_since": 70000,
+                "state_key": "a_state_key",
+                "type": "m.room.topic",
+            })
+        );
+    }
+
+    #[test]
+    fn scheduled_delayed_event_data_status() {
+        let event = DelayedEventData {
+            delay_id: "a_delay_id".to_owned(),
+            room_id: "!roomid:example.org".try_into().unwrap(),
+            event_type: "m.room.message".into(),
+            state_key: None,
+            content: json!({"msgtype": "m.text", "body": "test"}),
+            delay: Duration::from_millis(103),
+            running_since: crate::UnixMillis(70000),
+            error: None,
+            event_id: None,
+            finalized_ts: None,
+        };
+        assert_eq!(event.status(), DelayedEventStatus::Scheduled);
+
+        let serialized = serde_json::to_value(&event).unwrap();
+        assert!(serialized.get("event_id").is_none());
+        assert!(serialized.get("finalised_ts").is_none());
+        assert!(serialized.get("error").is_none());
+        assert!(serialized.get("state_key").is_none());
+    }
+
+    #[test]
+    fn error_delayed_event_data_status() {
+        let event = DelayedEventData {
+            delay_id: "a_delay_id".to_owned(),
+            room_id: "!roomid:example.org".try_into().unwrap(),
+            event_type: "m.room.message".into(),
+            state_key: None,
+            content: json!({"msgtype": "m.text", "body": "test"}),
+            delay: Duration::from_millis(103),
+            running_since: crate::UnixMillis(70000),
+            error: Some(DelayedEventError {
+                errcode: "M_FORBIDDEN".to_owned(),
+                error: Some("you shall not pass".to_owned()),
+            }),
+            event_id: None,
+            finalized_ts: Some(crate::UnixMillis(70103)),
+        };
+        assert_eq!(event.status(), DelayedEventStatus::Error);
+    }
+
+    #[test]
+    fn update_action_from_str() {
+        assert_eq!(UpdateAction::from("restart"), UpdateAction::Restart);
+        assert_eq!(UpdateAction::from("send"), UpdateAction::Send);
+        assert_eq!(UpdateAction::from("cancel"), UpdateAction::Cancel);
+
+        let body: UpdateDelayedEventReqBody =
+            serde_json::from_value(json!({"action": "cancel"})).unwrap();
+        assert_eq!(body.action, UpdateAction::Cancel);
+    }
+
+    #[test]
+    fn cancelled_delayed_event_data_status() {
+        let event = DelayedEventData {
+            delay_id: "a_delay_id".to_owned(),
+            room_id: "!roomid:example.org".try_into().unwrap(),
+            event_type: "m.room.message".into(),
+            state_key: None,
+            content: JsonValue::Null,
+            delay: Duration::from_millis(103),
+            running_since: crate::UnixMillis(70000),
+            error: None,
+            event_id: None,
+            finalized_ts: Some(crate::UnixMillis(70103)),
+        };
+        assert_eq!(event.status(), DelayedEventStatus::Cancel);
+    }
+}

--- a/crates/core/src/client/delayed_events.rs
+++ b/crates/core/src/client/delayed_events.rs
@@ -1,0 +1,387 @@
+//! Endpoints for sending and interacting with delayed events.
+//!
+//! Delayed events are an unstable feature added by [MSC4140].
+//!
+//! [MSC4140]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use salvo::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::events::TimelineEventType;
+use crate::serde::{JsonValue, StringEnum};
+use crate::{OwnedEventId, OwnedRoomId, OwnedTransactionId, PrivOwnedStr, UnixMillis};
+
+/// The standard error response body stored for a delayed event that failed to
+/// be sent.
+#[derive(ToSchema, Clone, Debug, Serialize, Deserialize)]
+pub struct DelayedEventError {
+    /// The Matrix error code of the failure, e.g. `M_FORBIDDEN`.
+    pub errcode: String,
+
+    /// A human-readable description of the failure.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+
+    /// Additional fields carried by the Matrix standard error response.
+    #[serde(flatten)]
+    #[salvo(schema(value_type = Object, additional_properties = true))]
+    pub extra: BTreeMap<String, JsonValue>,
+}
+
+/// How a delayed event was finalized.
+#[derive(ToSchema, Clone, Debug, Serialize, Deserialize)]
+pub struct DelayedEventFinalization {
+    /// The error that prevented the delayed event from being sent.
+    ///
+    /// Present only when sending failed. It is mutually exclusive with
+    /// [`event_id`](Self::event_id).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<DelayedEventError>,
+
+    /// The event ID allocated when the delayed event was sent successfully.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_id: Option<OwnedEventId>,
+
+    /// The time at which the delayed event was finalized.
+    pub finalised_ts: UnixMillis,
+}
+
+/// The structure returned by the delayed-event lookup endpoint.
+#[derive(ToSchema, Clone, Debug, Serialize, Deserialize)]
+pub struct DelayedEventData {
+    /// The ID of the delayed event.
+    pub delay_id: String,
+
+    /// The ID of the room that the delayed event was scheduled to be sent in.
+    pub room_id: OwnedRoomId,
+
+    /// The event type of the delayed event.
+    #[serde(rename = "type")]
+    pub event_type: TimelineEventType,
+
+    /// The state key if the event is a state event, nothing otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_key: Option<String>,
+
+    /// The event content to send.
+    ///
+    /// This is the content that was submitted to the send endpoint, not the
+    /// content of the final event.
+    #[salvo(schema(value_type = Object, additional_properties = true))]
+    pub content: JsonValue,
+
+    /// The duration that the server should wait before sending this event.
+    #[serde(rename = "delay_ms", with = "crate::serde::duration::ms")]
+    #[salvo(schema(value_type = u64))]
+    pub delay: Duration,
+
+    /// The timestamp when the delayed event was scheduled or last restarted.
+    #[serde(rename = "delayed_since_ts")]
+    pub running_since: UnixMillis,
+
+    /// How this event was finalized. Absent while it remains scheduled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finalised: Option<DelayedEventFinalization>,
+}
+
+/// The possible update actions for updating a delayed event.
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
+#[derive(ToSchema, Clone, StringEnum)]
+#[palpo_enum(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum UpdateAction {
+    /// Restart the delayed event timeout. (heartbeat ping)
+    Restart,
+
+    /// Send the delayed event immediately independent of the timeout state.
+    /// (deletes all timers)
+    Send,
+
+    /// Delete the delayed event and never send it. (deletes all timers)
+    Cancel,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+// /// `PUT /_matrix/client/unstable/org.matrix.msc4140/rooms/{room_id}/delayed_event/{event_type}/
+// {txn_id}` ///
+// /// Send a delayed event (a scheduled message) to a room.
+// const METADATA: Metadata = metadata! {
+//     method: PUT,
+//     rate_limited: true,
+//     authentication: AccessToken,
+//     history: {
+//         unstable("org.matrix.msc4140") =>
+// "/_matrix/client/unstable/org.matrix.msc4140/rooms/{room_id}/delayed_event/{event_type}/{txn_id}"
+// ,     }
+// };
+
+/// Request args for the `send_delayed_event` endpoint.
+#[derive(ToParameters, Deserialize, Debug)]
+pub struct SendDelayedEventReqArgs {
+    /// The room to send the event to.
+    #[salvo(parameter(parameter_in = Path))]
+    pub room_id: OwnedRoomId,
+
+    /// The type of event to send.
+    #[salvo(parameter(parameter_in = Path))]
+    pub event_type: TimelineEventType,
+
+    /// The transaction ID for this event.
+    ///
+    /// Clients should generate a unique ID across requests within the
+    /// same session. It will be used by the server to ensure idempotency of
+    /// requests.
+    #[salvo(parameter(parameter_in = Path))]
+    pub txn_id: OwnedTransactionId,
+
+    /// Timestamp to use for the `origin_server_ts` of the event when it is
+    /// sent.
+    ///
+    /// This is called [timestamp massaging] and can only be used by
+    /// Appservices.
+    ///
+    /// [timestamp massaging]: https://spec.matrix.org/latest/application-service-api/#timestamp-massaging
+    #[salvo(parameter(parameter_in = Query))]
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "ts")]
+    pub timestamp: Option<UnixMillis>,
+}
+
+/// Request body for the `send_delayed_event` endpoint.
+#[derive(ToSchema, Serialize, Deserialize, Debug)]
+pub struct SendDelayedEventReqBody {
+    /// The duration that the server should wait before sending this event.
+    #[serde(rename = "delay_ms", with = "crate::serde::duration::ms")]
+    #[salvo(schema(value_type = u64))]
+    pub delay: Duration,
+
+    /// The state key if the event is a state event, nothing otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_key: Option<String>,
+
+    /// The event content to send.
+    #[salvo(schema(value_type = Object, additional_properties = true))]
+    pub content: JsonValue,
+}
+
+/// Response type for the `send_delayed_event` endpoint.
+#[derive(ToSchema, Serialize, Deserialize, Debug)]
+pub struct SendDelayedEventResBody {
+    /// The `delay_id` generated for this delayed event. Used to interact with
+    /// delayed events.
+    pub delay_id: String,
+}
+
+impl SendDelayedEventResBody {
+    /// Creates a new `SendDelayedEventResBody` with the given delay id.
+    pub fn new(delay_id: String) -> Self {
+        Self { delay_id }
+    }
+}
+
+// /// `GET /_matrix/client/unstable/org.matrix.msc4140/delayed_events`
+// ///
+// /// Get all of the user's scheduled delayed events.
+// const METADATA: Metadata = metadata! {
+//     method: GET,
+//     rate_limited: true,
+//     authentication: AccessToken,
+//     history: {
+//         unstable("org.matrix.msc4140") =>
+// "/_matrix/client/unstable/org.matrix.msc4140/delayed_events",     }
+// };
+
+// /// `GET /_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}`
+// ///
+// /// Get the information about a delayed event. The response body is a single
+// /// `DelayedEventData` object.
+// const METADATA: Metadata = metadata! {
+//     method: GET,
+//     rate_limited: true,
+//     authentication: AccessToken,
+//     history: {
+//         unstable("org.matrix.msc4140") =>
+// "/_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}",     }
+// };
+
+// /// `POST /_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}/{action}`
+// ///
+// /// Update a delayed event: restart its timeout, send it immediately, or
+// /// cancel it.
+// const METADATA: Metadata = metadata! {
+//     method: POST,
+//     rate_limited: true,
+//     authentication: AccessToken,
+//     history: {
+//         unstable("org.matrix.msc4140") =>
+// "/_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}/{action}",     }
+// };
+
+/// Request args for the `update_delayed_event` endpoint.
+#[derive(ToParameters, Deserialize, Debug)]
+pub struct UpdateDelayedEventReqArgs {
+    /// The delay id that we want to update.
+    #[salvo(parameter(parameter_in = Path))]
+    pub delay_id: String,
+
+    /// Which kind of update we want to request for the delayed event.
+    #[salvo(parameter(parameter_in = Path))]
+    pub action: UpdateAction,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn deserialize_send_delayed_event_req_body() {
+        let body: SendDelayedEventReqBody = serde_json::from_value(json!({
+            "delay_ms": 103,
+            "content": {"msgtype": "m.text", "body": "test"},
+        }))
+        .unwrap();
+
+        assert_eq!(body.delay, Duration::from_millis(103));
+        assert_eq!(body.state_key, None);
+        assert_eq!(body.content, json!({"msgtype": "m.text", "body": "test"}));
+    }
+
+    #[test]
+    fn deserialize_send_delayed_state_event_req_body() {
+        let body: SendDelayedEventReqBody = serde_json::from_value(json!({
+            "delay_ms": 9000,
+            "state_key": "a_state_key",
+            "content": {"topic": "test topic"},
+        }))
+        .unwrap();
+
+        assert_eq!(body.delay, Duration::from_millis(9000));
+        assert_eq!(body.state_key.as_deref(), Some("a_state_key"));
+    }
+
+    #[test]
+    fn serialize_delayed_event_data() {
+        let event = DelayedEventData {
+            delay_id: "a_delay_id".to_owned(),
+            room_id: "!roomid:example.org".try_into().unwrap(),
+            event_type: "m.room.topic".into(),
+            state_key: Some("a_state_key".to_owned()),
+            content: json!({"topic": "test topic"}),
+            delay: Duration::from_millis(103),
+            running_since: crate::UnixMillis(70000),
+            finalised: Some(DelayedEventFinalization {
+                error: None,
+                event_id: Some("$event:example.org".try_into().unwrap()),
+                finalised_ts: crate::UnixMillis(70103),
+            }),
+        };
+
+        assert_eq!(
+            serde_json::to_value(&event).unwrap(),
+            json!({
+                "content": {"topic": "test topic"},
+                "delay_ms": 103,
+                "delay_id": "a_delay_id",
+                "delayed_since_ts": 70000,
+                "finalised": {
+                    "event_id": "$event:example.org",
+                    "finalised_ts": 70103,
+                },
+                "room_id": "!roomid:example.org",
+                "state_key": "a_state_key",
+                "type": "m.room.topic",
+            })
+        );
+    }
+
+    #[test]
+    fn scheduled_delayed_event_omits_finalisation() {
+        let event = DelayedEventData {
+            delay_id: "a_delay_id".to_owned(),
+            room_id: "!roomid:example.org".try_into().unwrap(),
+            event_type: "m.room.message".into(),
+            state_key: None,
+            content: json!({"msgtype": "m.text", "body": "test"}),
+            delay: Duration::from_millis(103),
+            running_since: crate::UnixMillis(70000),
+            finalised: None,
+        };
+
+        let serialized = serde_json::to_value(&event).unwrap();
+        assert!(serialized.get("finalised").is_none());
+        assert!(serialized.get("state_key").is_none());
+    }
+
+    #[test]
+    fn failed_finalisation_nests_the_standard_error() {
+        let finalised = DelayedEventFinalization {
+            error: Some(DelayedEventError {
+                errcode: "M_FORBIDDEN".to_owned(),
+                error: Some("you shall not pass".to_owned()),
+                extra: BTreeMap::new(),
+            }),
+            event_id: None,
+            finalised_ts: crate::UnixMillis(70103),
+        };
+
+        assert_eq!(
+            serde_json::to_value(finalised).unwrap(),
+            json!({
+                "error": {
+                    "errcode": "M_FORBIDDEN",
+                    "error": "you shall not pass",
+                },
+                "finalised_ts": 70103,
+            })
+        );
+    }
+
+    #[test]
+    fn delayed_event_error_preserves_standard_error_extensions() {
+        let error: DelayedEventError = serde_json::from_value(json!({
+            "errcode": "M_LIMIT_EXCEEDED",
+            "error": "slow down",
+            "retry_after_ms": 1500,
+        }))
+        .unwrap();
+
+        assert_eq!(error.extra.get("retry_after_ms"), Some(&json!(1500)));
+        assert_eq!(
+            serde_json::to_value(error).unwrap(),
+            json!({
+                "errcode": "M_LIMIT_EXCEEDED",
+                "error": "slow down",
+                "retry_after_ms": 1500,
+            })
+        );
+    }
+
+    #[test]
+    fn update_action_from_str() {
+        assert_eq!(UpdateAction::from("restart"), UpdateAction::Restart);
+        assert_eq!(UpdateAction::from("send"), UpdateAction::Send);
+        assert_eq!(UpdateAction::from("cancel"), UpdateAction::Cancel);
+    }
+
+    #[test]
+    fn cancelled_finalisation_has_only_its_timestamp() {
+        let finalised = DelayedEventFinalization {
+            error: None,
+            event_id: None,
+            finalised_ts: crate::UnixMillis(70103),
+        };
+
+        assert_eq!(
+            serde_json::to_value(finalised).unwrap(),
+            json!({"finalised_ts": 70103})
+        );
+    }
+}

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -17,7 +17,8 @@ mod kind;
 /// Separate module because it's a lot of code.
 mod kind_serde;
 pub use kind::*;
-use kind_serde::{ErrorCode, RetryAfter};
+use kind_serde::ErrorCode;
+pub use kind_serde::RetryAfter;
 
 use crate::{MatrixVersion, OwnedUserId, RoomVersionId};
 
@@ -225,6 +226,20 @@ impl Scribe for MatrixError {
         };
 
         let Self { kind, mut body, .. } = self;
+        if let ErrorKind::LimitExceeded {
+            retry_after: Some(RetryAfter::Delay(duration)),
+        } = &kind
+        {
+            res.add_header(
+                header::RETRY_AFTER,
+                duration.as_secs().max(1).to_string(),
+                true,
+            )
+            .ok();
+            if let Ok(ms) = u64::try_from(duration.as_millis()) {
+                body.0.insert("retry_after_ms".to_owned(), ms.into());
+            }
+        }
         body.0
             .insert("errcode".to_owned(), kind.code().to_string().into());
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -17,7 +17,8 @@ mod kind;
 /// Separate module because it's a lot of code.
 mod kind_serde;
 pub use kind::*;
-use kind_serde::{ErrorCode, RetryAfter};
+use kind_serde::ErrorCode;
+pub use kind_serde::RetryAfter;
 
 use crate::{MatrixVersion, OwnedUserId, RoomVersionId};
 
@@ -92,6 +93,7 @@ impl MatrixError {
         captcha_needed, CaptchaNeeded;
         connection_failed, ConnectionFailed;
         connection_timeout, ConnectionTimeout;
+        delay_too_large, DelayTooLarge;
         duplicate_annotation, DuplicateAnnotation;
         exclusive, Exclusive;
         guest_access_forbidden, GuestAccessForbidden;
@@ -225,6 +227,24 @@ impl Scribe for MatrixError {
         };
 
         let Self { kind, mut body, .. } = self;
+        if let ErrorKind::LimitExceeded {
+            retry_after: Some(RetryAfter::Delay(duration)),
+        } = &kind
+        {
+            res.add_header(
+                header::RETRY_AFTER,
+                duration
+                    .as_secs()
+                    .saturating_add(u64::from(duration.subsec_nanos() != 0))
+                    .max(1)
+                    .to_string(),
+                true,
+            )
+            .ok();
+            if let Ok(ms) = u64::try_from(duration.as_millis()) {
+                body.0.insert("retry_after_ms".to_owned(), ms.into());
+            }
+        }
         body.0
             .insert("errcode".to_owned(), kind.code().to_string().into());
 

--- a/crates/core/src/error/kind.rs
+++ b/crates/core/src/error/kind.rs
@@ -101,6 +101,11 @@ pub enum ErrorKind {
     /// The connection to the application service timed out.
     ConnectionTimeout,
 
+    /// `ORG.MATRIX.MSC4140_DELAY_TOO_LARGE`
+    ///
+    /// A delayed event requested a delay larger than the homeserver permits.
+    DelayTooLarge,
+
     /// `M_DUPLICATE_ANNOTATION`
     ///
     /// The request is an attempt to send a [duplicate annotation].
@@ -465,6 +470,7 @@ impl ErrorKind {
             ErrorKind::ConflictingUnsubscription => ErrorCode::ConflictingUnsubscription,
             ErrorKind::ConnectionFailed => ErrorCode::ConnectionFailed,
             ErrorKind::ConnectionTimeout => ErrorCode::ConnectionTimeout,
+            ErrorKind::DelayTooLarge => ErrorCode::DelayTooLarge,
             ErrorKind::DuplicateAnnotation => ErrorCode::DuplicateAnnotation,
             ErrorKind::Exclusive => ErrorCode::Exclusive,
             ErrorKind::Forbidden => ErrorCode::Forbidden,

--- a/crates/core/src/error/kind_serde.rs
+++ b/crates/core/src/error/kind_serde.rs
@@ -203,6 +203,7 @@ impl<'de> Visitor<'de> for ErrorKindVisitor {
             ErrorCode::ConflictingUnsubscription => ErrorKind::ConflictingUnsubscription,
             ErrorCode::ConnectionFailed => ErrorKind::ConnectionFailed,
             ErrorCode::ConnectionTimeout => ErrorKind::ConnectionTimeout,
+            ErrorCode::DelayTooLarge => ErrorKind::DelayTooLarge,
             ErrorCode::DuplicateAnnotation => ErrorKind::DuplicateAnnotation,
             ErrorCode::Exclusive => ErrorKind::Exclusive,
             ErrorCode::Forbidden => ErrorKind::Forbidden,
@@ -387,6 +388,12 @@ pub enum ErrorCode {
     ///
     /// The connection to the application service timed out.
     ConnectionTimeout,
+
+    /// `ORG.MATRIX.MSC4140_DELAY_TOO_LARGE`
+    ///
+    /// A delayed event requested a delay larger than the homeserver permits.
+    #[palpo_enum(rename = "ORG.MATRIX.MSC4140_DELAY_TOO_LARGE")]
+    DelayTooLarge,
 
     /// `M_DUPLICATE_ANNOTATION`
     ///
@@ -821,6 +828,17 @@ mod tests {
 
     //     assert_eq!(deserialized, ErrorKind::Forbidden);
     // }
+
+    #[test]
+    fn delay_too_large_serde() {
+        let value = json!({ "errcode": "ORG.MATRIX.MSC4140_DELAY_TOO_LARGE" });
+
+        assert_eq!(
+            from_json_value::<ErrorKind>(value.clone()).unwrap(),
+            ErrorKind::DelayTooLarge
+        );
+        assert_eq!(to_json_value(ErrorKind::DelayTooLarge).unwrap(), value);
+    }
 
     #[test]
     fn deserialize_incompatible_room_version() {

--- a/crates/data/migrations/2026-07-23-000001_delayed_events/down.sql
+++ b/crates/data/migrations/2026-07-23-000001_delayed_events/down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_delayed_events_finalized;
+DROP INDEX IF EXISTS idx_delayed_events_due;
+DROP INDEX IF EXISTS idx_delayed_events_user;
+DROP INDEX IF EXISTS idx_delayed_events_txn;
+DROP TABLE IF EXISTS delayed_events;

--- a/crates/data/migrations/2026-07-23-000001_delayed_events/down.sql
+++ b/crates/data/migrations/2026-07-23-000001_delayed_events/down.sql
@@ -1,0 +1,12 @@
+DROP TRIGGER IF EXISTS delayed_events_remove_output ON delayed_events;
+DROP FUNCTION IF EXISTS palpo_remove_delayed_event_output;
+DROP TRIGGER IF EXISTS events_record_delayed_event_output ON events;
+DROP FUNCTION IF EXISTS palpo_confirm_delayed_event_output;
+DROP TRIGGER IF EXISTS event_datas_track_delayed_event_output ON event_datas;
+DROP FUNCTION IF EXISTS palpo_track_delayed_event_output;
+DROP TABLE IF EXISTS delayed_event_outputs;
+DROP INDEX IF EXISTS idx_delayed_events_finalized;
+DROP INDEX IF EXISTS idx_delayed_events_due;
+DROP INDEX IF EXISTS idx_delayed_events_user;
+DROP INDEX IF EXISTS idx_delayed_events_txn;
+DROP TABLE IF EXISTS delayed_events;

--- a/crates/data/migrations/2026-07-23-000001_delayed_events/up.sql
+++ b/crates/data/migrations/2026-07-23-000001_delayed_events/up.sql
@@ -1,0 +1,31 @@
+-- MSC4140 delayed events.
+--
+-- Scheduled events that the homeserver sends into a room on the user's behalf
+-- once their delay elapses. Rows survive restarts so pending events are
+-- recovered and sent after the server comes back up. Finalized rows (sent,
+-- cancelled, or errored) are retained for lookup and pruned periodically.
+CREATE TABLE delayed_events (
+    id BIGSERIAL NOT NULL PRIMARY KEY,
+    delay_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    device_id TEXT,
+    room_id TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    state_key TEXT,
+    content JSONB NOT NULL,
+    delay_ms BIGINT NOT NULL,
+    txn_id TEXT NOT NULL,
+    origin_server_ts BIGINT,
+    running_since BIGINT NOT NULL,
+    send_at BIGINT NOT NULL,
+    event_id TEXT,
+    error JSONB,
+    finalized_at BIGINT,
+    created_at BIGINT NOT NULL,
+    UNIQUE (delay_id)
+);
+-- Idempotency: one delayed event per (user, device session, transaction id).
+CREATE UNIQUE INDEX idx_delayed_events_txn ON delayed_events(user_id, COALESCE(device_id, ''), txn_id);
+CREATE INDEX idx_delayed_events_user ON delayed_events(user_id);
+CREATE INDEX idx_delayed_events_due ON delayed_events(send_at) WHERE finalized_at IS NULL;
+CREATE INDEX idx_delayed_events_finalized ON delayed_events(finalized_at) WHERE finalized_at IS NOT NULL;

--- a/crates/data/migrations/2026-07-23-000001_delayed_events/up.sql
+++ b/crates/data/migrations/2026-07-23-000001_delayed_events/up.sql
@@ -1,0 +1,129 @@
+-- MSC4140 delayed events.
+--
+-- Scheduled events that the homeserver sends into a room on the user's behalf
+-- once their delay elapses. Rows survive restarts so pending events are
+-- recovered and sent after the server comes back up. Finalized rows (sent,
+-- cancelled, or errored) are retained for lookup and pruned periodically.
+CREATE TABLE delayed_events (
+    id BIGSERIAL NOT NULL PRIMARY KEY,
+    delay_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    device_id TEXT,
+    room_id TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    state_key TEXT,
+    content JSONB NOT NULL,
+    delay_ms BIGINT NOT NULL,
+    txn_id TEXT NOT NULL,
+    origin_server_ts BIGINT,
+    running_since BIGINT NOT NULL,
+    send_at BIGINT NOT NULL,
+    event_id TEXT,
+    error JSONB,
+    finalized_at BIGINT,
+    created_at BIGINT NOT NULL,
+    UNIQUE (delay_id)
+);
+-- Idempotency: one delayed event per (user, device session, transaction id).
+CREATE UNIQUE INDEX idx_delayed_events_txn ON delayed_events(user_id, COALESCE(device_id, ''), txn_id);
+CREATE INDEX idx_delayed_events_user ON delayed_events(user_id);
+CREATE INDEX idx_delayed_events_due ON delayed_events(send_at) WHERE finalized_at IS NULL;
+CREATE INDEX idx_delayed_events_finalized ON delayed_events(finalized_at) WHERE finalized_at IS NOT NULL;
+
+-- The timeline append and the delayed-event outcome are written through
+-- different connections. Record the output in the same transaction that
+-- promotes the event from an outlier into the timeline, so a process crash
+-- between append and outcome finalization cannot cause a second room event on
+-- recovery. The primary key also rejects any accidental second append for the
+-- same delay id.
+CREATE TABLE delayed_event_outputs (
+    delay_id TEXT NOT NULL PRIMARY KEY,
+    event_id TEXT NOT NULL UNIQUE
+);
+
+-- Remember the candidate as soon as its outlier is persisted. If an attempt
+-- fails before promotion, a later attempt may replace that still-outlier
+-- candidate. Once the mapped event is promoted, this mapping is immutable.
+CREATE FUNCTION palpo_track_delayed_event_output() RETURNS TRIGGER AS $$
+DECLARE
+    v_delayed_id TEXT;
+BEGIN
+    v_delayed_id := NEW.json_data -> 'unsigned' ->> 'org.matrix.msc4140.delay_id';
+    IF v_delayed_id IS NOT NULL AND EXISTS (
+        SELECT 1 FROM delayed_events
+        WHERE delay_id = v_delayed_id
+          AND user_id = NEW.json_data ->> 'sender'
+          AND room_id = NEW.room_id
+          AND finalized_at IS NULL
+    ) THEN
+        INSERT INTO delayed_event_outputs (delay_id, event_id)
+        VALUES (v_delayed_id, NEW.event_id)
+        ON CONFLICT (delay_id) DO UPDATE
+        SET event_id = EXCLUDED.event_id
+        WHERE EXISTS (
+            SELECT 1 FROM events
+            WHERE id = delayed_event_outputs.event_id
+              AND is_outlier = TRUE
+        );
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER event_datas_track_delayed_event_output
+AFTER INSERT ON event_datas
+FOR EACH ROW EXECUTE FUNCTION palpo_track_delayed_event_output();
+
+-- Promotion is the definitive commit point. A different event already mapped
+-- to this delay id must make this promotion fail, otherwise two events could
+-- become visible after recovery from a partially completed append.
+CREATE FUNCTION palpo_confirm_delayed_event_output() RETURNS TRIGGER AS $$
+DECLARE
+    v_delayed_id TEXT;
+    v_mapped_event_id TEXT;
+BEGIN
+    SELECT json_data -> 'unsigned' ->> 'org.matrix.msc4140.delay_id'
+    INTO v_delayed_id
+    FROM event_datas
+    WHERE event_id = NEW.id;
+    IF v_delayed_id IS NOT NULL AND EXISTS (
+        SELECT 1 FROM delayed_events
+        WHERE delay_id = v_delayed_id
+          AND user_id = NEW.sender_id
+          AND room_id = NEW.room_id
+          AND finalized_at IS NULL
+    ) THEN
+        SELECT output.event_id INTO v_mapped_event_id
+        FROM delayed_event_outputs AS output
+        WHERE output.delay_id = v_delayed_id;
+
+        IF v_mapped_event_id IS NULL THEN
+            INSERT INTO delayed_event_outputs (delay_id, event_id)
+            VALUES (v_delayed_id, NEW.id);
+        ELSIF v_mapped_event_id <> NEW.id THEN
+            RAISE EXCEPTION 'delay id % is already mapped to event %',
+                v_delayed_id, v_mapped_event_id
+                USING ERRCODE = 'unique_violation';
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER events_record_delayed_event_output
+AFTER UPDATE OF is_outlier ON events
+FOR EACH ROW
+WHEN (OLD.is_outlier IS DISTINCT FROM FALSE AND NEW.is_outlier = FALSE)
+EXECUTE FUNCTION palpo_confirm_delayed_event_output();
+
+-- Outcome markers only need to live as long as their delayed-event row.
+CREATE FUNCTION palpo_remove_delayed_event_output() RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM delayed_event_outputs WHERE delay_id = OLD.delay_id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER delayed_events_remove_output
+AFTER DELETE ON delayed_events
+FOR EACH ROW EXECUTE FUNCTION palpo_remove_delayed_event_output();

--- a/crates/data/migrations/2026-07-23-000001_delayed_events/up.sql
+++ b/crates/data/migrations/2026-07-23-000001_delayed_events/up.sql
@@ -20,6 +20,11 @@ CREATE TABLE delayed_events (
     send_at BIGINT NOT NULL,
     event_id TEXT,
     error JSONB,
+    -- Lease taken by the worker that is currently sending this event. Kept
+    -- separate from finalized_at so a crash mid-send leaves a row that is
+    -- still scheduled and can be reclaimed, rather than one that looks
+    -- finalized with no outcome.
+    claimed_at BIGINT,
     finalized_at BIGINT,
     created_at BIGINT NOT NULL,
     UNIQUE (delay_id)

--- a/crates/data/migrations/2026-08-31-000001_delayed_event_deliveries/down.sql
+++ b/crates/data/migrations/2026-08-31-000001_delayed_event_deliveries/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE delayed_event_deliveries;

--- a/crates/data/migrations/2026-08-31-000001_delayed_event_deliveries/up.sql
+++ b/crates/data/migrations/2026-08-31-000001_delayed_event_deliveries/up.sql
@@ -1,0 +1,10 @@
+-- Durable handoff from delayed-event completion to the federation queue.
+CREATE TABLE delayed_event_deliveries (
+    event_id TEXT PRIMARY KEY,
+    room_id TEXT NOT NULL
+);
+-- Existing completed events may have stopped before queueing. Re-delivery is
+-- idempotent by event ID; a missed delivery would otherwise be permanent.
+INSERT INTO delayed_event_deliveries (event_id, room_id)
+SELECT event_id, room_id FROM delayed_events WHERE event_id IS NOT NULL
+ON CONFLICT DO NOTHING;

--- a/crates/data/src/room.rs
+++ b/crates/data/src/room.rs
@@ -9,6 +9,7 @@ use crate::core::{MatrixError, Seqnum, UnixMillis};
 use crate::schema::*;
 use crate::{DataResult, connect};
 
+pub mod delayed_event;
 pub mod event;
 pub mod event_report;
 pub mod lazy_loading;

--- a/crates/data/src/room/delayed_event.rs
+++ b/crates/data/src/room/delayed_event.rs
@@ -1,0 +1,260 @@
+//! Persistence for MSC4140 delayed events.
+//!
+//! A delayed event is stored when scheduled and stays in the table after it is
+//! finalized (sent, cancelled, or errored) so clients can look up the outcome.
+//! The scheduler claims due rows by setting `finalized_at` first, then records
+//! the send outcome; this keeps the claim atomic under concurrent workers and
+//! management requests.
+
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+
+use crate::core::identifiers::*;
+use crate::core::serde::JsonValue;
+use crate::core::{DeviceId, TransactionId, UserId};
+use crate::schema::*;
+use crate::{DataResult, connect};
+
+#[derive(Identifiable, Queryable, Debug, Clone)]
+#[diesel(table_name = delayed_events)]
+pub struct DbDelayedEvent {
+    pub id: i64,
+    pub delay_id: String,
+    pub user_id: OwnedUserId,
+    pub device_id: Option<OwnedDeviceId>,
+    pub room_id: OwnedRoomId,
+    pub event_type: String,
+    pub state_key: Option<String>,
+    pub content: JsonValue,
+    pub delay_ms: i64,
+    pub txn_id: OwnedTransactionId,
+    pub origin_server_ts: Option<i64>,
+    pub running_since: i64,
+    pub send_at: i64,
+    pub event_id: Option<OwnedEventId>,
+    pub error: Option<JsonValue>,
+    pub finalized_at: Option<i64>,
+    pub created_at: i64,
+}
+
+#[derive(Insertable, Debug, Clone)]
+#[diesel(table_name = delayed_events)]
+pub struct NewDbDelayedEvent {
+    pub delay_id: String,
+    pub user_id: OwnedUserId,
+    pub device_id: Option<OwnedDeviceId>,
+    pub room_id: OwnedRoomId,
+    pub event_type: String,
+    pub state_key: Option<String>,
+    pub content: JsonValue,
+    pub delay_ms: i64,
+    pub txn_id: OwnedTransactionId,
+    pub origin_server_ts: Option<i64>,
+    pub running_since: i64,
+    pub send_at: i64,
+    pub created_at: i64,
+}
+
+/// Store a newly scheduled delayed event and return the stored row.
+pub async fn create(new: NewDbDelayedEvent) -> DataResult<DbDelayedEvent> {
+    diesel::insert_into(delayed_events::table)
+        .values(&new)
+        .get_result::<DbDelayedEvent>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// Look up a delayed event previously scheduled with the same transaction id
+/// on the same session, for idempotent retries of the scheduling request.
+pub async fn get_by_txn_id(
+    user_id: &UserId,
+    device_id: Option<&DeviceId>,
+    txn_id: &TransactionId,
+) -> DataResult<Option<DbDelayedEvent>> {
+    let mut query = delayed_events::table
+        .filter(delayed_events::user_id.eq(user_id))
+        .filter(delayed_events::txn_id.eq(txn_id))
+        .into_boxed();
+    if let Some(device_id) = device_id {
+        query = query.filter(delayed_events::device_id.eq(device_id));
+    } else {
+        query = query.filter(delayed_events::device_id.is_null());
+    }
+    query
+        .first::<DbDelayedEvent>(&mut connect().await?)
+        .await
+        .optional()
+        .map_err(Into::into)
+}
+
+/// Fetch one delayed event owned by the user, whether scheduled or finalized.
+pub async fn get_by_delay_id(
+    user_id: &UserId,
+    delay_id: &str,
+) -> DataResult<Option<DbDelayedEvent>> {
+    delayed_events::table
+        .filter(delayed_events::user_id.eq(user_id))
+        .filter(delayed_events::delay_id.eq(delay_id))
+        .first::<DbDelayedEvent>(&mut connect().await?)
+        .await
+        .optional()
+        .map_err(Into::into)
+}
+
+/// List the user's scheduled (not yet finalized) delayed events in
+/// chronological order of their intended send time.
+pub async fn list_scheduled(user_id: &UserId) -> DataResult<Vec<DbDelayedEvent>> {
+    delayed_events::table
+        .filter(delayed_events::user_id.eq(user_id))
+        .filter(delayed_events::finalized_at.is_null())
+        .order(delayed_events::send_at.asc())
+        .load::<DbDelayedEvent>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// Count the user's scheduled (not yet finalized) delayed events.
+pub async fn count_scheduled(user_id: &UserId) -> DataResult<i64> {
+    delayed_events::table
+        .filter(delayed_events::user_id.eq(user_id))
+        .filter(delayed_events::finalized_at.is_null())
+        .count()
+        .get_result::<i64>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// The soonest scheduled send time among the user's delayed events, used for
+/// the `Retry-After` header when the per-user limit is hit.
+pub async fn next_send_at_of_user(user_id: &UserId) -> DataResult<Option<i64>> {
+    delayed_events::table
+        .filter(delayed_events::user_id.eq(user_id))
+        .filter(delayed_events::finalized_at.is_null())
+        .select(diesel::dsl::min(delayed_events::send_at))
+        .get_result::<Option<i64>>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// The soonest scheduled send time across all users, used by the scheduler to
+/// compute how long to sleep.
+pub async fn next_send_at() -> DataResult<Option<i64>> {
+    delayed_events::table
+        .filter(delayed_events::finalized_at.is_null())
+        .select(diesel::dsl::min(delayed_events::send_at))
+        .get_result::<Option<i64>>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// List all delayed events that are due at `now`, in chronological order of
+/// their scheduled send times (restart-recovery sends overdue events in this
+/// order too).
+pub async fn list_due(now: i64) -> DataResult<Vec<DbDelayedEvent>> {
+    delayed_events::table
+        .filter(delayed_events::finalized_at.is_null())
+        .filter(delayed_events::send_at.le(now))
+        .order(delayed_events::send_at.asc())
+        .load::<DbDelayedEvent>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// Restart a scheduled delayed event's timer. Returns the updated row, or
+/// `None` if the event does not exist, is owned by another user, or was
+/// already finalized.
+pub async fn restart(
+    user_id: &UserId,
+    delay_id: &str,
+    now: i64,
+) -> DataResult<Option<DbDelayedEvent>> {
+    diesel::update(
+        delayed_events::table
+            .filter(delayed_events::user_id.eq(user_id))
+            .filter(delayed_events::delay_id.eq(delay_id))
+            .filter(delayed_events::finalized_at.is_null()),
+    )
+    .set((
+        delayed_events::running_since.eq(now),
+        delayed_events::send_at.eq(delayed_events::delay_ms + now),
+    ))
+    .get_result::<DbDelayedEvent>(&mut connect().await?)
+    .await
+    .optional()
+    .map_err(Into::into)
+}
+
+/// Atomically claim a scheduled delayed event for sending by finalizing it.
+/// Returns the claimed row, or `None` if it was already finalized (sent,
+/// cancelled, errored, or claimed by a concurrent worker).
+///
+/// After a successful claim the caller must record the outcome with
+/// [`set_sent`] or [`set_error`], or roll the claim back with [`unclaim`].
+pub async fn claim(row_id: i64, now: i64) -> DataResult<Option<DbDelayedEvent>> {
+    diesel::update(
+        delayed_events::table
+            .filter(delayed_events::id.eq(row_id))
+            .filter(delayed_events::finalized_at.is_null()),
+    )
+    .set(delayed_events::finalized_at.eq(now))
+    .get_result::<DbDelayedEvent>(&mut connect().await?)
+    .await
+    .optional()
+    .map_err(Into::into)
+}
+
+/// Record the event id of a claimed delayed event that was sent successfully.
+pub async fn set_sent(row_id: i64, event_id: &EventId) -> DataResult<()> {
+    diesel::update(delayed_events::table.filter(delayed_events::id.eq(row_id)))
+        .set(delayed_events::event_id.eq(event_id))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Record the error of a claimed delayed event that failed to send.
+pub async fn set_error(row_id: i64, error: &JsonValue) -> DataResult<()> {
+    diesel::update(delayed_events::table.filter(delayed_events::id.eq(row_id)))
+        .set(delayed_events::error.eq(error))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Roll back a claim so the delayed event stays scheduled (used when a manual
+/// `send` action fails; the MSC requires the event to remain scheduled then).
+pub async fn unclaim(row_id: i64) -> DataResult<()> {
+    diesel::update(delayed_events::table.filter(delayed_events::id.eq(row_id)))
+        .set(delayed_events::finalized_at.eq(None::<i64>))
+        .execute(&mut connect().await?)
+        .await?;
+    Ok(())
+}
+
+/// Cancel a scheduled delayed event. Returns `true` if the event was
+/// cancelled, `false` if it did not exist unfinalized (caller decides between
+/// idempotent success and conflict from the row's current state).
+pub async fn cancel(user_id: &UserId, delay_id: &str, now: i64) -> DataResult<bool> {
+    let count = diesel::update(
+        delayed_events::table
+            .filter(delayed_events::user_id.eq(user_id))
+            .filter(delayed_events::delay_id.eq(delay_id))
+            .filter(delayed_events::finalized_at.is_null()),
+    )
+    .set(delayed_events::finalized_at.eq(now))
+    .execute(&mut connect().await?)
+    .await?;
+    Ok(count > 0)
+}
+
+/// Delete finalized delayed events whose retention period has passed.
+pub async fn prune_finalized(finalized_before: i64) -> DataResult<usize> {
+    diesel::delete(
+        delayed_events::table
+            .filter(delayed_events::finalized_at.is_not_null())
+            .filter(delayed_events::finalized_at.le(finalized_before)),
+    )
+    .execute(&mut connect().await?)
+    .await
+    .map_err(Into::into)
+}

--- a/crates/data/src/room/delayed_event.rs
+++ b/crates/data/src/room/delayed_event.rs
@@ -1,0 +1,529 @@
+//! Persistence for MSC4140 delayed events.
+//!
+//! A delayed event is stored when scheduled and stays in the table after it is
+//! finalized (sent, cancelled, or errored) so clients can look up the outcome.
+//! A sender holds a PostgreSQL row lock from selection through the room append
+//! and outcome write. A worker crash rolls that transaction back, leaving the
+//! event scheduled for another worker without a time-based lease race.
+
+use diesel::prelude::*;
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+
+use crate::core::identifiers::*;
+use crate::core::serde::JsonValue;
+use crate::core::{DeviceId, TransactionId, UnixMillis, UserId};
+use crate::schema::*;
+use crate::{DataResult, connect};
+
+#[derive(Identifiable, Queryable, Debug, Clone)]
+#[diesel(table_name = delayed_events)]
+pub struct DbDelayedEvent {
+    pub id: i64,
+    pub delay_id: String,
+    pub user_id: OwnedUserId,
+    pub device_id: Option<OwnedDeviceId>,
+    pub room_id: OwnedRoomId,
+    pub event_type: String,
+    pub state_key: Option<String>,
+    pub content: JsonValue,
+    pub delay_ms: i64,
+    pub txn_id: OwnedTransactionId,
+    pub origin_server_ts: Option<i64>,
+    pub running_since: i64,
+    pub send_at: i64,
+    pub event_id: Option<OwnedEventId>,
+    pub error: Option<JsonValue>,
+    pub finalized_at: Option<i64>,
+    pub created_at: i64,
+}
+
+#[derive(Insertable, Debug, Clone)]
+#[diesel(table_name = delayed_events)]
+pub struct NewDbDelayedEvent {
+    pub delay_id: String,
+    pub user_id: OwnedUserId,
+    pub device_id: Option<OwnedDeviceId>,
+    pub room_id: OwnedRoomId,
+    pub event_type: String,
+    pub state_key: Option<String>,
+    pub content: JsonValue,
+    pub delay_ms: i64,
+    pub txn_id: OwnedTransactionId,
+    pub origin_server_ts: Option<i64>,
+    pub running_since: i64,
+    pub send_at: i64,
+    pub created_at: i64,
+}
+
+/// Outcome of trying to schedule a delayed event.
+pub enum Scheduled {
+    /// The event was stored.
+    Created(DbDelayedEvent),
+    /// A concurrent retry of the same transaction won the race; this is its
+    /// row.
+    AlreadyScheduled(DbDelayedEvent),
+    /// The user is already at `max_scheduled`.
+    LimitReached,
+}
+
+/// Store a newly scheduled delayed event, enforcing the per-user limit.
+///
+/// The count and the insert run under a transaction-scoped advisory lock keyed
+/// on the user. Checking the count in the caller and inserting here separately
+/// let concurrent requests with distinct transaction ids all observe a count
+/// below the limit and all succeed, so a limit of 100 could be pushed well
+/// past it; the unique transaction index does not serialize distinct
+/// transactions.
+///
+/// Two concurrent retries of the *same* transaction are a different race: both
+/// pass the caller's [`get_by_txn_id`] lookup before either commits. The
+/// transaction id is therefore re-resolved under the lock, so the loser is
+/// answered with the winner's row and scheduling stays idempotent.
+pub async fn create(new: NewDbDelayedEvent, max_scheduled: i64) -> DataResult<Scheduled> {
+    let user_id = new.user_id.clone();
+    let device_id = new.device_id.clone();
+    let txn_id = new.txn_id.clone();
+
+    let mut conn = connect().await?;
+    conn.transaction::<_, diesel::result::Error, _>(async |conn| {
+        // Serialize scheduling per user for the rest of this transaction;
+        // released automatically on commit or rollback.
+        diesel::sql_query("SELECT pg_advisory_xact_lock(hashtext($1))")
+            .bind::<diesel::sql_types::Text, _>(user_id.as_str())
+            .execute(&mut *conn)
+            .await?;
+
+        // Re-resolve the transaction now that this request holds the lock. The
+        // caller's lookup ran before it, so a concurrent retry of the same
+        // request may have committed in between. Doing this first means the
+        // insert can no longer hit the unique index -- which matters because a
+        // unique violation aborts the surrounding transaction in Postgres, and
+        // every statement after it would fail with 25P02 -- and it means an
+        // idempotent retry is answered with its delay id rather than being
+        // rejected by the limit check below when it took the last slot.
+        let mut existing = delayed_events::table
+            .filter(delayed_events::user_id.eq(&user_id))
+            .filter(delayed_events::txn_id.eq(&txn_id))
+            .into_boxed();
+        existing = match device_id.as_deref() {
+            Some(device_id) => existing.filter(delayed_events::device_id.eq(device_id)),
+            None => existing.filter(delayed_events::device_id.is_null()),
+        };
+        if let Some(row) = existing
+            .first::<DbDelayedEvent>(&mut *conn)
+            .await
+            .optional()?
+        {
+            return Ok(Scheduled::AlreadyScheduled(row));
+        }
+
+        let scheduled: i64 = delayed_events::table
+            .filter(delayed_events::user_id.eq(&user_id))
+            .filter(delayed_events::finalized_at.is_null())
+            .count()
+            .get_result(&mut *conn)
+            .await?;
+        if scheduled >= max_scheduled {
+            return Ok(Scheduled::LimitReached);
+        }
+
+        diesel::insert_into(delayed_events::table)
+            .values(&new)
+            .get_result::<DbDelayedEvent>(&mut *conn)
+            .await
+            .map(Scheduled::Created)
+    })
+    .await
+    .map_err(Into::into)
+}
+
+/// Look up a delayed event previously scheduled with the same transaction id
+/// on the same session, for idempotent retries of the scheduling request.
+pub async fn get_by_txn_id(
+    user_id: &UserId,
+    device_id: Option<&DeviceId>,
+    txn_id: &TransactionId,
+) -> DataResult<Option<DbDelayedEvent>> {
+    let mut query = delayed_events::table
+        .filter(delayed_events::user_id.eq(user_id))
+        .filter(delayed_events::txn_id.eq(txn_id))
+        .into_boxed();
+    if let Some(device_id) = device_id {
+        query = query.filter(delayed_events::device_id.eq(device_id));
+    } else {
+        query = query.filter(delayed_events::device_id.is_null());
+    }
+    query
+        .first::<DbDelayedEvent>(&mut connect().await?)
+        .await
+        .optional()
+        .map_err(Into::into)
+}
+
+/// Fetch one delayed event owned by the user, whether scheduled or finalized.
+pub async fn get_by_delay_id(
+    user_id: &UserId,
+    delay_id: &str,
+) -> DataResult<Option<DbDelayedEvent>> {
+    delayed_events::table
+        .filter(delayed_events::user_id.eq(user_id))
+        .filter(delayed_events::delay_id.eq(delay_id))
+        .first::<DbDelayedEvent>(&mut connect().await?)
+        .await
+        .optional()
+        .map_err(Into::into)
+}
+
+/// The soonest scheduled send time among the user's delayed events, used for
+/// the `Retry-After` header when the per-user limit is hit.
+pub async fn next_send_at_of_user(user_id: &UserId) -> DataResult<Option<i64>> {
+    delayed_events::table
+        .filter(delayed_events::user_id.eq(user_id))
+        .filter(delayed_events::finalized_at.is_null())
+        .select(diesel::dsl::min(delayed_events::send_at))
+        .get_result::<Option<i64>>(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+/// The soonest scheduled send time across all users, used by the scheduler to
+/// compute how long to sleep.
+pub async fn next_send_at() -> DataResult<Option<i64>> {
+    // An aggregate cannot use `SKIP LOCKED`, so select the first eligible row instead.
+    // Active senders hold their row lock until the append outcome is committed; omitting
+    // those rows prevents every other instance from repeatedly waking on a past `send_at`.
+    delayed_events::table
+        .filter(delayed_events::finalized_at.is_null())
+        .order((delayed_events::send_at.asc(), delayed_events::id.asc()))
+        .select(delayed_events::send_at)
+        .for_update()
+        .skip_locked()
+        .first::<i64>(&mut connect().await?)
+        .await
+        .optional()
+        .map_err(Into::into)
+}
+
+/// Lock the next due event without waiting for another worker's row.
+///
+/// The caller owns the surrounding transaction and must keep it open through
+/// the append and outcome write. `SKIP LOCKED` lets multiple server processes
+/// work on different rows while guaranteeing that only one can append a given
+/// delayed event.
+pub async fn lock_next_due(
+    conn: &mut AsyncPgConnection,
+    now: i64,
+) -> DataResult<Option<DbDelayedEvent>> {
+    delayed_events::table
+        .filter(delayed_events::finalized_at.is_null())
+        .filter(delayed_events::send_at.le(now))
+        .order((delayed_events::send_at.asc(), delayed_events::id.asc()))
+        .for_update()
+        .skip_locked()
+        .first::<DbDelayedEvent>(conn)
+        .await
+        .optional()
+        .map_err(Into::into)
+}
+
+/// Lock one user's delayed event for a manual send.
+///
+/// Unlike the scheduler this deliberately waits for an existing row holder:
+/// once the lock is acquired the caller can return the definitive sent/error
+/// result rather than guessing from an expiring lease.
+pub async fn lock_for_send(
+    conn: &mut AsyncPgConnection,
+    user_id: &UserId,
+    delay_id: &str,
+) -> DataResult<Option<DbDelayedEvent>> {
+    delayed_events::table
+        .filter(delayed_events::user_id.eq(user_id))
+        .filter(delayed_events::delay_id.eq(delay_id))
+        .for_update()
+        .first::<DbDelayedEvent>(conn)
+        .await
+        .optional()
+        .map_err(Into::into)
+}
+
+#[derive(QueryableByName)]
+struct DelayedEventOutput {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    event_id: String,
+}
+
+/// Find the event atomically recorded when an outlier enters the timeline.
+///
+/// This is the durable recovery fence for a process that dies after appending
+/// the room event but before finalizing the delayed-event row or recording its
+/// regular transaction-id mapping.
+async fn get_output_with_conn(
+    conn: &mut AsyncPgConnection,
+    delay_id: &str,
+) -> DataResult<Option<OwnedEventId>> {
+    let row = diesel::sql_query(
+        "SELECT output.event_id \
+         FROM delayed_event_outputs AS output \
+         INNER JOIN events ON events.id = output.event_id \
+         WHERE output.delay_id = $1 AND events.is_outlier = FALSE",
+    )
+    .bind::<diesel::sql_types::Text, _>(delay_id)
+    .get_result::<DelayedEventOutput>(conn)
+    .await
+    .optional()?;
+
+    row.map(|row| OwnedEventId::try_from(row.event_id).map_err(Into::into))
+        .transpose()
+}
+
+/// Find a delayed event's durable timeline output using a pooled connection.
+pub async fn get_output(delay_id: &str) -> DataResult<Option<OwnedEventId>> {
+    let mut conn = connect().await?;
+    get_output_with_conn(&mut conn, delay_id).await
+}
+
+async fn delete_output_with_conn(conn: &mut AsyncPgConnection, delay_id: &str) -> DataResult<()> {
+    diesel::sql_query("DELETE FROM delayed_event_outputs WHERE delay_id = $1")
+        .bind::<diesel::sql_types::Text, _>(delay_id)
+        .execute(conn)
+        .await?;
+    Ok(())
+}
+
+/// Restart a scheduled delayed event's timer. Returns the updated row, or
+/// `None` if the event does not exist, is owned by another user, or was
+/// already finalized.
+pub async fn restart(
+    conn: &mut AsyncPgConnection,
+    user_id: &UserId,
+    delay_id: &str,
+) -> DataResult<Option<DbDelayedEvent>> {
+    conn.transaction::<_, crate::DataError, _>(async |conn| {
+        // Take the row lock before reading the clock. If another process is
+        // sending this event, the restarted delay must begin after that wait,
+        // not when the HTTP request first arrived.
+        let Some(row) = delayed_events::table
+            .filter(delayed_events::user_id.eq(user_id))
+            .filter(delayed_events::delay_id.eq(delay_id))
+            .for_update()
+            .first::<DbDelayedEvent>(&mut *conn)
+            .await
+            .optional()?
+        else {
+            return Ok(None);
+        };
+        if row.finalized_at.is_some() {
+            return Ok(None);
+        }
+
+        // The timeline append commits independently of this row transaction.
+        // A crashed sender may therefore have persisted its output while this
+        // row still looks scheduled. Recover that outcome before changing the
+        // timer so restart cannot resurrect an event already in the room.
+        if let Some(event_id) = get_output_with_conn(&mut *conn, &row.delay_id).await? {
+            set_sent_locked(
+                &mut *conn,
+                row.id,
+                &event_id,
+                UnixMillis::now().get() as i64,
+            )
+            .await?;
+            return Ok(None);
+        }
+
+        let now = UnixMillis::now().get() as i64;
+        let send_at = now.saturating_add(row.delay_ms);
+        let restarted = diesel::update(delayed_events::table.find(row.id))
+            .filter(delayed_events::finalized_at.is_null())
+            .set((
+                delayed_events::running_since.eq(now),
+                delayed_events::send_at.eq(send_at),
+            ))
+            .get_result::<DbDelayedEvent>(&mut *conn)
+            .await
+            .optional()?;
+        Ok(restarted)
+    })
+    .await
+}
+
+/// Record the successful outcome while the caller still holds the row lock.
+pub async fn set_sent_locked(
+    conn: &mut AsyncPgConnection,
+    row_id: i64,
+    event_id: &EventId,
+    now: i64,
+) -> DataResult<()> {
+    // The caller holds the delayed row lock and commits this marker with the outcome.
+    let room_id = delayed_events::table
+        .find(row_id)
+        .select(delayed_events::room_id)
+        .first::<OwnedRoomId>(&mut *conn)
+        .await?;
+    diesel::insert_into(delayed_event_deliveries::table)
+        .values((
+            delayed_event_deliveries::event_id.eq(event_id),
+            delayed_event_deliveries::room_id.eq(room_id),
+        ))
+        .on_conflict_do_nothing()
+        .execute(&mut *conn)
+        .await?;
+    diesel::update(delayed_events::table.find(row_id))
+        .set((
+            delayed_events::event_id.eq(event_id),
+            delayed_events::finalized_at.eq(now),
+        ))
+        .execute(conn)
+        .await?;
+    Ok(())
+}
+
+/// Record a scheduled-send failure while the caller still holds the row lock.
+pub async fn set_error_locked(
+    conn: &mut AsyncPgConnection,
+    row_id: i64,
+    delay_id: &str,
+    error: &JsonValue,
+    now: i64,
+) -> DataResult<()> {
+    // A pre-promotion failure can leave an outlier candidate behind. Once this
+    // delayed event is finalized as failed, that candidate must no longer
+    // reserve its event ID against a later delayed event with the same signed
+    // fields.
+    delete_output_with_conn(&mut *conn, delay_id).await?;
+    diesel::update(delayed_events::table.find(row_id))
+        .set((
+            delayed_events::error.eq(error),
+            delayed_events::finalized_at.eq(now),
+        ))
+        .execute(conn)
+        .await?;
+    Ok(())
+}
+
+/// Cancel a scheduled delayed event. Returns `true` if the event was
+/// cancelled, `false` if it did not exist unfinalized (caller decides between
+/// idempotent success and conflict from the row's current state).
+pub async fn cancel(
+    conn: &mut AsyncPgConnection,
+    user_id: &UserId,
+    delay_id: &str,
+) -> DataResult<bool> {
+    conn.transaction::<_, crate::DataError, _>(async |conn| {
+        // As with restart, wait for an in-flight sender before timestamping the
+        // outcome so `finalized_at` reflects when cancellation actually won.
+        let Some(row) = delayed_events::table
+            .filter(delayed_events::user_id.eq(user_id))
+            .filter(delayed_events::delay_id.eq(delay_id))
+            .for_update()
+            .first::<DbDelayedEvent>(&mut *conn)
+            .await
+            .optional()?
+        else {
+            return Ok(false);
+        };
+        if row.finalized_at.is_some() {
+            return Ok(false);
+        }
+
+        // Treat an independently committed timeline append as authoritative.
+        // Otherwise a cancel arriving during crash recovery could report
+        // success even though the event is already visible in the room.
+        if let Some(event_id) = get_output_with_conn(&mut *conn, &row.delay_id).await? {
+            set_sent_locked(
+                &mut *conn,
+                row.id,
+                &event_id,
+                UnixMillis::now().get() as i64,
+            )
+            .await?;
+            return Ok(false);
+        }
+
+        let now = UnixMillis::now().get() as i64;
+        delete_output_with_conn(&mut *conn, &row.delay_id).await?;
+        let count = diesel::update(delayed_events::table.find(row.id))
+            .filter(delayed_events::finalized_at.is_null())
+            .set(delayed_events::finalized_at.eq(now))
+            .execute(&mut *conn)
+            .await?;
+        Ok(count > 0)
+    })
+    .await
+}
+
+/// Delete finalized delayed events whose retention period has passed.
+pub async fn prune_finalized(finalized_before: i64) -> DataResult<usize> {
+    let mut conn = connect().await?;
+    conn.transaction::<_, diesel::result::Error, _>(async |conn| {
+        // The normal send endpoint also records the transaction in
+        // `event_idempotents`. Remove that mapping with the delayed row, but
+        // only when it points at this delayed event's actual output. Leaving a
+        // stale mapping would let a later retry schedule a new delayed event
+        // while ordinary transaction lookup still points at the old output.
+        diesel::sql_query(
+            "DELETE FROM event_idempotents AS idempotent \
+             USING delayed_events AS delayed \
+             WHERE delayed.finalized_at IS NOT NULL \
+               AND delayed.finalized_at <= $1 \
+               AND delayed.event_id IS NOT NULL \
+               AND NOT EXISTS (SELECT 1 FROM delayed_event_deliveries AS pending WHERE pending.event_id = delayed.event_id) \
+               AND idempotent.event_id = delayed.event_id \
+               AND idempotent.user_id = delayed.user_id \
+               AND idempotent.device_id IS NOT DISTINCT FROM delayed.device_id \
+               AND idempotent.room_id = delayed.room_id \
+               AND idempotent.txn_id = delayed.txn_id",
+        )
+        .bind::<diesel::sql_types::BigInt, _>(finalized_before)
+        .execute(&mut *conn)
+        .await?;
+
+        diesel::delete(
+            delayed_events::table
+                .filter(delayed_events::finalized_at.is_not_null())
+                .filter(delayed_events::finalized_at.le(finalized_before))
+                .filter(diesel::dsl::sql::<diesel::sql_types::Bool>(
+                    "NOT EXISTS (SELECT 1 FROM delayed_event_deliveries AS pending WHERE pending.event_id = delayed_events.event_id)")),
+        )
+        .execute(&mut *conn)
+        .await
+    })
+    .await
+    .map_err(Into::into)
+}
+
+/// A bounded sweep ensures one failing destination cannot starve later events.
+pub async fn pending_deliveries(
+    after: Option<&EventId>,
+) -> DataResult<Vec<(OwnedEventId, OwnedRoomId)>> {
+    let mut query = delayed_event_deliveries::table.into_boxed();
+    if let Some(after) = after {
+        query = query.filter(delayed_event_deliveries::event_id.gt(after));
+    }
+    query
+        .order(delayed_event_deliveries::event_id)
+        .limit(100)
+        .load(&mut connect().await?)
+        .await
+        .map_err(Into::into)
+}
+
+pub async fn lock_delivery(conn: &mut AsyncPgConnection, event_id: &EventId) -> DataResult<bool> {
+    delayed_event_deliveries::table
+        .find(event_id)
+        .select(delayed_event_deliveries::event_id)
+        .for_update()
+        .skip_locked()
+        .first::<OwnedEventId>(conn)
+        .await
+        .optional()
+        .map(|v| v.is_some())
+        .map_err(Into::into)
+}
+
+pub async fn finish_delivery(conn: &mut AsyncPgConnection, event_id: &EventId) -> DataResult<()> {
+    diesel::delete(delayed_event_deliveries::table.find(event_id))
+        .execute(conn)
+        .await?;
+    Ok(())
+}

--- a/crates/data/src/room/delayed_event.rs
+++ b/crates/data/src/room/delayed_event.rs
@@ -95,6 +95,30 @@ pub async fn create(new: NewDbDelayedEvent, max_scheduled: i64) -> DataResult<Sc
             .execute(&mut *conn)
             .await?;
 
+        // Re-resolve the transaction now that this request holds the lock. The
+        // caller's lookup ran before it, so a concurrent retry of the same
+        // request may have committed in between. Doing this first means the
+        // insert can no longer hit the unique index -- which matters because a
+        // unique violation aborts the surrounding transaction in Postgres, and
+        // every statement after it would fail with 25P02 -- and it means an
+        // idempotent retry is answered with its delay id rather than being
+        // rejected by the limit check below when it took the last slot.
+        let mut existing = delayed_events::table
+            .filter(delayed_events::user_id.eq(&user_id))
+            .filter(delayed_events::txn_id.eq(&txn_id))
+            .into_boxed();
+        existing = match device_id.as_deref() {
+            Some(device_id) => existing.filter(delayed_events::device_id.eq(device_id)),
+            None => existing.filter(delayed_events::device_id.is_null()),
+        };
+        if let Some(row) = existing
+            .first::<DbDelayedEvent>(&mut *conn)
+            .await
+            .optional()?
+        {
+            return Ok(Scheduled::AlreadyScheduled(row));
+        }
+
         let scheduled: i64 = delayed_events::table
             .filter(delayed_events::user_id.eq(&user_id))
             .filter(delayed_events::finalized_at.is_null())
@@ -105,31 +129,11 @@ pub async fn create(new: NewDbDelayedEvent, max_scheduled: i64) -> DataResult<Sc
             return Ok(Scheduled::LimitReached);
         }
 
-        match diesel::insert_into(delayed_events::table)
+        diesel::insert_into(delayed_events::table)
             .values(&new)
             .get_result::<DbDelayedEvent>(&mut *conn)
             .await
-        {
-            Ok(row) => Ok(Scheduled::Created(row)),
-            Err(diesel::result::Error::DatabaseError(
-                diesel::result::DatabaseErrorKind::UniqueViolation,
-                _,
-            )) => {
-                let mut query = delayed_events::table
-                    .filter(delayed_events::user_id.eq(&user_id))
-                    .filter(delayed_events::txn_id.eq(&txn_id))
-                    .into_boxed();
-                query = match device_id.as_deref() {
-                    Some(device_id) => query.filter(delayed_events::device_id.eq(device_id)),
-                    None => query.filter(delayed_events::device_id.is_null()),
-                };
-                query
-                    .first::<DbDelayedEvent>(&mut *conn)
-                    .await
-                    .map(Scheduled::AlreadyScheduled)
-            }
-            Err(e) => Err(e),
-        }
+            .map(Scheduled::Created)
     })
     .await
     .map_err(Into::into)
@@ -354,37 +358,55 @@ pub async fn claim_due(row_id: i64, now: i64) -> DataResult<Option<DbDelayedEven
 }
 
 /// Record the event id of a claimed delayed event that was sent successfully.
-pub async fn set_sent(row_id: i64, event_id: &EventId, now: i64) -> DataResult<()> {
-    diesel::update(delayed_events::table.filter(delayed_events::id.eq(row_id)))
-        .set((
-            delayed_events::event_id.eq(event_id),
-            delayed_events::finalized_at.eq(now),
-        ))
-        .execute(&mut connect().await?)
-        .await?;
+///
+/// Fenced on `lease`, the `claimed_at` value this worker set: a worker whose
+/// lease was reclaimed while it was still running must not overwrite the
+/// outcome the worker that superseded it recorded.
+pub async fn set_sent(row_id: i64, lease: i64, event_id: &EventId, now: i64) -> DataResult<()> {
+    diesel::update(
+        delayed_events::table
+            .filter(delayed_events::id.eq(row_id))
+            .filter(delayed_events::claimed_at.eq(lease)),
+    )
+    .set((
+        delayed_events::event_id.eq(event_id),
+        delayed_events::finalized_at.eq(now),
+    ))
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }
 
-/// Record the error of a claimed delayed event that failed to send.
-pub async fn set_error(row_id: i64, error: &JsonValue, now: i64) -> DataResult<()> {
-    diesel::update(delayed_events::table.filter(delayed_events::id.eq(row_id)))
-        .set((
-            delayed_events::error.eq(error),
-            delayed_events::finalized_at.eq(now),
-        ))
-        .execute(&mut connect().await?)
-        .await?;
+/// Record the error of a claimed delayed event that failed to send. Fenced on
+/// the lease, as [`set_sent`] is.
+pub async fn set_error(row_id: i64, lease: i64, error: &JsonValue, now: i64) -> DataResult<()> {
+    diesel::update(
+        delayed_events::table
+            .filter(delayed_events::id.eq(row_id))
+            .filter(delayed_events::claimed_at.eq(lease)),
+    )
+    .set((
+        delayed_events::error.eq(error),
+        delayed_events::finalized_at.eq(now),
+    ))
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }
 
 /// Release a lease so the delayed event stays scheduled (used when a manual
 /// `send` action fails before the event could reach the timeline; the MSC
-/// requires the event to remain scheduled then).
-pub async fn unclaim(row_id: i64) -> DataResult<()> {
-    diesel::update(delayed_events::table.filter(delayed_events::id.eq(row_id)))
-        .set(delayed_events::claimed_at.eq(None::<i64>))
-        .execute(&mut connect().await?)
-        .await?;
+/// requires the event to remain scheduled then). Fenced on the lease so a
+/// superseded worker cannot release the lease its successor now holds.
+pub async fn unclaim(row_id: i64, lease: i64) -> DataResult<()> {
+    diesel::update(
+        delayed_events::table
+            .filter(delayed_events::id.eq(row_id))
+            .filter(delayed_events::claimed_at.eq(lease)),
+    )
+    .set(delayed_events::claimed_at.eq(None::<i64>))
+    .execute(&mut connect().await?)
+    .await?;
     Ok(())
 }
 

--- a/crates/data/src/room/delayed_event.rs
+++ b/crates/data/src/room/delayed_event.rs
@@ -33,6 +33,7 @@ pub struct DbDelayedEvent {
     pub send_at: i64,
     pub event_id: Option<OwnedEventId>,
     pub error: Option<JsonValue>,
+    pub claimed_at: Option<i64>,
     pub finalized_at: Option<i64>,
     pub created_at: i64,
 }
@@ -56,12 +57,32 @@ pub struct NewDbDelayedEvent {
 }
 
 /// Store a newly scheduled delayed event and return the stored row.
+///
+/// Two concurrent retries of the same request both pass the caller's
+/// [`get_by_txn_id`] lookup and race to insert. The unique transaction index
+/// lets exactly one win; the loser resolves to the winner's row instead of
+/// surfacing a database error, so scheduling stays idempotent under
+/// concurrency rather than returning a 500.
 pub async fn create(new: NewDbDelayedEvent) -> DataResult<DbDelayedEvent> {
-    diesel::insert_into(delayed_events::table)
+    let user_id = new.user_id.clone();
+    let device_id = new.device_id.clone();
+    let txn_id = new.txn_id.clone();
+
+    match diesel::insert_into(delayed_events::table)
         .values(&new)
         .get_result::<DbDelayedEvent>(&mut connect().await?)
         .await
-        .map_err(Into::into)
+    {
+        Ok(row) => Ok(row),
+        Err(diesel::result::Error::DatabaseError(
+            diesel::result::DatabaseErrorKind::UniqueViolation,
+            _,
+        )) => get_by_txn_id(&user_id, device_id.as_deref(), &txn_id)
+            .await?
+            .ok_or(diesel::result::Error::NotFound)
+            .map_err(Into::into),
+        Err(e) => Err(e.into()),
+    }
 }
 
 /// Look up a delayed event previously scheduled with the same transaction id
@@ -150,10 +171,18 @@ pub async fn next_send_at() -> DataResult<Option<i64>> {
 /// List all delayed events that are due at `now`, in chronological order of
 /// their scheduled send times (restart-recovery sends overdue events in this
 /// order too).
+/// Rows leased by a worker that has not reported an outcome within
+/// [`CLAIM_LEASE_MS`] are included again, so a send interrupted by a crash is
+/// retried after the server comes back up.
 pub async fn list_due(now: i64) -> DataResult<Vec<DbDelayedEvent>> {
     delayed_events::table
         .filter(delayed_events::finalized_at.is_null())
         .filter(delayed_events::send_at.le(now))
+        .filter(
+            delayed_events::claimed_at
+                .is_null()
+                .or(delayed_events::claimed_at.lt(now - CLAIM_LEASE_MS)),
+        )
         .order(delayed_events::send_at.asc())
         .load::<DbDelayedEvent>(&mut connect().await?)
         .await
@@ -172,7 +201,15 @@ pub async fn restart(
         delayed_events::table
             .filter(delayed_events::user_id.eq(user_id))
             .filter(delayed_events::delay_id.eq(delay_id))
-            .filter(delayed_events::finalized_at.is_null()),
+            .filter(delayed_events::finalized_at.is_null())
+            // A worker already sending this event cannot be called back, so
+            // the restart must fail rather than report a new send time the
+            // event will not honour.
+            .filter(
+                delayed_events::claimed_at
+                    .is_null()
+                    .or(delayed_events::claimed_at.lt(now - CLAIM_LEASE_MS)),
+            ),
     )
     .set((
         delayed_events::running_since.eq(now),
@@ -184,19 +221,61 @@ pub async fn restart(
     .map_err(Into::into)
 }
 
-/// Atomically claim a scheduled delayed event for sending by finalizing it.
-/// Returns the claimed row, or `None` if it was already finalized (sent,
-/// cancelled, errored, or claimed by a concurrent worker).
+/// How long a send lease is honoured before another worker may reclaim the
+/// row. Only reached when the process died mid-send, so it just has to be
+/// comfortably longer than a send takes.
+pub const CLAIM_LEASE_MS: i64 = 5 * 60 * 1000;
+
+/// Atomically lease a delayed event for sending.
 ///
-/// After a successful claim the caller must record the outcome with
-/// [`set_sent`] or [`set_error`], or roll the claim back with [`unclaim`].
+/// Returns the claimed row, or `None` if it was finalized (sent, cancelled or
+/// errored) or is already leased by a live worker.
+///
+/// The lease is recorded in `claimed_at`, leaving `finalized_at` null, so a
+/// row whose worker died is still scheduled rather than looking finalized with
+/// no outcome. After a successful claim the caller records the outcome with
+/// [`set_sent`] or [`set_error`], or releases the lease with [`unclaim`].
+///
+/// This is the manual `send` action's claim, which deliberately ignores
+/// `send_at` — sending ahead of the scheduled time is the point. The scheduler
+/// uses [`claim_due`] instead.
 pub async fn claim(row_id: i64, now: i64) -> DataResult<Option<DbDelayedEvent>> {
     diesel::update(
         delayed_events::table
             .filter(delayed_events::id.eq(row_id))
-            .filter(delayed_events::finalized_at.is_null()),
+            .filter(delayed_events::finalized_at.is_null())
+            .filter(
+                delayed_events::claimed_at
+                    .is_null()
+                    .or(delayed_events::claimed_at.lt(now - CLAIM_LEASE_MS)),
+            ),
     )
-    .set(delayed_events::finalized_at.eq(now))
+    .set(delayed_events::claimed_at.eq(now))
+    .get_result::<DbDelayedEvent>(&mut connect().await?)
+    .await
+    .optional()
+    .map_err(Into::into)
+}
+
+/// [`claim`] for the scheduler, additionally requiring the event to still be
+/// due at `now`.
+///
+/// That predicate is what lets a `restart` arriving after `list_due` win the
+/// race: it pushes `send_at` into the future, so the scheduler's now-stale
+/// entry no longer claims and the event is not sent early.
+pub async fn claim_due(row_id: i64, now: i64) -> DataResult<Option<DbDelayedEvent>> {
+    diesel::update(
+        delayed_events::table
+            .filter(delayed_events::id.eq(row_id))
+            .filter(delayed_events::finalized_at.is_null())
+            .filter(delayed_events::send_at.le(now))
+            .filter(
+                delayed_events::claimed_at
+                    .is_null()
+                    .or(delayed_events::claimed_at.lt(now - CLAIM_LEASE_MS)),
+            ),
+    )
+    .set(delayed_events::claimed_at.eq(now))
     .get_result::<DbDelayedEvent>(&mut connect().await?)
     .await
     .optional()
@@ -204,28 +283,35 @@ pub async fn claim(row_id: i64, now: i64) -> DataResult<Option<DbDelayedEvent>> 
 }
 
 /// Record the event id of a claimed delayed event that was sent successfully.
-pub async fn set_sent(row_id: i64, event_id: &EventId) -> DataResult<()> {
+pub async fn set_sent(row_id: i64, event_id: &EventId, now: i64) -> DataResult<()> {
     diesel::update(delayed_events::table.filter(delayed_events::id.eq(row_id)))
-        .set(delayed_events::event_id.eq(event_id))
+        .set((
+            delayed_events::event_id.eq(event_id),
+            delayed_events::finalized_at.eq(now),
+        ))
         .execute(&mut connect().await?)
         .await?;
     Ok(())
 }
 
 /// Record the error of a claimed delayed event that failed to send.
-pub async fn set_error(row_id: i64, error: &JsonValue) -> DataResult<()> {
+pub async fn set_error(row_id: i64, error: &JsonValue, now: i64) -> DataResult<()> {
     diesel::update(delayed_events::table.filter(delayed_events::id.eq(row_id)))
-        .set(delayed_events::error.eq(error))
+        .set((
+            delayed_events::error.eq(error),
+            delayed_events::finalized_at.eq(now),
+        ))
         .execute(&mut connect().await?)
         .await?;
     Ok(())
 }
 
-/// Roll back a claim so the delayed event stays scheduled (used when a manual
-/// `send` action fails; the MSC requires the event to remain scheduled then).
+/// Release a lease so the delayed event stays scheduled (used when a manual
+/// `send` action fails before the event could reach the timeline; the MSC
+/// requires the event to remain scheduled then).
 pub async fn unclaim(row_id: i64) -> DataResult<()> {
     diesel::update(delayed_events::table.filter(delayed_events::id.eq(row_id)))
-        .set(delayed_events::finalized_at.eq(None::<i64>))
+        .set(delayed_events::claimed_at.eq(None::<i64>))
         .execute(&mut connect().await?)
         .await?;
     Ok(())
@@ -239,7 +325,15 @@ pub async fn cancel(user_id: &UserId, delay_id: &str, now: i64) -> DataResult<bo
         delayed_events::table
             .filter(delayed_events::user_id.eq(user_id))
             .filter(delayed_events::delay_id.eq(delay_id))
-            .filter(delayed_events::finalized_at.is_null()),
+            .filter(delayed_events::finalized_at.is_null())
+            // A row a worker is actively sending must not be cancelled out from
+            // under it, or the caller is told the event was cancelled while it
+            // is on its way into the room.
+            .filter(
+                delayed_events::claimed_at
+                    .is_null()
+                    .or(delayed_events::claimed_at.lt(now - CLAIM_LEASE_MS)),
+            ),
     )
     .set(delayed_events::finalized_at.eq(now))
     .execute(&mut connect().await?)

--- a/crates/data/src/room/delayed_event.rs
+++ b/crates/data/src/room/delayed_event.rs
@@ -7,7 +7,7 @@
 //! management requests.
 
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncConnection, RunQueryDsl};
 
 use crate::core::identifiers::*;
 use crate::core::serde::JsonValue;
@@ -56,33 +56,83 @@ pub struct NewDbDelayedEvent {
     pub created_at: i64,
 }
 
-/// Store a newly scheduled delayed event and return the stored row.
+/// Outcome of trying to schedule a delayed event.
+pub enum Scheduled {
+    /// The event was stored.
+    Created(DbDelayedEvent),
+    /// A concurrent retry of the same transaction won the race; this is its
+    /// row.
+    AlreadyScheduled(DbDelayedEvent),
+    /// The user is already at `max_scheduled`.
+    LimitReached,
+}
+
+/// Store a newly scheduled delayed event, enforcing the per-user limit.
 ///
-/// Two concurrent retries of the same request both pass the caller's
-/// [`get_by_txn_id`] lookup and race to insert. The unique transaction index
-/// lets exactly one win; the loser resolves to the winner's row instead of
-/// surfacing a database error, so scheduling stays idempotent under
-/// concurrency rather than returning a 500.
-pub async fn create(new: NewDbDelayedEvent) -> DataResult<DbDelayedEvent> {
+/// The count and the insert run under a transaction-scoped advisory lock keyed
+/// on the user. Checking the count in the caller and inserting here separately
+/// let concurrent requests with distinct transaction ids all observe a count
+/// below the limit and all succeed, so a limit of 100 could be pushed well
+/// past it; the unique transaction index does not serialize distinct
+/// transactions.
+///
+/// Two concurrent retries of the *same* transaction are a different race: both
+/// pass the caller's [`get_by_txn_id`] lookup, and the unique index lets
+/// exactly one insert win. The loser resolves to the winner's row instead of
+/// surfacing a database error, so scheduling stays idempotent rather than
+/// returning a 500.
+pub async fn create(new: NewDbDelayedEvent, max_scheduled: i64) -> DataResult<Scheduled> {
     let user_id = new.user_id.clone();
     let device_id = new.device_id.clone();
     let txn_id = new.txn_id.clone();
 
-    match diesel::insert_into(delayed_events::table)
-        .values(&new)
-        .get_result::<DbDelayedEvent>(&mut connect().await?)
-        .await
-    {
-        Ok(row) => Ok(row),
-        Err(diesel::result::Error::DatabaseError(
-            diesel::result::DatabaseErrorKind::UniqueViolation,
-            _,
-        )) => get_by_txn_id(&user_id, device_id.as_deref(), &txn_id)
-            .await?
-            .ok_or(diesel::result::Error::NotFound)
-            .map_err(Into::into),
-        Err(e) => Err(e.into()),
-    }
+    let mut conn = connect().await?;
+    conn.transaction::<_, diesel::result::Error, _>(async |conn| {
+        // Serialize scheduling per user for the rest of this transaction;
+        // released automatically on commit or rollback.
+        diesel::sql_query("SELECT pg_advisory_xact_lock(hashtext($1))")
+            .bind::<diesel::sql_types::Text, _>(user_id.as_str())
+            .execute(&mut *conn)
+            .await?;
+
+        let scheduled: i64 = delayed_events::table
+            .filter(delayed_events::user_id.eq(&user_id))
+            .filter(delayed_events::finalized_at.is_null())
+            .count()
+            .get_result(&mut *conn)
+            .await?;
+        if scheduled >= max_scheduled {
+            return Ok(Scheduled::LimitReached);
+        }
+
+        match diesel::insert_into(delayed_events::table)
+            .values(&new)
+            .get_result::<DbDelayedEvent>(&mut *conn)
+            .await
+        {
+            Ok(row) => Ok(Scheduled::Created(row)),
+            Err(diesel::result::Error::DatabaseError(
+                diesel::result::DatabaseErrorKind::UniqueViolation,
+                _,
+            )) => {
+                let mut query = delayed_events::table
+                    .filter(delayed_events::user_id.eq(&user_id))
+                    .filter(delayed_events::txn_id.eq(&txn_id))
+                    .into_boxed();
+                query = match device_id.as_deref() {
+                    Some(device_id) => query.filter(delayed_events::device_id.eq(device_id)),
+                    None => query.filter(delayed_events::device_id.is_null()),
+                };
+                query
+                    .first::<DbDelayedEvent>(&mut *conn)
+                    .await
+                    .map(Scheduled::AlreadyScheduled)
+            }
+            Err(e) => Err(e),
+        }
+    })
+    .await
+    .map_err(Into::into)
 }
 
 /// Look up a delayed event previously scheduled with the same transaction id
@@ -159,12 +209,33 @@ pub async fn next_send_at_of_user(user_id: &UserId) -> DataResult<Option<i64>> {
 
 /// The soonest scheduled send time across all users, used by the scheduler to
 /// compute how long to sleep.
-pub async fn next_send_at() -> DataResult<Option<i64>> {
+/// Rows under a live lease are skipped, since the scheduler cannot act on them
+/// until the lease expires. Including their already-past `send_at` would make
+/// it compute a zero sleep and spin on the database for the whole lease.
+pub async fn next_send_at(now: i64) -> DataResult<Option<i64>> {
     delayed_events::table
         .filter(delayed_events::finalized_at.is_null())
+        .filter(
+            delayed_events::claimed_at
+                .is_null()
+                .or(delayed_events::claimed_at.lt(now - CLAIM_LEASE_MS)),
+        )
         .select(diesel::dsl::min(delayed_events::send_at))
         .get_result::<Option<i64>>(&mut connect().await?)
         .await
+        .map_err(Into::into)
+}
+
+/// When the earliest live lease expires, so the scheduler can wake up to
+/// reclaim it rather than sleeping through it.
+pub async fn next_lease_expiry(now: i64) -> DataResult<Option<i64>> {
+    delayed_events::table
+        .filter(delayed_events::finalized_at.is_null())
+        .filter(delayed_events::claimed_at.ge(now - CLAIM_LEASE_MS))
+        .select(diesel::dsl::min(delayed_events::claimed_at))
+        .get_result::<Option<i64>>(&mut connect().await?)
+        .await
+        .map(|claimed| claimed.map(|c| c + CLAIM_LEASE_MS))
         .map_err(Into::into)
 }
 

--- a/crates/data/src/room/delayed_event.rs
+++ b/crates/data/src/room/delayed_event.rs
@@ -2,9 +2,9 @@
 //!
 //! A delayed event is stored when scheduled and stays in the table after it is
 //! finalized (sent, cancelled, or errored) so clients can look up the outcome.
-//! The scheduler claims due rows by setting `finalized_at` first, then records
-//! the send outcome; this keeps the claim atomic under concurrent workers and
-//! management requests.
+//! The scheduler leases a due row in `claimed_at` and only sets `finalized_at`
+//! once it knows the outcome, so a worker that dies mid-send leaves a row that
+//! is still scheduled and can be reclaimed after [`CLAIM_LEASE_MS`].
 
 use diesel::prelude::*;
 use diesel_async::{AsyncConnection, RunQueryDsl};
@@ -77,10 +77,9 @@ pub enum Scheduled {
 /// transactions.
 ///
 /// Two concurrent retries of the *same* transaction are a different race: both
-/// pass the caller's [`get_by_txn_id`] lookup, and the unique index lets
-/// exactly one insert win. The loser resolves to the winner's row instead of
-/// surfacing a database error, so scheduling stays idempotent rather than
-/// returning a 500.
+/// pass the caller's [`get_by_txn_id`] lookup before either commits. The
+/// transaction id is therefore re-resolved under the lock, so the loser is
+/// answered with the winner's row and scheduling stays idempotent.
 pub async fn create(new: NewDbDelayedEvent, max_scheduled: i64) -> DataResult<Scheduled> {
     let user_id = new.user_id.clone();
     let device_id = new.device_id.clone();
@@ -289,6 +288,9 @@ pub async fn restart(
     .set((
         delayed_events::running_since.eq(now),
         delayed_events::send_at.eq(delayed_events::delay_ms + now),
+        // Invalidate any expired lease, so a worker that outlived it cannot
+        // still record an outcome against the row this restart just rescheduled.
+        delayed_events::claimed_at.eq(None::<i64>),
     ))
     .get_result::<DbDelayedEvent>(&mut connect().await?)
     .await
@@ -428,7 +430,11 @@ pub async fn cancel(user_id: &UserId, delay_id: &str, now: i64) -> DataResult<bo
                     .or(delayed_events::claimed_at.lt(now - CLAIM_LEASE_MS)),
             ),
     )
-    .set(delayed_events::finalized_at.eq(now))
+    .set((
+        delayed_events::finalized_at.eq(now),
+        // As in restart: drop the expired lease so its worker is fenced out.
+        delayed_events::claimed_at.eq(None::<i64>),
+    ))
     .execute(&mut connect().await?)
     .await?;
     Ok(count > 0)

--- a/crates/data/src/schema.rs
+++ b/crates/data/src/schema.rs
@@ -35,6 +35,31 @@ diesel::table! {
     use diesel::sql_types::*;
     use crate::full_text_search::*;
 
+    delayed_events (id) {
+        id -> Int8,
+        delay_id -> Text,
+        user_id -> Text,
+        device_id -> Nullable<Text>,
+        room_id -> Text,
+        event_type -> Text,
+        state_key -> Nullable<Text>,
+        content -> Jsonb,
+        delay_ms -> Int8,
+        txn_id -> Text,
+        origin_server_ts -> Nullable<Int8>,
+        running_since -> Int8,
+        send_at -> Int8,
+        event_id -> Nullable<Text>,
+        error -> Nullable<Jsonb>,
+        finalized_at -> Nullable<Int8>,
+        created_at -> Int8,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use crate::full_text_search::*;
+
     device_inboxes (id) {
         id -> Int8,
         user_id -> Text,
@@ -1160,6 +1185,7 @@ diesel::joinable!(user_ratelimit_override -> users (user_id));
 diesel::allow_tables_to_appear_in_same_query!(
     appservice_registrations,
     banned_rooms,
+    delayed_events,
     device_inboxes,
     device_streams,
     e2e_cross_signing_keys,

--- a/crates/data/src/schema.rs
+++ b/crates/data/src/schema.rs
@@ -51,6 +51,7 @@ diesel::table! {
         send_at -> Int8,
         event_id -> Nullable<Text>,
         error -> Nullable<Jsonb>,
+        claimed_at -> Nullable<Int8>,
         finalized_at -> Nullable<Int8>,
         created_at -> Int8,
     }

--- a/crates/data/src/schema.rs
+++ b/crates/data/src/schema.rs
@@ -35,6 +35,31 @@ diesel::table! {
     use diesel::sql_types::*;
     use crate::full_text_search::*;
 
+    delayed_events (id) {
+        id -> Int8,
+        delay_id -> Text,
+        user_id -> Text,
+        device_id -> Nullable<Text>,
+        room_id -> Text,
+        event_type -> Text,
+        state_key -> Nullable<Text>,
+        content -> Jsonb,
+        delay_ms -> Int8,
+        txn_id -> Text,
+        origin_server_ts -> Nullable<Int8>,
+        running_since -> Int8,
+        send_at -> Int8,
+        event_id -> Nullable<Text>,
+        error -> Nullable<Jsonb>,
+        finalized_at -> Nullable<Int8>,
+        created_at -> Int8,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use crate::full_text_search::*;
+
     device_inboxes (id) {
         id -> Int8,
         user_id -> Text,
@@ -1161,6 +1186,7 @@ diesel::joinable!(user_ratelimit_override -> users (user_id));
 diesel::allow_tables_to_appear_in_same_query!(
     appservice_registrations,
     banned_rooms,
+    delayed_events,
     device_inboxes,
     device_streams,
     e2e_cross_signing_keys,
@@ -1239,3 +1265,10 @@ diesel::allow_tables_to_appear_in_same_query!(
     user_uiaa_datas,
     users,
 );
+
+diesel::table! {
+    delayed_event_deliveries (event_id) {
+        event_id -> Text,
+        room_id -> Text,
+    }
+}

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -27,6 +27,8 @@ mod compression;
 pub use compression::*;
 mod db;
 pub use db::*;
+mod delayed_event;
+pub use delayed_event::*;
 // mod dns;
 // pub use dns::*;
 mod federation;

--- a/crates/server/src/config/delayed_event.rs
+++ b/crates/server/src/config/delayed_event.rs
@@ -1,0 +1,64 @@
+use serde::Deserialize;
+
+use crate::core::serde::default_true;
+use crate::macros::config_example;
+
+#[config_example(filename = "palpo-example.toml", section = "delayed_events")]
+#[derive(Clone, Debug, Deserialize)]
+pub struct DelayedEventsConfig {
+    /// Allow scheduling MSC4140 delayed events.
+    ///
+    /// Delayed events let clients schedule message or state events that the
+    /// server sends into a room after a delay, e.g. reliable MatrixRTC
+    /// "hang up" events. When disabled the endpoints are not registered and
+    /// the feature is not advertised.
+    #[serde(default = "default_true")]
+    pub enable: bool,
+
+    /// The maximum delay in milliseconds a client may request for a delayed
+    /// event. Requests above this limit are rejected with `M_FORBIDDEN`.
+    /// Defaults to 24 hours.
+    ///
+    /// default: 86400_000
+    #[serde(default = "default_max_delay_ms")]
+    pub max_delay_ms: u64,
+
+    /// How many delayed events a user may have scheduled at once. Requests
+    /// above this limit are rejected with `M_LIMIT_EXCEEDED`.
+    /// Defaults to 100.
+    ///
+    /// default: 100
+    #[serde(default = "default_max_scheduled")]
+    pub max_scheduled: u64,
+
+    /// How long finalized (sent, cancelled, or errored) delayed events are
+    /// retained for lookup before they are pruned, in milliseconds.
+    /// Defaults to 7 days.
+    ///
+    /// default: 604800_000
+    #[serde(default = "default_retention_ms")]
+    pub retention_ms: u64,
+}
+
+impl Default for DelayedEventsConfig {
+    fn default() -> Self {
+        Self {
+            enable: true,
+            max_delay_ms: default_max_delay_ms(),
+            max_scheduled: default_max_scheduled(),
+            retention_ms: default_retention_ms(),
+        }
+    }
+}
+
+fn default_max_delay_ms() -> u64 {
+    24 * 60 * 60_000
+}
+
+fn default_max_scheduled() -> u64 {
+    100
+}
+
+fn default_retention_ms() -> u64 {
+    7 * 24 * 60 * 60_000
+}

--- a/crates/server/src/config/delayed_event.rs
+++ b/crates/server/src/config/delayed_event.rs
@@ -1,0 +1,78 @@
+use serde::Deserialize;
+
+use crate::macros::config_example;
+
+#[config_example(filename = "palpo-example.toml", section = "delayed_events")]
+#[derive(Clone, Debug, Deserialize)]
+pub struct DelayedEventsConfig {
+    /// Allow scheduling MSC4140 delayed events.
+    ///
+    /// Delayed events let clients schedule message or state events that the
+    /// server sends into a room after a delay, e.g. reliable MatrixRTC
+    /// "hang up" events. When disabled new schedules are rejected and the
+    /// feature is not advertised; lookup and management routes remain available
+    /// so existing delayed events can still be inspected or cancelled. Disabled
+    /// by default while MSC4140 is unstable.
+    ///
+    /// default: false
+    #[serde(default)]
+    pub enable: bool,
+
+    /// The maximum delay in milliseconds a client may request for a delayed
+    /// event. Requests above this limit are rejected with the unstable
+    /// `ORG.MATRIX.MSC4140_DELAY_TOO_LARGE` error code.
+    /// Defaults to 24 hours.
+    ///
+    /// default: 86400_000
+    #[serde(default = "default_max_delay_ms")]
+    pub max_delay_ms: u64,
+
+    /// How many delayed events a user may have scheduled at once. Requests
+    /// above this limit are rejected with `M_LIMIT_EXCEEDED`.
+    /// Defaults to 100.
+    ///
+    /// default: 100
+    #[serde(default = "default_max_scheduled")]
+    pub max_scheduled: u64,
+
+    /// How long finalized (sent, cancelled, or errored) delayed events are
+    /// retained for lookup before they are pruned, in milliseconds.
+    /// Defaults to 7 days.
+    ///
+    /// default: 604800_000
+    #[serde(default = "default_retention_ms")]
+    pub retention_ms: u64,
+}
+
+impl Default for DelayedEventsConfig {
+    fn default() -> Self {
+        Self {
+            enable: false,
+            max_delay_ms: default_max_delay_ms(),
+            max_scheduled: default_max_scheduled(),
+            retention_ms: default_retention_ms(),
+        }
+    }
+}
+
+fn default_max_delay_ms() -> u64 {
+    24 * 60 * 60_000
+}
+
+fn default_max_scheduled() -> u64 {
+    100
+}
+
+fn default_retention_ms() -> u64 {
+    7 * 24 * 60 * 60_000
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delayed_events_are_disabled_by_default() {
+        assert!(!DelayedEventsConfig::default().enable);
+    }
+}

--- a/crates/server/src/config/server.rs
+++ b/crates/server/src/config/server.rs
@@ -5,10 +5,10 @@ use salvo::http::HeaderValue;
 use serde::Deserialize;
 
 use super::{
-    AdminConfig, BlurhashConfig, CompressionConfig, DbConfig, DelegatedAuthConfig,
-    FederationConfig, HttpClientConfig, JwtConfig, LoggerConfig, MediaConfig, OidcConfig,
-    PresenceConfig, ProxyConfig, ReadReceiptConfig, StorageConfig, TurnConfig, TypingConfig,
-    UrlPreviewConfig, WellKnownConfig,
+    AdminConfig, BlurhashConfig, CompressionConfig, DbConfig, DelayedEventsConfig,
+    DelegatedAuthConfig, FederationConfig, HttpClientConfig, JwtConfig, LoggerConfig, MediaConfig,
+    OidcConfig, PresenceConfig, ProxyConfig, ReadReceiptConfig, StorageConfig, TurnConfig,
+    TypingConfig, UrlPreviewConfig, WellKnownConfig,
 };
 use crate::core::serde::{default_false, default_true};
 use crate::core::{OwnedRoomOrAliasId, OwnedServerName, RoomVersionId};
@@ -75,7 +75,8 @@ impl ListenerConfig {
 ### https://palpo.im/guide/configuration.html
 "#,
     ignore = "federation well_known compression typing read_receipt presence \
-        admin url_preview turn media storage blurhash keypair ldap proxy jwt oidc logger db appservice"
+        admin url_preview turn media storage blurhash keypair ldap proxy jwt oidc logger db appservice \
+        delayed_events"
 )]
 #[derive(Clone, Debug, Deserialize)]
 pub struct ServerConfig {
@@ -724,6 +725,10 @@ pub struct ServerConfig {
     // external structure; separate section
     #[serde(default)]
     pub admin: AdminConfig,
+
+    // external structure; separate section
+    #[serde(default)]
+    pub delayed_events: DelayedEventsConfig,
 
     // external structure; separate section
     #[serde(default)]

--- a/crates/server/src/config/server.rs
+++ b/crates/server/src/config/server.rs
@@ -5,10 +5,10 @@ use salvo::http::HeaderValue;
 use serde::Deserialize;
 
 use super::{
-    AdminConfig, BlurhashConfig, CompressionConfig, DbConfig, DelegatedAuthConfig,
-    FederationConfig, HttpClientConfig, JwtConfig, LoggerConfig, MediaConfig, OidcConfig,
-    PresenceConfig, ProxyConfig, ReadReceiptConfig, StorageConfig, TurnConfig, TypingConfig,
-    UrlPreviewConfig, WellKnownConfig,
+    AdminConfig, BlurhashConfig, CompressionConfig, DbConfig, DelayedEventsConfig,
+    DelegatedAuthConfig, FederationConfig, HttpClientConfig, JwtConfig, LoggerConfig, MediaConfig,
+    OidcConfig, PresenceConfig, ProxyConfig, ReadReceiptConfig, StorageConfig, TurnConfig,
+    TypingConfig, UrlPreviewConfig, WellKnownConfig,
 };
 use crate::core::serde::{default_false, default_true};
 use crate::core::{OwnedRoomOrAliasId, OwnedServerName, RoomVersionId};
@@ -75,7 +75,8 @@ impl ListenerConfig {
 ### https://palpo.im/guide/configuration.html
 "#,
     ignore = "federation well_known compression typing read_receipt presence \
-        admin url_preview turn media storage blurhash keypair ldap proxy jwt oidc logger db appservice"
+        admin url_preview turn media storage blurhash keypair ldap proxy jwt oidc logger db appservice \
+        delayed_events"
 )]
 #[derive(Clone, Debug, Deserialize)]
 pub struct ServerConfig {
@@ -727,6 +728,10 @@ pub struct ServerConfig {
 
     // external structure; separate section
     #[serde(default)]
+    pub delayed_events: DelayedEventsConfig,
+
+    // external structure; separate section
+    #[serde(default)]
     pub presence: PresenceConfig,
 
     // external structure; separate section
@@ -890,6 +895,17 @@ impl ServerConfig {
                 "db.coordination_pool_size must be at least 1 and smaller than db.pool_size ({}), but it is {coordination_pool_size}",
                 self.db.pool_size
             )));
+        }
+
+        if self.delayed_events.enable
+            && crate::data::coordination_pool_capacity(
+                self.db.pool_size,
+                self.db.coordination_pool_size,
+            ) < 2
+        {
+            return Err(AppError::internal(
+                "MSC4140 delayed events require at least two coordination connections; increase db.pool_size or set db.coordination_pool_size",
+            ));
         }
 
         // NOTE: `check()` runs *before* `logging::init()` in main, so a

--- a/crates/server/src/delayed_event.rs
+++ b/crates/server/src/delayed_event.rs
@@ -1,0 +1,387 @@
+//! MSC4140 delayed events.
+//!
+//! Scheduling, management actions (`restart`/`send`/`cancel`), and the
+//! background scheduler that sends events into their room once the delay
+//! elapses. Scheduled events are persisted, so pending delayed events survive
+//! restarts: on startup the scheduler picks up overdue events and sends them
+//! in chronological order of their scheduled send times.
+//!
+//! Power levels and other auth rules are deliberately evaluated only at the
+//! point of sending, as the MSC requires.
+
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use salvo::http::StatusCode;
+use serde_json::value::to_raw_value;
+use tokio::sync::Notify;
+
+use crate::core::client::delayed_events::{
+    DelayedEventData, DelayedEventError, SendDelayedEventReqArgs, SendDelayedEventReqBody,
+    UpdateAction,
+};
+use crate::core::error::RetryAfter;
+use crate::core::events::{StateEventType, TimelineEventType};
+use crate::core::identifiers::*;
+use crate::core::serde::{JsonValue, to_canonical_value};
+use crate::core::{MatrixError, UnixMillis};
+use crate::data::room::delayed_event::{self, DbDelayedEvent, NewDbDelayedEvent};
+use crate::room::timeline;
+use crate::{AppError, AppResult, PduBuilder, config, room, utils};
+
+/// Retention sweep cadence for finalized delayed events.
+const PRUNE_INTERVAL: Duration = Duration::from_secs(60 * 60);
+/// Upper bound on the scheduler's sleep so newly due work is never missed for
+/// long even if a wakeup signal is lost.
+const MAX_IDLE: Duration = Duration::from_secs(60);
+
+static WAKEUP: OnceLock<Notify> = OnceLock::new();
+
+fn wakeup() -> &'static Notify {
+    WAKEUP.get_or_init(Notify::new)
+}
+
+/// Start the background scheduler that sends due delayed events.
+pub fn start() {
+    tokio::spawn(async move {
+        let mut prune = tokio::time::interval(PRUNE_INTERVAL);
+        loop {
+            if let Err(error) = process_due_events().await {
+                tracing::warn!(?error, "failed to process due delayed events");
+            }
+
+            let now = UnixMillis::now().get() as i64;
+            let sleep = match delayed_event::next_send_at().await {
+                Ok(Some(send_at)) => {
+                    Duration::from_millis(send_at.saturating_sub(now) as u64).min(MAX_IDLE)
+                }
+                Ok(None) => MAX_IDLE,
+                Err(error) => {
+                    tracing::warn!(?error, "failed to load next delayed event send time");
+                    MAX_IDLE
+                }
+            };
+            tokio::select! {
+                _ = wakeup().notified() => {},
+                _ = tokio::time::sleep(sleep) => {},
+                _ = prune.tick() => {
+                    let conf = config::get();
+                    let cutoff = UnixMillis::now().get() as i64
+                        - conf.delayed_events.retention_ms as i64;
+                    if let Err(error) = delayed_event::prune_finalized(cutoff).await {
+                        tracing::warn!(?error, "failed to prune finalized delayed events");
+                    }
+                },
+            }
+        }
+    });
+}
+
+/// Send every delayed event that is due, in chronological order of scheduled
+/// send times. Failures are recorded on the event instead of being retried,
+/// per the MSC.
+async fn process_due_events() -> AppResult<()> {
+    let now = UnixMillis::now().get() as i64;
+    for event in delayed_event::list_due(now).await? {
+        let Some(claimed) = delayed_event::claim(event.id, now).await? else {
+            // Finalized concurrently (cancelled or manually sent).
+            continue;
+        };
+        match send_delayed_pdu(&claimed).await {
+            Ok(event_id) => {
+                delayed_event::set_sent(claimed.id, &event_id).await?;
+            }
+            Err(error) => {
+                tracing::debug!(
+                    delay_id = %claimed.delay_id,
+                    room_id = %claimed.room_id,
+                    ?error,
+                    "delayed event failed to send at its scheduled time"
+                );
+                delayed_event::set_error(claimed.id, &error_body(error)).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Build and append the PDU for a claimed delayed event through the normal
+/// event authorization and federation paths.
+async fn send_delayed_pdu(event: &DbDelayedEvent) -> AppResult<OwnedEventId> {
+    let event_type: TimelineEventType = event.event_type.clone().into();
+    if let Some(state_key) = &event.state_key {
+        let state_event_type: StateEventType = event.event_type.clone().into();
+        crate::state::allowed_to_send_state_event(
+            &event.room_id,
+            &state_event_type,
+            state_key,
+            &serde_json::from_value(event.content.clone())?,
+        )
+        .await?;
+    }
+
+    let mut unsigned = BTreeMap::new();
+    unsigned.insert(
+        "org.matrix.msc4140.delay_id".to_owned(),
+        to_raw_value(&event.delay_id)?,
+    );
+    unsigned.insert("transaction_id".to_owned(), to_raw_value(&event.txn_id)?);
+
+    let state_lock = room::lock_state(&event.room_id).await;
+    let event_id = timeline::build_and_append_pdu(
+        PduBuilder {
+            event_type,
+            content: to_raw_value(&event.content)?,
+            unsigned,
+            state_key: event.state_key.clone(),
+            redacts: None,
+            timestamp: event.origin_server_ts.map(|ts| UnixMillis(ts as u64)),
+        },
+        &event.user_id,
+        &event.room_id,
+        &crate::room::get_version(&event.room_id).await?,
+        &state_lock,
+    )
+    .await?
+    .pdu
+    .event_id;
+    drop(state_lock);
+
+    crate::transaction_id::add_txn_id(
+        &event.txn_id,
+        &event.user_id,
+        event.device_id.as_deref(),
+        Some(&event.room_id),
+        Some(&event_id),
+    )
+    .await
+    .ok();
+
+    Ok((*event_id).to_owned())
+}
+
+/// Schedule a new delayed event, enforcing the configured limits. Returns the
+/// `delay_id`, reusing the one from a previous identical transaction for
+/// idempotency.
+pub async fn schedule(
+    user_id: &UserId,
+    device_id: Option<&DeviceId>,
+    is_appservice: bool,
+    args: &SendDelayedEventReqArgs,
+    body: &SendDelayedEventReqBody,
+) -> AppResult<String> {
+    let conf = config::get();
+
+    let delay_ms = body.delay.as_millis();
+    if delay_ms == 0 {
+        return Err(
+            MatrixError::invalid_param("delay must be a positive number of milliseconds").into(),
+        );
+    }
+    if delay_ms > conf.delayed_events.max_delay_ms as u128 {
+        return Err(MatrixError::forbidden(
+            format!(
+                "the requested delay exceeds the maximum allowed delay of {} ms",
+                conf.delayed_events.max_delay_ms
+            ),
+            None,
+        )
+        .into());
+    }
+
+    if !body.content.is_object() {
+        return Err(MatrixError::bad_json("event content is not an object").into());
+    }
+    to_canonical_value(&body.content).map_err(|e| {
+        MatrixError::bad_json(format!("event content is not valid canonical JSON: {e}"))
+    })?;
+
+    // Forbid m.room.encrypted if encryption is disabled, matching /send.
+    if args.event_type == TimelineEventType::RoomEncrypted && !conf.allow_encryption {
+        return Err(MatrixError::forbidden("Encryption has been disabled", None).into());
+    }
+
+    // The room must be known; auth rules themselves are evaluated at send time.
+    crate::room::get_version(&args.room_id).await?;
+
+    // Idempotency: same session + transaction id returns the same delay id.
+    if let Some(existing) = delayed_event::get_by_txn_id(user_id, device_id, &args.txn_id).await? {
+        return Ok(existing.delay_id);
+    }
+
+    let scheduled = delayed_event::count_scheduled(user_id).await?;
+    if scheduled >= conf.delayed_events.max_scheduled as i64 {
+        let retry_after = delayed_event::next_send_at_of_user(user_id)
+            .await?
+            .map(|send_at| {
+                let now = UnixMillis::now().get() as i64;
+                RetryAfter::Delay(Duration::from_millis(send_at.saturating_sub(now) as u64))
+            });
+        return Err(MatrixError::limit_exceeded(
+            "The maximum number of delayed events has been reached.",
+            retry_after,
+        )
+        .into());
+    }
+
+    let now = UnixMillis::now().get() as i64;
+    let new = NewDbDelayedEvent {
+        delay_id: utils::random_string(18),
+        user_id: user_id.to_owned(),
+        device_id: device_id.map(|d| d.to_owned()),
+        room_id: args.room_id.clone(),
+        event_type: args.event_type.to_string(),
+        state_key: body.state_key.clone(),
+        content: body.content.clone(),
+        delay_ms: delay_ms as i64,
+        txn_id: args.txn_id.clone(),
+        origin_server_ts: if is_appservice {
+            args.timestamp.map(|ts| ts.get() as i64)
+        } else {
+            None
+        },
+        running_since: now,
+        send_at: now + delay_ms as i64,
+        created_at: now,
+    };
+    let row = delayed_event::create(new).await?;
+    wakeup().notify_one();
+    Ok(row.delay_id)
+}
+
+/// Apply a management action (`restart`/`send`/`cancel`) to a delayed event.
+pub async fn update(user_id: &UserId, delay_id: &str, action: &UpdateAction) -> AppResult<()> {
+    let Some(event) = delayed_event::get_by_delay_id(user_id, delay_id).await? else {
+        return Err(MatrixError::not_found("no delayed event with that delay_id was found").into());
+    };
+    let now = UnixMillis::now().get() as i64;
+
+    match action {
+        UpdateAction::Restart => {
+            if delayed_event::restart(user_id, delay_id, now)
+                .await?
+                .is_some()
+            {
+                wakeup().notify_one();
+                Ok(())
+            } else {
+                let refreshed = delayed_event::get_by_delay_id(user_id, delay_id)
+                    .await?
+                    .unwrap_or(event);
+                Err(finalized_conflict(&refreshed, "restart"))
+            }
+        }
+        UpdateAction::Send => {
+            let Some(claimed) = delayed_event::claim(event.id, now).await? else {
+                // Already finalized: sending is idempotent if it was sent,
+                // conflicting otherwise.
+                let refreshed = delayed_event::get_by_delay_id(user_id, delay_id)
+                    .await?
+                    .unwrap_or(event);
+                if refreshed.event_id.is_some() {
+                    return Ok(());
+                }
+                return Err(finalized_conflict(&refreshed, "send"));
+            };
+            match send_delayed_pdu(&claimed).await {
+                Ok(event_id) => {
+                    delayed_event::set_sent(claimed.id, &event_id).await?;
+                    Ok(())
+                }
+                Err(error) => {
+                    // The MSC requires the event to stay scheduled so the
+                    // client can retry until the scheduled send time.
+                    delayed_event::unclaim(claimed.id).await?;
+                    Err(error)
+                }
+            }
+        }
+        UpdateAction::Cancel => {
+            if delayed_event::cancel(user_id, delay_id, now).await? {
+                Ok(())
+            } else {
+                let refreshed = delayed_event::get_by_delay_id(user_id, delay_id)
+                    .await?
+                    .unwrap_or(event);
+                if refreshed.event_id.is_some() {
+                    Err(finalized_conflict(&refreshed, "cancel"))
+                } else {
+                    // Already cancelled, either by user action or an error.
+                    Ok(())
+                }
+            }
+        }
+        _ => Err(MatrixError::invalid_param("unknown delayed event action").into()),
+    }
+}
+
+/// List the user's scheduled delayed events in chronological send order.
+pub async fn list(user_id: &UserId) -> AppResult<Vec<DelayedEventData>> {
+    Ok(delayed_event::list_scheduled(user_id)
+        .await?
+        .into_iter()
+        .map(to_event_data)
+        .collect())
+}
+
+/// Fetch one delayed event owned by the user, whether scheduled or finalized.
+pub async fn get(user_id: &UserId, delay_id: &str) -> AppResult<DelayedEventData> {
+    delayed_event::get_by_delay_id(user_id, delay_id)
+        .await?
+        .map(to_event_data)
+        .ok_or_else(|| {
+            MatrixError::not_found("no delayed event with that delay_id was found").into()
+        })
+}
+
+fn to_event_data(event: DbDelayedEvent) -> DelayedEventData {
+    DelayedEventData {
+        delay_id: event.delay_id,
+        room_id: event.room_id,
+        event_type: event.event_type.into(),
+        state_key: event.state_key,
+        content: event.content,
+        delay: Duration::from_millis(event.delay_ms as u64),
+        running_since: UnixMillis(event.running_since as u64),
+        error: event
+            .error
+            .and_then(|error| serde_json::from_value::<DelayedEventError>(error).ok()),
+        event_id: event.event_id,
+        finalized_ts: event.finalized_at.map(|ts| UnixMillis(ts as u64)),
+    }
+}
+
+/// HTTP 409 for a management action that conflicts with the outcome the
+/// delayed event was already finalized with.
+fn finalized_conflict(event: &DbDelayedEvent, action: &str) -> AppError {
+    let outcome = if event.event_id.is_some() {
+        "already been sent"
+    } else if event.error.is_some() {
+        "already failed to send"
+    } else {
+        "already been cancelled"
+    };
+    let mut error = MatrixError::unknown(format!(
+        "cannot {action} a delayed event that has {outcome}"
+    ));
+    error.status_code = Some(StatusCode::CONFLICT);
+    error.into()
+}
+
+/// The standard error body stored for a delayed event that failed to send.
+fn error_body(error: AppError) -> JsonValue {
+    match error {
+        AppError::Matrix(e) => {
+            let mut body = serde_json::to_value(&e).unwrap_or_default();
+            if let Some(map) = body.as_object_mut() {
+                map.insert("errcode".to_owned(), e.kind.code().to_string().into());
+            }
+            body
+        }
+        other => serde_json::json!({
+            "errcode": "M_UNKNOWN",
+            "error": other.to_string(),
+        }),
+    }
+}

--- a/crates/server/src/delayed_event.rs
+++ b/crates/server/src/delayed_event.rs
@@ -90,8 +90,13 @@ pub fn start() {
 /// send times. Failures are recorded on the event instead of being retried,
 /// per the MSC.
 async fn process_due_events() -> AppResult<()> {
-    let now = UnixMillis::now().get() as i64;
-    for event in delayed_event::list_due(now).await? {
+    let scan_at = UnixMillis::now().get() as i64;
+    for event in delayed_event::list_due(scan_at).await? {
+        // Re-read the clock per row: working through a backlog can take longer
+        // than CLAIM_LEASE_MS, and claiming with the scan-start timestamp
+        // would stamp a lease that is already expired, so a management request
+        // could report a successful cancel while the event is being appended.
+        let now = UnixMillis::now().get() as i64;
         let Some(claimed) = delayed_event::claim_due(event.id, now).await? else {
             // Finalized, restarted, or claimed concurrently since `list_due`.
             continue;
@@ -186,6 +191,10 @@ async fn send_delayed_pdu(event: &DbDelayedEvent) -> AppResult<OwnedEventId> {
     // Still under the room lock, so the mapping is visible to any worker that
     // is waiting on it before that worker can reach its own append. Recorded
     // before the lock is released for the same reason.
+    // Not `.ok()`: this mapping is what makes lease recovery idempotent. If it
+    // is missing and recording the outcome then fails, recovery would find
+    // neither and append the event a second time, so a failure here has to
+    // surface rather than be reported as a clean send.
     crate::transaction_id::add_txn_id(
         &event.txn_id,
         &event.user_id,
@@ -193,8 +202,7 @@ async fn send_delayed_pdu(event: &DbDelayedEvent) -> AppResult<OwnedEventId> {
         Some(&event.room_id),
         Some(&event_id),
     )
-    .await
-    .ok();
+    .await?;
     drop(state_lock);
 
     Ok((*event_id).to_owned())

--- a/crates/server/src/delayed_event.rs
+++ b/crates/server/src/delayed_event.rs
@@ -96,9 +96,10 @@ async fn process_due_events() -> AppResult<()> {
             // Finalized, restarted, or claimed concurrently since `list_due`.
             continue;
         };
+        let lease = claimed.claimed_at.unwrap_or(now);
         match send_delayed_pdu(&claimed).await {
             Ok(event_id) => {
-                delayed_event::set_sent(claimed.id, &event_id, now).await?;
+                delayed_event::set_sent(claimed.id, lease, &event_id, now).await?;
             }
             Err(error) => {
                 tracing::debug!(
@@ -109,7 +110,7 @@ async fn process_due_events() -> AppResult<()> {
                 );
                 // The MSC says a scheduled send is not retried either way, so
                 // both failure kinds finalize with the error here.
-                delayed_event::set_error(claimed.id, &error_body(error), now).await?;
+                delayed_event::set_error(claimed.id, lease, &error_body(error), now).await?;
             }
         }
     }
@@ -119,25 +120,14 @@ async fn process_due_events() -> AppResult<()> {
 /// Build and append the PDU for a claimed delayed event through the normal
 /// event authorization and federation paths.
 ///
-/// A send that is interrupted after the append but before the outcome is
-/// recorded leaves a row that the lease sweep later reclaims. Appending again
-/// would duplicate the event, so this first resolves the transaction id the
-/// same way `/send` does: the mapping is written right after the append, so a
-/// hit means the event already reached the room and the caller only has to
-/// record it. The remaining window -- a crash between the append and that
-/// mapping -- is the one palpo's ordinary `/send` idempotency already has.
+/// A send interrupted after the append but before the outcome is recorded
+/// leaves a row the lease sweep later reclaims, and appending again would
+/// duplicate the event. To make that recovery idempotent this resolves the
+/// transaction id the same way `/send` does, and both that lookup and the
+/// `add_txn_id` that satisfies it happen under the room lock, so a worker that
+/// reclaimed an over-running lease cannot slip past the check while the
+/// original worker is mid-append.
 async fn send_delayed_pdu(event: &DbDelayedEvent) -> AppResult<OwnedEventId> {
-    if let Some(event_id) = crate::transaction_id::get_event_id(
-        &event.txn_id,
-        &event.user_id,
-        event.device_id.as_deref(),
-        Some(&event.room_id),
-    )
-    .await?
-    {
-        return Ok(event_id);
-    }
-
     let event_type: TimelineEventType = event.event_type.clone().into();
     if let Some(state_key) = &event.state_key {
         let state_event_type: StateEventType = event.event_type.clone().into();
@@ -158,6 +148,23 @@ async fn send_delayed_pdu(event: &DbDelayedEvent) -> AppResult<OwnedEventId> {
     unsigned.insert("transaction_id".to_owned(), to_raw_value(&event.txn_id)?);
 
     let state_lock = room::lock_state(&event.room_id).await;
+
+    // Inside the room lock, so a worker that reclaimed an over-running lease
+    // cannot pass this check while the original worker is still between its
+    // append and its `add_txn_id` -- both of which happen under this same
+    // lock. Checking before taking it would let both reach the append and
+    // duplicate the event.
+    if let Some(event_id) = crate::transaction_id::get_event_id(
+        &event.txn_id,
+        &event.user_id,
+        event.device_id.as_deref(),
+        Some(&event.room_id),
+    )
+    .await?
+    {
+        return Ok(event_id);
+    }
+
     let event_id = timeline::build_and_append_pdu(
         PduBuilder {
             event_type,
@@ -175,8 +182,10 @@ async fn send_delayed_pdu(event: &DbDelayedEvent) -> AppResult<OwnedEventId> {
     .await?
     .pdu
     .event_id;
-    drop(state_lock);
 
+    // Still under the room lock, so the mapping is visible to any worker that
+    // is waiting on it before that worker can reach its own append. Recorded
+    // before the lock is released for the same reason.
     crate::transaction_id::add_txn_id(
         &event.txn_id,
         &event.user_id,
@@ -186,6 +195,7 @@ async fn send_delayed_pdu(event: &DbDelayedEvent) -> AppResult<OwnedEventId> {
     )
     .await
     .ok();
+    drop(state_lock);
 
     Ok((*event_id).to_owned())
 }
@@ -326,9 +336,10 @@ pub async fn update(user_id: &UserId, delay_id: &str, action: &UpdateAction) -> 
                 }
                 return Err(finalized_conflict(&refreshed, "send"));
             };
+            let lease = claimed.claimed_at.unwrap_or(now);
             match send_delayed_pdu(&claimed).await {
                 Ok(event_id) => {
-                    delayed_event::set_sent(claimed.id, &event_id, now).await?;
+                    delayed_event::set_sent(claimed.id, lease, &event_id, now).await?;
                     Ok(())
                 }
                 // The MSC requires the event to stay scheduled so the client
@@ -337,7 +348,7 @@ pub async fn update(user_id: &UserId, delay_id: &str, action: &UpdateAction) -> 
                 // `send_delayed_pdu` resolves the transaction id first and
                 // will not append a second time.
                 Err(error) => {
-                    delayed_event::unclaim(claimed.id).await?;
+                    delayed_event::unclaim(claimed.id, lease).await?;
                     Err(error)
                 }
             }

--- a/crates/server/src/delayed_event.rs
+++ b/crates/server/src/delayed_event.rs
@@ -52,16 +52,24 @@ pub fn start() {
             }
 
             let now = UnixMillis::now().get() as i64;
-            let sleep = match delayed_event::next_send_at().await {
-                Ok(Some(send_at)) => {
-                    Duration::from_millis(send_at.saturating_sub(now) as u64).min(MAX_IDLE)
-                }
-                Ok(None) => MAX_IDLE,
-                Err(error) => {
-                    tracing::warn!(?error, "failed to load next delayed event send time");
-                    MAX_IDLE
+            // Wake for whichever comes first: the next claimable event, or the
+            // expiry of a lease we may then have to reclaim.
+            let next_wake = match (
+                delayed_event::next_send_at(now).await,
+                delayed_event::next_lease_expiry(now).await,
+            ) {
+                (Ok(send_at), Ok(expiry)) => match (send_at, expiry) {
+                    (Some(a), Some(b)) => Some(a.min(b)),
+                    (a, b) => a.or(b),
+                },
+                (Err(error), _) | (_, Err(error)) => {
+                    tracing::warn!(?error, "failed to load next delayed event wake-up time");
+                    None
                 }
             };
+            let sleep = next_wake
+                .map(|at| Duration::from_millis(at.saturating_sub(now) as u64).min(MAX_IDLE))
+                .unwrap_or(MAX_IDLE);
             tokio::select! {
                 _ = wakeup().notified() => {},
                 _ = tokio::time::sleep(sleep) => {},
@@ -92,8 +100,7 @@ async fn process_due_events() -> AppResult<()> {
             Ok(event_id) => {
                 delayed_event::set_sent(claimed.id, &event_id, now).await?;
             }
-            Err(failure) => {
-                let error = failure.into_error();
+            Err(error) => {
                 tracing::debug!(
                     delay_id = %claimed.delay_id,
                     room_id = %claimed.room_id,
@@ -109,63 +116,52 @@ async fn process_due_events() -> AppResult<()> {
     Ok(())
 }
 
-/// Why a delayed event failed to send, split by whether a PDU can already
-/// exist in the room.
-enum SendFailure {
-    /// Refused before anything was written. Retrying is safe.
-    Rejected(AppError),
-    /// Failed at or after `build_and_append_pdu`, which persists the event
-    /// before its later push and federation steps. A retry could duplicate it.
-    Appending(AppError),
-}
-
-impl SendFailure {
-    fn into_error(self) -> AppError {
-        match self {
-            Self::Rejected(e) | Self::Appending(e) => e,
-        }
-    }
-}
-
 /// Build and append the PDU for a claimed delayed event through the normal
 /// event authorization and federation paths.
-async fn send_delayed_pdu(event: &DbDelayedEvent) -> Result<OwnedEventId, SendFailure> {
+///
+/// A send that is interrupted after the append but before the outcome is
+/// recorded leaves a row that the lease sweep later reclaims. Appending again
+/// would duplicate the event, so this first resolves the transaction id the
+/// same way `/send` does: the mapping is written right after the append, so a
+/// hit means the event already reached the room and the caller only has to
+/// record it. The remaining window -- a crash between the append and that
+/// mapping -- is the one palpo's ordinary `/send` idempotency already has.
+async fn send_delayed_pdu(event: &DbDelayedEvent) -> AppResult<OwnedEventId> {
+    if let Some(event_id) = crate::transaction_id::get_event_id(
+        &event.txn_id,
+        &event.user_id,
+        event.device_id.as_deref(),
+        Some(&event.room_id),
+    )
+    .await?
+    {
+        return Ok(event_id);
+    }
+
     let event_type: TimelineEventType = event.event_type.clone().into();
     if let Some(state_key) = &event.state_key {
         let state_event_type: StateEventType = event.event_type.clone().into();
-        let content = serde_json::from_value(event.content.clone())
-            .map_err(|e| SendFailure::Rejected(AppError::from(e)))?;
         crate::state::allowed_to_send_state_event(
             &event.room_id,
             &state_event_type,
             state_key,
-            &content,
+            &serde_json::from_value(event.content.clone())?,
         )
-        .await
-        .map_err(SendFailure::Rejected)?;
+        .await?;
     }
 
     let mut unsigned = BTreeMap::new();
     unsigned.insert(
         "org.matrix.msc4140.delay_id".to_owned(),
-        to_raw_value(&event.delay_id).map_err(|e| SendFailure::Rejected(AppError::from(e)))?,
+        to_raw_value(&event.delay_id)?,
     );
-    unsigned.insert(
-        "transaction_id".to_owned(),
-        to_raw_value(&event.txn_id).map_err(|e| SendFailure::Rejected(AppError::from(e)))?,
-    );
-    let content =
-        to_raw_value(&event.content).map_err(|e| SendFailure::Rejected(AppError::from(e)))?;
-    let room_version = crate::room::get_version(&event.room_id)
-        .await
-        .map_err(SendFailure::Rejected)?;
+    unsigned.insert("transaction_id".to_owned(), to_raw_value(&event.txn_id)?);
 
-    // Everything past this point may have written the event to the timeline.
     let state_lock = room::lock_state(&event.room_id).await;
     let event_id = timeline::build_and_append_pdu(
         PduBuilder {
             event_type,
-            content,
+            content: to_raw_value(&event.content)?,
             unsigned,
             state_key: event.state_key.clone(),
             redacts: None,
@@ -173,11 +169,10 @@ async fn send_delayed_pdu(event: &DbDelayedEvent) -> Result<OwnedEventId, SendFa
         },
         &event.user_id,
         &event.room_id,
-        &room_version,
+        &crate::room::get_version(&event.room_id).await?,
         &state_lock,
     )
-    .await
-    .map_err(SendFailure::Appending)?
+    .await?
     .pdu
     .event_id;
     drop(state_lock);
@@ -244,21 +239,6 @@ pub async fn schedule(
         return Ok(existing.delay_id);
     }
 
-    let scheduled = delayed_event::count_scheduled(user_id).await?;
-    if scheduled >= conf.delayed_events.max_scheduled as i64 {
-        let retry_after = delayed_event::next_send_at_of_user(user_id)
-            .await?
-            .map(|send_at| {
-                let now = UnixMillis::now().get() as i64;
-                RetryAfter::Delay(Duration::from_millis(send_at.saturating_sub(now) as u64))
-            });
-        return Err(MatrixError::limit_exceeded(
-            "The maximum number of delayed events has been reached.",
-            retry_after,
-        )
-        .into());
-    }
-
     let now = UnixMillis::now().get() as i64;
     let new = NewDbDelayedEvent {
         delay_id: utils::random_string(18),
@@ -279,9 +259,28 @@ pub async fn schedule(
         send_at: now + delay_ms as i64,
         created_at: now,
     };
-    let row = delayed_event::create(new).await?;
-    wakeup().notify_one();
-    Ok(row.delay_id)
+    // The limit is enforced inside the same transaction as the insert, so
+    // concurrent requests cannot each observe a count below it and all succeed.
+    match delayed_event::create(new, conf.delayed_events.max_scheduled as i64).await? {
+        delayed_event::Scheduled::Created(row) => {
+            wakeup().notify_one();
+            Ok(row.delay_id)
+        }
+        // A concurrent retry of this same transaction already scheduled it.
+        delayed_event::Scheduled::AlreadyScheduled(row) => Ok(row.delay_id),
+        delayed_event::Scheduled::LimitReached => {
+            let retry_after = delayed_event::next_send_at_of_user(user_id)
+                .await?
+                .map(|send_at| {
+                    RetryAfter::Delay(Duration::from_millis(send_at.saturating_sub(now) as u64))
+                });
+            Err(MatrixError::limit_exceeded(
+                "The maximum number of delayed events has been reached.",
+                retry_after,
+            )
+            .into())
+        }
+    }
 }
 
 /// Apply a management action (`restart`/`send`/`cancel`) to a delayed event.
@@ -332,23 +331,14 @@ pub async fn update(user_id: &UserId, delay_id: &str, action: &UpdateAction) -> 
                     delayed_event::set_sent(claimed.id, &event_id, now).await?;
                     Ok(())
                 }
-                // Rejected before anything was written, so the MSC's rule that
-                // the event stays scheduled applies: release the lease and
-                // report the error to the client.
-                Err(SendFailure::Rejected(error)) => {
+                // The MSC requires the event to stay scheduled so the client
+                // can retry until the scheduled send time. Releasing the lease
+                // is safe even for an error raised after the append, because
+                // `send_delayed_pdu` resolves the transaction id first and
+                // will not append a second time.
+                Err(error) => {
                     delayed_event::unclaim(claimed.id).await?;
                     Err(error)
-                }
-                // The append may already have reached the timeline, so the row
-                // must not become sendable again or a retry would duplicate
-                // the event. Finalize it with the error instead.
-                Err(SendFailure::Appending(error)) => {
-                    let body = error_body(error);
-                    delayed_event::set_error(claimed.id, &body, now).await?;
-                    Err(MatrixError::unknown(
-                        "the delayed event could not be completed and is no longer scheduled",
-                    )
-                    .into())
                 }
             }
         }

--- a/crates/server/src/delayed_event.rs
+++ b/crates/server/src/delayed_event.rs
@@ -134,6 +134,29 @@ async fn process_due_events() -> AppResult<()> {
 /// original worker is mid-append.
 async fn send_delayed_pdu(event: &DbDelayedEvent) -> AppResult<OwnedEventId> {
     let event_type: TimelineEventType = event.event_type.clone().into();
+    let state_lock = room::lock_state(&event.room_id).await;
+
+    // Taken under the room lock, so a worker that reclaimed an over-running
+    // lease cannot pass this check while the original worker is still between
+    // its append and its `add_txn_id` -- both of which happen under this same
+    // lock. Checking before taking it would let both reach the append and
+    // duplicate the event.
+    //
+    // It also runs before the state check below: recovering a state event that
+    // already reached the room must not re-run authorization, because the
+    // event it just sent may itself have changed the state that check reads,
+    // which would turn a completed send into a permanent failure.
+    if let Some(event_id) = crate::transaction_id::get_event_id(
+        &event.txn_id,
+        &event.user_id,
+        event.device_id.as_deref(),
+        Some(&event.room_id),
+    )
+    .await?
+    {
+        return Ok(event_id);
+    }
+
     if let Some(state_key) = &event.state_key {
         let state_event_type: StateEventType = event.event_type.clone().into();
         crate::state::allowed_to_send_state_event(
@@ -151,24 +174,6 @@ async fn send_delayed_pdu(event: &DbDelayedEvent) -> AppResult<OwnedEventId> {
         to_raw_value(&event.delay_id)?,
     );
     unsigned.insert("transaction_id".to_owned(), to_raw_value(&event.txn_id)?);
-
-    let state_lock = room::lock_state(&event.room_id).await;
-
-    // Inside the room lock, so a worker that reclaimed an over-running lease
-    // cannot pass this check while the original worker is still between its
-    // append and its `add_txn_id` -- both of which happen under this same
-    // lock. Checking before taking it would let both reach the append and
-    // duplicate the event.
-    if let Some(event_id) = crate::transaction_id::get_event_id(
-        &event.txn_id,
-        &event.user_id,
-        event.device_id.as_deref(),
-        Some(&event.room_id),
-    )
-    .await?
-    {
-        return Ok(event_id);
-    }
 
     let event_id = timeline::build_and_append_pdu(
         PduBuilder {
@@ -332,10 +337,13 @@ pub async fn update(user_id: &UserId, delay_id: &str, action: &UpdateAction) -> 
                 let refreshed = delayed_event::get_by_delay_id(user_id, delay_id)
                     .await?
                     .unwrap_or(event);
-                // Another worker is already sending it, which is the outcome
-                // this request wanted.
+                // Another worker holds the lease. Reporting success here would
+                // be a guess: that send can still fail a pre-append check and
+                // release the lease, leaving this caller told the event was
+                // sent when it never was. Report the conflict so a retry gets
+                // a definitive answer.
                 if send_in_flight(&refreshed, now) {
-                    return Ok(());
+                    return Err(in_flight_conflict("send"));
                 }
                 // Already finalized: sending is idempotent if it was sent,
                 // conflicting otherwise.

--- a/crates/server/src/delayed_event.rs
+++ b/crates/server/src/delayed_event.rs
@@ -1,0 +1,909 @@
+//! MSC4140 delayed events.
+//!
+//! Scheduling, management actions (`restart`/`send`/`cancel`), and the
+//! background scheduler that sends events into their room once the delay
+//! elapses. Scheduled events are persisted, so pending delayed events survive
+//! restarts: on startup the scheduler picks up overdue events and sends them
+//! in chronological order of their scheduled send times.
+//!
+//! Power levels and other auth rules are deliberately evaluated only at the
+//! point of sending, as the MSC requires.
+
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use diesel_async::{AsyncConnection, AsyncPgConnection};
+use salvo::http::StatusCode;
+use serde_json::value::to_raw_value;
+use tokio::sync::{Notify, Semaphore};
+
+use crate::core::client::delayed_events::{
+    DelayedEventData, DelayedEventError, DelayedEventFinalization, UpdateAction,
+};
+use crate::core::error::{ErrorKind, RetryAfter};
+use crate::core::events::{StateEventType, TimelineEventType};
+use crate::core::identifiers::*;
+use crate::core::serde::{JsonValue, to_canonical_value};
+use crate::core::{MatrixError, UnixMillis};
+use crate::data::room::delayed_event::{self, DbDelayedEvent, NewDbDelayedEvent};
+use crate::room::timeline;
+use crate::{AppError, AppResult, PduBuilder, config, room, utils};
+
+/// Retention sweep cadence for finalized delayed events.
+const PRUNE_INTERVAL: Duration = Duration::from_secs(60 * 60);
+/// Upper bound on the scheduler's sleep so newly due work is never missed for
+/// long even if a wakeup signal is lost.
+const MAX_IDLE: Duration = Duration::from_secs(30);
+/// Avoid a hot loop when another server process holds the earliest due row.
+const LOCK_RETRY: Duration = Duration::from_secs(1);
+
+static WAKEUP: OnceLock<Notify> = OnceLock::new();
+static OPERATION_GATE: OnceLock<Option<Semaphore>> = OnceLock::new();
+
+fn wakeup() -> &'static Notify {
+    WAKEUP.get_or_init(Notify::new)
+}
+
+/// Bound delayed appends and row-locking management operations below the
+/// coordination-pool capacity. One connection always remains available to an
+/// ordinary room append which may already hold the process-local state mutex.
+fn operation_gate() -> AppResult<&'static Semaphore> {
+    OPERATION_GATE
+        .get_or_init(|| {
+            operation_permits(
+                config::get().db.pool_size,
+                config::get().db.coordination_pool_size,
+            )
+            .map(Semaphore::new)
+        })
+        .as_ref()
+        .ok_or_else(|| {
+            MatrixError::unknown(
+                "delayed event operations require at least two coordination connections",
+            )
+            .into()
+        })
+}
+
+fn operation_permits(total_pool_size: u32, configured: Option<u32>) -> Option<usize> {
+    crate::data::coordination_pool_capacity(total_pool_size, configured)
+        .checked_sub(1)
+        .filter(|permits| *permits > 0)
+}
+
+fn scheduler_sleep(now: i64, next_wake: Option<i64>) -> Duration {
+    next_wake
+        .map(|at| {
+            let delay_ms = at.saturating_sub(now);
+            if delay_ms <= 0 {
+                LOCK_RETRY
+            } else {
+                Duration::from_millis(delay_ms as u64).min(MAX_IDLE)
+            }
+        })
+        .unwrap_or(MAX_IDLE)
+}
+
+fn may_be_authorized_without_joining(
+    user_id: &UserId,
+    event_type: &TimelineEventType,
+    state_key: Option<&str>,
+) -> bool {
+    *event_type == TimelineEventType::RoomMember && state_key == Some(user_id.as_str())
+}
+
+/// Start the background scheduler that sends due delayed events.
+pub fn start() {
+    tokio::spawn(async move {
+        let mut prune = tokio::time::interval(PRUNE_INTERVAL);
+        loop {
+            if let Err(error) = retry_pending_deliveries().await {
+                tracing::warn!(?error, "failed to retry delayed-event delivery");
+            }
+            if let Err(error) = process_due_events().await {
+                tracing::warn!(?error, "failed to process due delayed events");
+            }
+
+            let now = UnixMillis::now().get() as i64;
+            let next_wake = match delayed_event::next_send_at().await {
+                Ok(send_at) => send_at,
+                Err(error) => {
+                    tracing::warn!(?error, "failed to load next delayed event wake-up time");
+                    None
+                }
+            };
+            let sleep = scheduler_sleep(now, next_wake);
+            tokio::select! {
+                _ = wakeup().notified() => {},
+                _ = tokio::time::sleep(sleep) => {},
+                _ = prune.tick() => {
+                    let conf = config::get();
+                    let retention_ms = i64::try_from(conf.delayed_events.retention_ms)
+                        .unwrap_or(i64::MAX);
+                    let cutoff = (UnixMillis::now().get() as i64).saturating_sub(retention_ms);
+                    if let Err(error) = delayed_event::prune_finalized(cutoff).await {
+                        tracing::warn!(?error, "failed to prune finalized delayed events");
+                    }
+                },
+            }
+        }
+    });
+}
+
+/// Send every delayed event that is due, in chronological order of scheduled
+/// send times. Failures are recorded on the event instead of being retried,
+/// per the MSC.
+async fn process_due_events() -> AppResult<()> {
+    while process_one_due_event().await? {}
+    Ok(())
+}
+
+/// Lock, send, and finalize one due row in a single database transaction.
+async fn process_one_due_event() -> AppResult<bool> {
+    let _permit = operation_gate()?
+        .acquire()
+        .await
+        .expect("the delayed-event operation semaphore is never closed");
+    let mut conn = crate::data::coordination_connect().await?;
+    let (processed, delivery) = conn
+        .transaction::<_, AppError, _>(async |conn| {
+            let now = UnixMillis::now().get() as i64;
+            let Some(event) = delayed_event::lock_next_due(conn, now).await? else {
+                return Ok((false, None));
+            };
+            let delivery = match send_delayed_pdu(conn, &event).await {
+                Ok(event_id) => {
+                    delayed_event::set_sent_locked(
+                        conn,
+                        event.id,
+                        &event_id,
+                        UnixMillis::now().get() as i64,
+                    )
+                    .await?;
+                    Some((event.room_id.clone(), event_id))
+                }
+                Err(error) => {
+                    // A previous worker may have stopped after the event entered the
+                    // timeline but before it finalized this delayed row. The promotion
+                    // trigger is the authoritative commit point, so do not misclassify
+                    // that recovered case as a failed send.
+                    if let Some(event_id) = delayed_event::get_output(&event.delay_id).await? {
+                        tracing::warn!(
+                            delay_id = %event.delay_id,
+                            room_id = %event.room_id,
+                            %event_id,
+                            ?error,
+                            "delayed event entered the timeline before a later send step failed"
+                        );
+                        delayed_event::set_sent_locked(
+                            conn,
+                            event.id,
+                            &event_id,
+                            UnixMillis::now().get() as i64,
+                        )
+                        .await?;
+                        Some((event.room_id.clone(), event_id))
+                    } else {
+                        tracing::debug!(
+                            delay_id = %event.delay_id,
+                            room_id = %event.room_id,
+                            ?error,
+                            "delayed event failed to send at its scheduled time"
+                        );
+                        // The MSC says a scheduled send is not retried. The error
+                        // is committed under the same row lock that fenced the
+                        // append.
+                        delayed_event::set_error_locked(
+                            conn,
+                            event.id,
+                            &event.delay_id,
+                            &error_body(error),
+                            UnixMillis::now().get() as i64,
+                        )
+                        .await?;
+                        None
+                    }
+                }
+            };
+            Ok((true, delivery))
+        })
+        .await?;
+
+    drop(conn);
+    drop(_permit);
+    if let Some((room_id, event_id)) = delivery {
+        deliver_after_commit(&room_id, &event_id).await;
+    }
+    Ok(processed)
+}
+
+async fn retry_pending_deliveries() -> AppResult<()> {
+    let mut after: Option<OwnedEventId> = None;
+    loop {
+        let pending = delayed_event::pending_deliveries(after.as_deref()).await?;
+        if pending.is_empty() {
+            break;
+        }
+        after = pending.last().map(|(id, _)| id.clone());
+        for (event_id, room_id) in pending {
+            deliver_after_commit(&room_id, &event_id).await;
+        }
+    }
+    Ok(())
+}
+
+async fn queue_committed_delivery(room_id: &RoomId, event_id: &EventId) -> AppResult<()> {
+    let mut conn = crate::data::coordination_connect().await?;
+    conn.transaction::<_, AppError, _>(async |conn| {
+        if !delayed_event::lock_delivery(conn, event_id).await? {
+            return Ok(());
+        }
+        // A crash after enqueueing but before deleting the marker can repeat an
+        // event ID, which federation tolerates. Never delete before durable enqueue.
+        timeline::deliver_local_pdu(room_id, event_id).await?;
+        delayed_event::finish_delivery(conn, event_id).await?;
+        Ok(())
+    })
+    .await
+}
+
+async fn deliver_after_commit(room_id: &RoomId, event_id: &EventId) {
+    if let Err(error) = queue_committed_delivery(room_id, event_id).await {
+        tracing::warn!(%room_id, %event_id, ?error,
+            "delayed-event delivery remains queued for retry");
+    }
+}
+
+/// Build and append the PDU for a locked delayed event through the normal
+/// event authorization and timeline path. The caller queues federation delivery
+/// only after the surrounding row-locking transaction commits.
+///
+/// A send interrupted after the append but before the outcome is recorded
+/// leaves the delayed row scheduled. Database triggers track tentative
+/// outliers and atomically confirm the output when it enters the timeline, so
+/// recovery can replace an abandoned outlier but can never promote a second
+/// event for the same delay id.
+async fn send_delayed_pdu(
+    conn: &mut AsyncPgConnection,
+    event: &DbDelayedEvent,
+) -> AppResult<OwnedEventId> {
+    let event_type: TimelineEventType = event.event_type.clone().into();
+
+    // This runs before either room lock or the state check below: recovering an
+    // event that already reached the room must not wait behind unrelated room
+    // work or re-run authorization. The event it just sent may itself have
+    // changed the state that check reads, which would otherwise turn a
+    // completed send into a permanent failure.
+    // Use the delay-specific mapping: a reused transaction id can point at
+    // an older ordinary send, while this marker identifies the exact delayed
+    // event that actually entered the timeline.
+    if let Some(event_id) = delayed_event::get_output(&event.delay_id).await? {
+        // Repair the conventional transaction-id lookup when possible. The
+        // trigger-backed output is already a sufficient idempotency fence, so
+        // failure to write this secondary mapping must not turn a completed
+        // room append into a failed delayed event.
+        if let Err(error) = crate::transaction_id::add_txn_id(
+            &event.txn_id,
+            &event.user_id,
+            event.device_id.as_deref(),
+            Some(&event.room_id),
+            Some(&event_id),
+        )
+        .await
+        {
+            tracing::warn!(
+                delay_id = %event.delay_id,
+                %event_id,
+                ?error,
+                "failed to repair delayed-event transaction-id mapping"
+            );
+        }
+        return Ok(event_id);
+    }
+
+    // Delayed requests pass the HTTP limiter when they are scheduled, but the
+    // MSC also requires protection at the point the event enters the DAG.
+    crate::hoops::limit_delayed_message(&event.user_id)?;
+
+    // All local append paths take the process-local state lock before the database
+    // fence. Keeping one global order avoids deadlocking an ordinary local send with
+    // a delayed worker in another process.
+    let state_lock = room::lock_state(&event.room_id).await;
+    crate::data::room::timeline::lock_event_append(conn, &event.room_id).await?;
+
+    // A delayed send does not pass through the access-token hoop again. Apply
+    // the same current account-usability policy explicitly so deactivated,
+    // locked, or suspended users cannot emit previously queued events.
+    let user = crate::data::user::get_user(&event.user_id).await?;
+    crate::user::ensure_account_usable(&user)?;
+
+    // Re-evaluate server-side send policy as well as room authorization. An
+    // event scheduled while encryption was enabled must not bypass a later
+    // administrator decision to disable encrypted messages. This belongs
+    // after output recovery so an event that already entered the timeline is
+    // still finalized correctly.
+    if event_type == TimelineEventType::RoomEncrypted && !config::get().allow_encryption {
+        return Err(MatrixError::forbidden("Encryption has been disabled", None).into());
+    }
+    if let Some(state_key) = &event.state_key {
+        let state_event_type: StateEventType = event.event_type.clone().into();
+        crate::state::allowed_to_send_state_event(
+            &event.room_id,
+            &state_event_type,
+            state_key,
+            &serde_json::from_value(event.content.clone())?,
+        )
+        .await?;
+    }
+
+    let mut unsigned = BTreeMap::new();
+    unsigned.insert(
+        "org.matrix.msc4140.delay_id".to_owned(),
+        to_raw_value(&event.delay_id)?,
+    );
+
+    let event_id = timeline::build_and_append_pdu_force_locked(
+        PduBuilder {
+            event_type,
+            content: to_raw_value(&event.content)?,
+            unsigned,
+            state_key: event.state_key.clone(),
+            redacts: None,
+            timestamp: event.origin_server_ts.map(|ts| UnixMillis(ts as u64)),
+        },
+        &event.user_id,
+        &event.room_id,
+        &crate::room::get_version(&event.room_id).await?,
+        &state_lock,
+    )
+    .await?
+    .pdu
+    .event_id;
+
+    // The database trigger has already recorded the authoritative output in
+    // the same transaction that promoted the event into the timeline. Keep the
+    // standard transaction-id mapping for normal idempotency lookups, but do
+    // not misreport a completed room append if this secondary write fails.
+    if let Err(error) = crate::transaction_id::add_txn_id(
+        &event.txn_id,
+        &event.user_id,
+        event.device_id.as_deref(),
+        Some(&event.room_id),
+        Some(&event_id),
+    )
+    .await
+    {
+        tracing::warn!(
+            delay_id = %event.delay_id,
+            event_id = %event_id,
+            ?error,
+            "failed to record delayed-event transaction-id mapping"
+        );
+    }
+    drop(state_lock);
+
+    Ok((*event_id).to_owned())
+}
+
+/// Schedule a new delayed event, enforcing the configured limits. Returns the
+/// `delay_id`, reusing the one from a previous identical transaction for
+/// idempotency.
+pub async fn schedule(
+    user_id: &UserId,
+    device_id: Option<&DeviceId>,
+    is_appservice: bool,
+    room_id: &RoomId,
+    event_type: &TimelineEventType,
+    txn_id: &TransactionId,
+    timestamp: Option<UnixMillis>,
+    delay: Duration,
+    state_key: Option<String>,
+    content: JsonValue,
+) -> AppResult<String> {
+    let conf = config::get();
+    let now = UnixMillis::now().get() as i64;
+
+    // An already accepted transaction stays idempotent even if server limits,
+    // room state, or feature-related configuration changed since the original
+    // request. `create` repeats this lookup under its advisory lock to close
+    // the concurrent-first-request race.
+    if let Some(existing) = delayed_event::get_by_txn_id(user_id, device_id, txn_id).await? {
+        return Ok(existing.delay_id);
+    }
+
+    if !conf.delayed_events.enable {
+        return Err(MatrixError::forbidden("MSC4140 delayed events are disabled", None).into());
+    }
+
+    let requested_delay_ms = delay.as_millis();
+    if requested_delay_ms == 0 {
+        return Err(
+            MatrixError::invalid_param("delay must be a positive number of milliseconds").into(),
+        );
+    }
+    let max_delay_ms =
+        u128::from(conf.delayed_events.max_delay_ms).min(i64::MAX.saturating_sub(now) as u128);
+    if requested_delay_ms > max_delay_ms {
+        return Err(MatrixError::delay_too_large(format!(
+            "the requested delay exceeds the maximum allowed delay of {} ms",
+            max_delay_ms
+        ))
+        .into());
+    }
+    let delay_ms = i64::try_from(requested_delay_ms)
+        .map_err(|_| MatrixError::invalid_param("delay is too large"))?;
+
+    if !content.is_object() {
+        return Err(MatrixError::bad_json("event content is not an object").into());
+    }
+    to_canonical_value(&content).map_err(|e| {
+        MatrixError::bad_json(format!("event content is not valid canonical JSON: {e}"))
+    })?;
+
+    // Forbid m.room.encrypted if encryption is disabled, matching /send.
+    if event_type == &TimelineEventType::RoomEncrypted && !conf.allow_encryption {
+        return Err(MatrixError::forbidden("Encryption has been disabled", None).into());
+    }
+
+    // Reject work that already has no chance of succeeding. Authorization is
+    // still evaluated again against the then-current room state when the event
+    // is actually sent.
+    crate::room::get_version(room_id).await?;
+    if !crate::room::user::is_joined(user_id, room_id).await?
+        && !may_be_authorized_without_joining(user_id, event_type, state_key.as_deref())
+    {
+        return Err(MatrixError::forbidden(
+            "you must be joined to the room to schedule a delayed event",
+            None,
+        )
+        .into());
+    }
+    if let Some(state_key) = &state_key {
+        let state_event_type: StateEventType = event_type.to_string().into();
+        crate::state::allowed_to_send_state_event(
+            room_id,
+            &state_event_type,
+            state_key,
+            &serde_json::from_value(content.clone())?,
+        )
+        .await?;
+    }
+
+    let origin_server_ts = if is_appservice {
+        timestamp
+            .map(|ts| {
+                i64::try_from(ts.get())
+                    .map_err(|_| MatrixError::invalid_param("timestamp is too large"))
+            })
+            .transpose()?
+    } else {
+        None
+    };
+    let new = NewDbDelayedEvent {
+        delay_id: utils::random_string(18),
+        user_id: user_id.to_owned(),
+        device_id: device_id.map(|d| d.to_owned()),
+        room_id: room_id.to_owned(),
+        event_type: event_type.to_string(),
+        state_key,
+        content,
+        delay_ms,
+        txn_id: txn_id.to_owned(),
+        origin_server_ts,
+        running_since: now,
+        send_at: now + delay_ms,
+        created_at: now,
+    };
+    // The limit is enforced inside the same transaction as the insert, so
+    // concurrent requests cannot each observe a count below it and all succeed.
+    let max_scheduled = i64::try_from(conf.delayed_events.max_scheduled).unwrap_or(i64::MAX);
+    match delayed_event::create(new, max_scheduled).await? {
+        delayed_event::Scheduled::Created(row) => {
+            wakeup().notify_one();
+            Ok(row.delay_id)
+        }
+        // A concurrent retry of this same transaction already scheduled it.
+        delayed_event::Scheduled::AlreadyScheduled(row) => Ok(row.delay_id),
+        delayed_event::Scheduled::LimitReached => {
+            let retry_after = delayed_event::next_send_at_of_user(user_id)
+                .await?
+                .map(|send_at| RetryAfter::Delay(retry_after_delay(now, send_at)));
+            Err(MatrixError::limit_exceeded(
+                "The maximum number of delayed events has been reached.",
+                retry_after,
+            )
+            .into())
+        }
+    }
+}
+
+fn retry_after_delay(now: i64, send_at: i64) -> Duration {
+    Duration::from_millis(send_at.saturating_sub(now).max(0) as u64)
+}
+
+/// Apply a management action (`restart`/`send`/`cancel`) to a delayed event.
+pub async fn update(user_id: &UserId, delay_id: &str, action: &UpdateAction) -> AppResult<()> {
+    if delayed_event::get_by_delay_id(user_id, delay_id)
+        .await?
+        .is_none()
+    {
+        return Err(MatrixError::not_found("no delayed event with that delay_id was found").into());
+    }
+    match action {
+        UpdateAction::Restart => {
+            let _permit = operation_gate()?
+                .acquire()
+                .await
+                .expect("the delayed-event operation semaphore is never closed");
+            let mut conn = crate::data::coordination_connect().await?;
+            if delayed_event::restart(&mut conn, user_id, delay_id)
+                .await?
+                .is_some()
+            {
+                wakeup().notify_one();
+                Ok(())
+            } else {
+                let refreshed = delayed_event::get_by_delay_id(user_id, delay_id)
+                    .await?
+                    .ok_or_else(|| {
+                        MatrixError::not_found("no delayed event with that delay_id was found")
+                    })?;
+                Err(finalized_conflict(&refreshed, "restart"))
+            }
+        }
+        UpdateAction::Send => send_now(user_id, delay_id).await,
+        UpdateAction::Cancel => {
+            let _permit = operation_gate()?
+                .acquire()
+                .await
+                .expect("the delayed-event operation semaphore is never closed");
+            let mut conn = crate::data::coordination_connect().await?;
+            if delayed_event::cancel(&mut conn, user_id, delay_id).await? {
+                Ok(())
+            } else {
+                let refreshed = delayed_event::get_by_delay_id(user_id, delay_id)
+                    .await?
+                    .ok_or_else(|| {
+                        MatrixError::not_found("no delayed event with that delay_id was found")
+                    })?;
+                if refreshed.event_id.is_some() {
+                    Err(finalized_conflict(&refreshed, "cancel"))
+                } else {
+                    // The MSC treats cancelling an event that was already
+                    // cancelled -- "either due to user action or an error" --
+                    // as an idempotent success.
+                    Ok(())
+                }
+            }
+        }
+        _ => Err(MatrixError::invalid_param("unknown delayed event action").into()),
+    }
+}
+
+/// Manually send one row while holding its database lock through the append.
+async fn send_now(user_id: &UserId, delay_id: &str) -> AppResult<()> {
+    let _permit = operation_gate()?
+        .acquire()
+        .await
+        .expect("the delayed-event operation semaphore is never closed");
+    let mut conn = crate::data::coordination_connect().await?;
+    let delivery = conn
+        .transaction::<_, AppError, _>(async |conn| {
+            let Some(event) = delayed_event::lock_for_send(conn, user_id, delay_id).await? else {
+                return Err(
+                    MatrixError::not_found("no delayed event with that delay_id was found").into(),
+                );
+            };
+
+            if event.finalized_at.is_some() {
+                return if event.event_id.is_some() {
+                    Ok(None)
+                } else {
+                    Err(finalized_conflict(&event, "send"))
+                };
+            }
+            match send_delayed_pdu(conn, &event).await {
+                Ok(event_id) => {
+                    delayed_event::set_sent_locked(
+                        conn,
+                        event.id,
+                        &event_id,
+                        UnixMillis::now().get() as i64,
+                    )
+                    .await?;
+                    Ok(Some((event.room_id, event_id)))
+                }
+                Err(error) => {
+                    // A previous manual send may have committed the room append before
+                    // it finalized this delayed row. The trigger-backed output is
+                    // authoritative, just as it is for scheduled sends.
+                    if let Some(event_id) = delayed_event::get_output(&event.delay_id).await? {
+                        tracing::warn!(
+                            delay_id = %event.delay_id,
+                            room_id = %event.room_id,
+                            %event_id,
+                            ?error,
+                            "manually sent delayed event entered the timeline before a later step failed"
+                        );
+                        delayed_event::set_sent_locked(
+                            conn,
+                            event.id,
+                            &event_id,
+                            UnixMillis::now().get() as i64,
+                        )
+                        .await?;
+                        Ok(Some((event.room_id, event_id)))
+                    } else {
+                        Err(error)
+                    }
+                }
+            }
+        })
+        .await?;
+
+    drop(conn);
+    drop(_permit);
+    if let Some((room_id, event_id)) = delivery {
+        deliver_after_commit(&room_id, &event_id).await;
+    }
+    Ok(())
+}
+
+/// Fetch one delayed event owned by the user, whether scheduled or finalized.
+pub async fn get(user_id: &UserId, delay_id: &str) -> AppResult<DelayedEventData> {
+    delayed_event::get_by_delay_id(user_id, delay_id)
+        .await?
+        .map(to_event_data)
+        .ok_or_else(|| {
+            MatrixError::not_found("no delayed event with that delay_id was found").into()
+        })
+}
+
+fn to_event_data(event: DbDelayedEvent) -> DelayedEventData {
+    let event_id = event.event_id.clone();
+    let error = if event_id.is_none() {
+        event
+            .error
+            .clone()
+            .and_then(|error| serde_json::from_value::<DelayedEventError>(error).ok())
+    } else {
+        None
+    };
+    let finalised = event
+        .finalized_at
+        .map(|finalized_at| DelayedEventFinalization {
+            error,
+            event_id,
+            finalised_ts: unix_millis(finalized_at),
+        });
+
+    DelayedEventData {
+        delay_id: event.delay_id,
+        room_id: event.room_id,
+        event_type: event.event_type.into(),
+        state_key: event.state_key,
+        content: event.content,
+        delay: Duration::from_millis(u64::try_from(event.delay_ms).unwrap_or_default()),
+        running_since: unix_millis(event.running_since),
+        finalised,
+    }
+}
+
+fn unix_millis(value: i64) -> UnixMillis {
+    UnixMillis(u64::try_from(value).unwrap_or_default())
+}
+
+/// HTTP 409 for a management action that conflicts with the outcome the
+/// delayed event was already finalized with.
+fn finalized_conflict(event: &DbDelayedEvent, action: &str) -> AppError {
+    let outcome = if event.event_id.is_some() {
+        "already been sent"
+    } else if event.error.is_some() {
+        "already failed to send"
+    } else {
+        "already been cancelled"
+    };
+    let mut error = MatrixError::unknown(format!(
+        "cannot {action} a delayed event that has {outcome}"
+    ));
+    error.status_code = Some(StatusCode::CONFLICT);
+    error.into()
+}
+
+/// The standard error body stored for a delayed event that failed to send.
+fn error_body(error: AppError) -> JsonValue {
+    match error {
+        AppError::Matrix(e) => {
+            let retry_after = match &e.kind {
+                ErrorKind::LimitExceeded {
+                    retry_after: Some(RetryAfter::Delay(duration)),
+                } => Some(*duration),
+                _ => None,
+            };
+            let mut body = serde_json::to_value(&e).unwrap_or_default();
+            if let Some(map) = body.as_object_mut() {
+                map.insert("errcode".to_owned(), e.kind.code().to_string().into());
+                if let Some(duration) = retry_after
+                    && let Ok(ms) = u64::try_from(duration.as_millis())
+                {
+                    map.insert("retry_after_ms".to_owned(), ms.into());
+                }
+            }
+            body
+        }
+        _ => serde_json::json!({
+            "errcode": "M_UNKNOWN",
+            "error": "internal server error",
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::{
+        LOCK_RETRY, MAX_IDLE, error_body, may_be_authorized_without_joining, operation_permits,
+        retry_after_delay, scheduler_sleep,
+    };
+    use crate::AppError;
+    use crate::core::MatrixError;
+    use crate::core::error::RetryAfter;
+    use crate::core::events::TimelineEventType;
+
+    #[test]
+    fn delayed_event_internal_errors_do_not_expose_details() {
+        let body = error_body(AppError::internal("database secret path"));
+
+        assert_eq!(body["errcode"], "M_UNKNOWN");
+        assert_eq!(body["error"], "internal server error");
+        assert!(!body.to_string().contains("database secret path"));
+    }
+
+    #[test]
+    fn delayed_event_rate_limit_errors_keep_retry_delay() {
+        let body = error_body(
+            MatrixError::limit_exceeded(
+                "slow down",
+                Some(RetryAfter::Delay(Duration::from_millis(1500))),
+            )
+            .into(),
+        );
+
+        assert_eq!(body["errcode"], "M_LIMIT_EXCEEDED");
+        assert_eq!(body["retry_after_ms"], 1500);
+    }
+
+    #[test]
+    fn scheduler_retries_past_wakeups_without_unsigned_wraparound() {
+        assert_eq!(scheduler_sleep(1_000, Some(999)), LOCK_RETRY);
+        assert_eq!(scheduler_sleep(1_000, Some(1_000)), LOCK_RETRY);
+        assert_eq!(
+            scheduler_sleep(1_000, Some(1_250)),
+            Duration::from_millis(250)
+        );
+        assert_eq!(scheduler_sleep(1_000, None), MAX_IDLE);
+        assert_eq!(scheduler_sleep(1_000, Some(i64::MAX)), MAX_IDLE);
+    }
+
+    #[test]
+    fn overdue_limit_retry_does_not_wrap_to_a_huge_duration() {
+        assert_eq!(retry_after_delay(1_000, 999), Duration::ZERO);
+        assert_eq!(retry_after_delay(1_000, 1_000), Duration::ZERO);
+        assert_eq!(retry_after_delay(1_000, 1_250), Duration::from_millis(250));
+        assert_eq!(retry_after_delay(i64::MAX, i64::MIN), Duration::ZERO);
+    }
+
+    #[test]
+    fn delayed_operations_leave_one_coordination_connection_free() {
+        assert_eq!(operation_permits(4, Some(2)), Some(1));
+        assert_eq!(operation_permits(10, None), Some(1));
+        assert_eq!(operation_permits(64, None), Some(15));
+    }
+
+    #[test]
+    fn delayed_operations_reject_a_single_coordination_connection() {
+        assert_eq!(operation_permits(3, None), None);
+        assert_eq!(operation_permits(4, None), None);
+    }
+
+    #[test]
+    fn only_self_membership_may_be_authorized_before_joining() {
+        let user: crate::core::OwnedUserId = "@alice:example.org".try_into().unwrap();
+        assert!(may_be_authorized_without_joining(
+            &user,
+            &TimelineEventType::RoomMember,
+            Some(user.as_str())
+        ));
+        assert!(!may_be_authorized_without_joining(
+            &user,
+            &TimelineEventType::RoomMember,
+            Some("@bob:example.org")
+        ));
+        assert!(!may_be_authorized_without_joining(
+            &user,
+            &TimelineEventType::RoomMessage,
+            None
+        ));
+    }
+    #[tokio::test]
+    #[ignore = "requires an empty dedicated PALPO_TEST_DATABASE_URL"]
+    async fn database_delayed_delivery_survives_rollback_and_retention() {
+        use super::*;
+        crate::test_database::init();
+        let new = NewDbDelayedEvent {
+            delay_id: "delivery-regression".into(),
+            user_id: "@delayed:example.org".try_into().unwrap(),
+            device_id: Some("PHONE".into()),
+            room_id: "!delayed:example.org".try_into().unwrap(),
+            event_type: "m.room.message".into(),
+            state_key: None,
+            content: serde_json::json!({}),
+            delay_ms: 1000,
+            txn_id: "delivery-txn".into(),
+            origin_server_ts: None,
+            running_since: 1,
+            send_at: 1001,
+            created_at: 1,
+        };
+        let delayed_event::Scheduled::Created(row) = delayed_event::create(new, 10).await.unwrap()
+        else {
+            panic!("new row")
+        };
+        let event = EventId::parse("$delayed:example.org").unwrap();
+        let mut conn = crate::data::connect().await.unwrap();
+        let failed = conn
+            .transaction::<(), AppError, _>(async |conn| {
+                delayed_event::set_sent_locked(conn, row.id, &event, 2000).await?;
+                Err(AppError::internal(
+                    "simulate crash before completion commit",
+                ))
+            })
+            .await;
+        assert!(failed.is_err());
+        assert!(
+            delayed_event::get_by_delay_id(&row.user_id, &row.delay_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .finalized_at
+                .is_none()
+        );
+        assert!(
+            delayed_event::pending_deliveries(None)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        conn.transaction::<(), AppError, _>(async |conn| {
+            delayed_event::set_sent_locked(conn, row.id, &event, 2000).await?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+        assert_eq!(delayed_event::prune_finalized(i64::MAX).await.unwrap(), 0);
+        let failed = conn
+            .transaction::<(), AppError, _>(async |conn| {
+                assert!(delayed_event::lock_delivery(conn, &event).await?);
+                delayed_event::finish_delivery(conn, &event).await?;
+                Err(AppError::internal(
+                    "simulate crash before delivery acknowledgement",
+                ))
+            })
+            .await;
+        assert!(failed.is_err());
+        assert_eq!(
+            delayed_event::pending_deliveries(None).await.unwrap().len(),
+            1
+        );
+        conn.transaction::<(), AppError, _>(async |conn| {
+            assert!(delayed_event::lock_delivery(conn, &event).await?);
+            delayed_event::finish_delivery(conn, &event).await?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+        assert_eq!(delayed_event::prune_finalized(i64::MAX).await.unwrap(), 1);
+    }
+}

--- a/crates/server/src/delayed_event.rs
+++ b/crates/server/src/delayed_event.rs
@@ -84,55 +84,88 @@ pub fn start() {
 async fn process_due_events() -> AppResult<()> {
     let now = UnixMillis::now().get() as i64;
     for event in delayed_event::list_due(now).await? {
-        let Some(claimed) = delayed_event::claim(event.id, now).await? else {
-            // Finalized concurrently (cancelled or manually sent).
+        let Some(claimed) = delayed_event::claim_due(event.id, now).await? else {
+            // Finalized, restarted, or claimed concurrently since `list_due`.
             continue;
         };
         match send_delayed_pdu(&claimed).await {
             Ok(event_id) => {
-                delayed_event::set_sent(claimed.id, &event_id).await?;
+                delayed_event::set_sent(claimed.id, &event_id, now).await?;
             }
-            Err(error) => {
+            Err(failure) => {
+                let error = failure.into_error();
                 tracing::debug!(
                     delay_id = %claimed.delay_id,
                     room_id = %claimed.room_id,
                     ?error,
                     "delayed event failed to send at its scheduled time"
                 );
-                delayed_event::set_error(claimed.id, &error_body(error)).await?;
+                // The MSC says a scheduled send is not retried either way, so
+                // both failure kinds finalize with the error here.
+                delayed_event::set_error(claimed.id, &error_body(error), now).await?;
             }
         }
     }
     Ok(())
 }
 
+/// Why a delayed event failed to send, split by whether a PDU can already
+/// exist in the room.
+enum SendFailure {
+    /// Refused before anything was written. Retrying is safe.
+    Rejected(AppError),
+    /// Failed at or after `build_and_append_pdu`, which persists the event
+    /// before its later push and federation steps. A retry could duplicate it.
+    Appending(AppError),
+}
+
+impl SendFailure {
+    fn into_error(self) -> AppError {
+        match self {
+            Self::Rejected(e) | Self::Appending(e) => e,
+        }
+    }
+}
+
 /// Build and append the PDU for a claimed delayed event through the normal
 /// event authorization and federation paths.
-async fn send_delayed_pdu(event: &DbDelayedEvent) -> AppResult<OwnedEventId> {
+async fn send_delayed_pdu(event: &DbDelayedEvent) -> Result<OwnedEventId, SendFailure> {
     let event_type: TimelineEventType = event.event_type.clone().into();
     if let Some(state_key) = &event.state_key {
         let state_event_type: StateEventType = event.event_type.clone().into();
+        let content = serde_json::from_value(event.content.clone())
+            .map_err(|e| SendFailure::Rejected(AppError::from(e)))?;
         crate::state::allowed_to_send_state_event(
             &event.room_id,
             &state_event_type,
             state_key,
-            &serde_json::from_value(event.content.clone())?,
+            &content,
         )
-        .await?;
+        .await
+        .map_err(SendFailure::Rejected)?;
     }
 
     let mut unsigned = BTreeMap::new();
     unsigned.insert(
         "org.matrix.msc4140.delay_id".to_owned(),
-        to_raw_value(&event.delay_id)?,
+        to_raw_value(&event.delay_id).map_err(|e| SendFailure::Rejected(AppError::from(e)))?,
     );
-    unsigned.insert("transaction_id".to_owned(), to_raw_value(&event.txn_id)?);
+    unsigned.insert(
+        "transaction_id".to_owned(),
+        to_raw_value(&event.txn_id).map_err(|e| SendFailure::Rejected(AppError::from(e)))?,
+    );
+    let content =
+        to_raw_value(&event.content).map_err(|e| SendFailure::Rejected(AppError::from(e)))?;
+    let room_version = crate::room::get_version(&event.room_id)
+        .await
+        .map_err(SendFailure::Rejected)?;
 
+    // Everything past this point may have written the event to the timeline.
     let state_lock = room::lock_state(&event.room_id).await;
     let event_id = timeline::build_and_append_pdu(
         PduBuilder {
             event_type,
-            content: to_raw_value(&event.content)?,
+            content,
             unsigned,
             state_key: event.state_key.clone(),
             redacts: None,
@@ -140,10 +173,11 @@ async fn send_delayed_pdu(event: &DbDelayedEvent) -> AppResult<OwnedEventId> {
         },
         &event.user_id,
         &event.room_id,
-        &crate::room::get_version(&event.room_id).await?,
+        &room_version,
         &state_lock,
     )
-    .await?
+    .await
+    .map_err(SendFailure::Appending)?
     .pdu
     .event_id;
     drop(state_lock);
@@ -269,16 +303,25 @@ pub async fn update(user_id: &UserId, delay_id: &str, action: &UpdateAction) -> 
                 let refreshed = delayed_event::get_by_delay_id(user_id, delay_id)
                     .await?
                     .unwrap_or(event);
-                Err(finalized_conflict(&refreshed, "restart"))
+                if send_in_flight(&refreshed, now) {
+                    Err(in_flight_conflict("restart"))
+                } else {
+                    Err(finalized_conflict(&refreshed, "restart"))
+                }
             }
         }
         UpdateAction::Send => {
             let Some(claimed) = delayed_event::claim(event.id, now).await? else {
-                // Already finalized: sending is idempotent if it was sent,
-                // conflicting otherwise.
                 let refreshed = delayed_event::get_by_delay_id(user_id, delay_id)
                     .await?
                     .unwrap_or(event);
+                // Another worker is already sending it, which is the outcome
+                // this request wanted.
+                if send_in_flight(&refreshed, now) {
+                    return Ok(());
+                }
+                // Already finalized: sending is idempotent if it was sent,
+                // conflicting otherwise.
                 if refreshed.event_id.is_some() {
                     return Ok(());
                 }
@@ -286,14 +329,26 @@ pub async fn update(user_id: &UserId, delay_id: &str, action: &UpdateAction) -> 
             };
             match send_delayed_pdu(&claimed).await {
                 Ok(event_id) => {
-                    delayed_event::set_sent(claimed.id, &event_id).await?;
+                    delayed_event::set_sent(claimed.id, &event_id, now).await?;
                     Ok(())
                 }
-                Err(error) => {
-                    // The MSC requires the event to stay scheduled so the
-                    // client can retry until the scheduled send time.
+                // Rejected before anything was written, so the MSC's rule that
+                // the event stays scheduled applies: release the lease and
+                // report the error to the client.
+                Err(SendFailure::Rejected(error)) => {
                     delayed_event::unclaim(claimed.id).await?;
                     Err(error)
+                }
+                // The append may already have reached the timeline, so the row
+                // must not become sendable again or a retry would duplicate
+                // the event. Finalize it with the error instead.
+                Err(SendFailure::Appending(error)) => {
+                    let body = error_body(error);
+                    delayed_event::set_error(claimed.id, &body, now).await?;
+                    Err(MatrixError::unknown(
+                        "the delayed event could not be completed and is no longer scheduled",
+                    )
+                    .into())
                 }
             }
         }
@@ -304,10 +359,14 @@ pub async fn update(user_id: &UserId, delay_id: &str, action: &UpdateAction) -> 
                 let refreshed = delayed_event::get_by_delay_id(user_id, delay_id)
                     .await?
                     .unwrap_or(event);
-                if refreshed.event_id.is_some() {
+                if send_in_flight(&refreshed, now) {
+                    Err(in_flight_conflict("cancel"))
+                } else if refreshed.event_id.is_some() {
                     Err(finalized_conflict(&refreshed, "cancel"))
                 } else {
-                    // Already cancelled, either by user action or an error.
+                    // The MSC treats cancelling an event that was already
+                    // cancelled -- "either due to user action or an error" --
+                    // as an idempotent success.
                     Ok(())
                 }
             }
@@ -350,6 +409,25 @@ fn to_event_data(event: DbDelayedEvent) -> DelayedEventData {
         event_id: event.event_id,
         finalized_ts: event.finalized_at.map(|ts| UnixMillis(ts as u64)),
     }
+}
+
+/// Whether a worker currently holds the send lease on this row, meaning the
+/// event is on its way into the room and no management action can stop it.
+fn send_in_flight(event: &DbDelayedEvent, now: i64) -> bool {
+    event.finalized_at.is_none()
+        && event
+            .claimed_at
+            .is_some_and(|claimed| claimed >= now - delayed_event::CLAIM_LEASE_MS)
+}
+
+/// HTTP 409 for a management action that arrived while the event was already
+/// being sent.
+fn in_flight_conflict(action: &str) -> AppError {
+    let mut error = MatrixError::unknown(format!(
+        "cannot {action} a delayed event that is currently being sent"
+    ));
+    error.status_code = Some(StatusCode::CONFLICT);
+    error.into()
 }
 
 /// HTTP 409 for a management action that conflicts with the outcome the

--- a/crates/server/src/event/pdu.rs
+++ b/crates/server/src/event/pdu.rs
@@ -445,8 +445,14 @@ impl PduEvent {
         }
     }
 
-    pub fn remove_transaction_id(&mut self) -> AppResult<()> {
+    /// Strips the `unsigned` fields that only the event's own sender may see.
+    ///
+    /// `transaction_id` is sender-only per the spec, and MSC4140 requires the same of a delayed
+    /// event's `delay_id`: it is included "if, and only if, the client being given the event is
+    /// authenticated as the event's sender".
+    pub fn remove_sender_only_unsigned(&mut self) -> AppResult<()> {
         self.unsigned.remove("transaction_id");
+        self.unsigned.remove("org.matrix.msc4140.delay_id");
         Ok(())
     }
 

--- a/crates/server/src/event/pdu.rs
+++ b/crates/server/src/event/pdu.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::ops::{Deref, DerefMut};
@@ -458,9 +459,29 @@ impl PduEvent {
         }
     }
 
-    pub fn remove_transaction_id(&mut self) -> AppResult<()> {
+    /// Strip unsigned metadata which is only visible to the event sender.
+    pub fn remove_sender_only_unsigned(&mut self) -> AppResult<()> {
         self.unsigned.remove("transaction_id");
+        self.unsigned.remove("org.matrix.msc4140.delay_id");
         Ok(())
+    }
+
+    fn unsigned_for_recipient(
+        &self,
+        recipient: &UserId,
+    ) -> Cow<'_, BTreeMap<String, Box<RawJsonValue>>> {
+        if self.sender == recipient {
+            Cow::Borrowed(&self.unsigned)
+        } else {
+            Cow::Owned(self.unsigned_without_sender_only())
+        }
+    }
+
+    fn unsigned_without_sender_only(&self) -> BTreeMap<String, Box<RawJsonValue>> {
+        let mut unsigned = self.unsigned.clone();
+        unsigned.remove("transaction_id");
+        unsigned.remove("org.matrix.msc4140.delay_id");
+        unsigned
     }
 
     pub fn add_age(&mut self) -> AppResult<()> {
@@ -474,8 +495,10 @@ impl PduEvent {
         Ok(())
     }
 
-    #[tracing::instrument]
-    pub fn to_sync_room_event(&self) -> RawJson<AnySyncTimelineEvent> {
+    fn to_sync_room_event_with_unsigned(
+        &self,
+        unsigned: &BTreeMap<String, Box<RawJsonValue>>,
+    ) -> RawJson<AnySyncTimelineEvent> {
         let mut json = json!({
             "content": self.content,
             "type": self.event_ty,
@@ -484,8 +507,8 @@ impl PduEvent {
             "origin_server_ts": self.origin_server_ts,
         });
 
-        if !self.unsigned.is_empty() {
-            json["unsigned"] = json!(self.unsigned);
+        if !unsigned.is_empty() {
+            json["unsigned"] = json!(unsigned);
         }
         if let Some(state_key) = &self.state_key {
             json["state_key"] = json!(state_key);
@@ -497,8 +520,18 @@ impl PduEvent {
         serde_json::from_value(json).expect("RawJson::from_value always works")
     }
 
-    #[tracing::instrument]
-    pub fn to_room_event(&self) -> RawJson<AnyTimelineEvent> {
+    pub fn to_sync_room_event_for(&self, recipient: &UserId) -> RawJson<AnySyncTimelineEvent> {
+        self.to_sync_room_event_with_unsigned(self.unsigned_for_recipient(recipient).as_ref())
+    }
+
+    pub fn to_sync_room_event_without_sender_only_unsigned(&self) -> RawJson<AnySyncTimelineEvent> {
+        self.to_sync_room_event_with_unsigned(&self.unsigned_without_sender_only())
+    }
+
+    fn to_room_event_with_unsigned(
+        &self,
+        unsigned: &BTreeMap<String, Box<RawJsonValue>>,
+    ) -> RawJson<AnyTimelineEvent> {
         let age = UnixMillis::now()
             .get()
             .saturating_sub(self.origin_server_ts.get());
@@ -511,12 +544,12 @@ impl PduEvent {
             "room_id": self.room_id,
         });
 
-        if self.unsigned.is_empty() {
+        if unsigned.is_empty() {
             data["unsigned"] = json!({ "age": age });
         } else {
-            let mut unsigned = json!(self.unsigned);
-            unsigned["age"] = json!(age);
-            data["unsigned"] = unsigned;
+            let mut unsigned_json = json!(unsigned);
+            unsigned_json["age"] = json!(age);
+            data["unsigned"] = unsigned_json;
         }
         if let Some(state_key) = &self.state_key {
             data["state_key"] = json!(state_key);
@@ -528,8 +561,18 @@ impl PduEvent {
         serde_json::from_value(data).expect("RawJson::from_value always works")
     }
 
-    #[tracing::instrument]
-    pub fn to_message_like_event(&self) -> RawJson<AnyMessageLikeEvent> {
+    pub fn to_room_event_for(&self, recipient: &UserId) -> RawJson<AnyTimelineEvent> {
+        self.to_room_event_with_unsigned(self.unsigned_for_recipient(recipient).as_ref())
+    }
+
+    pub fn to_room_event_without_sender_only_unsigned(&self) -> RawJson<AnyTimelineEvent> {
+        self.to_room_event_with_unsigned(&self.unsigned_without_sender_only())
+    }
+
+    fn to_message_like_event_with_unsigned(
+        &self,
+        unsigned: &BTreeMap<String, Box<RawJsonValue>>,
+    ) -> RawJson<AnyMessageLikeEvent> {
         let mut data = json!({
             "content": self.content,
             "type": self.event_ty,
@@ -539,8 +582,8 @@ impl PduEvent {
             "room_id": self.room_id,
         });
 
-        if !self.unsigned.is_empty() {
-            data["unsigned"] = json!(self.unsigned);
+        if !unsigned.is_empty() {
+            data["unsigned"] = json!(unsigned);
         }
         if let Some(state_key) = &self.state_key {
             data["state_key"] = json!(state_key);
@@ -552,13 +595,35 @@ impl PduEvent {
         serde_json::from_value(data).expect("RawJson::from_value always works")
     }
 
+    pub fn to_message_like_event_for(&self, recipient: &UserId) -> RawJson<AnyMessageLikeEvent> {
+        self.to_message_like_event_with_unsigned(self.unsigned_for_recipient(recipient).as_ref())
+    }
+
+    pub fn to_message_like_event_without_sender_only_unsigned(
+        &self,
+    ) -> RawJson<AnyMessageLikeEvent> {
+        self.to_message_like_event_with_unsigned(&self.unsigned_without_sender_only())
+    }
+
     #[tracing::instrument]
-    pub fn to_state_event(&self) -> RawJson<AnyStateEvent> {
-        serde_json::from_value(self.to_state_event_value())
+    pub fn to_state_event_with_sender_only_unsigned(&self) -> RawJson<AnyStateEvent> {
+        serde_json::from_value(self.to_state_event_value_with_unsigned(&self.unsigned))
             .expect("RawJson::from_value always works")
     }
-    #[tracing::instrument]
-    pub fn to_state_event_value(&self) -> JsonValue {
+
+    pub fn to_state_event_for(&self, recipient: &UserId) -> RawJson<AnyStateEvent> {
+        serde_json::from_value(
+            self.to_state_event_value_with_unsigned(
+                self.unsigned_for_recipient(recipient).as_ref(),
+            ),
+        )
+        .expect("RawJson::from_value always works")
+    }
+
+    fn to_state_event_value_with_unsigned(
+        &self,
+        unsigned: &BTreeMap<String, Box<RawJsonValue>>,
+    ) -> JsonValue {
         let JsonValue::Object(mut data) = json!({
             "content": self.content,
             "type": self.event_ty,
@@ -571,8 +636,8 @@ impl PduEvent {
             panic!("Invalid JSON value, never happened!");
         };
 
-        if !self.unsigned.is_empty() {
-            data.insert("unsigned".into(), json!(self.unsigned));
+        if !unsigned.is_empty() {
+            data.insert("unsigned".into(), json!(unsigned));
         }
 
         for (key, value) in &self.extra_data {
@@ -584,8 +649,14 @@ impl PduEvent {
         JsonValue::Object(data)
     }
 
-    #[tracing::instrument]
-    pub fn to_sync_state_event(&self) -> RawJson<AnySyncStateEvent> {
+    pub fn to_state_event_value_for(&self, recipient: &UserId) -> JsonValue {
+        self.to_state_event_value_with_unsigned(self.unsigned_for_recipient(recipient).as_ref())
+    }
+
+    fn to_sync_state_event_with_unsigned(
+        &self,
+        unsigned: &BTreeMap<String, Box<RawJsonValue>>,
+    ) -> RawJson<AnySyncStateEvent> {
         let mut data = json!({
             "content": self.content,
             "type": self.event_ty,
@@ -595,11 +666,15 @@ impl PduEvent {
             "state_key": self.state_key,
         });
 
-        if !self.unsigned.is_empty() {
-            data["unsigned"] = json!(self.unsigned);
+        if !unsigned.is_empty() {
+            data["unsigned"] = json!(unsigned);
         }
 
         serde_json::from_value(data).expect("RawJson::from_value always works")
+    }
+
+    pub fn to_sync_state_event_for(&self, recipient: &UserId) -> RawJson<AnySyncStateEvent> {
+        self.to_sync_state_event_with_unsigned(self.unsigned_for_recipient(recipient).as_ref())
     }
 
     #[tracing::instrument]
@@ -639,7 +714,11 @@ impl PduEvent {
     }
 
     #[tracing::instrument]
-    pub fn to_member_event(&self) -> RawJson<StateEvent<RoomMemberEventContent>> {
+    pub fn to_member_event_for(
+        &self,
+        recipient: &UserId,
+    ) -> RawJson<StateEvent<RoomMemberEventContent>> {
+        let unsigned = self.unsigned_for_recipient(recipient);
         let mut data = json!({
             "content": self.content,
             "type": self.event_ty,
@@ -651,8 +730,8 @@ impl PduEvent {
             "state_key": self.state_key,
         });
 
-        if !self.unsigned.is_empty() {
-            data["unsigned"] = json!(self.unsigned);
+        if !unsigned.is_empty() {
+            data["unsigned"] = json!(unsigned);
         }
 
         serde_json::from_value(data).expect("RawJson::from_value always works")
@@ -1125,5 +1204,111 @@ impl Default for PduBuilder {
             redacts: None,
             timestamp: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod sender_only_unsigned_tests {
+    use serde_json::value::to_raw_value;
+
+    use super::*;
+
+    fn event_with_sender_only_unsigned() -> PduEvent {
+        let mut unsigned = BTreeMap::new();
+        unsigned.insert("transaction_id".to_owned(), to_raw_value("txn").unwrap());
+        unsigned.insert(
+            "org.matrix.msc4140.delay_id".to_owned(),
+            to_raw_value("delay").unwrap(),
+        );
+        unsigned.insert("age".to_owned(), to_raw_value(&10_u64).unwrap());
+
+        PduEvent {
+            event_id: "$event:example.org".try_into().unwrap(),
+            sender: "@alice:example.org".try_into().unwrap(),
+            origin_server_ts: UnixMillis(1),
+            event_ty: TimelineEventType::RoomMessage,
+            content: to_raw_value(&json!({"body": "hi", "msgtype": "m.text"})).unwrap(),
+            state_key: None,
+            room_id: "!room:example.org".try_into().unwrap(),
+            prev_events: Vec::new(),
+            depth: 1,
+            auth_events: Vec::new(),
+            redacts: None,
+            hashes: EventHash {
+                sha256: String::new(),
+            },
+            signatures: None,
+            unsigned,
+            extra_data: Default::default(),
+            rejection_reason: None,
+        }
+    }
+
+    #[test]
+    fn sender_keeps_sender_only_unsigned_fields() {
+        let event = event_with_sender_only_unsigned();
+        let sender: OwnedUserId = "@alice:example.org".try_into().unwrap();
+
+        let converted = event.to_room_event_for(&sender);
+        let json: JsonValue = serde_json::from_str(converted.as_str()).unwrap();
+
+        assert_eq!(
+            json.pointer("/unsigned/transaction_id"),
+            Some(&json!("txn"))
+        );
+        assert_eq!(
+            json.pointer("/unsigned/org.matrix.msc4140.delay_id"),
+            Some(&json!("delay"))
+        );
+    }
+
+    #[test]
+    fn other_users_do_not_receive_sender_only_unsigned_fields() {
+        let event = event_with_sender_only_unsigned();
+        let recipient: OwnedUserId = "@bob:example.org".try_into().unwrap();
+
+        let converted = event.to_room_event_for(&recipient);
+        let json: JsonValue = serde_json::from_str(converted.as_str()).unwrap();
+
+        assert!(json.pointer("/unsigned/transaction_id").is_none());
+        assert!(
+            json.pointer("/unsigned/org.matrix.msc4140.delay_id")
+                .is_none()
+        );
+        assert!(json.pointer("/unsigned/age").is_some());
+    }
+
+    #[test]
+    fn member_listing_does_not_leak_sender_only_unsigned_fields() {
+        let mut event = event_with_sender_only_unsigned();
+        event.event_ty = TimelineEventType::RoomMember;
+        event.state_key = Some(event.sender.to_string());
+        event.content = to_raw_value(&json!({"membership": "join"})).unwrap();
+        let recipient: OwnedUserId = "@bob:example.org".try_into().unwrap();
+
+        let converted = event.to_member_event_for(&recipient);
+        let json: JsonValue = serde_json::from_str(converted.as_str()).unwrap();
+
+        assert!(json.pointer("/unsigned/transaction_id").is_none());
+        assert!(
+            json.pointer("/unsigned/org.matrix.msc4140.delay_id")
+                .is_none()
+        );
+        assert_eq!(json.pointer("/unsigned/age"), Some(&json!(10)));
+    }
+
+    #[test]
+    fn nested_events_never_expose_sender_only_unsigned_fields() {
+        let event = event_with_sender_only_unsigned();
+
+        let converted = event.to_message_like_event_without_sender_only_unsigned();
+        let json: JsonValue = serde_json::from_str(converted.as_str()).unwrap();
+
+        assert!(json.pointer("/unsigned/transaction_id").is_none());
+        assert!(
+            json.pointer("/unsigned/org.matrix.msc4140.delay_id")
+                .is_none()
+        );
+        assert_eq!(json.pointer("/unsigned/age"), Some(&json!(10)));
     }
 }

--- a/crates/server/src/event/search.rs
+++ b/crates/server/src/event/search.rs
@@ -129,7 +129,7 @@ pub async fn search_pdus(
                 .await
                 .unwrap_or_default(),
             rank: Some(rank as f64),
-            result: Some(pdu.to_room_event()),
+            result: Some(pdu.to_room_event_for(user_id)),
         });
     }
 
@@ -205,11 +205,11 @@ async fn calc_event_context(
             .map(|(sn, _)| BatchToken::new_live(*sn).to_string()),
         events_before: before_pdus
             .into_iter()
-            .map(|(_, pdu)| pdu.to_room_event())
+            .map(|(_, pdu)| pdu.to_room_event_for(user_id))
             .collect(),
         events_after: after_pdus
             .into_iter()
-            .map(|(_, pdu)| pdu.to_room_event())
+            .map(|(_, pdu)| pdu.to_room_event_for(user_id))
             .collect(),
         profile_info: BTreeMap::new(),
     };

--- a/crates/server/src/hoops.rs
+++ b/crates/server/src/hoops.rs
@@ -102,6 +102,7 @@ static LOGIN_LIMITER: LazyLock<RateLimiter> = LazyLock::new(RateLimiter::new);
 static REGISTRATION_LIMITER: LazyLock<RateLimiter> = LazyLock::new(RateLimiter::new);
 static PASSWORD_LIMITER: LazyLock<RateLimiter> = LazyLock::new(RateLimiter::new);
 static MESSAGE_LIMITER: LazyLock<RateLimiter> = LazyLock::new(RateLimiter::new);
+static DELAYED_MESSAGE_LIMITER: LazyLock<RateLimiter> = LazyLock::new(RateLimiter::new);
 
 #[handler]
 pub async fn limit_rate_login(req: &mut Request) -> AppResult<()> {
@@ -134,6 +135,13 @@ pub async fn limit_rate(req: &mut Request) -> AppResult<()> {
         MESSAGE_LIMITER.check(&ip, &crate::config::get().rc_message)?;
     }
     Ok(())
+}
+
+/// Apply the normal message rate to an event emitted later by the delayed-event
+/// scheduler. There is no originating HTTP connection at that point, so use the
+/// authenticated sender as the bucket key.
+pub fn limit_delayed_message(user_id: &crate::core::UserId) -> AppResult<()> {
+    DELAYED_MESSAGE_LIMITER.check(user_id.as_str(), &crate::config::get().rc_message)
 }
 
 // utf8 will cause complement testing fail.
@@ -194,5 +202,25 @@ pub async fn catch_status_error(
         let matrix = MatrixError::unrecognized("method not allowed");
         matrix.write(req, depot, res).await;
         ctrl.skip_rest();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RateLimiter;
+    use crate::config::RateLimitConfig;
+
+    #[test]
+    fn rate_limit_buckets_are_isolated_by_key() {
+        let limiter = RateLimiter::new();
+        let config = RateLimitConfig {
+            per_second: 1.0,
+            burst: 2,
+        };
+
+        assert!(limiter.check("alice", &config).is_ok());
+        assert!(limiter.check("alice", &config).is_ok());
+        assert!(limiter.check("alice", &config).is_err());
+        assert!(limiter.check("bob", &config).is_ok());
     }
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -25,6 +25,7 @@ pub mod utils;
 pub use auth::{AuthArgs, AuthedInfo};
 pub mod admin;
 pub mod appservice;
+pub mod delayed_event;
 pub mod directory;
 pub mod event;
 pub mod exts;
@@ -250,6 +251,13 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             tracing::error!("admin command processor stopped");
         }
     });
+
+    // MSC4140: send scheduled delayed events once their delay elapses; on
+    // startup this also recovers events that became due while the server was
+    // offline.
+    if config::get().delayed_events.enable {
+        crate::delayed_event::start();
+    }
 
     // MSC2444: periodically renew our outbound room peeks and drop lapsed inbound
     // peekers.

--- a/crates/server/src/room/pdu_metadata.rs
+++ b/crates/server/src/room/pdu_metadata.rs
@@ -138,7 +138,7 @@ pub async fn get_relations(
     for relation in relations {
         if let Ok(mut pdu) = timeline::get_pdu(&relation.child_id).await {
             if pdu.sender != user_id {
-                pdu.remove_transaction_id()?;
+                pdu.remove_sender_only_unsigned()?;
             }
             if pdu.user_can_see(user_id).await.unwrap_or(false) {
                 pdus.push((relation.child_sn, pdu));

--- a/crates/server/src/room/pdu_metadata.rs
+++ b/crates/server/src/room/pdu_metadata.rs
@@ -99,7 +99,7 @@ pub async fn paginate_relations_with_filter(
 
     let events: Vec<_> = events
         .into_iter()
-        .map(|(_, pdu)| pdu.to_message_like_event())
+        .map(|(_, pdu)| pdu.to_message_like_event_for(user_id))
         .collect();
 
     Ok(RelationEventsResBody {
@@ -138,7 +138,7 @@ pub async fn get_relations(
     for relation in relations {
         if let Ok(mut pdu) = timeline::get_pdu(&relation.child_id).await {
             if pdu.sender != user_id {
-                pdu.remove_transaction_id()?;
+                pdu.remove_sender_only_unsigned()?;
             }
             if pdu.user_can_see(user_id).await.unwrap_or(false) {
                 pdus.push((relation.child_sn, pdu));

--- a/crates/server/src/room/thread.rs
+++ b/crates/server/src/room/thread.rs
@@ -43,7 +43,7 @@ pub async fn add_to_thread(thread_id: &EventId, pdu: &SnPduEvent) -> AppResult<(
         {
             // Thread already existed
             relations.count += 1;
-            relations.latest_event = pdu.to_message_like_event();
+            relations.latest_event = pdu.to_message_like_event_without_sender_only_unsigned();
 
             let content = serde_json::to_value(relations).expect("to_value always works");
 
@@ -56,7 +56,7 @@ pub async fn add_to_thread(thread_id: &EventId, pdu: &SnPduEvent) -> AppResult<(
         } else {
             // New thread
             let relations = BundledThread {
-                latest_event: pdu.to_message_like_event(),
+                latest_event: pdu.to_message_like_event_without_sender_only_unsigned(),
                 count: 1,
                 current_user_participated: true,
             };

--- a/crates/server/src/room/timeline.rs
+++ b/crates/server/src/room/timeline.rs
@@ -370,7 +370,7 @@ pub async fn append_pdu(
         .await?;
     }
 
-    let sync_pdu = pdu.to_sync_room_event();
+    let sync_pdu = pdu.to_sync_room_event_without_sender_only_unsigned();
     let mut notifies = Vec::new();
     let mut highlights = Vec::new();
 
@@ -828,8 +828,15 @@ pub async fn build_and_append_pdu(
                         "failed to acquire the event append lock for room {room_id}: {e}"
                     ))
                 })?;
-            build_and_append_pdu_locked(pdu_builder, sender, room_id, room_version, state_lock)
-                .await
+            build_and_append_pdu_locked(
+                pdu_builder,
+                sender,
+                room_id,
+                room_version,
+                state_lock,
+                false,
+            )
+            .await
         })
         .await?;
 
@@ -844,14 +851,44 @@ pub async fn build_and_append_pdu(
     Ok(pdu)
 }
 
+/// Creates and appends a PDU even when an equivalent state event is already
+/// current. Delayed events need this so each successful delay id is observable
+/// on its own timeline event.
+/// The caller must already hold the cross-process room append lock and must queue
+/// federation delivery after its surrounding transaction commits.
+#[tracing::instrument(skip_all)]
+pub async fn build_and_append_pdu_force_locked(
+    pdu_builder: PduBuilder,
+    sender: &UserId,
+    room_id: &RoomId,
+    room_version: &RoomVersionId,
+    state_lock: &RoomMutexGuard,
+) -> AppResult<SnPduEvent> {
+    let (pdu, appended) =
+        build_and_append_pdu_locked(pdu_builder, sender, room_id, room_version, state_lock, true)
+            .await?;
+    debug_assert!(appended, "forced room event append cannot be deduplicated");
+    Ok(pdu)
+}
+
+/// Queue a locally authored PDU for participating remote servers after its room append
+/// fence has been released. Delayed-event callers invoke this after their row-locking
+/// transaction commits as well.
+pub(crate) async fn deliver_local_pdu(room_id: &RoomId, event_id: &EventId) -> AppResult<()> {
+    let servers = super::participating_servers(room_id, false).await?;
+    crate::sending::send_pdu_servers(servers.into_iter(), event_id).await
+}
+
 async fn build_and_append_pdu_locked(
     pdu_builder: PduBuilder,
     sender: &UserId,
     room_id: &RoomId,
     room_version: &RoomVersionId,
     state_lock: &RoomMutexGuard,
+    force: bool,
 ) -> AppResult<(SnPduEvent, bool)> {
-    if let Some(state_key) = &pdu_builder.state_key
+    if !force
+        && let Some(state_key) = &pdu_builder.state_key
         && let Ok(curr_state) = super::get_state(
             room_id,
             &pdu_builder.event_type.to_string().into(),

--- a/crates/server/src/room/timeline/stream.rs
+++ b/crates/server/src/room/timeline/stream.rs
@@ -203,7 +203,7 @@ pub async fn load_pdus(
                     }
                     if let Some(user_id) = user_id {
                         if pdu.sender != user_id {
-                            pdu.remove_transaction_id()?;
+                            pdu.remove_sender_only_unsigned()?;
                         }
                         let _ = pdu.add_unsigned_membership(user_id).await;
                     }

--- a/crates/server/src/room/timeline/topolo.rs
+++ b/crates/server/src/room/timeline/topolo.rs
@@ -226,7 +226,7 @@ pub async fn load_pdus(
                         continue;
                     }
                     if pdu.sender != user_id {
-                        pdu.remove_transaction_id()?;
+                        pdu.remove_sender_only_unsigned()?;
                     }
                     pdu.add_unsigned_membership(user_id).await?;
                 }

--- a/crates/server/src/room/timeline/topolo.rs
+++ b/crates/server/src/room/timeline/topolo.rs
@@ -230,7 +230,7 @@ pub async fn load_pdus(
                         continue;
                     }
                     if pdu.sender != user_id {
-                        pdu.remove_transaction_id()?;
+                        pdu.remove_sender_only_unsigned()?;
                     }
                     pdu.add_unsigned_membership(user_id).await?;
                 }

--- a/crates/server/src/routing/admin/debug.rs
+++ b/crates/server/src/routing/admin/debug.rs
@@ -236,7 +236,9 @@ pub async fn get_room_state(room_id: PathParam<OwnedRoomId>) -> JsonResult<RoomS
     let events = state::get_full_state(frame_id)
         .await?
         .values()
-        .map(|pdu| serde_json::to_value(pdu.to_state_event()).unwrap_or_default())
+        .map(|pdu| {
+            serde_json::to_value(pdu.to_state_event_with_sender_only_unsigned()).unwrap_or_default()
+        })
         .collect::<Vec<_>>();
 
     json_ok(RoomStateResponse {

--- a/crates/server/src/routing/client.rs
+++ b/crates/server/src/routing/client.rs
@@ -2,6 +2,7 @@ mod account;
 mod admin;
 mod appservice;
 mod auth;
+mod delayed_event;
 mod device;
 mod directory;
 mod key;
@@ -29,6 +30,7 @@ use std::collections::BTreeMap;
 
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
+use serde_json::json;
 
 use crate::config;
 use crate::core::client::discovery::capabilities::{
@@ -168,21 +170,30 @@ fn get_capabilities(_aa: AuthArgs, depot: &mut Depot) -> JsonResult<Capabilities
         available.insert(room_version.clone(), RoomVersionStability::Stable);
     }
     let change_password_enabled = conf.enabled_delegated_auth().is_none();
-    json_ok(CapabilitiesResBody {
-        capabilities: Capabilities {
-            room_versions: RoomVersionsCapability {
-                default: conf.default_room_version.clone(),
-                available,
-            },
-            change_password: ChangePasswordCapability {
-                enabled: change_password_enabled,
-            },
-            thirdparty_id_changes: ThirdPartyIdChangesCapability::new(false),
-            profile_fields: Some(ProfileFieldsCapability::new(true)),
-            account_moderation,
-            ..Default::default()
+    let mut capabilities = Capabilities {
+        room_versions: RoomVersionsCapability {
+            default: conf.default_room_version.clone(),
+            available,
         },
-    })
+        change_password: ChangePasswordCapability {
+            enabled: change_password_enabled,
+        },
+        thirdparty_id_changes: ThirdPartyIdChangesCapability::new(false),
+        profile_fields: Some(ProfileFieldsCapability::new(true)),
+        account_moderation,
+        ..Default::default()
+    };
+    if conf.delayed_events.enable {
+        // MSC4140 limits capability, using the unstable-prefixed name.
+        capabilities.custom_capabilities.insert(
+            "org.matrix.msc4140.delayed_events".to_owned(),
+            json!({
+                "max_delay_ms": conf.delayed_events.max_delay_ms,
+                "max_scheduled": conf.delayed_events.max_scheduled,
+            }),
+        );
+    }
+    json_ok(CapabilitiesResBody { capabilities })
 }
 
 /// #GET /_matrix/client/versions
@@ -210,29 +221,36 @@ const SUPPORTED_MATRIX_VERSIONS: &[&str] = &[
 ];
 
 fn supported_versions_body() -> VersionsResBody {
+    let mut unstable_features = BTreeMap::from_iter([
+        ("org.matrix.e2e_cross_signing".to_owned(), true),
+        ("org.matrix.msc2285.stable".to_owned(), true), /* private read receipts (https://github.com/matrix-org/matrix-spec-proposals/pull/2285) */
+        ("uk.half-shot.msc2666.query_mutual_rooms".to_owned(), true), /* query mutual rooms (https://github.com/matrix-org/matrix-spec-proposals/pull/2666) */
+        ("org.matrix.msc2836".to_owned(), true), /* threading/threads (https://github.com/matrix-org/matrix-spec-proposals/pull/2836) */
+        ("org.matrix.msc2946".to_owned(), true), /* spaces/hierarchy summaries (https://github.com/matrix-org/matrix-spec-proposals/pull/2946) */
+        ("org.matrix.msc3026.busy_presence".to_owned(), true), /* busy presence status (https://github.com/matrix-org/matrix-spec-proposals/pull/3026) */
+        ("org.matrix.msc3827".to_owned(), true), /* filtering of /publicRooms by room type (https://github.com/matrix-org/matrix-spec-proposals/pull/3827) */
+        ("org.matrix.msc3952_intentional_mentions".to_owned(), true), /* intentional mentions (https://github.com/matrix-org/matrix-spec-proposals/pull/3952) */
+        ("org.matrix.msc3575".to_owned(), true), /* sliding sync (https://github.com/matrix-org/matrix-spec-proposals/pull/3575/files#r1588877046) */
+        ("org.matrix.msc3916.stable".to_owned(), true), /* authenticated media (https://github.com/matrix-org/matrix-spec-proposals/pull/3916) */
+        ("org.matrix.msc4180".to_owned(), true), /* stable flag for 3916 (https://github.com/matrix-org/matrix-spec-proposals/pull/4180) */
+        ("uk.tcpip.msc4133".to_owned(), true), /* Extending User Profile API with Key:Value Pairs (https://github.com/matrix-org/matrix-spec-proposals/pull/4133) */
+        ("us.cloke.msc4175".to_owned(), true), /* Profile field for user time zone (https://github.com/matrix-org/matrix-spec-proposals/pull/4175) */
+        ("org.matrix.simplified_msc3575".to_owned(), true), /* Simplified Sliding sync (https://github.com/matrix-org/matrix-spec-proposals/pull/4186) */
+        ("uk.timedout.msc4323".to_owned(), true),           // Account suspension and locking.
+        ("net.zemos.msc4383".to_owned(), true), /* Homeserver implementation metadata (https://github.com/matrix-org/matrix-spec-proposals/pull/4383) */
+    ]);
+
+    if config::get().delayed_events.enable {
+        // delayed events (https://github.com/matrix-org/matrix-spec-proposals/pull/4140)
+        unstable_features.insert("org.matrix.msc4140".to_owned(), true);
+    }
+
     VersionsResBody {
         versions: SUPPORTED_MATRIX_VERSIONS
             .iter()
             .map(|version| (*version).to_owned())
             .collect(),
-        unstable_features: BTreeMap::from_iter([
-            ("org.matrix.e2e_cross_signing".to_owned(), true),
-            ("org.matrix.msc2285.stable".to_owned(), true), /* private read receipts (https://github.com/matrix-org/matrix-spec-proposals/pull/2285) */
-            ("uk.half-shot.msc2666.query_mutual_rooms".to_owned(), true), /* query mutual rooms (https://github.com/matrix-org/matrix-spec-proposals/pull/2666) */
-            ("org.matrix.msc2836".to_owned(), true), /* threading/threads (https://github.com/matrix-org/matrix-spec-proposals/pull/2836) */
-            ("org.matrix.msc2946".to_owned(), true), /* spaces/hierarchy summaries (https://github.com/matrix-org/matrix-spec-proposals/pull/2946) */
-            ("org.matrix.msc3026.busy_presence".to_owned(), true), /* busy presence status (https://github.com/matrix-org/matrix-spec-proposals/pull/3026) */
-            ("org.matrix.msc3827".to_owned(), true), /* filtering of /publicRooms by room type (https://github.com/matrix-org/matrix-spec-proposals/pull/3827) */
-            ("org.matrix.msc3952_intentional_mentions".to_owned(), true), /* intentional mentions (https://github.com/matrix-org/matrix-spec-proposals/pull/3952) */
-            ("org.matrix.msc3575".to_owned(), true), /* sliding sync (https://github.com/matrix-org/matrix-spec-proposals/pull/3575/files#r1588877046) */
-            ("org.matrix.msc3916.stable".to_owned(), true), /* authenticated media (https://github.com/matrix-org/matrix-spec-proposals/pull/3916) */
-            ("org.matrix.msc4180".to_owned(), true), /* stable flag for 3916 (https://github.com/matrix-org/matrix-spec-proposals/pull/4180) */
-            ("uk.tcpip.msc4133".to_owned(), true), /* Extending User Profile API with Key:Value Pairs (https://github.com/matrix-org/matrix-spec-proposals/pull/4133) */
-            ("us.cloke.msc4175".to_owned(), true), /* Profile field for user time zone (https://github.com/matrix-org/matrix-spec-proposals/pull/4175) */
-            ("org.matrix.simplified_msc3575".to_owned(), true), /* Simplified Sliding sync (https://github.com/matrix-org/matrix-spec-proposals/pull/4186) */
-            ("uk.timedout.msc4323".to_owned(), true),           // Account suspension and locking.
-            ("net.zemos.msc4383".to_owned(), true), /* Homeserver implementation metadata (https://github.com/matrix-org/matrix-spec-proposals/pull/4383) */
-        ]),
+        unstable_features,
         server: Some(Server::new(
             "Palpo".to_owned(),
             crate::info::version().to_owned(),

--- a/crates/server/src/routing/client.rs
+++ b/crates/server/src/routing/client.rs
@@ -207,7 +207,7 @@ fn get_capabilities(_aa: AuthArgs, depot: &mut Depot) -> JsonResult<Capabilities
 /// unstable features in their stable releases
 #[endpoint]
 fn supported_versions() -> JsonResult<VersionsResBody> {
-    json_ok(supported_versions_body())
+    json_ok(supported_versions_body(config::get().delayed_events.enable))
 }
 
 /// Client-Server specification versions whose behavior has been reviewed for
@@ -220,7 +220,11 @@ const SUPPORTED_MATRIX_VERSIONS: &[&str] = &[
     "v1.10", "v1.11", "v1.12",
 ];
 
-fn supported_versions_body() -> VersionsResBody {
+/// Builds the `/versions` body.
+///
+/// `delayed_events` is passed in rather than read from the global config so this stays a pure
+/// function that unit tests can drive both ways.
+fn supported_versions_body(delayed_events: bool) -> VersionsResBody {
     let mut unstable_features = BTreeMap::from_iter([
         ("org.matrix.e2e_cross_signing".to_owned(), true),
         ("org.matrix.msc2285.stable".to_owned(), true), /* private read receipts (https://github.com/matrix-org/matrix-spec-proposals/pull/2285) */
@@ -240,7 +244,7 @@ fn supported_versions_body() -> VersionsResBody {
         ("net.zemos.msc4383".to_owned(), true), /* Homeserver implementation metadata (https://github.com/matrix-org/matrix-spec-proposals/pull/4383) */
     ]);
 
-    if config::get().delayed_events.enable {
+    if delayed_events {
         // delayed events (https://github.com/matrix-org/matrix-spec-proposals/pull/4140)
         unstable_features.insert("org.matrix.msc4140".to_owned(), true);
     }
@@ -266,7 +270,7 @@ mod supported_versions_tests {
 
     #[test]
     fn advertised_versions_are_explicitly_reviewed() {
-        let body = supported_versions_body();
+        let body = supported_versions_body(false);
 
         assert_eq!(
             body.versions,
@@ -280,7 +284,7 @@ mod supported_versions_tests {
 
     #[test]
     fn includes_msc4383_server_metadata_and_feature_flag() {
-        let body = supported_versions_body();
+        let body = supported_versions_body(false);
         let server = body.server.as_ref().unwrap();
 
         assert_eq!(body.unstable_features.get("net.zemos.msc4383"), Some(&true));
@@ -289,6 +293,23 @@ mod supported_versions_tests {
         assert_eq!(
             to_json_value(server).unwrap(),
             json!({ "name": "Palpo", "version": server.version })
+        );
+    }
+
+    /// MSC4140 is only advertised when delayed events are actually enabled.
+    #[test]
+    fn msc4140_flag_tracks_the_delayed_events_setting() {
+        assert_eq!(
+            supported_versions_body(false)
+                .unstable_features
+                .get("org.matrix.msc4140"),
+            None
+        );
+        assert_eq!(
+            supported_versions_body(true)
+                .unstable_features
+                .get("org.matrix.msc4140"),
+            Some(&true)
         );
     }
 }

--- a/crates/server/src/routing/client.rs
+++ b/crates/server/src/routing/client.rs
@@ -2,6 +2,7 @@ mod account;
 mod admin;
 mod appservice;
 mod auth;
+mod delayed_event;
 mod device;
 mod directory;
 mod key;
@@ -29,6 +30,7 @@ use std::collections::BTreeMap;
 
 use salvo::oapi::extract::*;
 use salvo::prelude::*;
+use serde_json::json;
 
 use crate::config;
 use crate::core::client::discovery::capabilities::{
@@ -41,6 +43,10 @@ use crate::core::client::search::{ResultCategories, SearchReqArgs, SearchReqBody
 use crate::routing::prelude::*;
 
 pub fn router() -> Router {
+    router_inner()
+}
+
+fn router_inner() -> Router {
     let mut client = Router::with_path("client").oapi_tag("client");
     for v in ["v3", "v1", "r0"] {
         client = client
@@ -168,21 +174,30 @@ fn get_capabilities(_aa: AuthArgs, depot: &mut Depot) -> JsonResult<Capabilities
         available.insert(room_version.clone(), RoomVersionStability::Stable);
     }
     let change_password_enabled = conf.enabled_delegated_auth().is_none();
-    json_ok(CapabilitiesResBody {
-        capabilities: Capabilities {
-            room_versions: RoomVersionsCapability {
-                default: conf.default_room_version.clone(),
-                available,
-            },
-            change_password: ChangePasswordCapability {
-                enabled: change_password_enabled,
-            },
-            thirdparty_id_changes: ThirdPartyIdChangesCapability::new(false),
-            profile_fields: Some(ProfileFieldsCapability::new(true)),
-            account_moderation,
-            ..Default::default()
+    let mut capabilities = Capabilities {
+        room_versions: RoomVersionsCapability {
+            default: conf.default_room_version.clone(),
+            available,
         },
-    })
+        change_password: ChangePasswordCapability {
+            enabled: change_password_enabled,
+        },
+        thirdparty_id_changes: ThirdPartyIdChangesCapability::new(false),
+        profile_fields: Some(ProfileFieldsCapability::new(true)),
+        account_moderation,
+        ..Default::default()
+    };
+    if conf.delayed_events.enable {
+        // MSC4140 limits capability, using the unstable-prefixed name.
+        capabilities.custom_capabilities.insert(
+            "org.matrix.msc4140.delayed_events".to_owned(),
+            json!({
+                "max_delay_ms": conf.delayed_events.max_delay_ms,
+                "max_scheduled": conf.delayed_events.max_scheduled,
+            }),
+        );
+    }
+    json_ok(CapabilitiesResBody { capabilities })
 }
 
 /// #GET /_matrix/client/versions
@@ -196,7 +211,7 @@ fn get_capabilities(_aa: AuthArgs, depot: &mut Depot) -> JsonResult<Capabilities
 /// unstable features in their stable releases
 #[endpoint]
 fn supported_versions() -> JsonResult<VersionsResBody> {
-    json_ok(supported_versions_body())
+    json_ok(supported_versions_body(config::get().delayed_events.enable))
 }
 
 /// Client-Server specification versions whose behavior has been reviewed for
@@ -209,37 +224,46 @@ const SUPPORTED_MATRIX_VERSIONS: &[&str] = &[
     "v1.10", "v1.11", "v1.12",
 ];
 
-fn supported_versions_body() -> VersionsResBody {
+/// Builds the `/versions` body.
+///
+/// `delayed_events` is passed in rather than read from the global config so this stays a pure
+/// function that unit tests can drive both ways.
+fn supported_versions_body(delayed_events: bool) -> VersionsResBody {
+    let mut unstable_features = BTreeMap::from_iter([
+        ("org.matrix.e2e_cross_signing".to_owned(), true),
+        ("org.matrix.msc2285.stable".to_owned(), true), /* private read receipts (https://github.com/matrix-org/matrix-spec-proposals/pull/2285) */
+        ("uk.half-shot.msc2666.query_mutual_rooms".to_owned(), true), /* query mutual rooms (https://github.com/matrix-org/matrix-spec-proposals/pull/2666) */
+        (
+            "uk.half-shot.msc2666.query_mutual_rooms.stable".to_owned(),
+            true,
+        ),
+        ("org.matrix.msc2836".to_owned(), true), /* threading/threads (https://github.com/matrix-org/matrix-spec-proposals/pull/2836) */
+        ("org.matrix.msc2946".to_owned(), true), /* spaces/hierarchy summaries (https://github.com/matrix-org/matrix-spec-proposals/pull/2946) */
+        ("org.matrix.msc3026.busy_presence".to_owned(), true), /* busy presence status (https://github.com/matrix-org/matrix-spec-proposals/pull/3026) */
+        ("org.matrix.msc3827".to_owned(), true), /* filtering of /publicRooms by room type (https://github.com/matrix-org/matrix-spec-proposals/pull/3827) */
+        ("org.matrix.msc3952_intentional_mentions".to_owned(), true), /* intentional mentions (https://github.com/matrix-org/matrix-spec-proposals/pull/3952) */
+        ("org.matrix.msc3575".to_owned(), true), /* sliding sync (https://github.com/matrix-org/matrix-spec-proposals/pull/3575/files#r1588877046) */
+        ("org.matrix.msc3916.stable".to_owned(), true), /* authenticated media (https://github.com/matrix-org/matrix-spec-proposals/pull/3916) */
+        ("org.matrix.msc4180".to_owned(), true), /* stable flag for 3916 (https://github.com/matrix-org/matrix-spec-proposals/pull/4180) */
+        ("uk.tcpip.msc4133".to_owned(), true), /* Extending User Profile API with Key:Value Pairs (https://github.com/matrix-org/matrix-spec-proposals/pull/4133) */
+        ("uk.tcpip.msc4133.stable".to_owned(), true), // profile fields also use stable `/v3` routes
+        ("us.cloke.msc4175".to_owned(), true), /* Profile field for user time zone (https://github.com/matrix-org/matrix-spec-proposals/pull/4175) */
+        ("org.matrix.simplified_msc3575".to_owned(), true), /* Simplified Sliding sync (https://github.com/matrix-org/matrix-spec-proposals/pull/4186) */
+        ("uk.timedout.msc4323".to_owned(), true),           // Account suspension and locking.
+        ("net.zemos.msc4383".to_owned(), true), /* Homeserver implementation metadata (https://github.com/matrix-org/matrix-spec-proposals/pull/4383) */
+    ]);
+
+    if delayed_events {
+        // delayed events (https://github.com/matrix-org/matrix-spec-proposals/pull/4140)
+        unstable_features.insert("org.matrix.msc4140".to_owned(), true);
+    }
+
     VersionsResBody {
         versions: SUPPORTED_MATRIX_VERSIONS
             .iter()
             .map(|version| (*version).to_owned())
             .collect(),
-        unstable_features: BTreeMap::from_iter([
-            ("org.matrix.e2e_cross_signing".to_owned(), true),
-            ("org.matrix.msc2285.stable".to_owned(), true), /* private read receipts (https://github.com/matrix-org/matrix-spec-proposals/pull/2285) */
-            ("uk.half-shot.msc2666.query_mutual_rooms".to_owned(), true), /* query mutual rooms (https://github.com/matrix-org/matrix-spec-proposals/pull/2666) */
-            (
-                "uk.half-shot.msc2666.query_mutual_rooms.stable".to_owned(),
-                true,
-            ),
-            ("org.matrix.msc2836".to_owned(), true), /* threading/threads (https://github.com/matrix-org/matrix-spec-proposals/pull/2836) */
-            ("org.matrix.msc2946".to_owned(), true), /* spaces/hierarchy summaries (https://github.com/matrix-org/matrix-spec-proposals/pull/2946) */
-            ("org.matrix.msc3026.busy_presence".to_owned(), true), /* busy presence status (https://github.com/matrix-org/matrix-spec-proposals/pull/3026) */
-            ("org.matrix.msc3827".to_owned(), true), /* filtering of /publicRooms by room type (https://github.com/matrix-org/matrix-spec-proposals/pull/3827) */
-            ("org.matrix.msc3952_intentional_mentions".to_owned(), true), /* intentional mentions (https://github.com/matrix-org/matrix-spec-proposals/pull/3952) */
-            ("org.matrix.msc3575".to_owned(), true), /* sliding sync (https://github.com/matrix-org/matrix-spec-proposals/pull/3575/files#r1588877046) */
-            ("org.matrix.msc3916.stable".to_owned(), true), /* authenticated media (https://github.com/matrix-org/matrix-spec-proposals/pull/3916) */
-            ("org.matrix.msc4180".to_owned(), true), /* stable flag for 3916 (https://github.com/matrix-org/matrix-spec-proposals/pull/4180) */
-            ("uk.tcpip.msc4133".to_owned(), true), /* Extending User Profile API with Key:Value Pairs (https://github.com/matrix-org/matrix-spec-proposals/pull/4133) */
-            ("uk.tcpip.msc4133.stable".to_owned(), true), /* the profile-field endpoints are
-                                                    * served on the stable `/v3` prefix
-                                                    * too */
-            ("us.cloke.msc4175".to_owned(), true), /* Profile field for user time zone (https://github.com/matrix-org/matrix-spec-proposals/pull/4175) */
-            ("org.matrix.simplified_msc3575".to_owned(), true), /* Simplified Sliding sync (https://github.com/matrix-org/matrix-spec-proposals/pull/4186) */
-            ("uk.timedout.msc4323".to_owned(), true),           // Account suspension and locking.
-            ("net.zemos.msc4383".to_owned(), true), /* Homeserver implementation metadata (https://github.com/matrix-org/matrix-spec-proposals/pull/4383) */
-        ]),
+        unstable_features,
         server: Some(Server::new(
             "Palpo".to_owned(),
             crate::info::version().to_owned(),
@@ -255,7 +279,7 @@ mod supported_versions_tests {
 
     #[test]
     fn advertised_versions_are_explicitly_reviewed() {
-        let body = supported_versions_body();
+        let body = supported_versions_body(false);
 
         assert_eq!(
             body.versions,
@@ -269,7 +293,7 @@ mod supported_versions_tests {
 
     #[test]
     fn advertises_msc4133_profile_fields_on_the_stable_prefix() {
-        let body = supported_versions_body();
+        let body = supported_versions_body(false);
 
         assert_eq!(body.unstable_features.get("uk.tcpip.msc4133"), Some(&true));
         assert_eq!(
@@ -280,7 +304,7 @@ mod supported_versions_tests {
 
     #[test]
     fn includes_msc4383_server_metadata_and_feature_flag() {
-        let body = supported_versions_body();
+        let body = supported_versions_body(false);
         let server = body.server.as_ref().unwrap();
 
         assert_eq!(body.unstable_features.get("net.zemos.msc4383"), Some(&true));
@@ -292,9 +316,26 @@ mod supported_versions_tests {
         );
     }
 
+    /// MSC4140 is only advertised when delayed events are actually enabled.
+    #[test]
+    fn msc4140_flag_tracks_the_delayed_events_setting() {
+        assert_eq!(
+            supported_versions_body(false)
+                .unstable_features
+                .get("org.matrix.msc4140"),
+            None
+        );
+        assert_eq!(
+            supported_versions_body(true)
+                .unstable_features
+                .get("org.matrix.msc4140"),
+            Some(&true)
+        );
+    }
+
     #[test]
     fn advertises_stable_mutual_rooms_endpoint() {
-        let body = supported_versions_body();
+        let body = supported_versions_body(false);
 
         assert_eq!(
             body.unstable_features
@@ -309,15 +350,35 @@ mod router_tests {
     use salvo::http::{Method, Request};
     use salvo::routing::PathState;
 
-    use super::router;
+    use super::router_inner;
 
     /// Resolve `path` against the client router without running any handler.
     async fn is_routed(method: Method, path: &str) -> bool {
-        let router = router();
+        let router = router_inner();
         let mut req = Request::default();
         *req.method_mut() = method;
         let mut path_state = PathState::from_owned_path(path.to_owned());
         router.detect(&mut req, &mut path_state).await.is_some()
+    }
+
+    #[tokio::test]
+    async fn current_delayed_event_routes_are_registered() {
+        let prefix = "/client/unstable/org.matrix.msc4140";
+        assert!(
+            is_routed(
+                Method::PUT,
+                &format!("{prefix}/rooms/!room:example.org/delayed_event/m.room.message/txn")
+            )
+            .await
+        );
+        assert!(is_routed(Method::GET, &format!("{prefix}/delayed_events/delay-id")).await);
+        assert!(
+            is_routed(
+                Method::POST,
+                &format!("{prefix}/delayed_events/delay-id/cancel")
+            )
+            .await
+        );
     }
 
     #[tokio::test]

--- a/crates/server/src/routing/client/delayed_event.rs
+++ b/crates/server/src/routing/client/delayed_event.rs
@@ -1,0 +1,107 @@
+//! Client endpoints for MSC4140 delayed events.
+
+use salvo::oapi::extract::*;
+use salvo::prelude::*;
+
+use crate::core::client::delayed_events::{
+    DelayedEventData, DelayedEventsResBody, SendDelayedEventReqArgs, SendDelayedEventReqBody,
+    SendDelayedEventResBody, UpdateDelayedEventReqArgs, UpdateDelayedEventReqBody,
+};
+use crate::routing::prelude::*;
+
+pub(super) fn authed_router() -> Router {
+    Router::with_path("org.matrix.msc4140")
+        .push(
+            Router::with_path("rooms/{room_id}/delayed_event/{event_type}/{txn_id}")
+                .put(send_delayed_event),
+        )
+        .push(
+            Router::with_path("delayed_events")
+                .get(list_delayed_events)
+                .push(
+                    Router::with_path("{delay_id}")
+                        .get(get_delayed_event)
+                        .post(update_delayed_event_v1)
+                        .push(Router::with_path("{action}").post(update_delayed_event)),
+                ),
+        )
+}
+
+/// `PUT /_matrix/client/unstable/org.matrix.msc4140/rooms/{room_id}/delayed_event/{event_type}/
+/// {txn_id}`
+///
+/// Schedule a message or state event to be sent into the room after a delay.
+#[endpoint]
+async fn send_delayed_event(
+    _aa: AuthArgs,
+    args: SendDelayedEventReqArgs,
+    body: JsonBody<SendDelayedEventReqBody>,
+    depot: &mut Depot,
+) -> JsonResult<SendDelayedEventResBody> {
+    let authed = depot.authed_info()?;
+    let delay_id = crate::delayed_event::schedule(
+        authed.user_id(),
+        Some(authed.device_id()),
+        authed.appservice().is_some(),
+        &args,
+        &body,
+    )
+    .await?;
+    json_ok(SendDelayedEventResBody::new(delay_id))
+}
+
+/// `GET /_matrix/client/unstable/org.matrix.msc4140/delayed_events`
+///
+/// List the requesting user's scheduled delayed events in chronological order
+/// of their intended send time.
+#[endpoint]
+async fn list_delayed_events(_aa: AuthArgs, depot: &mut Depot) -> JsonResult<DelayedEventsResBody> {
+    let authed = depot.authed_info()?;
+    let delayed_events = crate::delayed_event::list(authed.user_id()).await?;
+    json_ok(DelayedEventsResBody::new(delayed_events))
+}
+
+/// `GET /_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}`
+///
+/// Get the details of one of the requesting user's delayed events, whether
+/// still scheduled or already finalized.
+#[endpoint]
+async fn get_delayed_event(
+    _aa: AuthArgs,
+    delay_id: PathParam<String>,
+    depot: &mut Depot,
+) -> JsonResult<DelayedEventData> {
+    let authed = depot.authed_info()?;
+    let delayed_event = crate::delayed_event::get(authed.user_id(), &delay_id.into_inner()).await?;
+    json_ok(delayed_event)
+}
+
+/// `POST /_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}/{action}`
+///
+/// Restart, send, or cancel a scheduled delayed event.
+#[endpoint]
+async fn update_delayed_event(
+    _aa: AuthArgs,
+    args: UpdateDelayedEventReqArgs,
+    depot: &mut Depot,
+) -> EmptyResult {
+    let authed = depot.authed_info()?;
+    crate::delayed_event::update(authed.user_id(), &args.delay_id, &args.action).await?;
+    empty_ok()
+}
+
+/// `POST /_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}`
+///
+/// Deprecated body-action variant of the update endpoint, kept for clients
+/// that implement the earlier iteration of MSC4140.
+#[endpoint]
+async fn update_delayed_event_v1(
+    _aa: AuthArgs,
+    delay_id: PathParam<String>,
+    body: JsonBody<UpdateDelayedEventReqBody>,
+    depot: &mut Depot,
+) -> EmptyResult {
+    let authed = depot.authed_info()?;
+    crate::delayed_event::update(authed.user_id(), &delay_id.into_inner(), &body.action).await?;
+    empty_ok()
+}

--- a/crates/server/src/routing/client/delayed_event.rs
+++ b/crates/server/src/routing/client/delayed_event.rs
@@ -1,0 +1,82 @@
+//! Client endpoints for MSC4140 delayed events.
+
+use salvo::oapi::extract::*;
+use salvo::prelude::*;
+
+use crate::core::client::delayed_events::{
+    DelayedEventData, SendDelayedEventReqArgs, SendDelayedEventReqBody, SendDelayedEventResBody,
+    UpdateDelayedEventReqArgs,
+};
+use crate::routing::prelude::*;
+
+pub(super) fn authed_router() -> Router {
+    Router::with_path("org.matrix.msc4140")
+        .push(
+            Router::with_path("rooms/{room_id}/delayed_event/{event_type}/{txn_id}")
+                .put(send_delayed_event),
+        )
+        .push(
+            Router::with_path("delayed_events").push(
+                Router::with_path("{delay_id}")
+                    .get(get_delayed_event)
+                    .push(Router::with_path("{action}").post(update_delayed_event)),
+            ),
+        )
+}
+
+/// `PUT /_matrix/client/unstable/org.matrix.msc4140/rooms/{room_id}/delayed_event/{event_type}/
+/// {txn_id}`
+///
+/// Schedule a message or state event to be sent into the room after a delay.
+#[endpoint]
+async fn send_delayed_event(
+    _aa: AuthArgs,
+    args: SendDelayedEventReqArgs,
+    body: JsonBody<SendDelayedEventReqBody>,
+    depot: &mut Depot,
+) -> JsonResult<SendDelayedEventResBody> {
+    let authed = depot.authed_info()?;
+    let delay_id = crate::delayed_event::schedule(
+        authed.user_id(),
+        Some(authed.device_id()),
+        authed.appservice().is_some(),
+        &args.room_id,
+        &args.event_type,
+        &args.txn_id,
+        args.timestamp,
+        body.delay,
+        body.state_key.clone(),
+        body.content.clone(),
+    )
+    .await?;
+    json_ok(SendDelayedEventResBody::new(delay_id))
+}
+
+/// `GET /_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}`
+///
+/// Get the details of one of the requesting user's delayed events, whether
+/// still scheduled or already finalized.
+#[endpoint]
+async fn get_delayed_event(
+    _aa: AuthArgs,
+    delay_id: PathParam<String>,
+    depot: &mut Depot,
+) -> JsonResult<DelayedEventData> {
+    let authed = depot.authed_info()?;
+    let delayed_event = crate::delayed_event::get(authed.user_id(), &delay_id.into_inner()).await?;
+    json_ok(delayed_event)
+}
+
+/// `POST /_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}/{action}`
+///
+/// Restart, send, or cancel a scheduled delayed event.
+#[endpoint]
+async fn update_delayed_event(
+    _aa: AuthArgs,
+    args: UpdateDelayedEventReqArgs,
+    depot: &mut Depot,
+) -> EmptyResult {
+    let authed = depot.authed_info()?;
+    crate::delayed_event::update(authed.user_id(), &args.delay_id, &args.action).await?;
+    empty_ok()
+}

--- a/crates/server/src/routing/client/room.rs
+++ b/crates/server/src/routing/client/room.rs
@@ -176,7 +176,7 @@ async fn initial_sync(
             .server_name()
             .is_ok_and(|server| *server != config::get().server_name)
         {
-            return remote_peek_preview(room_id, args.limit.unwrap_or(20)).await;
+            return remote_peek_preview(sender_id, room_id, args.limit.unwrap_or(20)).await;
         }
         return Err(MatrixError::forbidden("No room preview available.", None).into());
     }
@@ -195,7 +195,7 @@ async fn initial_sync(
         .await
         .unwrap_or_default()
         .into_values()
-        .map(|event| event.to_state_event())
+        .map(|event| event.to_state_event_for(sender_id))
         .collect::<Vec<_>>();
 
     let messages = PaginationChunk {
@@ -212,7 +212,7 @@ async fn initial_sync(
             .unwrap_or_default(),
         chunk: events
             .into_iter()
-            .map(|(_sn, event)| event.to_room_event())
+            .map(|(_sn, event)| event.to_room_event_for(sender_id))
             .collect(),
     };
 
@@ -241,7 +241,11 @@ async fn initial_sync(
 /// Any failure (room not world-readable, federation disabled, server
 /// unreachable, malformed response) collapses to a clean "no preview" error so
 /// the client falls back to showing the join prompt instead of a hard error.
-async fn remote_peek_preview(room_id: &RoomId, limit: usize) -> JsonResult<InitialSyncResBody> {
+async fn remote_peek_preview(
+    recipient: &UserId,
+    room_id: &RoomId,
+    limit: usize,
+) -> JsonResult<InitialSyncResBody> {
     let no_preview = || MatrixError::forbidden("No room preview available.", None);
 
     let server = room_id.server_name().map_err(|_| no_preview())?;
@@ -278,7 +282,7 @@ async fn remote_peek_preview(room_id: &RoomId, limit: usize) -> JsonResult<Initi
         .pdus
         .iter()
         .filter_map(|raw| {
-            parse_peek_pdu(room_id, &room_version, raw).map(|pdu| pdu.to_state_event())
+            parse_peek_pdu(room_id, &room_version, raw).map(|pdu| pdu.to_state_event_for(recipient))
         })
         .collect();
 
@@ -291,7 +295,7 @@ async fn remote_peek_preview(room_id: &RoomId, limit: usize) -> JsonResult<Initi
         .messages
         .iter()
         .filter_map(|raw| {
-            parse_peek_pdu(room_id, &room_version, raw).map(|pdu| pdu.to_room_event())
+            parse_peek_pdu(room_id, &room_version, raw).map(|pdu| pdu.to_room_event_for(recipient))
         })
         .collect();
 

--- a/crates/server/src/routing/client/room/event.rs
+++ b/crates/server/src/routing/client/room/event.rs
@@ -66,6 +66,13 @@ pub(super) async fn get_room_event(
     }
 
     let mut event = event.clone();
+    // The timeline and relation loaders scrub sender-only `unsigned` fields,
+    // but this endpoint serves a directly fetched PDU and did not, so
+    // `transaction_id` -- and now MSC4140's `delay_id` -- reached any room
+    // member who asked for the event by id.
+    if event.sender != authed.user_id() {
+        event.remove_sender_only_unsigned()?;
+    }
     event.add_age()?;
 
     json_ok(RoomEventResBody::new(event.to_room_event()))

--- a/crates/server/src/routing/client/room/event.rs
+++ b/crates/server/src/routing/client/room/event.rs
@@ -65,10 +65,9 @@ pub(super) async fn get_room_event(
         return Err(MatrixError::not_found("event not found").into());
     }
 
-    let mut event = event.clone();
-    event.add_age()?;
-
-    json_ok(RoomEventResBody::new(event.to_room_event()))
+    json_ok(RoomEventResBody::new(
+        event.to_room_event_for(authed.user_id()),
+    ))
 }
 
 /// #POST /_matrix/client/r0/rooms/{room_id}/report/{event_id}
@@ -198,7 +197,7 @@ pub(super) async fn get_context(
 
     // Use limit with maximum 100
     let limit = args.limit.min(100);
-    let base_event = base_event.to_room_event();
+    let base_event = base_event.to_room_event_for(sender_id);
     let events_before_loaded = timeline::stream::load_pdus_backward(
         Some(sender_id),
         &room_id,
@@ -238,7 +237,7 @@ pub(super) async fn get_context(
         .unwrap_or_else(|| base_token);
     let events_before = events_before
         .into_iter()
-        .map(|(_, pdu)| pdu.to_room_event())
+        .map(|(_, pdu)| pdu.to_room_event_for(sender_id))
         .collect::<Vec<_>>();
     let events_after = timeline::stream::load_pdus_forward(
         Some(sender_id),
@@ -285,7 +284,7 @@ pub(super) async fn get_context(
         .unwrap_or_else(|| base_token);
     let events_after: Vec<_> = events_after
         .into_iter()
-        .map(|(_, pdu)| pdu.to_room_event())
+        .map(|(_, pdu)| pdu.to_room_event_for(sender_id))
         .collect();
     let mut state = Vec::new();
 
@@ -304,7 +303,7 @@ pub(super) async fn get_context(
                     continue;
                 }
             };
-            state.push(pdu.to_state_event());
+            state.push(pdu.to_state_event_for(sender_id));
         } else if !lazy_load_enabled || lazy_loaded.contains(&state_key) {
             let pdu = match timeline::get_pdu(&event_id).await {
                 Ok(pdu) => pdu,
@@ -313,7 +312,7 @@ pub(super) async fn get_context(
                     continue;
                 }
             };
-            state.push(pdu.to_state_event());
+            state.push(pdu.to_state_event_for(sender_id));
         }
     }
 

--- a/crates/server/src/routing/client/room/membership.rs
+++ b/crates/server/src/routing/client/room/membership.rs
@@ -103,7 +103,7 @@ pub(super) async fn get_members(
         .into_iter()
         .filter(|(key, _)| key.0 == StateEventType::RoomMember)
         .filter_map(|(_, pdu)| membership_filter(pdu, membership, not_membership, until_sn))
-        .map(|pdu| pdu.to_member_event())
+        .map(|pdu| pdu.to_member_event_for(authed.user_id()))
         .collect();
 
     json_ok(MembersResBody { chunk: states })

--- a/crates/server/src/routing/client/room/message.rs
+++ b/crates/server/src/routing/client/room/message.rs
@@ -4,13 +4,13 @@ use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use serde_json::value::to_raw_value;
 
-use crate::core::Direction;
 use crate::core::client::message::{
     CreateMessageReqArgs, CreateMessageWithTxnReqArgs, MessagesReqArgs, MessagesResBody,
     SendMessageResBody,
 };
 use crate::core::events::{StateEventType, TimelineEventType};
-use crate::core::serde::{RawJsonValue, to_canonical_value};
+use crate::core::serde::to_canonical_value;
+use crate::core::{Direction, UnixMillis};
 use crate::data::schema::*;
 use crate::data::{connect, diesel_exists};
 use crate::event::BatchToken;
@@ -18,7 +18,7 @@ use crate::room::timeline::{self, topolo};
 use crate::routing::prelude::*;
 use crate::{PduBuilder, room};
 
-fn parse_event_content(payload: &[u8]) -> AppResult<Box<RawJsonValue>> {
+fn parse_event_content(payload: &[u8]) -> AppResult<JsonValue> {
     let content: JsonValue =
         serde_json::from_slice(payload).map_err(|_| MatrixError::bad_json("invalid json body"))?;
     if !content.is_object() {
@@ -27,7 +27,18 @@ fn parse_event_content(payload: &[u8]) -> AppResult<Box<RawJsonValue>> {
     to_canonical_value(&content).map_err(|e| {
         MatrixError::bad_json(format!("event content is not valid canonical JSON: {e}"))
     })?;
-    Ok(to_raw_value(&content).expect("validated JSON content can be serialized as raw JSON"))
+    Ok(content)
+}
+
+fn appservice_timestamp(
+    is_appservice: bool,
+    requested_timestamp: Option<UnixMillis>,
+) -> Option<UnixMillis> {
+    if is_appservice {
+        requested_timestamp
+    } else {
+        None
+    }
 }
 
 /// #GET /_matrix/client/r0/rooms/{room_id}/messages
@@ -145,7 +156,7 @@ pub(super) async fn get_messages(
 
             let events: Vec<_> = events
                 .into_iter()
-                .map(|(_, pdu)| pdu.to_room_event())
+                .map(|(_, pdu)| pdu.to_room_event_for(sender_id))
                 .collect();
 
             resp.start = from_tk.to_string();
@@ -200,7 +211,10 @@ pub(super) async fn get_messages(
             next_token = events.last().map(|(_, pdu)| pdu.prev_historic_token());
             resp.start = from_tk.to_string();
             resp.end = next_token.map(|tk| tk.to_string());
-            resp.chunk = events.values().map(|pdu| pdu.to_room_event()).collect();
+            resp.chunk = events
+                .values()
+                .map(|pdu| pdu.to_room_event_for(sender_id))
+                .collect();
         }
     }
 
@@ -214,7 +228,7 @@ pub(super) async fn get_messages(
         )
         .await
         {
-            resp.state.push(member_event.to_state_event());
+            resp.state.push(member_event.to_state_event_for(sender_id));
         }
     }
 
@@ -280,13 +294,9 @@ pub(super) async fn send_message(
     let event_id = timeline::build_and_append_pdu(
         PduBuilder {
             event_type: args.event_type.to_string().into(),
-            content,
+            content: to_raw_value(&content)?,
             unsigned,
-            timestamp: if authed.appservice().is_some() {
-                args.timestamp
-            } else {
-                None
-            },
+            timestamp: appservice_timestamp(authed.appservice().is_some(), args.timestamp),
             ..Default::default()
         },
         authed.user_id(),
@@ -326,7 +336,6 @@ pub(super) async fn post_message(
     let authed = depot.authed_info()?;
 
     let conf = config::get();
-    let state_lock = room::lock_state(&args.room_id).await;
     // Forbid m.room.encrypted if encryption is disabled
     if TimelineEventType::RoomEncrypted == args.event_type.to_string().into()
         && !conf.allow_encryption
@@ -337,11 +346,13 @@ pub(super) async fn post_message(
     let payload = req.payload().await?;
     let content = parse_event_content(payload)?;
 
+    let state_lock = room::lock_state(&args.room_id).await;
     let event_id = timeline::build_and_append_pdu(
         PduBuilder {
             event_type: args.event_type.to_string().into(),
-            content,
+            content: to_raw_value(&content)?,
             unsigned: BTreeMap::new(),
+            timestamp: appservice_timestamp(authed.appservice().is_some(), args.timestamp),
             ..Default::default()
         },
         authed.user_id(),
@@ -354,4 +365,18 @@ pub(super) async fn post_message(
     .event_id;
 
     json_ok(SendMessageResBody::new((*event_id).to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::appservice_timestamp;
+    use crate::core::UnixMillis;
+
+    #[test]
+    fn timestamp_massaging_is_limited_to_appservices() {
+        let timestamp = UnixMillis(123_456);
+
+        assert_eq!(appservice_timestamp(true, Some(timestamp)), Some(timestamp));
+        assert_eq!(appservice_timestamp(false, Some(timestamp)), None);
+    }
 }

--- a/crates/server/src/routing/client/room/state.rs
+++ b/crates/server/src/routing/client/room/state.rs
@@ -5,13 +5,14 @@ use serde_json::json;
 use crate::core::UnixMillis;
 use crate::core::client::room::ReportContentReqBody;
 use crate::core::client::state::{
-    SendStateEventReqBody, SendStateEventResBody, StateEventFormat, StateEventsForEmptyKeyReqArgs,
-    StateEventsForKeyReqArgs, StateEventsForKeyResBody, StateEventsResBody,
+    SendStateEventReqArgs, SendStateEventReqBody, SendStateEventResBody, StateEventFormat,
+    StateEventsForEmptyKeyReqArgs, StateEventsForKeyReqArgs, StateEventsForKeyResBody,
+    StateEventsResBody,
 };
 use crate::core::client::typing::{CreateTypingEventReqBody, Typing};
 use crate::core::events::room::message::RoomMessageEventContent;
 use crate::core::identifiers::*;
-use crate::core::room::{RoomEventReqArgs, RoomEventTypeReqArgs, RoomTypingReqArgs};
+use crate::core::room::{RoomEventReqArgs, RoomTypingReqArgs};
 use crate::room::{state, timeline};
 use crate::utils::HtmlEscape;
 use crate::{AuthArgs, DepotExt, EmptyResult, JsonResult, MatrixError, empty_ok, json_ok, room};
@@ -50,7 +51,7 @@ pub(super) async fn get_state(
         .await
         .unwrap_or_default()
         .values()
-        .map(|pdu| pdu.to_state_event())
+        .map(|pdu| pdu.to_state_event_for(sender_id))
         .collect();
     json_ok(StateEventsResBody::new(room_state))
 }
@@ -166,7 +167,7 @@ pub(super) async fn state_for_key(
     json_ok(StateEventsForKeyResBody {
         content: Some(event.get_content()?),
         event: if event_format {
-            Some(event.to_state_event_value())
+            Some(event.to_state_event_value_for(sender_id))
         } else {
             None
         },
@@ -207,7 +208,7 @@ pub(super) async fn state_for_empty_key(
     json_ok(StateEventsForKeyResBody {
         content: Some(event.get_content()?),
         event: if event_format {
-            Some(event.to_state_event_value())
+            Some(event.to_state_event_value_for(sender_id))
         } else {
             None
         },
@@ -223,12 +224,13 @@ pub(super) async fn state_for_empty_key(
 #[endpoint]
 pub(super) async fn send_state_for_key(
     _aa: AuthArgs,
-    args: StateEventsForKeyReqArgs,
+    args: SendStateEventReqArgs,
     body: JsonBody<SendStateEventReqBody>,
     depot: &mut Depot,
 ) -> JsonResult<SendStateEventResBody> {
     let authed = depot.authed_info()?;
     let body = body.into_inner();
+    let state_key = args.state_key.clone().unwrap_or_default();
 
     let event_id = crate::state::send_state_event_for_key(
         authed.user_id(),
@@ -236,13 +238,12 @@ pub(super) async fn send_state_for_key(
         &crate::room::get_version(&args.room_id).await?,
         &args.event_type,
         body.0,
-        args.state_key.to_owned(),
+        state_key,
+        appservice_timestamp(authed.appservice().is_some(), args.timestamp),
     )
     .await?;
 
-    json_ok(SendStateEventResBody {
-        event_id: (*event_id).to_owned(),
-    })
+    json_ok(SendStateEventResBody::new((*event_id).to_owned()))
 }
 
 /// #PUT /_matrix/client/r0/rooms/{room_id}/state/{event_type}
@@ -254,7 +255,7 @@ pub(super) async fn send_state_for_key(
 #[endpoint]
 pub(super) async fn send_state_for_empty_key(
     _aa: AuthArgs,
-    args: RoomEventTypeReqArgs,
+    args: SendStateEventReqArgs,
     body: JsonBody<SendStateEventReqBody>,
     depot: &mut Depot,
 ) -> JsonResult<SendStateEventResBody> {
@@ -267,12 +268,36 @@ pub(super) async fn send_state_for_empty_key(
         &args.event_type.to_string().into(),
         body.0,
         "".into(),
+        appservice_timestamp(authed.appservice().is_some(), args.timestamp),
     )
     .await?;
 
-    json_ok(SendStateEventResBody {
-        event_id: (*event_id).to_owned(),
-    })
+    json_ok(SendStateEventResBody::new((*event_id).to_owned()))
+}
+
+fn appservice_timestamp(
+    is_appservice: bool,
+    requested_timestamp: Option<UnixMillis>,
+) -> Option<UnixMillis> {
+    if is_appservice {
+        requested_timestamp
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::appservice_timestamp;
+    use crate::core::UnixMillis;
+
+    #[test]
+    fn timestamp_massaging_is_limited_to_appservices() {
+        let timestamp = UnixMillis(123_456);
+
+        assert_eq!(appservice_timestamp(true, Some(timestamp)), Some(timestamp));
+        assert_eq!(appservice_timestamp(false, Some(timestamp)), None);
+    }
 }
 
 /// #PUT /_matrix/client/r0/rooms/{room_id}/typing/{user_id}

--- a/crates/server/src/routing/client/room/thread.rs
+++ b/crates/server/src/routing/client/room/thread.rs
@@ -42,7 +42,7 @@ pub(super) async fn list_threads(
     json_ok(ThreadsResBody {
         chunk: threads
             .into_iter()
-            .map(|(_, pdu)| pdu.to_room_event())
+            .map(|(_, pdu)| pdu.to_room_event_for(authed.user_id()))
             .collect(),
         next_batch: next_batch.map(|b| b.to_string()),
     })

--- a/crates/server/src/routing/client/unstable.rs
+++ b/crates/server/src/routing/client/unstable.rs
@@ -5,6 +5,12 @@ use crate::core::client::discovery::rendezvous::DiscoverRendezvousResBody;
 use crate::{JsonResult, config, hoops, json_ok};
 
 pub(super) fn router() -> Router {
+    let mut authed = Router::new()
+        .hoop(hoops::limit_rate)
+        .hoop(hoops::auth_by_access_token);
+    if config::get().delayed_events.enable {
+        authed = authed.push(super::delayed_event::authed_router());
+    }
     Router::with_path("unstable")
         // Public routes (no auth required) — MSC2965 OIDC discovery
         .push(
@@ -16,9 +22,7 @@ pub(super) fn router() -> Router {
         .push(Router::with_path("io.element.msc4388/rendezvous").get(discover_rendezvous))
         // Authed routes
         .push(
-            Router::new()
-                .hoop(hoops::limit_rate)
-                .hoop(hoops::auth_by_access_token)
+            authed
                 .push(
                     Router::with_path(
                         "org.matrix.msc3391/user/{user_id}/account_data/{account_type}",

--- a/crates/server/src/routing/client/unstable.rs
+++ b/crates/server/src/routing/client/unstable.rs
@@ -5,6 +5,10 @@ use crate::core::client::discovery::rendezvous::DiscoverRendezvousResBody;
 use crate::{JsonResult, config, hoops, json_ok};
 
 pub(super) fn router() -> Router {
+    let authed = Router::new()
+        .hoop(hoops::limit_rate)
+        .hoop(hoops::auth_by_access_token)
+        .push(super::delayed_event::authed_router());
     Router::with_path("unstable")
         // Public routes (no auth required) — MSC2965 OIDC discovery
         .push(
@@ -17,9 +21,7 @@ pub(super) fn router() -> Router {
         .push(super::profile::msc4133_public_router())
         // Authed routes
         .push(
-            Router::new()
-                .hoop(hoops::limit_rate)
-                .hoop(hoops::auth_by_access_token)
+            authed
                 .push(
                     Router::with_path(
                         "org.matrix.msc3391/user/{user_id}/account_data/{account_type}",

--- a/crates/server/src/sending.rs
+++ b/crates/server/src/sending.rs
@@ -1022,9 +1022,10 @@ async fn claim_queued_requests(
 
 /// This does not return a full `Pdu` it is only to satisfy palpo's types.
 ///
-/// Strips internal fields (`event_sn`, `transaction_id`) and conditionally removes
-/// `event_id` based on the room version. Room versions V1/V2 require `event_id` in
-/// the federation format; V3+ derive it from the event hash.
+/// Strips internal and sender-only fields (`event_sn`, `transaction_id`, MSC4140's
+/// `delay_id`) and conditionally removes `event_id` based on the room version. Room
+/// versions V1/V2 require `event_id` in the federation format; V3+ derive it from the
+/// event hash.
 #[tracing::instrument]
 pub async fn convert_to_outgoing_federation_event(
     mut pdu_json: CanonicalJsonObject,
@@ -1034,6 +1035,9 @@ pub async fn convert_to_outgoing_federation_event(
         .and_then(|val| val.as_object_mut())
     {
         unsigned.remove("transaction_id");
+        // MSC4140: the delay_id is only ever shown to the event's own sender, so it must
+        // never cross a federation boundary.
+        unsigned.remove("org.matrix.msc4140.delay_id");
     }
 
     // Determine room version to decide whether to strip event_id.

--- a/crates/server/src/sending.rs
+++ b/crates/server/src/sending.rs
@@ -440,7 +440,7 @@ async fn send_events(
                             timeline::get_pdu(event_id)
                                 .await
                                 .map_err(|e| (kind.clone(), e))?
-                                .to_room_event(),
+                                .to_room_event_without_sender_only_unsigned(),
                         );
                     }
                     SendingEventType::Edu(_) => {
@@ -1016,19 +1016,15 @@ async fn claim_queued_requests(
 
 /// This does not return a full `Pdu` it is only to satisfy palpo's types.
 ///
-/// Strips internal fields (`event_sn`, `transaction_id`) and conditionally removes
-/// `event_id` based on the room version. Room versions V1/V2 require `event_id` in
-/// the federation format; V3+ derive it from the event hash.
+/// Strips internal and sender-only fields (`event_sn`, `transaction_id`, MSC4140's
+/// `delay_id`) and conditionally removes `event_id` based on the room version. Room
+/// versions V1/V2 require `event_id` in the federation format; V3+ derive it from the
+/// event hash.
 #[tracing::instrument]
 pub async fn convert_to_outgoing_federation_event(
     mut pdu_json: CanonicalJsonObject,
 ) -> Box<RawJsonValue> {
-    if let Some(unsigned) = pdu_json
-        .get_mut("unsigned")
-        .and_then(|val| val.as_object_mut())
-    {
-        unsigned.remove("transaction_id");
-    }
+    strip_sender_only_unsigned(&mut pdu_json);
 
     // Determine room version to decide whether to strip event_id.
     // V1/V2 require event_id in federation format; V3+ derive it from content hash.
@@ -1074,6 +1070,18 @@ pub async fn convert_to_outgoing_federation_event(
     to_raw_value(&pdu_json).expect("CanonicalJson is valid serde_json::Value")
 }
 
+fn strip_sender_only_unsigned(pdu_json: &mut CanonicalJsonObject) {
+    if let Some(unsigned) = pdu_json
+        .get_mut("unsigned")
+        .and_then(|val| val.as_object_mut())
+    {
+        unsigned.remove("transaction_id");
+        // MSC4140: the delay_id is only ever shown to the event's own sender, so it must
+        // never cross a federation boundary.
+        unsigned.remove("org.matrix.msc4140.delay_id");
+    }
+}
+
 fn reqwest_client_builder(config: &ServerConfig) -> AppResult<reqwest::ClientBuilder> {
     let mut reqwest_client_builder = reqwest::Client::builder()
         .pool_idle_timeout(Some(Duration::from_millis(config.request_idle_timeout)))
@@ -1103,6 +1111,25 @@ fn reqwest_client_builder(config: &ServerConfig) -> AppResult<reqwest::ClientBui
 mod tests {
     use super::*;
     use crate::config::FederationConfig;
+
+    #[test]
+    fn federation_events_strip_all_sender_only_unsigned_fields() {
+        let mut pdu_json: CanonicalJsonObject = serde_json::from_value(serde_json::json!({
+            "unsigned": {
+                "transaction_id": "txn",
+                "org.matrix.msc4140.delay_id": "delay",
+                "age": 10,
+            }
+        }))
+        .unwrap();
+
+        strip_sender_only_unsigned(&mut pdu_json);
+
+        let unsigned = pdu_json["unsigned"].as_object().unwrap();
+        assert!(!unsigned.contains_key("transaction_id"));
+        assert!(!unsigned.contains_key("org.matrix.msc4140.delay_id"));
+        assert!(unsigned.contains_key("age"));
+    }
 
     #[tokio::test]
     async fn full_wakeup_queue_drops_wakeups_but_closed_queue_fails() {

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -40,7 +40,7 @@ pub async fn send_state_event_for_key(
     Ok(pdu.event_id)
 }
 
-async fn allowed_to_send_state_event(
+pub(crate) async fn allowed_to_send_state_event(
     room_id: &RoomId,
     event_type: &StateEventType,
     state_key: &str,

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -1,3 +1,4 @@
+use crate::core::UnixMillis;
 use crate::core::events::room::canonical_alias::RoomCanonicalAliasEventContent;
 use crate::core::events::room::history_visibility::{
     HistoryVisibility, RoomHistoryVisibilityEventContent,
@@ -20,6 +21,7 @@ pub async fn send_state_event_for_key(
     event_type: &StateEventType,
     json: RawJson<AnyStateEventContent>,
     state_key: String,
+    timestamp: Option<UnixMillis>,
 ) -> AppResult<OwnedEventId> {
     allowed_to_send_state_event(room_id, event_type, &state_key, &json).await?;
     let pdu = timeline::build_and_append_pdu(
@@ -27,6 +29,7 @@ pub async fn send_state_event_for_key(
             event_type: event_type.to_string().into(),
             content: serde_json::from_value(serde_json::to_value(json)?)?,
             state_key: Some(state_key),
+            timestamp,
             ..Default::default()
         },
         user_id,
@@ -40,7 +43,7 @@ pub async fn send_state_event_for_key(
     Ok(pdu.event_id)
 }
 
-async fn allowed_to_send_state_event(
+pub(crate) async fn allowed_to_send_state_event(
     room_id: &RoomId,
     event_type: &StateEventType,
     state_key: &str,

--- a/crates/server/src/sync_v3.rs
+++ b/crates/server/src/sync_v3.rs
@@ -920,13 +920,13 @@ async fn load_joined_room(
             events: timeline
                 .events
                 .iter()
-                .map(|(_, pdu)| pdu.to_sync_room_event())
+                .map(|(_, pdu)| pdu.to_sync_room_event_for(sender_id))
                 .collect(),
         },
         state: State::Before(
             state_events
                 .iter()
-                .map(|pdu| pdu.to_sync_state_event())
+                .map(|pdu| pdu.to_sync_state_event_for(sender_id))
                 .collect::<Vec<_>>()
                 .into(),
         ),
@@ -998,7 +998,7 @@ async fn load_left_room(
                 prev_batch: Some(next_batch.to_string()),
                 events: Vec::new(),
             },
-            state: State::Before(vec![event.to_sync_state_event()].into()),
+            state: State::Before(vec![event.to_sync_state_event_for(sender_id)].into()),
         });
     }
 
@@ -1086,7 +1086,6 @@ async fn load_left_room(
             .map(|(sn, _)| BatchToken::new_live(*sn).to_string())
     };
 
-    // let left_event = timeline::get_pdu(&left_event_id).map(|pdu| pdu.to_sync_room_event());
     Ok(LeftRoom {
         account_data: RoomAccountData { events: Vec::new() },
         timeline: Timeline {
@@ -1095,13 +1094,13 @@ async fn load_left_room(
             events: timeline
                 .events
                 .iter()
-                .map(|(_, pdu)| pdu.to_sync_room_event())
+                .map(|(_, pdu)| pdu.to_sync_room_event_for(sender_id))
                 .collect(),
         },
         state: State::Before(
             state_events
                 .iter()
-                .map(|pdu| pdu.to_sync_state_event())
+                .map(|pdu| pdu.to_sync_state_event_for(sender_id))
                 .collect::<Vec<_>>()
                 .into(),
         ),

--- a/crates/server/src/sync_v5.rs
+++ b/crates/server/src/sync_v5.rs
@@ -758,7 +758,7 @@ async fn process_rooms(
             .events
             .iter()
             .filter(|item| ignored_filter_with_ignored_users(*item, ignored_users))
-            .map(|(_, pdu)| pdu.to_sync_room_event())
+            .map(|(_, pdu)| pdu.to_sync_room_event_for(sender_id))
             .collect();
 
         for (_, pdu) in &timeline.events {
@@ -811,7 +811,7 @@ async fn process_rooms(
                                 pdu.event_sn,
                             )
                             .await;
-                            required_state_events.push(pdu.to_sync_state_event());
+                            required_state_events.push(pdu.to_sync_state_event_for(sender_id));
                         }
                     }
                 }
@@ -837,7 +837,7 @@ async fn process_rooms(
                                     pdu.event_sn,
                                 )
                                 .await;
-                                required_state_events.push(pdu.to_sync_state_event());
+                                required_state_events.push(pdu.to_sync_state_event_for(sender_id));
                             }
                         }
                     }
@@ -861,7 +861,7 @@ async fn process_rooms(
                             pdu.event_sn,
                         )
                         .await;
-                        required_state_events.push(pdu.to_sync_state_event());
+                        required_state_events.push(pdu.to_sync_state_event_for(sender_id));
                     }
                 }
                 // Specific state key
@@ -882,7 +882,7 @@ async fn process_rooms(
                             pdu.event_sn,
                         )
                         .await;
-                        required_state_events.push(pdu.to_sync_state_event());
+                        required_state_events.push(pdu.to_sync_state_event_for(sender_id));
                     }
                 }
             }

--- a/crates/server/src/user/pusher.rs
+++ b/crates/server/src/user/pusher.rs
@@ -138,7 +138,7 @@ pub async fn send_push_notice(
         user,
         &ruleset,
         &power_levels,
-        &pdu.to_sync_room_event(),
+        &pdu.to_sync_room_event_for(user),
         &pdu.room_id,
     )
     .await?

--- a/palpo-example.toml
+++ b/palpo-example.toml
@@ -48,13 +48,13 @@
 # Seconds to cache native (non-delegated) access-token authentications in
 # memory, avoiding a per-request database lookup on the auth hot path.
 #
-# The cache is process-local and is only invalidated within the process that
-# performs a logout / token rotation / account-state change. In a multi-instance
-# deployment sharing one database, another instance could keep accepting a
-# just-revoked token for up to this many seconds. Leave at 0 (disabled) unless
-# you run a single instance.
+# The cache is process-local and only invalidated within the process that
+# performs a logout / token rotation / account-state change. In a
+# multi-instance deployment sharing one database, another instance could
+# keep accepting a just-revoked token for up to this many seconds. Leave at
+# 0 (disabled) unless you run a single instance.
 #
-# native_token_cache_ttl = 0
+# native_token_cache_ttl = 0 (disabled)
 
 # Text which will be added to the end of the user's displayname upon
 # registration with a space before the text. In Conduit, this was the
@@ -453,8 +453,8 @@
 #
 # Currently this does not account for proxies in use like Synapse does.
 #
-# To disable, set this to be an empty vector (`[]`) or omit the field.
-# If omitted, no IP range filtering is performed (use a firewall instead).
+# To disable, set this to be an empty vector (`[]`). If omitted, the
+# default denylist below is used.
 #
 # A safer recommended set is:
 # ["127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12",
@@ -463,7 +463,7 @@
 # "203.0.113.0/24", "224.0.0.0/4", "::1/128", "fe80::/10", "fc00::/7",
 # "2001:db8::/32", "ff00::/8", "fec0::/10"]
 #
-# ip_range_denylist = []
+# ip_range_denylist =
 
 # Whether to query the servers listed in trusted_servers first or query
 # the origin server first. For best security, querying the origin server
@@ -798,6 +798,35 @@
 #
 # enforce_tls =
 
+# [delayed_events]
+
+# Allow scheduling MSC4140 delayed events.
+#
+# Delayed events let clients schedule message or state events that the
+# server sends into a room after a delay, e.g. reliable MatrixRTC
+# "hang up" events. When disabled the endpoints are not registered and
+# the feature is not advertised.
+#
+# enable =
+
+# The maximum delay in milliseconds a client may request for a delayed
+# event. Requests above this limit are rejected with `M_FORBIDDEN`.
+# Defaults to 24 hours.
+#
+# max_delay_ms = 86400_000
+
+# How many delayed events a user may have scheduled at once. Requests
+# above this limit are rejected with `M_LIMIT_EXCEEDED`.
+# Defaults to 100.
+#
+# max_scheduled = 100
+
+# How long finalized (sent, cancelled, or errored) delayed events are
+# retained for lookup before they are pruned, in milliseconds.
+# Defaults to 7 days.
+#
+# retention_ms = 604800_000
+
 # [federation]
 
 # Controls whether federation is allowed or not. It is not recommended to
@@ -931,9 +960,18 @@
 #
 # allow_legacy =
 
-# This item is undocumented. Please contribute documentation for it.
+# Withhold the outbound-fetching legacy `preview_url` endpoint. When
+# enabled, download, thumbnail, config, create, and upload stay available
+# (upload is the only media upload path on this server); only the legacy
+# `preview_url` endpoint is not mounted.
 #
 # freeze_legacy =
+
+# Maximum number of bytes accepted when fetching a thumbnail from a
+# remote homeserver. Both authenticated and legacy thumbnail responses
+# are subject to this streamed hard limit.
+#
+# max_remote_thumbnail_size = 20000000
 
 # Check consistency of the media directory at startup:
 # 1. When `media_compat_file_link` is enabled, this check will upgrade media when switching
@@ -1183,6 +1221,12 @@
 #
 # max_spider_size = 256000
 
+# Maximum number of bytes accepted for an image fetched while building a
+# URL preview. `Content-Length` is checked early and the response stream
+# is also counted so chunked responses cannot bypass this limit.
+#
+# max_image_size = 10000000
+
 # Option to decide whether you would like to run the domain allowlist
 # checks (contains and explicit) on the root domain or not. Does not apply
 # to URL contains allowlist. Defaults to false.
@@ -1404,17 +1448,17 @@
 #
 # introspection_endpoint =
 
+# The OAuth2 client_id that Palpo uses when redirecting users to the
+# authorization server for SSO login.
+#
+# client_id =
+
 # Internal endpoint that accepts a Matrix password login exchange.
 # Palpo authenticates with `admin.mas_secret` as a Bearer token and expects
 # a delegated access token in response. When unset, `m.login.password` is
 # not advertised while delegated auth is enabled.
 #
-# password_login_endpoint = "http://localhost:8080/api/internal/matrix/password-login"
-
-# The OAuth2 client_id that Palpo uses when redirecting users to the
-# authorization server for SSO login.
-#
-# client_id =
+# password_login_endpoint =
 
 # Optional URL for account management UI.
 # Included in the well-known client response under m.authentication.

--- a/palpo-example.toml
+++ b/palpo-example.toml
@@ -811,6 +811,26 @@
 #
 # enforce_tls =
 
+# [delayed_events]
+
+# Allow scheduling MSC4140 delayed events. Disabled by default while the MSC
+# is unstable. When disabled, the endpoints are not registered and the feature
+# is not advertised.
+#
+# enable = false
+
+# Maximum requested delay in milliseconds. Defaults to 24 hours.
+#
+# max_delay_ms = 86400_000
+
+# Maximum number of delayed events a user may have scheduled at once.
+#
+# max_scheduled = 100
+
+# Retention period for finalized delayed events, in milliseconds.
+#
+# retention_ms = 604800_000
+
 # [federation]
 
 # Controls whether federation is allowed or not. It is not recommended to


### PR DESCRIPTION
Closes #319

## Summary

Implements the current MSC4140 delayed-events proposal with persistent scheduling, crash-safe delivery, management actions, and sender-only event metadata.

Recommended prerequisite merge order: #412, then #411 / #413 / #414, then this PR. This branch includes those fixes so the feature can be reviewed and tested as a coherent whole; merging the prerequisite PRs first will reduce this PR to its MSC4140-specific changes.

### API

- `PUT /_matrix/client/unstable/org.matrix.msc4140/rooms/{room_id}/delayed_event/{event_type}/{txn_id}` schedules a message or state event from `delay_ms`, optional `state_key`, and `content`.
- `GET /_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}` returns one scheduled or finalized event owned by the requester.
- `POST /_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}/{action}` supports `restart`, `send`, and `cancel`.
- Lookup responses use `delay_ms`, `delayed_since_ts`, and the nested `finalised` result defined by the current proposal.
- Application-service `?ts=` timestamp massaging is preserved for delayed and immediate message/state sends.

### Delivery and concurrency

- Scheduled rows persist across restarts and are selected with `FOR UPDATE SKIP LOCKED` while the row lock is held through delivery and outcome recording.
- Timeline promotion records a durable delay-specific output in the same database transaction, allowing recovery after a crash between append and finalization without emitting a second event.
- Management actions resolve a persisted output before restarting or cancelling, and manual send failures remain retryable unless the event already entered the timeline.
- A transaction-scoped room advisory lock serializes all local appends across server instances, including ordinary and delayed sends.
- Per-user scheduling limits and transaction-id retries are serialized under a per-user advisory lock.
- Query and coordination pools are split within the configured `db.pool_size`; delayed row-lock waiters cannot consume the query connections needed by an active timeline append.

### Protocol and privacy

- `org.matrix.msc4140.delay_id` is visible only to the sending user and is removed from other client responses, nested event data, application-service delivery, and federation.
- Delayed PDUs do not contain a transaction ID; ordinary transaction IDs are likewise visible only to their sender.
- Authorization, account usability, rate limiting, and current server policy are re-evaluated at send time.
- Scheduled-send failures are finalized without automatic retry.
- Oversized delays use `ORG.MATRIX.MSC4140_DELAY_TOO_LARGE`; scheduling limits preserve standard `M_LIMIT_EXCEEDED`, `Retry-After`, and `retry_after_ms` behavior.

### Configuration

The new `[delayed_events]` section is disabled by default while MSC4140 is unstable. It provides `enable`, `max_delay_ms` (24 hours), `max_scheduled` (100), and `retention_ms` (7 days). The unstable feature flag and routes are exposed only when enabled.

## Verification

- `cargo +1.97 test --workspace --all-features`
- `cargo +1.97 clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo +1.97 check --workspace --all-targets --all-features`
- `cargo +nightly fmt --all -- --check`
- `cargo deny check`
- Fresh Linux image + PostgreSQL HTTP end-to-end coverage for scheduling, lookup shape, manual send, cancellation, automatic send, sender-only metadata, forward/backward pagination, restart timer reset, and overdue recovery after server restart
- Three clean local review rounds covering protocol shape, sender-only serialization, crash recovery, row/advisory-lock ordering, pool usage, scheduling limits, and management/pruning races