### PR TITLE
Expose room message thread relations

### DIFF
--- a/crates/core/src/events/room/message.rs
+++ b/crates/core/src/events/room/message.rs
@@ -335,7 +335,7 @@ impl RoomMessageEventContent {
     }
 
     /// Get the thread relation from this content, if any.
-    fn thread(&self) -> Option<&Thread> {
+    pub fn thread(&self) -> Option<&Thread> {
         self.relates_to
             .as_ref()
             .and_then(|relates_to| as_variant!(relates_to, Relation::Thread))

--- a/crates/core/tests/room_message.rs
+++ b/crates/core/tests/room_message.rs
@@ -1,0 +1,39 @@
+use palpo_core::events::relation::{InReplyTo, Replacement, Thread};
+use palpo_core::events::room::message::{
+    Relation, RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
+};
+use palpo_core::owned_event_id;
+
+#[test]
+fn thread_accessor_returns_only_thread_relations() {
+    let mut content = RoomMessageEventContent::text_plain("Thread reply");
+    content.relates_to = Some(Relation::Thread(Thread::plain(
+        owned_event_id!("$root:example.org"),
+        owned_event_id!("$latest:example.org"),
+    )));
+
+    let thread = content.thread().expect("thread relation");
+    assert_eq!(thread.event_id, "$root:example.org");
+    assert_eq!(
+        thread
+            .in_reply_to
+            .as_ref()
+            .map(|reply| reply.event_id.as_str()),
+        Some("$latest:example.org")
+    );
+    assert!(thread.is_falling_back);
+
+    content.relates_to = Some(Relation::Reply {
+        in_reply_to: InReplyTo::new(owned_event_id!("$reply:example.org")),
+    });
+    assert!(content.thread().is_none());
+
+    content.relates_to = Some(Relation::Replacement(Replacement::new(
+        owned_event_id!("$original:example.org"),
+        RoomMessageEventContentWithoutRelation::from(RoomMessageEventContent::text_plain("Edit")),
+    )));
+    assert!(content.thread().is_none());
+
+    content.relates_to = None;
+    assert!(content.thread().is_none());
+}


### PR DESCRIPTION
## Summary

- make `RoomMessageEventContent::thread` available to downstream `palpo-core` users
- keep the accessor borrowed and allocation-free
- add an external integration test covering thread, reply, replacement, and absent relations

## Why

The helper already existed internally and is used when constructing reply metadata. Making it public lets homeserver code and other `palpo-core` consumers inspect thread context without manually matching the generic `Relation` enum.

This is an API-only change and does not alter event serialization.

## Checks

- `cargo fmt --all -- --check`
- `cargo test -p palpo-core --test room_message`
- `cargo test -p palpo-core --doc`
- `git diff --check`

Closes #365

Upstream reference: https://github.com/ruma/ruma/commit/50475947a7fa615f6ee7ba991318195c427036d6