### PR TITLE
Fix plain-text replacement fallbacks

### DIFF
--- a/crates/core/src/events/room/message.rs
+++ b/crates/core/src/events/room/message.rs
@@ -640,22 +640,11 @@ impl MessageType {
     }
 
     fn make_replacement_body(&mut self) {
-        let empty_formatted_body = || FormattedBody::html(String::new());
-
         let (body, formatted) = {
             match self {
-                MessageType::Emote(m) => (
-                    &mut m.body,
-                    Some(m.formatted.get_or_insert_with(empty_formatted_body)),
-                ),
-                MessageType::Notice(m) => (
-                    &mut m.body,
-                    Some(m.formatted.get_or_insert_with(empty_formatted_body)),
-                ),
-                MessageType::Text(m) => (
-                    &mut m.body,
-                    Some(m.formatted.get_or_insert_with(empty_formatted_body)),
-                ),
+                MessageType::Emote(m) => (&mut m.body, m.formatted.as_mut()),
+                MessageType::Notice(m) => (&mut m.body, m.formatted.as_mut()),
+                MessageType::Text(m) => (&mut m.body, m.formatted.as_mut()),
                 MessageType::Audio(m) => (&mut m.body, None),
                 MessageType::File(m) => (&mut m.body, None),
                 MessageType::Image(m) => (&mut m.body, None),
@@ -679,6 +668,82 @@ impl MessageType {
 
             f.body = format!("* {}", f.body);
         }
+    }
+}
+
+#[cfg(test)]
+mod replacement_tests {
+    use assert_matches2::assert_let;
+    use serde_json::json;
+
+    use super::{
+        MessageType, Relation, ReplacementMetadata, RoomMessageEventContent,
+        TextMessageEventContent,
+    };
+    use crate::owned_event_id;
+
+    #[test]
+    fn plain_text_replacement_does_not_gain_formatted_body() {
+        let content =
+            RoomMessageEventContent::text_plain("This is an edited message.").make_replacement(
+                ReplacementMetadata::new(owned_event_id!("$original:example.org"), None),
+            );
+
+        assert_let!(
+            MessageType::Text(TextMessageEventContent {
+                body,
+                formatted,
+                ..
+            }) = &content.msgtype
+        );
+        assert_eq!(body, "* This is an edited message.");
+        assert!(formatted.is_none());
+
+        let json = serde_json::to_value(&content).unwrap();
+        assert_eq!(
+            json.get("body"),
+            Some(&json!("* This is an edited message."))
+        );
+        assert!(json.get("format").is_none());
+        assert!(json.get("formatted_body").is_none());
+
+        assert_let!(Some(Relation::Replacement(replacement)) = &content.relates_to);
+        assert_let!(MessageType::Text(new_content) = &replacement.new_content.msgtype);
+        assert_eq!(new_content.body, "This is an edited message.");
+        assert!(new_content.formatted.is_none());
+    }
+
+    #[test]
+    fn html_replacement_keeps_both_fallbacks() {
+        let content = RoomMessageEventContent::text_html(
+            "This is an edited message.",
+            "<strong>This is an edited message.</strong>",
+        )
+        .make_replacement(ReplacementMetadata::new(
+            owned_event_id!("$original:example.org"),
+            None,
+        ));
+
+        assert_let!(MessageType::Text(message) = &content.msgtype);
+        assert_eq!(message.body, "* This is an edited message.");
+        assert_eq!(
+            message
+                .formatted
+                .as_ref()
+                .map(|formatted| formatted.body.as_str()),
+            Some("* <strong>This is an edited message.</strong>")
+        );
+
+        assert_let!(Some(Relation::Replacement(replacement)) = &content.relates_to);
+        assert_let!(MessageType::Text(new_content) = &replacement.new_content.msgtype);
+        assert_eq!(new_content.body, "This is an edited message.");
+        assert_eq!(
+            new_content
+                .formatted
+                .as_ref()
+                .map(|formatted| formatted.body.as_str()),
+            Some("<strong>This is an edited message.</strong>")
+        );
     }
 }
 

--- a/crates/core/src/events/room/message.rs
+++ b/crates/core/src/events/room/message.rs
@@ -678,7 +678,7 @@ mod replacement_tests {
 
     use super::{
         MessageType, Relation, ReplacementMetadata, RoomMessageEventContent,
-        TextMessageEventContent,
+        RoomMessageEventContentWithoutRelation, TextMessageEventContent,
     };
     use crate::owned_event_id;
 
@@ -744,6 +744,41 @@ mod replacement_tests {
                 .map(|formatted| formatted.body.as_str()),
             Some("<strong>This is an edited message.</strong>")
         );
+    }
+
+    #[test]
+    fn plain_notice_and_emote_replacements_do_not_gain_formatted_bodies() {
+        for content in [
+            RoomMessageEventContent::notice_plain("Edited notice"),
+            RoomMessageEventContent::emote_plain("Edited emote"),
+        ] {
+            let content = content.make_replacement(ReplacementMetadata::new(
+                owned_event_id!("$original:example.org"),
+                None,
+            ));
+            let json = serde_json::to_value(content).unwrap();
+
+            assert!(json.get("format").is_none());
+            assert!(json.get("formatted_body").is_none());
+        }
+    }
+
+    #[test]
+    fn without_relation_plain_replacements_do_not_gain_formatted_bodies() {
+        for content in [
+            RoomMessageEventContentWithoutRelation::text_plain("Edited text"),
+            RoomMessageEventContentWithoutRelation::notice_plain("Edited notice"),
+            RoomMessageEventContentWithoutRelation::emote_plain("Edited emote"),
+        ] {
+            let content = content.make_replacement(ReplacementMetadata::new(
+                owned_event_id!("$original:example.org"),
+                None,
+            ));
+            let json = serde_json::to_value(content).unwrap();
+
+            assert!(json.get("format").is_none());
+            assert!(json.get("formatted_body").is_none());
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- keep plain-text message edits plain by avoiding a synthetic empty HTML fallback
- preserve the existing formatted fallback behavior for HTML edits
- add regression coverage for text, notice, and emote edits through both content entry points
- verify the untouched `m.new_content` wire representation

## Root cause

`MessageType::make_replacement_body` used `get_or_insert_with` for text, notice, and emote messages. That created an empty `formatted_body` even when the edit only contained a plain `body`, changing the serialized message into an HTML-formatted event.

The helper now mutates formatted content only when it already exists.

## Impact

Plain-text edits no longer serialize `format` or `formatted_body`. HTML edits continue to prepend the fallback to both representations, and relation and mention handling remain unchanged.

## Checks

- `cargo fmt --all -- --check`
- `cargo test -p palpo-core replacement_tests` (4 passed)
- `cargo test -p palpo-core` (312 unit tests and 38 doctests)
- `cargo clippy -p palpo-core --all-targets -- -D warnings`
- `git diff --check`

Closes #364

Upstream reference: https://github.com/ruma/ruma/commit/04d5d68841c3c8d71e5fe6f7899ccccad94274c3