### PR TITLE
Apply the media blocklist to remote content downloads

### DIFF
--- a/crates/server/src/media/remote.rs
+++ b/crates/server/src/media/remote.rs
@@ -17,11 +17,15 @@ use crate::utils::read_response_limited;
 use crate::{AppError, AppResult, config};
 
 pub async fn fetch_remote_content(
-    _mxc: &str,
     server_name: &ServerName,
     media_id: &str,
     res: &mut Response,
 ) -> AppResult<()> {
+    check_fetch_authorized(&Mxc {
+        server_name,
+        media_id,
+    })?;
+
     let content_req = crate::core::media::content_request(
         &server_name.origin().await,
         crate::core::media::ContentReqArgs {

--- a/crates/server/src/routing/client/media.rs
+++ b/crates/server/src/routing/client/media.rs
@@ -89,8 +89,7 @@ pub async fn get_content(
             Err(MatrixError::not_yet_uploaded("Media has not been uploaded yet").into())
         }
     } else if *args.server_name != config::get().server_name && args.allow_remote {
-        let mxc = format!("mxc://{}/{}", args.server_name, args.media_id);
-        fetch_remote_content(&mxc, &args.server_name, &args.media_id, res).await
+        fetch_remote_content(&args.server_name, &args.media_id, res).await
     } else {
         Err(MatrixError::not_yet_uploaded("Media has not been uploaded yet").into())
     }
@@ -141,8 +140,7 @@ pub async fn get_content_with_filename(
         res.body = ResBody::Once(data.into());
         Ok(())
     } else if *args.server_name != config::get().server_name && args.allow_remote {
-        let mxc = format!("mxc://{}/{}", args.server_name, args.media_id);
-        fetch_remote_content(&mxc, &args.server_name, &args.media_id, res).await
+        fetch_remote_content(&args.server_name, &args.media_id, res).await
     } else {
         Err(MatrixError::not_yet_uploaded("Media has not been uploaded yet").into())
     }


### PR DESCRIPTION
`check_fetch_authorized` enforces `media.prevent_downloads_from` and `forbidden_remote_server_names`, and it is called from `fetch_remote_thumbnail` — but not from `fetch_remote_content`.

So a client that asks for `/_matrix/client/v1/media/download/{blocked_server}/{media_id}` still makes us fetch the file over federation and hand it back. The blocklist can be walked around by requesting the full-size media instead of a thumbnail, which is the easier request of the two to make.

This runs the same check at the top of `fetch_remote_content`. Blocked media now reports "not found" for downloads, exactly as it already does for thumbnails.

The unused `_mxc: &str` parameter goes away with it: the `Mxc` the check needs is built from the `server_name` and `media_id` the function already takes, so the two callers no longer have to format an `mxc://` string that nothing read.

## Testing

- `cargo clippy --workspace --all-targets -- -D warnings` — clean

Found while reviewing #348; independent of it.