### PR TITLE
Fix OpenDAL S3 HTTP transport initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3520,6 +3520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77d02c6564e376d3670aaf66ad886cd34f83c0aca407b6364777c624a63e0e2d"
 dependencies = [
  "opendal-core",
+ "opendal-http-transport-reqwest",
  "opendal-layer-logging",
  "opendal-service-fs",
  "opendal-service-s3",
@@ -3549,6 +3550,20 @@ dependencies = [
  "url",
  "uuid",
  "web-time",
+]
+
+[[package]]
+name = "opendal-http-transport-reqwest"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b7fd001b204df76be5d2b3f7a81c48b5cf25b28e2cfb3b8a819bb89cdc0ea3a"
+dependencies = [
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "opendal-core",
+ "reqwest",
 ]
 
 [[package]]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -60,7 +60,12 @@ hmac = { workspace = true }
 hyper-util = { workspace = true, features = ["client"] }
 image = { workspace = true }
 indexmap = { workspace = true }
-opendal = { workspace = true, features = ["layers-logging", "services-fs", "services-s3"] }
+opendal = { workspace = true, features = [
+    "http-transport-reqwest",
+    "layers-logging",
+    "services-fs",
+    "services-s3",
+] }
 ipaddress = { workspace = true }
 itertools = { workspace = true }
 jsonwebtoken = { workspace = true }

--- a/crates/server/src/storage.rs
+++ b/crates/server/src/storage.rs
@@ -17,6 +17,10 @@ struct RedirectConfig {
 /// Initialize the global storage operator from configuration.
 /// Must be called once at startup after config is loaded.
 pub fn init(config: &StorageConfig) -> AppResult<()> {
+    if matches!(config, StorageConfig::S3 { .. }) {
+        opendal::install_default();
+    }
+
     let op = build_operator(config)?;
     OPERATOR
         .set(op)


### PR DESCRIPTION
## Summary

- enable OpenDAL's `http-transport-reqwest` feature for the server
- install OpenDAL's default HTTP transport before constructing an S3 operator
- keep filesystem storage initialization unchanged by limiting the install call to `StorageConfig::S3`
- update the lockfile for the newly enabled transport crate

## Root cause

Palpo uses OpenDAL 0.58 with default features disabled. The S3 service was enabled, but no HTTP transport was compiled or installed. OpenDAL 0.58 therefore returned `ConfigInvalid` on the first S3 HTTP operation.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p palpo --locked`
- `cargo tree -p palpo -e features -i opendal-http-transport-reqwest --locked`
- `git diff --check`