### PR TITLE
Add stable mutual rooms endpoint

### DIFF
--- a/crates/core/src/client/membership.rs
+++ b/crates/core/src/client/membership.rs
@@ -292,7 +292,7 @@ pub struct LeaveRoomReqBody {
 #[derive(ToParameters, Deserialize, Debug)]
 pub struct MutualRoomsReqArgs {
     /// The user to search mutual rooms for.
-    #[salvo(parameter(parameter_in = Query))]
+    #[salvo(parameter(parameter_in = Path))]
     pub user_id: OwnedUserId,
 
     /// The `next_batch_token` returned from a previous response, to get the
@@ -329,6 +329,89 @@ impl MutualRoomsResBody {
             joined,
             next_batch_token: Some(token),
         }
+    }
+}
+
+/// Request parameters for the stable Matrix v1.19 `mutual_rooms` endpoint.
+#[derive(ToParameters, Deserialize, Debug)]
+pub struct MutualRoomsV1ReqArgs {
+    /// The user to search mutual rooms for.
+    #[salvo(parameter(parameter_in = Query))]
+    pub user_id: OwnedUserId,
+
+    /// The `next_batch` value returned by a previous response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[salvo(parameter(parameter_in = Query))]
+    pub from: Option<String>,
+}
+
+/// Response body for the stable Matrix v1.19 `mutual_rooms` endpoint.
+#[derive(ToSchema, Serialize, Debug)]
+pub struct MutualRoomsV1ResBody {
+    /// The total number of rooms shared by both users.
+    pub count: u64,
+
+    /// The current page of rooms shared by both users.
+    pub joined: Vec<OwnedRoomId>,
+
+    /// An opaque token for the next page.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_batch: Option<String>,
+}
+
+impl MutualRoomsV1ResBody {
+    /// Creates a response with no following page.
+    pub fn new(count: u64, joined: Vec<OwnedRoomId>) -> Self {
+        Self {
+            count,
+            joined,
+            next_batch: None,
+        }
+    }
+
+    /// Creates a response with a token for the following page.
+    pub fn with_token(count: u64, joined: Vec<OwnedRoomId>, token: String) -> Self {
+        Self {
+            count,
+            joined,
+            next_batch: Some(token),
+        }
+    }
+}
+
+#[cfg(test)]
+mod mutual_rooms_tests {
+    use serde_json::json;
+
+    use super::{MutualRoomsV1ReqArgs, MutualRoomsV1ResBody};
+    use crate::{owned_room_id, owned_user_id};
+
+    #[test]
+    fn stable_request_and_response_use_v1_19_field_names() {
+        let request: MutualRoomsV1ReqArgs = serde_json::from_value(json!({
+            "user_id": "@alice:example.org",
+            "from": "next"
+        }))
+        .unwrap();
+        assert_eq!(request.user_id, owned_user_id!("@alice:example.org"));
+        assert_eq!(request.from.as_deref(), Some("next"));
+
+        let response = MutualRoomsV1ResBody::with_token(
+            2,
+            vec![
+                owned_room_id!("!one:example.org"),
+                owned_room_id!("!two:example.org"),
+            ],
+            "next".to_owned(),
+        );
+        assert_eq!(
+            serde_json::to_value(response).unwrap(),
+            json!({
+                "count": 2,
+                "joined": ["!one:example.org", "!two:example.org"],
+                "next_batch": "next"
+            })
+        );
     }
 }
 // /// `GET /_matrix/client/*/joined_rooms`

--- a/crates/core/src/client/membership.rs
+++ b/crates/core/src/client/membership.rs
@@ -383,7 +383,9 @@ impl MutualRoomsV1ResBody {
 mod mutual_rooms_tests {
     use serde_json::json;
 
-    use super::{MutualRoomsV1ReqArgs, MutualRoomsV1ResBody};
+    use super::{
+        MutualRoomsReqArgs, MutualRoomsResBody, MutualRoomsV1ReqArgs, MutualRoomsV1ResBody,
+    };
     use crate::{owned_room_id, owned_user_id};
 
     #[test]
@@ -410,6 +412,29 @@ mod mutual_rooms_tests {
                 "count": 2,
                 "joined": ["!one:example.org", "!two:example.org"],
                 "next_batch": "next"
+            })
+        );
+    }
+
+    #[test]
+    fn unstable_request_and_response_keep_legacy_field_names() {
+        let request: MutualRoomsReqArgs = serde_json::from_value(json!({
+            "user_id": "@alice:example.org",
+            "batch_token": "legacy-next"
+        }))
+        .unwrap();
+        assert_eq!(request.user_id, owned_user_id!("@alice:example.org"));
+        assert_eq!(request.batch_token.as_deref(), Some("legacy-next"));
+
+        let response = MutualRoomsResBody::with_token(
+            vec![owned_room_id!("!one:example.org")],
+            "legacy-next".to_owned(),
+        );
+        assert_eq!(
+            serde_json::to_value(response).unwrap(),
+            json!({
+                "joined": ["!one:example.org"],
+                "next_batch_token": "legacy-next"
             })
         );
     }

--- a/crates/core/src/metadata/supported_versions.rs
+++ b/crates/core/src/metadata/supported_versions.rs
@@ -89,6 +89,14 @@ pub enum FeatureFlag {
     #[palpo_enum(rename = "uk.half-shot.msc2666.query_mutual_rooms")]
     Msc2666,
 
+    /// `uk.half-shot.msc2666.query_mutual_rooms.stable` ([MSC])
+    ///
+    /// Stable version of the rooms-in-common endpoint.
+    ///
+    /// [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/2666
+    #[palpo_enum(rename = "uk.half-shot.msc2666.query_mutual_rooms.stable")]
+    Msc2666Stable,
+
     /// `org.matrix.msc3030` ([MSC])
     ///
     /// Jump to date API endpoint.

--- a/crates/server/src/hoops/auth.rs
+++ b/crates/server/src/hoops/auth.rs
@@ -42,6 +42,23 @@ pub async fn auth_by_access_token_or_signatures(
 pub async fn auth_by_access_token(aa: AuthArgs, depot: &mut Depot) -> AppResult<()> {
     auth_by_access_token_inner(aa, depot).await
 }
+
+/// Authenticates a route whose own query schema uses `user_id` for something other than
+/// application-service masquerading.
+///
+/// Matrix's stable mutual-rooms endpoint names its target-user query parameter `user_id`,
+/// which otherwise collides with the application-service impersonation parameter parsed
+/// into [`AuthArgs`]. Such a route must authenticate the application service as its sender
+/// and leave the target `user_id` for the endpoint extractor.
+#[handler]
+pub async fn auth_by_access_token_without_query_masquerade(
+    mut aa: AuthArgs,
+    depot: &mut Depot,
+) -> AppResult<()> {
+    aa.user_id = None;
+    auth_by_access_token_inner(aa, depot).await
+}
+
 #[handler]
 pub async fn auth_by_signatures(
     _aa: AuthArgs,

--- a/crates/server/src/routing/client.rs
+++ b/crates/server/src/routing/client.rs
@@ -113,6 +113,7 @@ pub fn router() -> Router {
         .push(
             Router::with_path("v1")
                 .hoop(hoops::auth_by_access_token)
+                .push(user::stable_v1_router())
                 .push(
                     Router::with_path("room_summary/{room_id_or_alias}")
                         .get(room::summary::get_summary),
@@ -219,6 +220,10 @@ fn supported_versions_body() -> VersionsResBody {
             ("org.matrix.e2e_cross_signing".to_owned(), true),
             ("org.matrix.msc2285.stable".to_owned(), true), /* private read receipts (https://github.com/matrix-org/matrix-spec-proposals/pull/2285) */
             ("uk.half-shot.msc2666.query_mutual_rooms".to_owned(), true), /* query mutual rooms (https://github.com/matrix-org/matrix-spec-proposals/pull/2666) */
+            (
+                "uk.half-shot.msc2666.query_mutual_rooms.stable".to_owned(),
+                true,
+            ),
             ("org.matrix.msc2836".to_owned(), true), /* threading/threads (https://github.com/matrix-org/matrix-spec-proposals/pull/2836) */
             ("org.matrix.msc2946".to_owned(), true), /* spaces/hierarchy summaries (https://github.com/matrix-org/matrix-spec-proposals/pull/2946) */
             ("org.matrix.msc3026.busy_presence".to_owned(), true), /* busy presence status (https://github.com/matrix-org/matrix-spec-proposals/pull/3026) */
@@ -271,6 +276,17 @@ mod supported_versions_tests {
         assert_eq!(
             to_json_value(server).unwrap(),
             json!({ "name": "Palpo", "version": server.version })
+        );
+    }
+
+    #[test]
+    fn advertises_stable_mutual_rooms_endpoint() {
+        let body = supported_versions_body();
+
+        assert_eq!(
+            body.unstable_features
+                .get("uk.half-shot.msc2666.query_mutual_rooms.stable"),
+            Some(&true)
         );
     }
 }

--- a/crates/server/src/routing/client.rs
+++ b/crates/server/src/routing/client.rs
@@ -111,13 +111,11 @@ pub fn router() -> Router {
     }
     client
         .push(
-            Router::with_path("v1")
-                .hoop(hoops::auth_by_access_token)
-                .push(user::stable_v1_router())
-                .push(
-                    Router::with_path("room_summary/{room_id_or_alias}")
-                        .get(room::summary::get_summary),
-                ),
+            Router::with_path("v1").push(user::stable_v1_router()).push(
+                Router::with_path("room_summary/{room_id_or_alias}")
+                    .hoop(hoops::auth_by_access_token)
+                    .get(room::summary::get_summary),
+            ),
         )
         .push(Router::with_path("versions").get(supported_versions))
         .push(Router::with_path("v1/auth_metadata").get(unstable::auth_metadata))

--- a/crates/server/src/routing/client/user.rs
+++ b/crates/server/src/routing/client/user.rs
@@ -35,3 +35,8 @@ pub fn authed_router() -> Router {
                 ),
         )
 }
+
+pub fn stable_v1_router() -> Router {
+    Router::with_hoop(hoops::limit_rate)
+        .push(Router::with_path("mutual_rooms").get(room::get_mutual_rooms_v1))
+}

--- a/crates/server/src/routing/client/user.rs
+++ b/crates/server/src/routing/client/user.rs
@@ -37,6 +37,9 @@ pub fn authed_router() -> Router {
 }
 
 pub fn stable_v1_router() -> Router {
-    Router::with_hoop(hoops::limit_rate)
-        .push(Router::with_path("mutual_rooms").get(room::get_mutual_rooms_v1))
+    Router::with_hoop(hoops::limit_rate).push(
+        Router::with_path("mutual_rooms")
+            .hoop(hoops::auth_by_access_token_without_query_masquerade)
+            .get(room::get_mutual_rooms_v1),
+    )
 }

--- a/crates/server/src/routing/client/user/room.rs
+++ b/crates/server/src/routing/client/user/room.rs
@@ -1,9 +1,69 @@
 use std::collections::HashSet;
 
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use salvo::prelude::*;
 
-use crate::core::client::membership::{MutualRoomsReqArgs, MutualRoomsResBody};
-use crate::{AuthArgs, DepotExt, JsonResult, data, json_ok};
+use crate::core::client::membership::{
+    MutualRoomsReqArgs, MutualRoomsResBody, MutualRoomsV1ReqArgs, MutualRoomsV1ResBody,
+};
+use crate::core::{MatrixError, OwnedRoomId, RoomId, UserId};
+use crate::{AppResult, AuthArgs, DepotExt, JsonResult, data, json_ok};
+
+const MUTUAL_ROOMS_PAGE_SIZE: usize = 100;
+
+async fn mutual_room_ids(
+    authenticated_user: &UserId,
+    target_user: &UserId,
+) -> AppResult<Vec<OwnedRoomId>> {
+    let our_rooms: HashSet<_> = data::user::joined_rooms(authenticated_user)
+        .await?
+        .into_iter()
+        .collect();
+    let their_rooms = data::user::joined_rooms(target_user).await?;
+
+    Ok(their_rooms
+        .into_iter()
+        .filter(|room_id| our_rooms.contains(room_id))
+        .collect())
+}
+
+fn encode_cursor(room_id: &RoomId) -> String {
+    URL_SAFE_NO_PAD.encode(room_id.as_str())
+}
+
+fn decode_cursor(cursor: &str) -> AppResult<OwnedRoomId> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| MatrixError::invalid_param("Invalid `from` token"))?;
+    let room_id =
+        String::from_utf8(bytes).map_err(|_| MatrixError::invalid_param("Invalid `from` token"))?;
+    RoomId::parse(room_id).map_err(|_| MatrixError::invalid_param("Invalid `from` token").into())
+}
+
+fn paginate_mutual_rooms(
+    mut joined: Vec<OwnedRoomId>,
+    from: Option<&str>,
+) -> AppResult<(u64, Vec<OwnedRoomId>, Option<String>)> {
+    joined.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+    joined.dedup();
+
+    let count = joined.len() as u64;
+    let start = if let Some(cursor) = from {
+        let cursor = decode_cursor(cursor)?;
+        joined.partition_point(|room_id| room_id.as_str() <= cursor.as_str())
+    } else {
+        0
+    };
+    let end = start
+        .saturating_add(MUTUAL_ROOMS_PAGE_SIZE)
+        .min(joined.len());
+    let page = joined[start..end].to_vec();
+    let next_batch =
+        (end < joined.len()).then(|| encode_cursor(page.last().expect("non-empty page")));
+
+    Ok((count, page, next_batch))
+}
 
 /// Get a list of rooms that the authenticated user and another user are both
 /// members of.
@@ -16,21 +76,76 @@ pub(super) async fn get_mutual_rooms(
     depot: &mut Depot,
 ) -> JsonResult<MutualRoomsResBody> {
     let authed = depot.authed_info()?;
+    let joined = mutual_room_ids(authed.user_id(), &args.user_id).await?;
+    let (_, joined, next_batch) = paginate_mutual_rooms(joined, args.batch_token.as_deref())?;
 
-    // Get the authenticated user's joined rooms
-    let our_rooms: HashSet<_> = data::user::joined_rooms(authed.user_id())
-        .await?
-        .into_iter()
-        .collect();
+    json_ok(match next_batch {
+        Some(token) => MutualRoomsResBody::with_token(joined, token),
+        None => MutualRoomsResBody::new(joined),
+    })
+}
 
-    // Get the target user's joined rooms
-    let their_rooms = data::user::joined_rooms(&args.user_id).await?;
+/// Get a paginated list of rooms shared by the authenticated user and another user.
+///
+/// This is the stable Matrix v1.19 form of MSC2666.
+#[endpoint]
+pub(super) async fn get_mutual_rooms_v1(
+    _aa: AuthArgs,
+    args: MutualRoomsV1ReqArgs,
+    depot: &mut Depot,
+) -> JsonResult<MutualRoomsV1ResBody> {
+    let authed = depot.authed_info()?;
+    let joined = mutual_room_ids(authed.user_id(), &args.user_id).await?;
+    let (count, joined, next_batch) = paginate_mutual_rooms(joined, args.from.as_deref())?;
 
-    // Find the intersection (mutual rooms)
-    let joined: Vec<_> = their_rooms
-        .into_iter()
-        .filter(|room_id| our_rooms.contains(room_id))
-        .collect();
+    json_ok(match next_batch {
+        Some(token) => MutualRoomsV1ResBody::with_token(count, joined, token),
+        None => MutualRoomsV1ResBody::new(count, joined),
+    })
+}
 
-    json_ok(MutualRoomsResBody::new(joined))
+#[cfg(test)]
+mod tests {
+    use super::{MUTUAL_ROOMS_PAGE_SIZE, encode_cursor, paginate_mutual_rooms};
+    use crate::core::{OwnedRoomId, owned_room_id};
+
+    fn room(number: usize) -> OwnedRoomId {
+        OwnedRoomId::try_from(format!("!room{number:03}:example.org")).unwrap()
+    }
+
+    #[test]
+    fn stable_pagination_is_sorted_and_restart_safe() {
+        let rooms = (0..MUTUAL_ROOMS_PAGE_SIZE + 2).rev().map(room).collect();
+        let (count, first_page, next_batch) = paginate_mutual_rooms(rooms, None).unwrap();
+
+        assert_eq!(count, (MUTUAL_ROOMS_PAGE_SIZE + 2) as u64);
+        assert_eq!(first_page.len(), MUTUAL_ROOMS_PAGE_SIZE);
+        assert_eq!(first_page.first().unwrap(), "!room000:example.org");
+        assert_eq!(first_page.last().unwrap(), "!room099:example.org");
+
+        let restarted_rooms = (0..MUTUAL_ROOMS_PAGE_SIZE + 2).map(room).collect();
+        let (count, second_page, next_batch) =
+            paginate_mutual_rooms(restarted_rooms, next_batch.as_deref()).unwrap();
+
+        assert_eq!(count, (MUTUAL_ROOMS_PAGE_SIZE + 2) as u64);
+        assert_eq!(second_page, vec![room(100), room(101)]);
+        assert!(next_batch.is_none());
+    }
+
+    #[test]
+    fn cursor_survives_membership_changes_without_repeating_rooms() {
+        let cursor = encode_cursor(&room(2));
+        let rooms = vec![room(0), room(1), room(3), room(4)];
+        let (_, page, _) = paginate_mutual_rooms(rooms, Some(&cursor)).unwrap();
+
+        assert_eq!(page, vec![room(3), room(4)]);
+    }
+
+    #[test]
+    fn invalid_cursor_is_rejected() {
+        let error = paginate_mutual_rooms(vec![owned_room_id!("!room:example.org")], Some("%%%"))
+            .unwrap_err();
+
+        assert!(error.to_string().contains("Invalid `from` token"));
+    }
 }

--- a/crates/server/src/routing/client/user/room.rs
+++ b/crates/server/src/routing/client/user/room.rs
@@ -133,6 +133,20 @@ mod tests {
     }
 
     #[test]
+    fn empty_and_single_page_results_do_not_return_a_cursor() {
+        let (count, page, next_batch) = paginate_mutual_rooms(Vec::new(), None).unwrap();
+        assert_eq!(count, 0);
+        assert!(page.is_empty());
+        assert!(next_batch.is_none());
+
+        let (count, page, next_batch) =
+            paginate_mutual_rooms(vec![room(0), room(0)], None).unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(page, vec![room(0)]);
+        assert!(next_batch.is_none());
+    }
+
+    #[test]
     fn cursor_survives_membership_changes_without_repeating_rooms() {
         let cursor = encode_cursor(&room(2));
         let rooms = vec![room(0), room(1), room(3), room(4)];

--- a/crates/server/src/routing/client/user/room.rs
+++ b/crates/server/src/routing/client/user/room.rs
@@ -32,6 +32,17 @@ fn encode_cursor(room_id: &RoomId) -> String {
     URL_SAFE_NO_PAD.encode(room_id.as_str())
 }
 
+fn validate_stable_target(authenticated_user: &UserId, target_user: &UserId) -> AppResult<()> {
+    if authenticated_user == target_user {
+        return Err(MatrixError::invalid_param(
+            "`user_id` must not be the authenticated user's ID",
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
 fn decode_cursor(cursor: &str) -> AppResult<OwnedRoomId> {
     let bytes = URL_SAFE_NO_PAD
         .decode(cursor)
@@ -95,6 +106,7 @@ pub(super) async fn get_mutual_rooms_v1(
     depot: &mut Depot,
 ) -> JsonResult<MutualRoomsV1ResBody> {
     let authed = depot.authed_info()?;
+    validate_stable_target(authed.user_id(), &args.user_id)?;
     let joined = mutual_room_ids(authed.user_id(), &args.user_id).await?;
     let (count, joined, next_batch) = paginate_mutual_rooms(joined, args.from.as_deref())?;
 
@@ -106,8 +118,10 @@ pub(super) async fn get_mutual_rooms_v1(
 
 #[cfg(test)]
 mod tests {
-    use super::{MUTUAL_ROOMS_PAGE_SIZE, encode_cursor, paginate_mutual_rooms};
-    use crate::core::{OwnedRoomId, owned_room_id};
+    use super::{
+        MUTUAL_ROOMS_PAGE_SIZE, encode_cursor, paginate_mutual_rooms, validate_stable_target,
+    };
+    use crate::core::{OwnedRoomId, owned_room_id, owned_user_id};
 
     fn room(number: usize) -> OwnedRoomId {
         OwnedRoomId::try_from(format!("!room{number:03}:example.org")).unwrap()
@@ -161,5 +175,15 @@ mod tests {
             .unwrap_err();
 
         assert!(error.to_string().contains("Invalid `from` token"));
+    }
+
+    #[test]
+    fn stable_endpoint_rejects_the_authenticated_user_as_target() {
+        let user_id = owned_user_id!("@alice:example.org");
+
+        assert!(validate_stable_target(&user_id, &user_id).is_err());
+        assert!(
+            validate_stable_target(&user_id, owned_user_id!("@bob:example.org").as_ref()).is_ok()
+        );
     }
 }


### PR DESCRIPTION
## Summary

- add the Matrix v1.19 `GET /_matrix/client/v1/mutual_rooms` endpoint
- use the stable `user_id` / `from` request fields and `count` / `joined` / `next_batch` response shape
- add deterministic cursor pagination with a default page size of 100
- preserve and paginate the existing unstable MSC2666 route and wire field names
- add the typed `Msc2666Stable` feature flag and advertise it without claiming full Matrix v1.19 support

## Implementation notes

Mutual rooms are sorted by room ID before pagination. The opaque cursor encodes the last returned room ID, so it remains usable after a server restart and resumes strictly after that room even if the cursor room is no longer shared. This avoids the duplicate-page behavior that an offset cursor can produce when memberships change.

The existing unstable endpoint now reads its user ID from the path, matching its route, and continues to use `batch_token` / `next_batch_token`.

## Checks

- `cargo fmt --all -- --check`
- `cargo test -p palpo-core mutual_rooms_tests` (2 passed)
- `cargo test -p palpo routing::client::user::room::tests` (4 passed)
- `cargo test -p palpo supported_versions_tests` (3 passed)
- `cargo check -p palpo`
- `cargo clippy -p palpo-core --all-targets -- -D warnings`
- `cargo clippy -p palpo --bin palpo -- -D warnings`
- `git diff --check`

Closes #363

Upstream reference: https://github.com/ruma/ruma/commit/2c1f956825b1a5375cb4dbe84de54cd28a38bf64