### PR TITLE
Add MSC4495 protocol types

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -98,6 +98,7 @@ unstable-msc4362 = []
 unstable-msc4380 = []
 unstable-msc4383 = []
 unstable-msc4466 = []
+unstable-msc4495 = []
 unstable-pdu = []
 unstable-unspecified = []
 

--- a/crates/core/src/events/enums.rs
+++ b/crates/core/src/events/enums.rs
@@ -35,6 +35,8 @@ pub const RECOMMENDED_TRANSFERABLE_STATE_EVENT_TYPES: &[StateEventType] = &[
     StateEventType::RoomHistoryVisibility,
     StateEventType::RoomJoinRules,
     StateEventType::RoomPowerLevels,
+    #[cfg(feature = "unstable-msc4495")]
+    StateEventType::RoomPresenceSharing,
 ];
 
 event_enum! {
@@ -49,6 +51,12 @@ event_enum! {
         "m.ignored_user_list" => super::ignored_user_list,
         "m.key_backup" => super::key_backup,
         "m.push_rules" => super::push_rules,
+        #[cfg(feature = "unstable-msc4495")]
+        #[palpo_enum(ident = PresencePrompted)]
+        "org.continuwuity.presence_v2.msc4495.presence.prompted" => super::presence::prompted,
+        #[cfg(feature = "unstable-msc4495")]
+        #[palpo_enum(ident = PresenceSharing)]
+        "org.continuwuity.presence_v2.msc4495.presence.sharing" => super::presence::sharing,
         "m.secret_storage.default_key" => super::secret_storage::default_key,
         "m.secret_storage.key.*" => super::secret_storage::key,
          #[cfg(feature = "unstable-msc4278")]
@@ -184,6 +192,9 @@ event_enum! {
         "m.room.pinned_events" => super::room::pinned_events,
         "m.room.policy" => super::room::policy,
         "m.room.power_levels" => super::room::power_levels,
+        #[cfg(feature = "unstable-msc4495")]
+        #[palpo_enum(alias = "m.room.presence_sharing")]
+        "org.continuwuity.presence_v2.msc4495.room.presence_sharing" => super::room::presence_sharing,
         "m.room.server_acl" => super::room::server_acl,
         "m.room.third_party_invite" => super::room::third_party_invite,
         "m.room.tombstone" => super::room::tombstone,

--- a/crates/core/src/events/presence.rs
+++ b/crates/core/src/events/presence.rs
@@ -7,6 +7,11 @@ use serde::{Deserialize, Serialize};
 use crate::presence::PresenceState;
 use crate::{OwnedMxcUri, OwnedUserId};
 
+#[cfg(feature = "unstable-msc4495")]
+pub mod prompted;
+#[cfg(feature = "unstable-msc4495")]
+pub mod sharing;
+
 /// Presence event.
 #[derive(ToSchema, Serialize, Deserialize, Clone, Debug)]
 #[allow(clippy::exhaustive_structs)]

--- a/crates/core/src/events/presence/prompted.rs
+++ b/crates/core/src/events/presence/prompted.rs
@@ -1,0 +1,55 @@
+//! Types for the MSC4495 presence-prompt account data.
+
+use salvo::oapi::ToSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::macros::EventContent;
+use crate::{OwnedRoomId, OwnedUserId};
+
+/// Users and rooms for which the presence-sharing prompt was already shown.
+#[derive(ToSchema, Clone, Default, Debug, Deserialize, Serialize, EventContent)]
+#[non_exhaustive]
+#[palpo_event(
+    type = "org.continuwuity.presence_v2.msc4495.presence.prompted",
+    kind = GlobalAccountData
+)]
+pub struct PresencePromptedEventContent {
+    /// Users for which the prompt was already shown.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub users: Vec<OwnedUserId>,
+
+    /// Rooms for which the prompt was already shown.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rooms: Vec<OwnedRoomId>,
+}
+
+impl PresencePromptedEventContent {
+    /// Creates presence-prompt state.
+    pub fn new(users: Vec<OwnedUserId>, rooms: Vec<OwnedRoomId>) -> Self {
+        Self { users, rooms }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::PresencePromptedEventContent;
+    use crate::{owned_room_id, owned_user_id};
+
+    #[test]
+    fn serde() {
+        let content = PresencePromptedEventContent::new(
+            vec![owned_user_id!("@alice:example.org")],
+            vec![owned_room_id!("!room:example.org")],
+        );
+
+        assert_eq!(
+            serde_json::to_value(content).unwrap(),
+            json!({
+                "users": ["@alice:example.org"],
+                "rooms": ["!room:example.org"]
+            })
+        );
+    }
+}

--- a/crates/core/src/events/presence/sharing.rs
+++ b/crates/core/src/events/presence/sharing.rs
@@ -1,0 +1,126 @@
+//! Types for the MSC4495 presence-sharing account data.
+
+use std::collections::BTreeMap;
+
+use salvo::oapi::ToSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::macros::EventContent;
+use crate::serde::StringEnum;
+use crate::{OwnedRoomId, OwnedServerName, OwnedUserId, PrivOwnedStr};
+
+/// Whether a user may receive presence updates.
+#[derive(ToSchema, Clone, StringEnum)]
+#[non_exhaustive]
+#[palpo_enum(rename_all = "snake_case")]
+pub enum UserPresenceSharingState {
+    /// Allow presence sharing with the user.
+    Allow,
+
+    /// Deny presence sharing with the user.
+    Deny,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+/// Whether a room may contribute presence recipients.
+#[derive(ToSchema, Clone, StringEnum)]
+#[non_exhaustive]
+#[palpo_enum(rename_all = "snake_case")]
+pub enum RoomPresenceSharingState {
+    /// Allow presence sharing with members of the room.
+    Allow,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+/// Whether a server may receive presence updates.
+#[derive(ToSchema, Clone, StringEnum)]
+#[non_exhaustive]
+#[palpo_enum(rename_all = "snake_case")]
+pub enum ServerPresenceSharingState {
+    /// Deny presence sharing with the server.
+    Deny,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+/// A user's selective-presence sharing configuration.
+#[derive(ToSchema, Clone, Default, Debug, Deserialize, Serialize, EventContent)]
+#[non_exhaustive]
+#[palpo_event(
+    type = "org.continuwuity.presence_v2.msc4495.presence.sharing",
+    kind = GlobalAccountData
+)]
+pub struct PresenceSharingEventContent {
+    /// Whether all users on the local homeserver may receive presence.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub share_locally: bool,
+
+    /// Per-user sharing rules.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub users: BTreeMap<OwnedUserId, UserPresenceSharingState>,
+
+    /// Per-room sharing rules.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub rooms: BTreeMap<OwnedRoomId, RoomPresenceSharingState>,
+
+    /// Per-server sharing rules.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub servers: BTreeMap<OwnedServerName, ServerPresenceSharingState>,
+}
+
+impl PresenceSharingEventContent {
+    /// Creates a selective-presence sharing configuration.
+    pub fn new(
+        share_locally: bool,
+        users: BTreeMap<OwnedUserId, UserPresenceSharingState>,
+        rooms: BTreeMap<OwnedRoomId, RoomPresenceSharingState>,
+        servers: BTreeMap<OwnedServerName, ServerPresenceSharingState>,
+    ) -> Self {
+        Self {
+            share_locally,
+            users,
+            rooms,
+            servers,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{PresenceSharingEventContent, UserPresenceSharingState};
+    use crate::{owned_user_id, user_id};
+
+    #[test]
+    fn serde() {
+        let mut content = PresenceSharingEventContent {
+            share_locally: true,
+            ..Default::default()
+        };
+        content.users.insert(
+            owned_user_id!("@alice:example.org"),
+            UserPresenceSharingState::Allow,
+        );
+
+        let json = serde_json::to_value(&content).unwrap();
+        assert_eq!(
+            json,
+            json!({
+                "share_locally": true,
+                "users": { "@alice:example.org": "allow" }
+            })
+        );
+
+        let parsed: PresenceSharingEventContent = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            parsed.users.get(user_id!("@alice:example.org")),
+            Some(&UserPresenceSharingState::Allow)
+        );
+    }
+}

--- a/crates/core/src/events/room.rs
+++ b/crates/core/src/events/room.rs
@@ -30,6 +30,8 @@ pub mod name;
 pub mod pinned_events;
 pub mod policy;
 pub mod power_levels;
+#[cfg(feature = "unstable-msc4495")]
+pub mod presence_sharing;
 pub mod redaction;
 pub mod server_acl;
 pub mod third_party_invite;

--- a/crates/core/src/events/room/presence_sharing.rs
+++ b/crates/core/src/events/room/presence_sharing.rs
@@ -1,0 +1,61 @@
+//! Types for the MSC4495 room presence-sharing state event.
+
+use salvo::oapi::ToSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::PrivOwnedStr;
+use crate::events::EmptyStateKey;
+use crate::macros::EventContent;
+use crate::serde::StringEnum;
+
+/// A room's presence-sharing hint.
+#[derive(ToSchema, Clone, StringEnum)]
+#[non_exhaustive]
+#[palpo_enum(rename_all = "snake_case")]
+pub enum PresenceSharingHint {
+    /// Presence sharing in this room is prohibited.
+    Forbid,
+
+    /// Clients should suggest enabling presence sharing for this room.
+    Suggest,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+/// The content of the MSC4495 room presence-sharing state event.
+#[derive(ToSchema, Clone, Debug, Deserialize, Serialize, EventContent)]
+#[non_exhaustive]
+#[palpo_event(
+    type = "org.continuwuity.presence_v2.msc4495.room.presence_sharing",
+    kind = State,
+    state_key_type = EmptyStateKey
+)]
+pub struct RoomPresenceSharingEventContent {
+    /// The room's presence-sharing hint.
+    pub presence_sharing: PresenceSharingHint,
+}
+
+impl RoomPresenceSharingEventContent {
+    /// Creates room presence-sharing state.
+    pub fn new(presence_sharing: PresenceSharingHint) -> Self {
+        Self { presence_sharing }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{PresenceSharingHint, RoomPresenceSharingEventContent};
+
+    #[test]
+    fn serde() {
+        let content = RoomPresenceSharingEventContent::new(PresenceSharingHint::Suggest);
+
+        assert_eq!(
+            serde_json::to_value(content).unwrap(),
+            json!({ "presence_sharing": "suggest" })
+        );
+    }
+}

--- a/crates/core/src/federation/query.rs
+++ b/crates/core/src/federation/query.rs
@@ -178,6 +178,59 @@ impl Extend<ProfileFieldValue> for ProfileResBody {
     }
 }
 
+/// Request parameters for the MSC4495 presence recipients query.
+#[cfg(feature = "unstable-msc4495")]
+#[derive(ToParameters, Deserialize, Debug)]
+pub struct PresenceRecipientsReqArgs {
+    /// The local user whose current recipients are requested.
+    #[salvo(parameter(parameter_in = Query))]
+    pub user_id: OwnedUserId,
+}
+
+#[cfg(feature = "unstable-msc4495")]
+impl PresenceRecipientsReqArgs {
+    /// Creates a presence recipients query.
+    pub fn new(user_id: OwnedUserId) -> Self {
+        Self { user_id }
+    }
+}
+
+/// Creates an MSC4495 presence recipients query request.
+#[cfg(feature = "unstable-msc4495")]
+pub fn presence_recipients_request(
+    origin: &str,
+    args: PresenceRecipientsReqArgs,
+) -> SendResult<SendRequest> {
+    let mut url = Url::parse(&format!(
+        "{origin}/_matrix/federation/unstable/org.continuwuity.presence_v2.msc4495/query/presence_recipients"
+    ))?;
+    url.query_pairs_mut()
+        .append_pair("user_id", args.user_id.as_str());
+    Ok(crate::sending::get(url))
+}
+
+/// Response body for the MSC4495 presence recipients query.
+#[cfg(feature = "unstable-msc4495")]
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone)]
+pub struct PresenceRecipientsResBody {
+    /// The stream ID of the current recipient set.
+    pub stream_id: i64,
+
+    /// Local users that should receive this user's presence.
+    pub recipients: Vec<OwnedUserId>,
+}
+
+#[cfg(feature = "unstable-msc4495")]
+impl PresenceRecipientsResBody {
+    /// Creates a presence recipients response.
+    pub fn new(stream_id: i64, recipients: Vec<OwnedUserId>) -> Self {
+        Self {
+            stream_id,
+            recipients,
+        }
+    }
+}
+
 impl IntoIterator for ProfileResBody {
     type Item = (String, JsonValue);
     type IntoIter = btree_map::IntoIter<String, JsonValue>;
@@ -228,5 +281,26 @@ impl CustomResBody {
     /// Creates a new response with the given body.
     pub fn new(body: JsonValue) -> Self {
         Self(body)
+    }
+}
+
+#[cfg(all(test, feature = "unstable-msc4495"))]
+mod msc4495_tests {
+    use super::{PresenceRecipientsReqArgs, presence_recipients_request};
+    use crate::owned_user_id;
+
+    #[test]
+    fn presence_recipients_request_uses_unstable_endpoint() {
+        let request = presence_recipients_request(
+            "https://example.org",
+            PresenceRecipientsReqArgs::new(owned_user_id!("@alice:example.org")),
+        )
+        .unwrap()
+        .into_inner();
+
+        assert_eq!(
+            request.url().as_str(),
+            "https://example.org/_matrix/federation/unstable/org.continuwuity.presence_v2.msc4495/query/presence_recipients?user_id=%40alice%3Aexample.org"
+        );
     }
 }

--- a/crates/core/src/metadata/supported_versions.rs
+++ b/crates/core/src/metadata/supported_versions.rs
@@ -164,6 +164,28 @@ pub enum FeatureFlag {
     #[palpo_enum(rename = "org.matrix.msc4380")]
     Msc4380,
 
+    /// `org.continuwuity.presence_v2.msc4495` ([MSC])
+    ///
+    /// Selective Presence.
+    ///
+    /// [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
+    #[cfg(feature = "unstable-msc4495")]
+    #[palpo_enum(rename = "org.continuwuity.presence_v2.msc4495")]
+    Msc4495,
+
     #[doc(hidden)]
     _Custom(PrivOwnedStr),
+}
+
+#[cfg(all(test, feature = "unstable-msc4495"))]
+mod msc4495_tests {
+    use super::FeatureFlag;
+
+    #[test]
+    fn selective_presence_feature_flag_uses_unstable_identifier() {
+        assert_eq!(
+            FeatureFlag::Msc4495.as_str(),
+            "org.continuwuity.presence_v2.msc4495"
+        );
+    }
 }

--- a/crates/core/src/presence.rs
+++ b/crates/core/src/presence.rs
@@ -73,6 +73,24 @@ pub struct PresenceUpdate {
     /// Defaults to false.
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub currently_active: bool,
+
+    /// Changes to the user's presence recipient list since the previous update.
+    #[cfg(feature = "unstable-msc4495")]
+    #[serde(
+        default,
+        skip_serializing_if = "PresenceRecipientListUpdates::is_empty"
+    )]
+    pub recipients: PresenceRecipientListUpdates,
+
+    /// The stream ID of the user's current presence recipient list.
+    #[cfg(feature = "unstable-msc4495")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_id: Option<i64>,
+
+    /// The previous stream ID for this recipient-list delta.
+    #[cfg(feature = "unstable-msc4495")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prev_id: Option<i64>,
 }
 
 impl PresenceUpdate {
@@ -85,6 +103,100 @@ impl PresenceUpdate {
             last_active_ago: last_activity,
             status_msg: None,
             currently_active: false,
+            #[cfg(feature = "unstable-msc4495")]
+            recipients: PresenceRecipientListUpdates::default(),
+            #[cfg(feature = "unstable-msc4495")]
+            stream_id: None,
+            #[cfg(feature = "unstable-msc4495")]
+            prev_id: None,
         }
+    }
+}
+
+/// Added and removed users in a presence recipient list.
+#[cfg(feature = "unstable-msc4495")]
+#[derive(ToSchema, Deserialize, Serialize, Clone, Debug, Default)]
+pub struct PresenceRecipientListUpdates {
+    /// Users added to the recipient list.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub add: Vec<OwnedUserId>,
+
+    /// Users removed from the recipient list.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub delete: Vec<OwnedUserId>,
+}
+
+#[cfg(feature = "unstable-msc4495")]
+impl PresenceRecipientListUpdates {
+    /// Creates recipient-list updates from added and removed users.
+    pub fn new(add: Vec<OwnedUserId>, delete: Vec<OwnedUserId>) -> Self {
+        Self { add, delete }
+    }
+
+    /// Whether this update contains no changes.
+    pub fn is_empty(&self) -> bool {
+        self.add.is_empty() && self.delete.is_empty()
+    }
+}
+
+#[cfg(all(test, feature = "unstable-msc4495"))]
+mod msc4495_tests {
+    use serde_json::json;
+
+    use super::{PresenceRecipientListUpdates, PresenceState, PresenceUpdate};
+    use crate::owned_user_id;
+
+    #[test]
+    fn presence_recipient_delta_round_trips() {
+        let update = PresenceUpdate {
+            user_id: owned_user_id!("@alice:example.org"),
+            presence: PresenceState::Online,
+            status_msg: None,
+            last_active_ago: 1_000,
+            currently_active: true,
+            recipients: PresenceRecipientListUpdates::new(
+                vec![owned_user_id!("@bob:example.org")],
+                vec![owned_user_id!("@charlie:example.org")],
+            ),
+            stream_id: Some(321),
+            prev_id: Some(123),
+        };
+
+        let json = serde_json::to_value(&update).unwrap();
+        assert_eq!(
+            json,
+            json!({
+                "user_id": "@alice:example.org",
+                "presence": "online",
+                "last_active_ago": 1_000,
+                "currently_active": true,
+                "recipients": {
+                    "add": ["@bob:example.org"],
+                    "delete": ["@charlie:example.org"]
+                },
+                "stream_id": 321,
+                "prev_id": 123
+            })
+        );
+
+        let parsed: PresenceUpdate = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.stream_id, Some(321));
+        assert_eq!(parsed.prev_id, Some(123));
+        assert_eq!(parsed.recipients.add.len(), 1);
+        assert_eq!(parsed.recipients.delete.len(), 1);
+    }
+
+    #[test]
+    fn legacy_presence_update_omits_msc4495_fields() {
+        let update = PresenceUpdate::new(
+            owned_user_id!("@alice:example.org"),
+            PresenceState::Online,
+            1_000,
+        );
+
+        let json = serde_json::to_value(update).unwrap();
+        assert!(json.get("recipients").is_none());
+        assert!(json.get("stream_id").is_none());
+        assert!(json.get("prev_id").is_none());
     }
 }

--- a/crates/core/src/presence.rs
+++ b/crates/core/src/presence.rs
@@ -118,11 +118,9 @@ impl PresenceUpdate {
 #[derive(ToSchema, Deserialize, Serialize, Clone, Debug, Default)]
 pub struct PresenceRecipientListUpdates {
     /// Users added to the recipient list.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub add: Vec<OwnedUserId>,
 
     /// Users removed from the recipient list.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub delete: Vec<OwnedUserId>,
 }
 
@@ -198,5 +196,19 @@ mod msc4495_tests {
         assert!(json.get("recipients").is_none());
         assert!(json.get("stream_id").is_none());
         assert!(json.get("prev_id").is_none());
+    }
+
+    #[test]
+    fn recipient_delta_keeps_both_update_arrays() {
+        let recipients =
+            PresenceRecipientListUpdates::new(vec![owned_user_id!("@bob:example.org")], Vec::new());
+
+        assert_eq!(
+            serde_json::to_value(recipients).unwrap(),
+            json!({
+                "add": ["@bob:example.org"],
+                "delete": []
+            })
+        );
     }
 }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 unstable-msc4262 = ["palpo-core/unstable-msc4262"]
 unstable-msc4293 = ["palpo-core/unstable-msc4293"]
 unstable-msc4466 = ["palpo-core/unstable-msc4466"]
+unstable-msc4495 = ["palpo-core/unstable-msc4495"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/crates/server/src/sending/guard.rs
+++ b/crates/server/src/sending/guard.rs
@@ -598,6 +598,12 @@ async fn select_edus_presence(
             currently_active: presence_event.content.currently_active.unwrap_or(false),
             status_msg: presence_event.content.status_msg,
             last_active_ago: presence_event.content.last_active_ago.unwrap_or(0),
+            #[cfg(feature = "unstable-msc4495")]
+            recipients: Default::default(),
+            #[cfg(feature = "unstable-msc4495")]
+            stream_id: None,
+            #[cfg(feature = "unstable-msc4495")]
+            prev_id: None,
         };
 
         presence_updates.insert(user_id, update);

--- a/crates/server/src/user/presence.rs
+++ b/crates/server/src/user/presence.rs
@@ -88,6 +88,12 @@ pub async fn set_presence(
                 last_active_ago: 0,
                 currently_active: presence_state == PresenceState::Online,
                 presence: presence_state,
+                #[cfg(feature = "unstable-msc4495")]
+                recipients: Default::default(),
+                #[cfg(feature = "unstable-msc4495")]
+                stream_id: None,
+                #[cfg(feature = "unstable-msc4495")]
+                prev_id: None,
             }],
         });
 


### PR DESCRIPTION
## Summary

- add the feature-gated `Msc4495` capability identifier, account data events, and room state event types
- extend presence EDUs with recipient deltas and stream identifiers using the upstream wire shape
- add federation presence-recipient query request/response types and request construction
- keep server presence behavior unchanged while making existing struct construction compile with the feature enabled

## Scope

This is the protocol/type foundation for #362, not a complete MSC4495 implementation. It deliberately does not advertise MSC4495 or change presence visibility. Policy persistence, recipient computation and filtering, stream recovery handling, and the inbound federation endpoint remain follow-up work.

Part of #362.

## Checks

- `cargo test -p palpo-core --features unstable-msc4495` (316 unit tests and 38 doctests)
- `cargo check -p palpo --features unstable-msc4495`
- `cargo clippy -p palpo-core --all-targets --features unstable-msc4495 -- -D warnings`
- `cargo clippy -p palpo --bin palpo --features unstable-msc4495 -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Upstream references

- ruma/ruma@1ade0a6eb444c1e1b125bfdab6985450f9cb3b7e
- ruma/ruma@930f32068992759e7d2b5cf800c22353d73858f2
- ruma/ruma@3ad047126b321d5fdcf170e1f2e545fed820cf75