### PR TITLE
Parse federation multipart media with a shared, tested parser

### DIFF
--- a/crates/core/src/federation/media.rs
+++ b/crates/core/src/federation/media.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write;
+use std::str::FromStr;
 /// Endpoints for the media repository.
 use std::time::Duration;
 
@@ -271,5 +272,424 @@ impl ContentMetadata {
     /// Creates a new empty `ContentMetadata`.
     pub fn new() -> Self {
         Self {}
+    }
+}
+
+/// An error encountered while parsing the `multipart/mixed` body of a
+/// federation media response.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum MultipartMixedError {
+    /// The `Content-Type` header is not a valid mime type.
+    #[error("the `Content-Type` header is not a valid mime type: `{0}`")]
+    InvalidContentType(String),
+
+    /// The `Content-Type` header is not `multipart/mixed`.
+    #[error("expected a `multipart/mixed` response, got `{0}`")]
+    NotMultipartMixed(String),
+
+    /// The `Content-Type` header is missing the `boundary` parameter.
+    #[error("the `Content-Type` header is missing the `boundary` parameter")]
+    MissingBoundary,
+
+    /// The body does not contain the two expected body parts.
+    #[error("expected 2 body parts, found {found}")]
+    MissingBodyParts {
+        /// The number of body parts that could be found.
+        found: usize,
+    },
+
+    /// A body part is missing the empty line that separates its headers from
+    /// its content.
+    #[error("a body part is missing the separator between its headers and its content")]
+    MissingBodyPartSeparator,
+
+    /// A body part has headers that are not valid UTF-8.
+    #[error("a body part has headers that are not valid UTF-8")]
+    InvalidHeaders,
+}
+
+/// Deserialize the metadata and content of a federation media response with a
+/// `multipart/mixed` body, as described in the [spec].
+///
+/// `content_type` is the value of the response's `Content-Type` header, and
+/// `body` its full body.
+///
+/// [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1mediadownloadmediaid
+pub fn try_from_multipart_mixed(
+    content_type: &str,
+    body: &[u8],
+) -> Result<(ContentMetadata, FileOrLocation), MultipartMixedError> {
+    let mime = content_type
+        .parse::<mime::Mime>()
+        .map_err(|_| MultipartMixedError::InvalidContentType(content_type.to_owned()))?;
+
+    if !mime.essence_str().eq_ignore_ascii_case(MULTIPART_MIXED) {
+        return Err(MultipartMixedError::NotMultipartMixed(
+            mime.essence_str().to_owned(),
+        ));
+    }
+
+    let boundary = mime
+        .get_param(mime::BOUNDARY)
+        .ok_or(MultipartMixedError::MissingBoundary)?;
+
+    // The delimiter between body parts is the boundary preceded by a CRLF. The
+    // closing delimiter starts with the same bytes, so searching for this also
+    // finds the end of the last part.
+    let mut delimiter = Vec::with_capacity(boundary.as_str().len() + 4);
+    delimiter.extend_from_slice(b"\r\n--");
+    delimiter.extend_from_slice(boundary.as_str().as_bytes());
+    let delimiter_no_crlf = &delimiter[2..];
+
+    // If there is no preamble before the first delimiter, it may omit the
+    // preceding CRLF.
+    let metadata_start = if body.starts_with(delimiter_no_crlf) {
+        delimiter_no_crlf.len()
+    } else {
+        find_from(body, &delimiter, 0).ok_or(MultipartMixedError::MissingBodyParts { found: 0 })?
+            + delimiter.len()
+    };
+    let metadata_end = find_from(body, &delimiter, metadata_start)
+        .ok_or(MultipartMixedError::MissingBodyParts { found: 0 })?;
+
+    // Don't look at the headers of the metadata part, its content is always
+    // JSON. It carries no field yet, so a body we cannot parse is not worth
+    // failing the whole response over.
+    let (_, raw_metadata) = parse_body_part(body, metadata_start, metadata_end)?;
+    let metadata = serde_json::from_slice(raw_metadata).unwrap_or_default();
+
+    // The second part holds the file itself, or the location where it can be
+    // found.
+    let content_start = metadata_end + delimiter.len();
+    let content_end = find_from(body, &delimiter, content_start)
+        .ok_or(MultipartMixedError::MissingBodyParts { found: 1 })?;
+
+    let (raw_headers, file) = parse_body_part(body, content_start, content_end)?;
+    let headers = parse_body_part_headers(raw_headers)?;
+
+    let content = if let Some(location) = headers.location {
+        FileOrLocation::Location(location)
+    } else {
+        FileOrLocation::File(Content {
+            file: file.to_owned(),
+            content_type: headers.content_type,
+            content_disposition: headers.content_disposition,
+        })
+    };
+
+    Ok((metadata, content))
+}
+
+/// Find the first occurrence of `needle` in `haystack`, starting the search at
+/// `start`. The returned position is relative to the start of `haystack`.
+fn find_from(haystack: &[u8], needle: &[u8], start: usize) -> Option<usize> {
+    if start > haystack.len() {
+        return None;
+    }
+
+    haystack[start..]
+        .windows(needle.len())
+        .position(|window| window == needle)
+        .map(|pos| pos + start)
+}
+
+/// Parse the body part in the given bytes, starting and ending at the given
+/// positions.
+///
+/// Returns a `(headers_bytes, content_bytes)` tuple.
+fn parse_body_part(
+    bytes: &[u8],
+    start: usize,
+    end: usize,
+) -> Result<(&[u8], &[u8]), MultipartMixedError> {
+    // The part starts with the rest of the delimiter line. We need to ignore
+    // characters before its line feed in case of extra whitespace, and for
+    // compatibility it might not have a carriage return.
+    let headers_start = find_line_feed(bytes, start, end)? + 1;
+
+    // Then the headers end at the first empty line.
+    let mut line_start = headers_start;
+    loop {
+        let line_end = find_line_feed(bytes, line_start, end)? + 1;
+
+        if matches!(&bytes[line_start..line_end], b"\r\n" | b"\n") {
+            return Ok((&bytes[headers_start..line_start], &bytes[line_end..end]));
+        }
+
+        line_start = line_end;
+    }
+}
+
+/// Find the position of the next line feed in `bytes[start..end]`.
+fn find_line_feed(bytes: &[u8], start: usize, end: usize) -> Result<usize, MultipartMixedError> {
+    bytes
+        .get(start..end)
+        .and_then(|bytes| bytes.iter().position(|byte| *byte == b'\n'))
+        .map(|pos| pos + start)
+        .ok_or(MultipartMixedError::MissingBodyPartSeparator)
+}
+
+/// The headers of a body part that palpo cares about.
+#[derive(Default)]
+struct BodyPartHeaders {
+    location: Option<String>,
+    content_type: Option<String>,
+    content_disposition: Option<ContentDisposition>,
+}
+
+fn parse_body_part_headers(raw: &[u8]) -> Result<BodyPartHeaders, MultipartMixedError> {
+    let raw = std::str::from_utf8(raw).map_err(|_| MultipartMixedError::InvalidHeaders)?;
+    let mut headers = BodyPartHeaders::default();
+
+    for line in raw.lines() {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        let (name, value) = (name.trim(), value.trim());
+
+        if name.eq_ignore_ascii_case(http::header::LOCATION.as_str()) {
+            headers.location = Some(value.to_owned());
+        } else if name.eq_ignore_ascii_case(http::header::CONTENT_TYPE.as_str()) {
+            headers.content_type = Some(value.to_owned());
+        } else if name.eq_ignore_ascii_case(http::header::CONTENT_DISPOSITION.as_str()) {
+            // A `Content-Disposition` we cannot parse only costs us the
+            // filename, so it is not worth rejecting the response.
+            headers.content_disposition = ContentDisposition::from_str(value).ok();
+        }
+    }
+
+    Ok(headers)
+}
+
+#[cfg(test)]
+mod tests {
+    use salvo::http::ResBody;
+    use salvo::prelude::Scribe;
+
+    use super::{
+        Content, ContentMetadata, FileOrLocation, MultipartMixedError, ThumbnailResBody,
+        try_from_multipart_mixed,
+    };
+    use crate::http_headers::{ContentDisposition, ContentDispositionType};
+
+    const BOUNDARY: &str = "multipart/mixed; boundary=abcdef";
+
+    fn file(content: FileOrLocation) -> Content {
+        match content {
+            FileOrLocation::File(content) => content,
+            FileOrLocation::Location(location) => {
+                panic!("expected a file, got the location `{location}`")
+            }
+        }
+    }
+
+    #[test]
+    fn parse_simple_response() {
+        let body = "\r\n--abcdef\r\ncontent-type: application/json\r\n\r\n{}\r\n--abcdef\r\n\
+                    content-type: text/plain\r\n\r\nsome plain text\r\n--abcdef--";
+
+        let (_metadata, content) = try_from_multipart_mixed(BOUNDARY, body.as_bytes()).unwrap();
+        let content = file(content);
+
+        assert_eq!(content.file, b"some plain text");
+        assert_eq!(content.content_type.unwrap(), "text/plain");
+        assert_eq!(content.content_disposition, None);
+    }
+
+    #[test]
+    fn parse_headers_case_insensitively() {
+        let body = "\r\n--abcdef\r\nCONTENT-type: application/json\r\n\r\n{}\r\n--abcdef\r\n\
+                    CONTENT-TYPE: text/plain\r\ncoNtenT-disPosItioN: attachment; \
+                    filename=my_file.txt\r\n\r\nsome plain text\r\n--abcdef--";
+
+        let (_metadata, content) = try_from_multipart_mixed(BOUNDARY, body.as_bytes()).unwrap();
+        let content = file(content);
+
+        assert_eq!(content.file, b"some plain text");
+        assert_eq!(content.content_type.unwrap(), "text/plain");
+        let content_disposition = content.content_disposition.unwrap();
+        assert_eq!(
+            content_disposition.disposition_type,
+            ContentDispositionType::Attachment
+        );
+        assert_eq!(content_disposition.filename.unwrap(), "my_file.txt");
+    }
+
+    #[test]
+    fn parse_quoted_and_uppercase_boundary_param() {
+        let body = "\r\n--abcdef\r\ncontent-type: application/json\r\n\r\n{}\r\n--abcdef\r\n\
+                    content-type: text/plain\r\n\r\nsome plain text\r\n--abcdef--";
+
+        let (_metadata, content) =
+            try_from_multipart_mixed("multipart/mixed; BOUNDARY=\"abcdef\"", body.as_bytes())
+                .unwrap();
+
+        assert_eq!(file(content).file, b"some plain text");
+    }
+
+    #[test]
+    fn parse_response_with_extra_whitespace() {
+        let body = "   \r\n--abcdef\r\ncontent-type:   application/json   \r\n\r\n {} \
+                    \r\n--abcdef\r\ncontent-type: text/plain  \r\n\r\nsome plain \
+                    text\r\n--abcdef--  ";
+
+        let (_metadata, content) = try_from_multipart_mixed(BOUNDARY, body.as_bytes()).unwrap();
+        let content = file(content);
+
+        assert_eq!(content.file, b"some plain text");
+        assert_eq!(content.content_type.unwrap(), "text/plain");
+    }
+
+    #[test]
+    fn parse_response_without_carriage_returns_inside_parts() {
+        let body = "\r\n--abcdef\ncontent-type: application/json\n\n{}\r\n--abcdef\n\
+                    content-type: text/plain  \n\nsome plain text\r\n--abcdef--";
+
+        let (_metadata, content) = try_from_multipart_mixed(BOUNDARY, body.as_bytes()).unwrap();
+        let content = file(content);
+
+        assert_eq!(content.file, b"some plain text");
+        assert_eq!(content.content_type.unwrap(), "text/plain");
+    }
+
+    #[test]
+    fn parse_response_without_leading_crlf() {
+        let body = "--abcdef\r\n\r\n{}\r\n--abcdef\r\n\r\nsome plain text\r\n--abcdef--";
+
+        let (_metadata, content) = try_from_multipart_mixed(BOUNDARY, body.as_bytes()).unwrap();
+        let content = file(content);
+
+        assert_eq!(content.file, b"some plain text");
+        assert_eq!(content.content_type, None);
+    }
+
+    #[test]
+    fn parse_response_with_boundary_text_in_preamble() {
+        // The preamble has no leading CRLF before the boundary, so it must be
+        // ignored.
+        let body = "foo--abcdef\r\n--abcdef\r\n\r\n{}\r\n--abcdef\r\n\r\nsome plain \
+                    text\r\n--abcdef--";
+
+        let (_metadata, content) = try_from_multipart_mixed(BOUNDARY, body.as_bytes()).unwrap();
+
+        assert_eq!(file(content).file, b"some plain text");
+    }
+
+    #[test]
+    fn parse_body_parts_without_headers() {
+        let body = "\r\n--abcdef\r\n\r\n{}\r\n--abcdef\r\n\r\nsome plain text\r\n--abcdef--";
+
+        let (_metadata, content) = try_from_multipart_mixed(BOUNDARY, body.as_bytes()).unwrap();
+        let content = file(content);
+
+        assert_eq!(content.file, b"some plain text");
+        assert_eq!(content.content_type, None);
+        assert_eq!(content.content_disposition, None);
+    }
+
+    #[test]
+    fn parse_binary_content_containing_crlf() {
+        // The file must be returned byte for byte, even when it contains the
+        // sequences the parser looks for.
+        let file_bytes = b"\r\n--abcde\r\n\r\nnot a boundary\r\n";
+        let mut body = b"\r\n--abcdef\r\ncontent-type: application/json\r\n\r\n{}\r\n--abcdef\r\n\
+                         content-type: application/octet-stream\r\n\r\n"
+            .to_vec();
+        body.extend_from_slice(file_bytes);
+        body.extend_from_slice(b"\r\n--abcdef--");
+
+        let (_metadata, content) = try_from_multipart_mixed(BOUNDARY, &body).unwrap();
+
+        assert_eq!(file(content).file, file_bytes);
+    }
+
+    #[test]
+    fn parse_location_response() {
+        let body = "\r\n--abcdef\r\ncontent-type: application/json\r\n\r\n{}\r\n--abcdef\r\n\
+                    location: https://server.local/media/filename.txt\r\n\r\n\r\n--abcdef--";
+
+        let (_metadata, content) = try_from_multipart_mixed(BOUNDARY, body.as_bytes()).unwrap();
+
+        let FileOrLocation::Location(location) = content else {
+            panic!("expected a location");
+        };
+        assert_eq!(location, "https://server.local/media/filename.txt");
+    }
+
+    #[test]
+    fn reject_invalid_responses() {
+        let body = "\r\n--abcdef\r\n\r\n{}\r\n--abcdef\r\nContent-Type: text/plain\r\n\r\nsome \
+                    plain text\r\n--abcdef--";
+
+        // Not a multipart response.
+        assert!(matches!(
+            try_from_multipart_mixed("text/plain", body.as_bytes()),
+            Err(MultipartMixedError::NotMultipartMixed(_))
+        ));
+
+        // Missing boundary parameter.
+        assert!(matches!(
+            try_from_multipart_mixed("multipart/mixed", body.as_bytes()),
+            Err(MultipartMixedError::MissingBoundary)
+        ));
+
+        // Wrong boundary.
+        assert!(matches!(
+            try_from_multipart_mixed("multipart/mixed; boundary=012345", body.as_bytes()),
+            Err(MultipartMixedError::MissingBodyParts { found: 0 })
+        ));
+
+        // Missing the closing delimiter.
+        let body = "\r\n--abcdef\r\n\r\n{}\r\n--abcdef\r\nContent-Type: text/plain\r\n\r\nsome \
+                    plain text";
+        assert!(matches!(
+            try_from_multipart_mixed(BOUNDARY, body.as_bytes()),
+            Err(MultipartMixedError::MissingBodyParts { found: 1 })
+        ));
+
+        // Missing the empty line between the headers and the content of a part.
+        let body = "\r\n--abcdef\r\n{}\r\n--abcdef\r\nContent-Type: text/plain\r\nsome plain \
+                    text\r\n--abcdef--";
+        assert!(matches!(
+            try_from_multipart_mixed(BOUNDARY, body.as_bytes()),
+            Err(MultipartMixedError::MissingBodyPartSeparator)
+        ));
+    }
+
+    #[test]
+    fn round_trip_rendered_response() {
+        // What palpo renders must be what palpo parses.
+        let content_disposition = ContentDisposition::new(ContentDispositionType::Inline)
+            .with_filename(Some("fȈlƩnąmǝ.txt".to_owned()));
+        let mut res = salvo::Response::new();
+        ThumbnailResBody {
+            metadata: ContentMetadata::new(),
+            content: FileOrLocation::File(Content {
+                file: b"s\xffme UTF-8 \xc5\xa4ext".to_vec(),
+                content_type: Some("text/plain".to_owned()),
+                content_disposition: Some(content_disposition.clone()),
+            }),
+        }
+        .render(&mut res);
+
+        let rendered_content_type = res
+            .headers()
+            .get(http::header::CONTENT_TYPE)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_owned();
+        let ResBody::Once(rendered_body) = &res.body else {
+            panic!("expected a rendered body");
+        };
+
+        let (_metadata, content) =
+            try_from_multipart_mixed(&rendered_content_type, rendered_body).unwrap();
+        let content = file(content);
+
+        assert_eq!(content.file, b"s\xffme UTF-8 \xc5\xa4ext");
+        assert_eq!(content.content_type.unwrap(), "text/plain");
+        assert_eq!(content.content_disposition.unwrap(), content_disposition);
     }
 }

--- a/crates/server/src/media/remote.rs
+++ b/crates/server/src/media/remote.rs
@@ -1,18 +1,21 @@
+use std::str::FromStr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use bytes::Bytes;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use salvo::Response;
 use salvo::http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
+use salvo::http::{ResBody, StatusCode};
 
 use super::{Dimension, FileMeta};
-use crate::core::federation::media::ContentReqArgs;
+use crate::core::federation::media::{ContentReqArgs, FileOrLocation, try_from_multipart_mixed};
+use crate::core::http_headers::ContentDisposition;
 use crate::core::identifiers::*;
 use crate::core::{Mxc, ServerName, UserId};
 use crate::data::connect;
 use crate::data::schema::*;
 use crate::exts::*;
+use crate::utils::content_disposition::make_content_disposition;
 use crate::utils::read_response_limited;
 use crate::{AppError, AppResult, config};
 
@@ -49,121 +52,129 @@ pub async fn fetch_remote_content(
         crate::sending::send_federation_request(server_name, content_req, None).await?
     };
 
-    let content_type_header = content_response
-        .headers()
-        .get(CONTENT_TYPE)
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_owned());
-
-    if let Some(ct) = &content_type_header
-        && ct.contains("multipart/mixed")
-    {
-        let body =
-            read_response_limited(content_response, config::get().media.max_remote_media_size)
-                .await?;
-
-        if let Some((content_type, content_disposition, binary)) =
-            parse_multipart_federation_response(ct, &body)
-        {
-            res.add_header(CONTENT_TYPE, &content_type, true)?;
-            res.add_header("Cross-Origin-Resource-Policy", "cross-origin", true)?;
-            if let Some(disp) = &content_disposition {
-                res.add_header(CONTENT_DISPOSITION, disp, true)?;
-            }
-            res.status_code(salvo::http::StatusCode::OK);
-            res.body = salvo::http::ResBody::Once(binary);
-        } else {
-            res.status_code(salvo::http::StatusCode::BAD_GATEWAY);
-            res.body = salvo::http::ResBody::Once(
-                r#"{"errcode":"M_UNKNOWN","error":"Failed to parse remote media response"}"#.into(),
-            );
-        }
-    } else {
+    let Some(content_type_header) = response_content_type(&content_response)
+        .filter(|content_type| is_multipart_mixed(content_type))
+    else {
+        // The legacy endpoint answers with the file itself, so it can be
+        // forwarded as it is streamed in.
         for (key, value) in content_response.headers().iter() {
             res.headers_mut().insert(key.clone(), value.clone());
         }
         res.status_code(content_response.status());
         res.stream(content_response.bytes_stream());
-    }
+        return Ok(());
+    };
+
+    let body =
+        read_response_limited(content_response, config::get().media.max_remote_media_size).await?;
+
+    let content = match try_from_multipart_mixed(&content_type_header, &body) {
+        Ok((_metadata, FileOrLocation::File(content))) => content,
+        Ok((_metadata, FileOrLocation::Location(location))) => {
+            // Following the location requires an outbound request to a server
+            // controlled URL, which needs its own protections before we can
+            // make it.
+            warn!("remote media {media_id} on {server_name} is served from {location}");
+            render_bad_gateway(
+                res,
+                "Remote media is served from an external location, which is not supported",
+            );
+            return Ok(());
+        }
+        Err(e) => {
+            warn!("failed to parse media response from {server_name}: {e}");
+            render_bad_gateway(res, "Failed to parse remote media response");
+            return Ok(());
+        }
+    };
+
+    let content_type = content
+        .content_type
+        .filter(|content_type| !content_type.is_empty())
+        .unwrap_or_else(|| mime::APPLICATION_OCTET_STREAM.to_string());
+    // Keep the filename the remote server sent, but decide for ourselves
+    // whether the file may be displayed inline.
+    let content_disposition = make_content_disposition(
+        None,
+        Some(&content_type),
+        content
+            .content_disposition
+            .as_ref()
+            .and_then(|disposition| disposition.filename.as_deref()),
+    );
+
+    res.add_header(CONTENT_TYPE, &content_type, true)?;
+    res.add_header(CONTENT_DISPOSITION, content_disposition.to_string(), true)?;
+    res.add_header("Cross-Origin-Resource-Policy", "cross-origin", true)?;
+    res.status_code(StatusCode::OK);
+    res.body = ResBody::Once(content.file.into());
 
     Ok(())
 }
 
-fn parse_multipart_federation_response(
-    content_type: &str,
-    body: &Bytes,
-) -> Option<(String, Option<String>, Bytes)> {
-    let boundary = content_type.split(';').find_map(|part| {
-        let part = part.trim();
-        part.strip_prefix("boundary=")
-            .map(|b| b.trim().trim_matches('"').to_owned())
-    })?;
+/// Read a federation media response, unwrapping the `multipart/mixed` body the
+/// authenticated endpoints answer with.
+async fn read_media_response(response: reqwest::Response, max_size: usize) -> AppResult<FileMeta> {
+    let content_type = response_content_type(&response);
 
-    let start_boundary = format!("--{boundary}\r\n").into_bytes();
-    let delimiter = format!("\r\n--{boundary}\r\n").into_bytes();
-    let closing_delimiter = format!("\r\n--{boundary}--").into_bytes();
-    let data = body.as_ref();
+    let Some(content_type) = content_type
+        .clone()
+        .filter(|content_type| is_multipart_mixed(content_type))
+    else {
+        let content_disposition = response
+            .headers()
+            .get(CONTENT_DISPOSITION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| ContentDisposition::from_str(s).ok());
+        let file = read_response_limited(response, max_size).await?.to_vec();
 
-    // Advance past the first boundary (which may or may not have a leading CRLF)
-    let after_first_boundary = if data.starts_with(&start_boundary) {
-        start_boundary.len()
-    } else {
-        let pos = find_subsequence(data, &delimiter)?;
-        pos + delimiter.len()
+        return Ok(FileMeta {
+            content: Some(file),
+            content_type,
+            content_disposition,
+        });
     };
 
-    // Skip the first part entirely (it is always JSON metadata in Matrix federation)
-    let part1_header_end = find_subsequence(&data[after_first_boundary..], b"\r\n\r\n")?;
-    let part2_boundary = find_subsequence(
-        &data[after_first_boundary + part1_header_end + 4..],
-        &delimiter,
-    )?;
-    let after_part2_boundary =
-        after_first_boundary + part1_header_end + 4 + part2_boundary + delimiter.len();
+    let body = read_response_limited(response, max_size).await?;
+    let (_metadata, content) = try_from_multipart_mixed(&content_type, &body)
+        .map_err(|e| AppError::public(format!("Failed to parse remote media response: {e}")))?;
 
-    // Parse the second part (actual file content)
-    let part2_header_end = find_subsequence(&data[after_part2_boundary..], b"\r\n\r\n")?;
-    let part2_header_bytes = &data[after_part2_boundary..after_part2_boundary + part2_header_end];
-    let part2_header_str = std::str::from_utf8(part2_header_bytes).ok()?;
-
-    let mut ct = String::new();
-    let mut cd = None;
-
-    for header in part2_header_str.lines() {
-        if let Some(idx) = header.find(':') {
-            let field_name = &header[..idx].trim();
-            let field_value = header[idx + 1..].trim();
-            if field_name.eq_ignore_ascii_case("Content-Type") {
-                ct = field_value.to_owned();
-            } else if field_name.eq_ignore_ascii_case("Content-Disposition") {
-                cd = Some(field_value.to_owned());
-            }
-        }
-    }
-
-    let binary_start = after_part2_boundary + part2_header_end + 4;
-
-    if let Some(end_pos) = find_subsequence(&data[binary_start..], &delimiter) {
-        Some((
-            ct,
-            cd,
-            Bytes::copy_from_slice(&data[binary_start..binary_start + end_pos]),
-        ))
-    } else if let Some(end_pos) = find_subsequence(&data[binary_start..], &closing_delimiter) {
-        Some((
-            ct,
-            cd,
-            Bytes::copy_from_slice(&data[binary_start..binary_start + end_pos]),
-        ))
-    } else {
-        Some((ct, cd, Bytes::copy_from_slice(&data[binary_start..])))
+    match content {
+        FileOrLocation::File(content) => Ok(FileMeta {
+            content: Some(content.file),
+            content_type: content.content_type,
+            content_disposition: content.content_disposition,
+        }),
+        FileOrLocation::Location(_) => Err(AppError::public(
+            "Remote media is served from an external location, which is not supported",
+        )),
     }
 }
 
-fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack
-        .windows(needle.len())
-        .position(|window| window == needle)
+fn response_content_type(response: &reqwest::Response) -> Option<String> {
+    response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(ToOwned::to_owned)
+}
+
+fn is_multipart_mixed(content_type: &str) -> bool {
+    content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim()
+        .eq_ignore_ascii_case("multipart/mixed")
+}
+
+fn render_bad_gateway(res: &mut Response, error: &str) {
+    res.status_code(StatusCode::BAD_GATEWAY);
+    res.body = ResBody::Once(
+        serde_json::json!({ "errcode": "M_UNKNOWN", "error": error })
+            .to_string()
+            .into(),
+    );
 }
 
 pub async fn fetch_remote_thumbnail(
@@ -208,12 +219,6 @@ async fn fetch_thumbnail_authenticated(
     timeout_ms: Duration,
     dim: &Dimension,
 ) -> AppResult<FileMeta> {
-    use std::str::FromStr;
-
-    use reqwest::header;
-
-    use crate::core::http_headers::ContentDisposition;
-
     let target_server = server.unwrap_or(mxc.server_name);
     let origin = target_server.origin().await;
 
@@ -231,51 +236,15 @@ async fn fetch_thumbnail_authenticated(
     )?
     .into_inner();
 
-    // Send federation request
+    // Send federation request. The authenticated endpoint answers with a
+    // `multipart/mixed` body, which `read_media_response` unwraps for us.
     let response =
         crate::sending::send_federation_request(target_server, thumbnail_req, None).await?;
+    let meta = read_media_response(response, config::get().media.max_remote_thumbnail_size).await?;
 
-    // Extract content from response headers
-    let content_type = response
-        .headers()
-        .get(header::CONTENT_TYPE)
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_owned());
+    save_fetched_thumbnail(mxc, user, dim, &meta).await;
 
-    let content_disposition = response
-        .headers()
-        .get(header::CONTENT_DISPOSITION)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| ContentDisposition::from_str(s).ok());
-
-    // Get the file content
-    let file = crate::utils::read_response_limited(
-        response,
-        config::get().media.max_remote_thumbnail_size,
-    )
-    .await?
-    .to_vec();
-
-    // Save the thumbnail locally for caching
-    if !file.is_empty()
-        && let Err(e) = crate::media::save_thumbnail(
-            mxc,
-            user,
-            content_type.as_deref(),
-            content_disposition.as_ref(),
-            dim,
-            &file,
-        )
-        .await
-    {
-        warn!("Failed to save fetched thumbnail locally: {e}");
-    }
-
-    Ok(FileMeta {
-        content: Some(file),
-        content_type,
-        content_disposition,
-    })
+    Ok(meta)
 }
 
 // async fn fetch_content_authenticated(
@@ -308,12 +277,6 @@ async fn fetch_thumbnail_unauthenticated(
     timeout_ms: Duration,
     dim: &Dimension,
 ) -> AppResult<FileMeta> {
-    use std::str::FromStr;
-
-    use reqwest::header;
-
-    use crate::core::http_headers::ContentDisposition;
-
     let target_server = server.unwrap_or(mxc.server_name);
     let origin = target_server.origin().await;
 
@@ -337,48 +300,36 @@ async fn fetch_thumbnail_unauthenticated(
     // Send federation request
     let response =
         crate::sending::send_federation_request(target_server, thumbnail_req, None).await?;
+    let meta = read_media_response(response, config::get().media.max_remote_thumbnail_size).await?;
 
-    // Extract content from response headers
-    let content_type = response
-        .headers()
-        .get(header::CONTENT_TYPE)
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_owned());
+    save_fetched_thumbnail(mxc, user, dim, &meta).await;
 
-    let content_disposition = response
-        .headers()
-        .get(header::CONTENT_DISPOSITION)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| ContentDisposition::from_str(s).ok());
+    Ok(meta)
+}
 
-    // Get the file content
-    let file = crate::utils::read_response_limited(
-        response,
-        config::get().media.max_remote_thumbnail_size,
+/// Save a thumbnail fetched from a remote server locally, for caching.
+async fn save_fetched_thumbnail(
+    mxc: &Mxc<'_>,
+    user: Option<&UserId>,
+    dim: &Dimension,
+    meta: &FileMeta,
+) {
+    let Some(file) = meta.content.as_deref().filter(|file| !file.is_empty()) else {
+        return;
+    };
+
+    if let Err(e) = crate::media::save_thumbnail(
+        mxc,
+        user,
+        meta.content_type.as_deref(),
+        meta.content_disposition.as_ref(),
+        dim,
+        file,
     )
-    .await?
-    .to_vec();
-
-    // Save the thumbnail locally for caching
-    if !file.is_empty()
-        && let Err(e) = crate::media::save_thumbnail(
-            mxc,
-            user,
-            content_type.as_deref(),
-            content_disposition.as_ref(),
-            dim,
-            &file,
-        )
-        .await
+    .await
     {
         warn!("Failed to save fetched thumbnail locally: {e}");
     }
-
-    Ok(FileMeta {
-        content: Some(file),
-        content_type,
-        content_disposition,
-    })
 }
 
 // async fn fetch_content_unauthenticated(


### PR DESCRIPTION
Follow-up to #348, which fixed the visible half of this: remote media proxied to clients was served with the raw `multipart/mixed` wrapper. Two things were left over.

**The thumbnail path never unwrapped the multipart body at all.** `fetch_thumbnail_authenticated` reads the federation response and hands it straight to `save_thumbnail`, so the boundary, the JSON metadata part and the part headers are stored *as the image* — and written to the local thumbnail cache, so the corruption sticks. This affects every remote server, palpo included, since our own `/_matrix/federation/v1/media/thumbnail` renders multipart.

**The parser #348 added only handles the shapes we happen to see today.** It looks for `\r\n\r\n` to find the end of a part's headers, which walks past the next boundary when a part has no headers; matches `boundary=` case-sensitively; and treats a part with a `Location` header (allowed by the spec, and what our own federation thumbnail endpoint returns when media is stored in S3) as a file, serving an empty body with an empty `Content-Type` under a `200`.

## What this does

Moves the parsing into `palpo-core`, next to the renderer it mirrors, as `try_from_multipart_mixed`. It follows the reference implementation that was already sitting commented out in `crates/core/src/federation/authenticated_media.rs`, and comes with its unit tests: no-header parts, missing CRs, absent leading CRLF, a boundary-like preamble, case-insensitive headers and boundary parameter, binary content containing the delimiter, `Location` parts, and the malformed cases. Plus a round trip against our own `Scribe` impl, so the renderer and the parser cannot drift apart.

Both remote media paths then use it, which also removes the duplicated response-reading code in the two thumbnail functions.

While unwrapping the response:

- A part carrying a `Location` is reported as a bad gateway instead of an empty `200`. Following it means an outbound request to a server-controlled URL; that deserves its own PR, using `utils::url_guard::ensure_safe_outbound_url`. Note the thumbnail path already degrades gracefully — the error makes `fetch_remote_thumbnail` fall back to the legacy unauthenticated endpoint.
- A part without a `Content-Type` falls back to `application/octet-stream` instead of setting an empty header.
- The remote `Content-Disposition` no longer decides whether the file may be rendered inline. Only its filename is kept; the disposition type is picked by `make_content_disposition`, as the local media path already does. A remote server can otherwise get `text/html` served `inline` from our media endpoint.

## Testing

- `cargo test -p palpo-core --lib federation::media` — 12 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean

Not covered here: remote media is still refetched over federation on every request rather than cached locally, and `fetch_remote_content` still skips the `prevent_downloads_from` blocklist. Both are separate PRs.