### PR TITLE
Verify policy-server signatures during event validation

### DIFF
--- a/crates/core/src/federation/knock.rs
+++ b/crates/core/src/federation/knock.rs
@@ -142,12 +142,26 @@ crate::json_body_modifier!(SendKnockReqBody);
 pub struct SendKnockResBody {
     /// State events providing public room metadata.
     pub knock_room_state: Vec<RawJson<AnyStrippedStateEvent>>,
+
+    /// The accepted knock PDU, including supplementary signatures added by the resident.
+    ///
+    /// Older servers omit this field. It is an optional backwards-compatible extension
+    /// which lets the knocking server persist Policy Server signatures transitively.
+    #[serde(
+        default,
+        rename = "org.matrix.msc4284.event",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub signed_event: Option<Box<RawJsonValue>>,
 }
 
 impl SendKnockResBody {
     /// Creates a new `Response` with the given public room metadata state
     /// events.
     pub fn new(knock_room_state: Vec<RawJson<AnyStrippedStateEvent>>) -> Self {
-        Self { knock_room_state }
+        Self {
+            knock_room_state,
+            signed_event: None,
+        }
     }
 }

--- a/crates/core/src/federation/policy/sign_event.rs
+++ b/crates/core/src/federation/policy/sign_event.rs
@@ -4,12 +4,20 @@
 
 use salvo::prelude::*;
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 use crate::events::room::policy::POLICY_SERVER_ED25519_SIGNING_KEY_ID;
+use crate::sending::{SendRequest, SendResult};
 use crate::serde::RawJsonValue;
 use crate::{
     OwnedServerName, OwnedServerSigningKeyId, ServerName, ServerSignatures, ServerSigningKeyId,
 };
+
+/// Build a `POST /_matrix/policy/v1/sign` request for the given Policy Server origin.
+pub fn sign_event_request(origin: &str, body: PolicySignEventReqBody) -> SendResult<SendRequest> {
+    let url = Url::parse(&format!("{origin}/_matrix/policy/v1/sign"))?;
+    crate::sending::post(url).stuff(body)
+}
 
 /// Request body for the `sign_event` endpoint.
 #[derive(ToSchema, Serialize, Deserialize, Debug)]

--- a/crates/core/src/signatures/functions/tests.rs
+++ b/crates/core/src/signatures/functions/tests.rs
@@ -888,3 +888,59 @@ fn verify_policy_server_signature_allows_policy_configuration_event() {
         Ok(())
     );
 }
+
+/// The Policy Server signature covers the *redacted* event.
+///
+/// This is what `/_matrix/policy/v1/sign` implementations must sign; signing the event as
+/// sent would only happen to work for events whose content redaction leaves alone.
+#[test]
+fn verify_policy_server_signature_covers_the_redacted_event() {
+    let key_pair = generate_key_pair("policy_server");
+    let room_policy = RoomPolicyEventContent::new(
+        owned_server_name!("domain-policy-server"),
+        Base64::new(key_pair.public_key().to_vec()),
+    );
+
+    let mut event = policy_signature_test_event();
+    // `body` does not survive redaction for an `m.room.message`, so the redacted and
+    // unredacted signature bases differ.
+    event.insert(
+        "type".to_owned(),
+        CanonicalJsonValue::String("m.room.message".to_owned()),
+    );
+    event.insert(
+        "content".to_owned(),
+        serde_json::from_value(json!({ "msgtype": "m.text", "body": "hi" })).unwrap(),
+    );
+
+    let sign_with = |object: &CanonicalJsonObject| {
+        let canonical = to_canonical_json_string_for_signing(object).unwrap();
+        key_pair.sign(canonical.as_bytes()).base64()
+    };
+    let with_signature = |event: &CanonicalJsonObject, signature: String| {
+        let mut event = event.clone();
+        event.insert(
+            "signatures".to_owned(),
+            serde_json::from_value(json!({
+                "domain-policy-server": { "ed25519:policy_server": signature },
+            }))
+            .unwrap(),
+        );
+        event
+    };
+
+    let signed_as_sent = with_signature(&event, sign_with(&event));
+    assert_matches!(
+        verify_policy_server_signature(&room_policy, &signed_as_sent, &RoomVersionRules::V6),
+        Err(Error::Verification(VerificationError::Signature(_)))
+    );
+
+    let redacted =
+        crate::serde::canonical_json::redact(event.clone(), &RoomVersionRules::V6.redaction, None)
+            .unwrap();
+    let signed_redacted = with_signature(&event, sign_with(&redacted));
+    assert_matches!(
+        verify_policy_server_signature(&room_policy, &signed_redacted, &RoomVersionRules::V6),
+        Ok(())
+    );
+}

--- a/crates/data/src/error.rs
+++ b/crates/data/src/error.rs
@@ -63,6 +63,14 @@ impl DataError {
     pub fn internal<S: Into<String>>(msg: S) -> Self {
         Self::Internal(msg.into())
     }
+
+    pub fn is_not_found(&self) -> bool {
+        match self {
+            Self::Diesel(diesel::result::Error::NotFound) => true,
+            Self::Matrix(e) => e.is_not_found(),
+            _ => false,
+        }
+    }
 }
 
 fn expose_diesel_not_found(method: &Method) -> bool {
@@ -162,6 +170,19 @@ mod tests {
     use salvo::http::Method;
 
     use super::*;
+
+    #[test]
+    fn only_missing_resources_are_classified_as_not_found() {
+        assert!(DataError::Diesel(DieselError::NotFound).is_not_found());
+        assert!(DataError::Matrix(MatrixError::not_found("missing")).is_not_found());
+        assert!(
+            !DataError::Diesel(DieselError::DatabaseError(
+                DatabaseErrorKind::Unknown,
+                Box::new(String::from("boom")),
+            ))
+            .is_not_found()
+        );
+    }
 
     #[tokio::test]
     async fn get_not_found_stays_404() {

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -112,8 +112,7 @@ impl AppError {
     pub fn is_not_found(&self) -> bool {
         match self {
             Self::Diesel(diesel::result::Error::NotFound) => true,
-            Self::Data(crate::data::DataError::Diesel(diesel::result::Error::NotFound)) => true,
-            Self::Data(crate::data::DataError::Matrix(e)) => e.is_not_found(),
+            Self::Data(e) => e.is_not_found(),
             Self::Matrix(e) => e.is_not_found(),
             _ => false,
         }
@@ -311,6 +310,13 @@ mod tests {
     use salvo::http::Method;
 
     use super::*;
+
+    #[test]
+    fn data_layer_not_found_is_preserved() {
+        assert!(
+            AppError::Data(crate::data::DataError::Diesel(DieselError::NotFound)).is_not_found()
+        );
+    }
 
     #[test]
     fn access_tokens_are_redacted_from_log_text() {

--- a/crates/server/src/event/handler.rs
+++ b/crates/server/src/event/handler.rs
@@ -117,7 +117,10 @@ pub(crate) async fn process_incoming_pdu(
         .process_incoming(remote_server, is_backfill)
         .await?;
 
-    if incoming_pdu.rejected() {
+    // A soft-failed event is kept for inspection but must not reach the timeline. This
+    // matches `process_pulled_pdu`, and it is what keeps an event the room's Policy Server
+    // refused (MSC4284) from being promoted by the DAG-recovery paths.
+    if incoming_pdu.rejected() || incoming_pdu.soft_failed {
         return Ok(());
     }
 
@@ -237,6 +240,7 @@ pub(crate) async fn process_pulled_pdu(
                     if let Ok(pdu) = timeline::get_pdu(&next_id).await
                         && pdu.is_outlier
                         && !pdu.rejected()
+                        && !pdu.soft_failed
                     {
                         let content = pdu.get_content()?;
                         if let Err(e) =
@@ -287,6 +291,7 @@ pub async fn process_to_outlier_pdu(
             pdu: pdu.into_inner(),
             json_data: val,
             soft_failed: false,
+            policy_refused: false,
             remote_server: remote_server.to_owned(),
             room_id: room_id.to_owned(),
             room_version: room_version.to_owned(),
@@ -345,6 +350,7 @@ pub async fn process_to_outlier_pdu(
         "event_id".to_owned(),
         CanonicalJsonValue::String(event_id.as_str().to_owned()),
     );
+
     let mut incoming_pdu = PduEvent::from_json_value(
         room_id,
         event_id,
@@ -366,6 +372,7 @@ pub async fn process_to_outlier_pdu(
                 pdu: incoming_pdu,
                 json_data: val,
                 soft_failed: false,
+                policy_refused: false,
                 remote_server: remote_server.to_owned(),
                 room_id: room_id.to_owned(),
                 room_version: room_version.to_owned(),
@@ -436,6 +443,7 @@ pub async fn process_to_outlier_pdu(
             Some("incoming event refers to wrong create event".to_owned());
     }
 
+    let mut authorised = false;
     if incoming_pdu.rejection_reason.is_none() {
         // Remember whether soft_failed was already set due to missing prev/auth
         // events. We must NOT clear it just because the auth check happened to
@@ -455,12 +463,21 @@ pub async fn process_to_outlier_pdu(
             }
         } else if !was_soft_failed {
             soft_failed = false;
+            authorised = true;
         }
     }
+
+    // Never let an unauthorised PDU trigger a request to the Policy Server. Besides being
+    // unnecessary, the request can occupy the shared federation semaphore until its
+    // timeout. Events with missing DAG state are checked after recovery in
+    // `OutlierPdu::process_pulled` instead.
+    let policy_refused = authorised
+        && !crate::room::policy::is_event_allowed(room_id, &mut val, &version_rules).await;
 
     Ok(Some(OutlierPdu {
         pdu: incoming_pdu,
         soft_failed,
+        policy_refused,
         json_data: val,
         remote_server: remote_server.to_owned(),
         room_id: room_id.to_owned(),
@@ -471,8 +488,8 @@ pub async fn process_to_outlier_pdu(
 
 #[tracing::instrument(skip(incoming_pdu, json_data))]
 pub async fn process_to_timeline_pdu(
-    incoming_pdu: SnPduEvent,
-    json_data: CanonicalJsonObject,
+    mut incoming_pdu: SnPduEvent,
+    mut json_data: CanonicalJsonObject,
     remote_server: Option<&ServerName>,
 ) -> AppResult<()> {
     // Skip the PDU if we already have it as a timeline event
@@ -484,6 +501,10 @@ pub async fn process_to_timeline_pdu(
             "cannot process rejected event to timeline",
         ));
     }
+    // Backfill saves a whole batch before promoting it, so a missing predecessor
+    // can have arrived since soft_failed was set (including for existing outliers).
+    // Re-authorize those events below. Policy refusals have a persisted rejection
+    // reason and never reach recovery.
     debug!("process to timeline event {}", incoming_pdu.event_id);
     let room_version_id = &room::get_version(&incoming_pdu.room_id).await?;
     let version_rules = crate::room::get_version_rules(room_version_id)?;
@@ -502,6 +523,11 @@ pub async fn process_to_timeline_pdu(
                 .unwrap_or(false);
 
     if !server_joined {
+        if incoming_pdu.soft_failed {
+            return Err(AppError::internal(
+                "cannot recover backfill without joined or peeked room state",
+            ));
+        }
         if let Some(state_key) = incoming_pdu.state_key.as_deref()
             && incoming_pdu.event_ty == TimelineEventType::RoomMember
             && state_key != incoming_pdu.sender().as_str() //????
@@ -595,6 +621,14 @@ pub async fn process_to_timeline_pdu(
         Some(&state_at_incoming_event),
     )
     .await?;
+
+    if incoming_pdu.soft_failed {
+        // The initial outlier check defers policy enforcement when DAG state is
+        // missing. Only ask for a policy signature after the recovered auth check.
+        crate::room::policy::check_recovered_event(&incoming_pdu, &mut json_data, &version_rules)
+            .await?;
+        incoming_pdu.soft_failed = false;
+    }
 
     // Soft fail check before doing state res
     debug!("performing soft-fail check");

--- a/crates/server/src/event/handler.rs
+++ b/crates/server/src/event/handler.rs
@@ -117,7 +117,10 @@ pub(crate) async fn process_incoming_pdu(
         .process_incoming(remote_server, is_backfill)
         .await?;
 
-    if incoming_pdu.rejected() {
+    // A soft-failed event is kept for inspection but must not reach the timeline. This
+    // matches `process_pulled_pdu`, and it is what keeps an event the room's Policy Server
+    // refused (MSC4284) from being promoted by the DAG-recovery paths.
+    if incoming_pdu.rejected() || incoming_pdu.soft_failed {
         return Ok(());
     }
 
@@ -237,6 +240,7 @@ pub(crate) async fn process_pulled_pdu(
                     if let Ok(pdu) = timeline::get_pdu(&next_id).await
                         && pdu.is_outlier
                         && !pdu.rejected()
+                        && !pdu.soft_failed
                     {
                         let content = pdu.get_content()?;
                         if let Err(e) =
@@ -287,6 +291,7 @@ pub async fn process_to_outlier_pdu(
             pdu: pdu.into_inner(),
             json_data: val,
             soft_failed: false,
+            policy_refused: false,
             remote_server: remote_server.to_owned(),
             room_id: room_id.to_owned(),
             room_version: room_version.to_owned(),
@@ -375,6 +380,7 @@ pub async fn process_to_outlier_pdu(
                 pdu: incoming_pdu,
                 json_data: val,
                 soft_failed: false,
+                policy_refused: false,
                 remote_server: remote_server.to_owned(),
                 room_id: room_id.to_owned(),
                 room_version: room_version.to_owned(),
@@ -386,9 +392,7 @@ pub async fn process_to_outlier_pdu(
         return Ok(None);
     }
 
-    // Events the Policy Server declined are kept (so admins can inspect them) but never
-    // reach the timeline, and are not used as prev_events.
-    let mut soft_failed = !policy_allowed;
+    let mut soft_failed = false;
     let (prev_events, missing_prev_event_ids) =
         timeline::get_may_missing_pdus(room_id, &incoming_pdu.prev_events).await?;
     if !missing_prev_event_ids.is_empty() {
@@ -487,6 +491,7 @@ pub async fn process_to_outlier_pdu(
     Ok(Some(OutlierPdu {
         pdu: incoming_pdu,
         soft_failed,
+        policy_refused: !policy_allowed,
         json_data: val,
         remote_server: remote_server.to_owned(),
         room_id: room_id.to_owned(),

--- a/crates/server/src/event/handler.rs
+++ b/crates/server/src/event/handler.rs
@@ -347,6 +347,13 @@ pub async fn process_to_outlier_pdu(
         "event_id".to_owned(),
         CanonicalJsonValue::String(event_id.as_str().to_owned()),
     );
+
+    // The room may require a Policy Server signature (MSC4284). Do this before building
+    // the PDU so that a signature we had to fetch ourselves ends up in both the parsed
+    // event and the stored JSON, and is therefore passed on transitively.
+    let policy_allowed =
+        crate::room::policy::is_event_allowed(room_id, &mut val, &version_rules).await;
+
     let mut incoming_pdu = PduEvent::from_json_value(
         room_id,
         event_id,
@@ -379,7 +386,9 @@ pub async fn process_to_outlier_pdu(
         return Ok(None);
     }
 
-    let mut soft_failed = false;
+    // Events the Policy Server declined are kept (so admins can inspect them) but never
+    // reach the timeline, and are not used as prev_events.
+    let mut soft_failed = !policy_allowed;
     let (prev_events, missing_prev_event_ids) =
         timeline::get_may_missing_pdus(room_id, &incoming_pdu.prev_events).await?;
     if !missing_prev_event_ids.is_empty() {

--- a/crates/server/src/event/handler.rs
+++ b/crates/server/src/event/handler.rs
@@ -512,6 +512,14 @@ pub async fn process_to_timeline_pdu(
     if !incoming_pdu.is_outlier {
         return Ok(());
     }
+    // The single boundary every promotion path goes through, so the guard lives here
+    // rather than being repeated (and forgotten) in each caller -- backfill in particular
+    // promotes PDUs straight from `backfill_pdu`.
+    if incoming_pdu.soft_failed {
+        return Err(AppError::internal(
+            "cannot process soft-failed event to timeline",
+        ));
+    }
     if incoming_pdu.rejected() {
         return Err(AppError::internal(
             "cannot process rejected event to timeline",

--- a/crates/server/src/event/outlier.rs
+++ b/crates/server/src/event/outlier.rs
@@ -28,12 +28,29 @@ pub struct OutlierPdu {
     pub pdu: PduEvent,
     pub json_data: CanonicalJsonObject,
     pub soft_failed: bool,
+    /// The room's Policy Server (MSC4284) refused to vouch for this event.
+    ///
+    /// Kept apart from `soft_failed` because the DAG-recovery paths clear that flag once
+    /// the event turns out to be well-formed and authorised, which a policy refusal has
+    /// nothing to do with. It is folded in when the event is persisted, so no recovery
+    /// path can promote a refused event to the timeline.
+    pub policy_refused: bool,
 
     pub remote_server: OwnedServerName,
     pub room_id: OwnedRoomId,
     pub room_version: RoomVersionId,
     pub event_sn: Option<Seqnum>,
 }
+
+pub(crate) const POLICY_REFUSED_REASON: &str = "event refused by the room policy server";
+
+fn rejection_reason_for_storage(
+    rejection_reason: Option<String>,
+    policy_refused: bool,
+) -> Option<String> {
+    rejection_reason.or_else(|| policy_refused.then(|| POLICY_REFUSED_REASON.to_owned()))
+}
+
 impl AsRef<PduEvent> for OutlierPdu {
     fn as_ref(&self) -> &PduEvent {
         &self.pdu
@@ -111,14 +128,29 @@ impl OutlierPdu {
         is_backfill: bool,
     ) -> AppResult<(SnPduEvent, CanonicalJsonObject, Option<SeqnumQueueGuard>)> {
         let Self {
-            pdu,
+            mut pdu,
             json_data,
             soft_failed,
+            policy_refused,
             room_id,
             event_sn,
             ..
         } = self;
+        let soft_failed = soft_failed || policy_refused;
+        pdu.rejection_reason = rejection_reason_for_storage(pdu.rejection_reason, policy_refused);
         if let Some(event_sn) = event_sn {
+            if policy_refused {
+                // Existing outliers may be checked again after their auth arrives.
+                // Persist the refusal as well as carrying it on the returned PDU.
+                diesel::update(events::table.filter(events::id.eq(&pdu.event_id)))
+                    .set((
+                        events::is_rejected.eq(true),
+                        events::soft_failed.eq(true),
+                        events::rejection_reason.eq(&pdu.rejection_reason),
+                    ))
+                    .execute(&mut connect().await?)
+                    .await?;
+            }
             return Ok((
                 SnPduEvent {
                     pdu,
@@ -141,7 +173,7 @@ impl OutlierPdu {
         )?;
         db_event.is_outlier = true;
         db_event.soft_failed = soft_failed;
-        db_event.is_rejected = pdu.rejection_reason.is_some();
+        db_event.is_rejected = pdu.rejected();
         db_event.rejection_reason = pdu.rejection_reason.clone();
         let event_data = DbEventData {
             event_id: pdu.event_id.clone(),
@@ -153,14 +185,47 @@ impl OutlierPdu {
         };
         // An outlier becomes queryable as soon as its JSON row commits. Keep metadata and
         // JSON together so feature-specific outlier indexes can share this transaction.
-        connect()
+        let (is_rejected, rejection_reason) = connect()
             .await?
             .transaction::<_, AppError, _>(async |conn| {
+                // Create the row before locking it so the lock below always has one to
+                // take. A concurrent replay of the same event serialises against this
+                // transaction either here, while the row is still uncommitted, or on the
+                // lock once it is, so neither can merge onto a verdict it cannot see.
+                diesel::insert_into(events::table)
+                    .values(&db_event)
+                    .on_conflict_do_nothing()
+                    .execute(conn)
+                    .await?;
+                // A stored rejection is durable and a replay must never lift one. Auth
+                // rejection follows from the event's immutable auth references, and an
+                // MSC4284 refusal stays refused. A replay, however, carries no verdict of
+                // its own whenever the DAG is momentarily incomplete: it leaves the event
+                // unauthorised in `process_to_outlier_pdu`, which deliberately skips the
+                // Policy Server request and so yields `policy_refused == false`. Letting
+                // that overwrite the stored row would clear `is_rejected`, the only column
+                // `timeline::stream` filters on, and hand a refused event to clients.
+                let (was_rejected, stored_reason) = events::table
+                    .find(&db_event.id)
+                    .select((events::is_rejected, events::rejection_reason))
+                    .for_update()
+                    .first::<(bool, Option<String>)>(conn)
+                    .await?;
+                db_event.is_rejected |= was_rejected;
+                // The first verdict wins; a later one can only supply a missing reason.
+                db_event.rejection_reason = stored_reason.or(db_event.rejection_reason.take());
+                // Both explicit rejection writers pair these columns, and the returned PDU
+                // below reports the same. Keep the stored row from disagreeing with either.
+                db_event.soft_failed |= db_event.is_rejected;
                 db_event.save_with_conn(conn).await?;
                 event_data.save_with_conn(conn).await?;
-                Ok(())
+                Ok((db_event.is_rejected, db_event.rejection_reason.clone()))
             })
             .await?;
+        // Report what was persisted rather than what this replay believed: a caller handed
+        // a promoted PDU would append it to the timeline and undo the merge above.
+        pdu.rejection_reason = rejection_reason;
+        let soft_failed = soft_failed || is_rejected;
         let pdu = SnPduEvent {
             pdu,
             event_sn,
@@ -181,7 +246,7 @@ impl OutlierPdu {
         // event IDs and their auth references are immutable. Persist it without
         // issuing federation requests so later valid descendants can reconnect
         // to the last accepted state.
-        if !self.soft_failed || self.rejected() {
+        if self.policy_refused || !self.soft_failed || self.rejected() {
             return self.save_to_database(is_backfill).await;
         }
 
@@ -225,7 +290,7 @@ impl OutlierPdu {
     ) -> AppResult<(SnPduEvent, CanonicalJsonObject, Option<SeqnumQueueGuard>)> {
         let version_rules = crate::room::get_version_rules(&self.room_version)?;
 
-        if !self.soft_failed || self.rejected() {
+        if self.policy_refused || !self.soft_failed || self.rejected() {
             return self.save_to_database(is_backfill).await;
         }
 
@@ -328,8 +393,32 @@ impl OutlierPdu {
                 }
             } else {
                 self.soft_failed = false;
+                self.policy_refused = !crate::room::policy::is_event_allowed(
+                    &self.room_id,
+                    &mut self.json_data,
+                    &version_rules,
+                )
+                .await;
             }
         }
         self.save_to_database(is_backfill).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{POLICY_REFUSED_REASON, rejection_reason_for_storage};
+
+    #[test]
+    fn policy_refusal_is_persisted_as_a_rejection() {
+        assert_eq!(
+            rejection_reason_for_storage(None, true).as_deref(),
+            Some(POLICY_REFUSED_REASON)
+        );
+        assert_eq!(
+            rejection_reason_for_storage(Some("auth rejected".to_owned()), true).as_deref(),
+            Some("auth rejected")
+        );
+        assert_eq!(rejection_reason_for_storage(None, false), None);
     }
 }

--- a/crates/server/src/event/outlier.rs
+++ b/crates/server/src/event/outlier.rs
@@ -28,6 +28,13 @@ pub struct OutlierPdu {
     pub pdu: PduEvent,
     pub json_data: CanonicalJsonObject,
     pub soft_failed: bool,
+    /// The room's Policy Server (MSC4284) refused to vouch for this event.
+    ///
+    /// Kept apart from `soft_failed` because the DAG-recovery paths clear that flag once
+    /// the event turns out to be well-formed and authorised, which a policy refusal has
+    /// nothing to do with. It is folded in when the event is persisted, so no recovery
+    /// path can promote a refused event to the timeline.
+    pub policy_refused: bool,
 
     pub remote_server: OwnedServerName,
     pub room_id: OwnedRoomId,
@@ -116,10 +123,12 @@ impl OutlierPdu {
             pdu,
             json_data,
             soft_failed,
+            policy_refused,
             room_id,
             event_sn,
             ..
         } = self;
+        let soft_failed = soft_failed || policy_refused;
         if let Some(event_sn) = event_sn {
             return Ok((
                 SnPduEvent {

--- a/crates/server/src/event/pdu.rs
+++ b/crates/server/src/event/pdu.rs
@@ -35,7 +35,7 @@ use crate::data::schema::*;
 use crate::event::{BatchToken, SeqnumQueueGuard};
 use crate::room::state;
 use crate::room::timeline::get_pdu;
-use crate::{AppError, AppResult, MatrixError, RoomMutexGuard, room};
+use crate::{AppError, AppResult, MatrixError, room};
 
 /// Content hashes of a PDU.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -76,6 +76,10 @@ impl SnPduEvent {
     }
 
     pub async fn user_can_see(&self, user_id: &UserId) -> AppResult<bool> {
+        // A policy refusal must not be bypassed by the own-membership exception.
+        if self.rejection_reason.is_some() {
+            return Ok(false);
+        }
         // Clients must always be able to observe their own membership transitions.
         // In particular, a `knock` -> `leave` transition would otherwise be hidden
         // by shared history visibility because neither side is a joined membership.
@@ -846,14 +850,17 @@ impl PduBuilder {
         }
     }
 
-    pub async fn hash_sign_save(
-        self,
+    /// Persist an already authorised and signed local event as an outlier.
+    ///
+    /// Keeping this separate from [`Self::hash_sign`] lets callers perform checks which
+    /// may fail (notably a Policy Server round trip) without leaving an event that can
+    /// never be appended behind in the database.
+    pub async fn save_as_outlier(
+        pdu: PduEvent,
+        pdu_json: CanonicalJsonObject,
         sender_id: &UserId,
-        room_id: &RoomId,
-        room_version: &RoomVersionId,
-        _state_lock: &RoomMutexGuard,
     ) -> AppResult<(SnPduEvent, CanonicalJsonObject, Option<SeqnumQueueGuard>)> {
-        let (pdu, pdu_json) = self.hash_sign(sender_id, room_id, room_version).await?;
+        let room_id = &pdu.room_id;
         let (event_sn, event_guard) = crate::event::ensure_event_sn(room_id, &pdu.event_id).await?;
         let content_value: JsonValue = serde_json::from_str(pdu.content.get())?;
         let db_event = NewDbEvent {

--- a/crates/server/src/federation.rs
+++ b/crates/server/src/federation.rs
@@ -5,7 +5,7 @@ use crate::core::error::{AuthenticateError, ErrorKind};
 use crate::core::federation::authentication::XMatrix;
 use crate::core::identifiers::*;
 use crate::core::room::{AllowRule, JoinRule};
-use crate::core::serde::{CanonicalJsonObject, JsonValue};
+use crate::core::serde::{CanonicalJsonObject, CanonicalJsonValue, JsonValue};
 use crate::core::{MatrixError, signatures};
 use crate::{AppError, AppResult, config, room, sending};
 
@@ -238,5 +238,76 @@ pub(crate) fn maybe_strip_event_id(
             pdu_json.remove("event_id");
             true
         }
+    }
+}
+
+/// Merge signatures added by a federation membership endpoint into our original PDU.
+///
+/// The caller must first verify that the returned PDU has the expected event ID, valid
+/// sender signatures, and a valid content hash. Signatures are excluded from both the
+/// content and reference hashes, so supplementary signatures can then be copied without
+/// changing the event. Existing signatures always win: a resident server must never be
+/// able to replace the signature made by the event's origin.
+pub(crate) fn merge_supplementary_signatures(
+    target: &mut CanonicalJsonObject,
+    returned: &CanonicalJsonObject,
+) -> AppResult<()> {
+    let returned_signatures = returned
+        .get("signatures")
+        .and_then(CanonicalJsonValue::as_object)
+        .ok_or_else(|| MatrixError::invalid_param("server returned invalid signatures"))?;
+    let target_signatures = target
+        .get_mut("signatures")
+        .and_then(CanonicalJsonValue::as_object_mut)
+        .ok_or_else(|| MatrixError::invalid_param("local event has invalid signatures"))?;
+
+    for (server, returned_set) in returned_signatures {
+        let returned_set = returned_set.as_object().ok_or_else(|| {
+            MatrixError::invalid_param("server returned an invalid signature set")
+        })?;
+        let target_set = target_signatures
+            .entry(server.clone())
+            .or_insert_with(|| CanonicalJsonValue::Object(Default::default()))
+            .as_object_mut()
+            .ok_or_else(|| {
+                MatrixError::invalid_param("local event has an invalid signature set")
+            })?;
+        for (key_id, signature) in returned_set {
+            target_set
+                .entry(key_id.clone())
+                .or_insert_with(|| signature.clone());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::merge_supplementary_signatures;
+    use crate::core::serde::CanonicalJsonObject;
+
+    #[test]
+    fn supplementary_signatures_never_replace_origin_signatures() {
+        let mut target: CanonicalJsonObject = serde_json::from_value(json!({
+            "signatures": { "origin.example": { "ed25519:one": "original" } }
+        }))
+        .unwrap();
+        let returned: CanonicalJsonObject = serde_json::from_value(json!({
+            "signatures": {
+                "origin.example": { "ed25519:one": "replacement" },
+                "policy.example": { "ed25519:policy_server": "policy" }
+            }
+        }))
+        .unwrap();
+
+        merge_supplementary_signatures(&mut target, &returned).unwrap();
+
+        let signatures = target["signatures"].as_object().unwrap();
+        let origin = signatures["origin.example"].as_object().unwrap();
+        let policy = signatures["policy.example"].as_object().unwrap();
+        assert_eq!(origin["ed25519:one"].as_str(), Some("original"));
+        assert_eq!(policy["ed25519:policy_server"].as_str(), Some("policy"));
     }
 }

--- a/crates/server/src/federation/membership/join.rs
+++ b/crates/server/src/federation/membership/join.rs
@@ -156,6 +156,13 @@ pub async fn send_join_v1(
     crate::server_key::hash_and_sign_event(&mut value, &room_version_id)
         .map_err(|e| MatrixError::invalid_param(format!("failed to sign send_join event: {e}")))?;
 
+    // Unlike ordinary transaction PDUs, send_join is synchronous: MSC4284 requires a
+    // Policy Server refusal to fail the federation request, not to be hidden behind the
+    // generic incoming-event soft-fail result. The signature added here is also returned
+    // to the joining server in `event` below.
+    crate::room::policy::check_federation_event(room_id, &event_id, &mut value, &room_version_id)
+        .await?;
+
     let origin: OwnedServerName = serde_json::from_value(
         serde_json::to_value(
             value

--- a/crates/server/src/membership/invite.rs
+++ b/crates/server/src/membership/invite.rs
@@ -44,17 +44,21 @@ pub async fn invite_user(
             };
 
             let state_lock = crate::room::lock_state(room_id).await;
-            let (pdu, pdu_json, _event_guard) = PduBuilder::state(invitee_id.to_string(), &content)
-                .hash_sign_save(
-                    inviter_id,
-                    room_id,
-                    crate::room::get_version(room_id)
-                        .await
-                        .as_ref()
-                        .unwrap_or(&conf.default_room_version),
-                    &state_lock,
-                )
-                .await?;
+            let room_version = crate::room::get_version(room_id)
+                .await
+                .unwrap_or_else(|_| conf.default_room_version.clone());
+            let (pdu, mut pdu_json, _event_guard) =
+                PduBuilder::state(invitee_id.to_string(), &content)
+                    .hash_sign_save(inviter_id, room_id, &room_version, &state_lock)
+                    .await?;
+
+            // This path builds and federates the invite itself rather than going through
+            // `build_and_append_pdu`, so the Policy Server check has to happen here too --
+            // otherwise a refused invite is still sent, and a policy-aware invitee rejects
+            // an unsigned event we cannot take back.
+            let version_rules = crate::room::get_version_rules(&room_version)?;
+            crate::room::policy::check_event(room_id, &mut pdu_json, &version_rules).await?;
+            crate::room::timeline::replace_pdu(&pdu.event_id, &pdu_json).await?;
             drop(state_lock);
 
             let invite_room_state = state::summary_stripped(&pdu).await?;

--- a/crates/server/src/membership/invite.rs
+++ b/crates/server/src/membership/invite.rs
@@ -44,17 +44,21 @@ pub async fn invite_user(
             };
 
             let state_lock = crate::room::lock_state(room_id).await;
-            let (pdu, pdu_json, _event_guard) = PduBuilder::state(invitee_id.to_string(), &content)
-                .hash_sign_save(
-                    inviter_id,
-                    room_id,
-                    crate::room::get_version(room_id)
-                        .await
-                        .as_ref()
-                        .unwrap_or(&conf.default_room_version),
-                    &state_lock,
-                )
+            let room_version = crate::room::get_version(room_id)
+                .await
+                .unwrap_or_else(|_| conf.default_room_version.clone());
+            let (pdu, mut pdu_json) = PduBuilder::state(invitee_id.to_string(), &content)
+                .hash_sign(inviter_id, room_id, &room_version)
                 .await?;
+
+            // This path builds and federates the invite itself rather than going through
+            // `build_and_append_pdu`, so the Policy Server check has to happen here too --
+            // otherwise a refused invite is still sent, and a policy-aware invitee rejects
+            // an unsigned event we cannot take back.
+            let version_rules = crate::room::get_version_rules(&room_version)?;
+            crate::room::policy::check_event(room_id, &mut pdu_json, &version_rules).await?;
+            let (pdu, pdu_json, _event_guard) =
+                PduBuilder::save_as_outlier(pdu, pdu_json, inviter_id).await?;
             drop(state_lock);
 
             let invite_room_state = state::summary_stripped(&pdu).await?;

--- a/crates/server/src/membership/join.rs
+++ b/crates/server/src/membership/join.rs
@@ -265,31 +265,22 @@ pub async fn join_room(
             return Err(MatrixError::invalid_param("server sent event with wrong event id").into());
         }
 
-        match signed_value["signatures"]
-            .as_object()
-            .ok_or(MatrixError::invalid_param(
-                "server sent invalid signatures type",
-            ))
-            .and_then(|e| {
-                e.get(remote_server.as_str())
-                    .ok_or(MatrixError::invalid_param(
-                        "server did not send its signature",
-                    ))
-            }) {
-            Ok(signature) => {
-                join_event
-                    .get_mut("signatures")
-                    .expect("we created a valid pdu")
-                    .as_object_mut()
-                    .expect("we created a valid pdu")
-                    .insert(remote_server.to_string(), signature.clone());
+        match crate::server_key::verify_event(&signed_value, &room_version).await {
+            Ok(crate::core::signatures::Verified::All) => {}
+            Ok(crate::core::signatures::Verified::Signatures) => {
+                return Err(MatrixError::invalid_param(
+                    "server returned a join event with an invalid content hash",
+                )
+                .into());
             }
             Err(e) => {
-                warn!(
-                    "server {remote_server} sent invalid signature in sendjoin signatures for event {signed_value:?}: {e:?}",
-                );
+                return Err(MatrixError::invalid_param(format!(
+                    "server returned an invalid join event signature: {e}"
+                ))
+                .into());
             }
         }
+        crate::federation::merge_supplementary_signatures(&mut join_event, &signed_value)?;
     }
 
     room::ensure_room(room_id, &room_version).await?;
@@ -488,6 +479,21 @@ pub async fn join_room(
     .await?;
 
     state::force_state(room_id, frame_id, appended, disposed).await?;
+    // The returned event can carry the resident's restricted-join signature and a
+    // separate Policy Server signature. The merge above preserves both. Now that the
+    // trusted room state is installed, validate the policy signature against that state;
+    // if an old resident omitted it, fetch a fresh one before publishing our join.
+    crate::room::policy::check_event(
+        room_id,
+        &mut join_event,
+        &crate::room::get_version_rules(&room_version)?,
+    )
+    .await?;
+    let parsed_join_pdu = PduEvent::from_canonical_object(room_id, &event_id, join_event.clone())
+        .map_err(|e| {
+        warn!("invalid pdu in send_join response after supplementary signatures: {e}");
+        AppError::public("invalid join event pdu")
+    })?;
     info!("appending new room join event");
     diesel::insert_into(events::table)
         .values(NewDbEvent::from_canonical_json_with_room_id(

--- a/crates/server/src/membership/knock.rs
+++ b/crates/server/src/membership/knock.rs
@@ -185,7 +185,7 @@ pub async fn knock_room(
     );
 
     // It has enough fields to be called a proper event now
-    let knock_event = knock_event_stub;
+    let mut knock_event = knock_event_stub;
 
     info!("asking {remote_server} for send_knock in room {room_id}");
     let send_knock_request = send_knock_request(
@@ -200,12 +200,41 @@ pub async fn knock_room(
     )?
     .into_inner();
 
-    let _send_knock_body =
+    let send_knock_body =
         crate::sending::send_federation_request(&remote_server, send_knock_request, None)
             .await?
             .json::<SendKnockResBody>()
             .await?;
     info!("send knock finished");
+
+    if let Some(signed_raw) = &send_knock_body.signed_event {
+        let (returned_event_id, returned_event) =
+            crate::event::gen_event_id_canonical_json(signed_raw, &room_version).map_err(|_| {
+                MatrixError::invalid_param("server returned an invalid knock event")
+            })?;
+        if returned_event_id != event_id {
+            return Err(MatrixError::invalid_param(
+                "server returned a knock event with the wrong event ID",
+            )
+            .into());
+        }
+        match crate::server_key::verify_event(&returned_event, &room_version).await {
+            Ok(crate::core::signatures::Verified::All) => {}
+            Ok(crate::core::signatures::Verified::Signatures) => {
+                return Err(MatrixError::invalid_param(
+                    "server returned a knock event with an invalid content hash",
+                )
+                .into());
+            }
+            Err(e) => {
+                return Err(MatrixError::invalid_param(format!(
+                    "server returned an invalid knock event signature: {e}"
+                ))
+                .into());
+            }
+        }
+        crate::federation::merge_supplementary_signatures(&mut knock_event, &returned_event)?;
+    }
 
     info!("parsing knock event");
     let parsed_knock_pdu = PduEvent::from_canonical_object(room_id, &event_id, knock_event.clone())

--- a/crates/server/src/membership/leave.rs
+++ b/crates/server/src/membership/leave.rs
@@ -210,6 +210,12 @@ async fn leave_room_remote(
         CanonicalJsonValue::String(event_id.as_str().to_owned()),
     );
 
+    // This fallback path builds, stores, and federates the leave directly. It can be
+    // reached after the normal local path failed, including on a Policy Server refusal,
+    // so enforce the same policy before any database write or remote send.
+    let version_rules = room::get_version_rules(&room_version_id)?;
+    crate::room::policy::check_event(room_id, &mut leave_event_stub, &version_rules).await?;
+
     let (event_sn, event_guard) = ensure_event_sn(room_id, &event_id).await?;
     NewDbEvent {
         id: event_id.to_owned(),

--- a/crates/server/src/room.rs
+++ b/crates/server/src/room.rs
@@ -41,6 +41,7 @@ mod current;
 pub mod directory;
 pub mod lazy_loading;
 pub mod pdu_metadata;
+pub mod policy;
 pub mod receipt;
 pub mod space;
 pub mod state;

--- a/crates/server/src/room/policy.rs
+++ b/crates/server/src/room/policy.rs
@@ -1,0 +1,250 @@
+//! Policy Server support ([MSC4284]).
+//!
+//! A room opts in to a Policy Server through an `m.room.policy` state event with an empty
+//! state key. Every other event in such a room must carry an `ed25519:policy_server`
+//! signature from the configured server before it is shown to users; the local server asks
+//! the Policy Server for that signature when it is missing.
+//!
+//! [MSC4284]: https://github.com/matrix-org/matrix-spec-proposals/pull/4284
+
+use crate::core::SigningKeyAlgorithm;
+use crate::core::events::StaticEventContent;
+use crate::core::events::room::policy::RoomPolicyEventContent;
+use crate::core::federation::policy::sign_event::{
+    PolicySignEventReqBody, PolicySignEventResBody, sign_event_request,
+};
+use crate::core::identifiers::*;
+use crate::core::room_version_rules::{EventIdFormatVersion, RoomVersionRules};
+use crate::core::serde::{CanonicalJsonObject, CanonicalJsonValue, to_raw_json_value};
+use crate::core::signatures::verify_policy_server_signature;
+use crate::exts::*;
+use crate::{AppResult, MatrixError, config};
+
+/// How long to wait for `POST /_matrix/policy/v1/sign` before giving up.
+///
+/// Sending an event blocks on this round trip, so it is deliberately much shorter than the
+/// default federation timeout.
+const SIGN_TIMEOUT_SECS: u64 = 30;
+
+/// The error surfaced to clients whose event the Policy Server declined to sign.
+const SPAM_MESSAGE: &str = "This message has been rejected as probable spam";
+
+/// Whether the event configures the room's Policy Server.
+///
+/// Such events are exempt: requiring a signature on them would make it impossible to
+/// remove a Policy Server that has stopped signing.
+pub fn is_policy_config_event(event_ty: &str, state_key: Option<&str>) -> bool {
+    event_ty == RoomPolicyEventContent::TYPE && state_key == Some("")
+}
+
+/// Reads the room's usable Policy Server configuration, if it has one.
+///
+/// Returns `None` — meaning "this room does not use a Policy Server" — when the
+/// `m.room.policy` state event is absent or unusable, matching the MSC's requirement that
+/// an invalid configuration behaves as no configuration:
+///
+/// * no `m.room.policy` state event with an empty state key,
+/// * no `ed25519` entry in `public_keys`,
+/// * `via` points at this server (we cannot ask ourselves), or
+/// * `via` is not joined to the room.
+pub async fn policy_server(room_id: &RoomId) -> Option<RoomPolicyEventContent> {
+    let content = crate::room::get_state_content::<RoomPolicyEventContent>(
+        room_id,
+        &RoomPolicyEventContent::TYPE.into(),
+        "",
+        None,
+    )
+    .await
+    .ok()?;
+
+    if !content
+        .public_keys
+        .contains_key(&SigningKeyAlgorithm::Ed25519)
+    {
+        return None;
+    }
+    if content.via == *config::server_name() {
+        return None;
+    }
+    if !crate::room::is_server_joined(&content.via, room_id)
+        .await
+        .ok()?
+    {
+        return None;
+    }
+
+    Some(content)
+}
+
+/// The event JSON that a Policy Server signature covers.
+///
+/// Signatures are computed over the PDU, which for every room version after v2 does not
+/// carry `event_id`. Palpo keeps `event_id` in the stored JSON, so strip it here rather
+/// than at each call site.
+fn signable_pdu(pdu_json: &CanonicalJsonObject, rules: &RoomVersionRules) -> CanonicalJsonObject {
+    let mut pdu_json = pdu_json.clone();
+    if rules.event_id_format != EventIdFormatVersion::V1 {
+        pdu_json.remove("event_id");
+    }
+    pdu_json
+}
+
+/// Whether `pdu_json` already carries a valid signature from `policy`.
+fn has_valid_signature(
+    policy: &RoomPolicyEventContent,
+    pdu_json: &CanonicalJsonObject,
+    rules: &RoomVersionRules,
+) -> bool {
+    match verify_policy_server_signature(policy, &signable_pdu(pdu_json, rules), rules) {
+        Ok(()) => true,
+        Err(e) => {
+            debug!(
+                policy_server = %policy.via,
+                error = %e,
+                "event is not validly signed by the room's policy server"
+            );
+            false
+        }
+    }
+}
+
+/// Adds the Policy Server's signature for `pdu_json` to its `signatures` block.
+///
+/// Returns an error when the Policy Server refuses to sign (the event is spam), cannot be
+/// reached, or returns a signature that does not verify against the key in the room's
+/// `m.room.policy` event.
+async fn add_signature(
+    policy: &RoomPolicyEventContent,
+    pdu_json: &mut CanonicalJsonObject,
+    rules: &RoomVersionRules,
+) -> AppResult<()> {
+    let body = PolicySignEventReqBody::new(to_raw_json_value(&signable_pdu(pdu_json, rules))?);
+    let request = sign_event_request(&policy.via.origin().await, body)?.into_inner();
+    let res_body =
+        crate::sending::send_federation_request(&policy.via, request, Some(SIGN_TIMEOUT_SECS))
+            .await?
+            .json::<PolicySignEventResBody>()
+            .await?;
+
+    let Some(signature) = res_body.ed25519_signature(&policy.via) else {
+        return Err(MatrixError::forbidden(SPAM_MESSAGE, None).into());
+    };
+
+    // Merge rather than replace: the sender's own signature must survive, otherwise the
+    // event fails authorization everywhere.
+    let signatures = match pdu_json
+        .entry("signatures".to_owned())
+        .or_insert_with(|| CanonicalJsonValue::Object(Default::default()))
+    {
+        CanonicalJsonValue::Object(signatures) => signatures,
+        _ => return Err(MatrixError::bad_json("signatures must be a JSON object").into()),
+    };
+    let entry = match signatures
+        .entry(policy.via.to_string())
+        .or_insert_with(|| CanonicalJsonValue::Object(Default::default()))
+    {
+        CanonicalJsonValue::Object(entry) => entry,
+        _ => return Err(MatrixError::bad_json("signatures must be a JSON object").into()),
+    };
+    entry.insert(
+        PolicySignEventResBody::POLICY_SERVER_ED25519_SIGNING_KEY_ID.to_owned(),
+        CanonicalJsonValue::String(signature.to_owned()),
+    );
+
+    if !has_valid_signature(policy, pdu_json, rules) {
+        return Err(MatrixError::unknown(format!(
+            "policy server {} failed to sign event correctly",
+            policy.via
+        ))
+        .into());
+    }
+
+    Ok(())
+}
+
+/// Checks `pdu_json` against the room's Policy Server, fetching a signature when needed.
+///
+/// `pdu_json` is updated in place with any signature obtained from the Policy Server so
+/// that callers persist it and pass it on transitively.
+///
+/// Returns `Ok(())` when the room has no usable Policy Server, when the event configures
+/// the Policy Server, or when the event is signed. Any other outcome is an error: callers
+/// on the local send path turn it into a client-visible rejection, callers on the
+/// federation path soft fail the event.
+pub async fn check_event(
+    room_id: &RoomId,
+    pdu_json: &mut CanonicalJsonObject,
+    rules: &RoomVersionRules,
+) -> AppResult<()> {
+    let event_ty = match pdu_json.get("type") {
+        Some(CanonicalJsonValue::String(event_ty)) => event_ty.as_str(),
+        _ => return Err(MatrixError::bad_json("pdu has no valid type field").into()),
+    };
+    let state_key = match pdu_json.get("state_key") {
+        Some(CanonicalJsonValue::String(state_key)) => Some(state_key.as_str()),
+        _ => None,
+    };
+    if is_policy_config_event(event_ty, state_key) {
+        return Ok(());
+    }
+
+    let Some(policy) = policy_server(room_id).await else {
+        return Ok(());
+    };
+
+    if has_valid_signature(&policy, pdu_json, rules) {
+        return Ok(());
+    }
+
+    add_signature(&policy, pdu_json, rules).await
+}
+
+/// Whether the event is allowed into the room by the room's Policy Server.
+///
+/// The federation variant of [`check_event`]: a Policy Server that refuses to sign or
+/// cannot be reached means the event must not reach clients, but it is not a protocol
+/// violation by the sending server, so it is reported as a soft failure rather than an
+/// error.
+pub async fn is_event_allowed(
+    room_id: &RoomId,
+    pdu_json: &mut CanonicalJsonObject,
+    rules: &RoomVersionRules,
+) -> bool {
+    match check_event(room_id, pdu_json, rules).await {
+        Ok(()) => true,
+        Err(e) => {
+            warn!(%room_id, error = %e, "event was not allowed by the room's policy server");
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_policy_config_event, signable_pdu};
+    use crate::core::room_version_rules::RoomVersionRules;
+    use crate::core::serde::CanonicalJsonObject;
+
+    #[test]
+    fn policy_configuration_event_is_exempt() {
+        assert!(is_policy_config_event("m.room.policy", Some("")));
+        // A non-empty state key is a different event and is not exempt.
+        assert!(!is_policy_config_event("m.room.policy", Some("@a:b.org")));
+        assert!(!is_policy_config_event("m.room.policy", None));
+        assert!(!is_policy_config_event("m.room.message", Some("")));
+    }
+
+    #[test]
+    fn signable_pdu_drops_event_id_for_hashed_event_ids() {
+        let pdu_json: CanonicalJsonObject = serde_json::from_str(
+            r#"{"event_id": "$abc", "type": "m.room.message", "content": {}}"#,
+        )
+        .unwrap();
+
+        // Room version 1 puts `event_id` in the PDU, so it is part of what gets signed.
+        assert!(signable_pdu(&pdu_json, &RoomVersionRules::V1).contains_key("event_id"));
+        // Every later room version computes the event ID from the event, so palpo's stored
+        // copy of it must not leak into the signature base.
+        assert!(!signable_pdu(&pdu_json, &RoomVersionRules::V11).contains_key("event_id"));
+    }
+}

--- a/crates/server/src/room/policy.rs
+++ b/crates/server/src/room/policy.rs
@@ -1,0 +1,703 @@
+//! Policy Server support ([MSC4284]).
+//!
+//! A room opts in to a Policy Server through an `m.room.policy` state event with an empty
+//! state key. Every other event in such a room must carry an `ed25519:policy_server`
+//! signature from the configured server before it is shown to users; the local server asks
+//! the Policy Server for that signature when it is missing.
+//!
+//! [MSC4284]: https://github.com/matrix-org/matrix-spec-proposals/pull/4284
+
+use crate::core::SigningKeyAlgorithm;
+use crate::core::events::StaticEventContent;
+use crate::core::events::room::policy::RoomPolicyEventContent;
+use crate::core::federation::policy::sign_event::{
+    PolicySignEventReqBody, PolicySignEventResBody, sign_event_request,
+};
+use crate::core::identifiers::*;
+use crate::core::room_version_rules::{EventIdFormatVersion, RoomVersionRules};
+use crate::core::serde::{
+    CanonicalJsonObject, CanonicalJsonValue, RawJsonValue, canonical_json, to_raw_json_value,
+};
+use crate::core::signatures::{
+    KeyPair, to_canonical_json_string_for_signing, verify_policy_server_signature,
+};
+use crate::core::state::Event;
+use crate::exts::*;
+use crate::{AppResult, MatrixError, config};
+
+/// How long to wait for `POST /_matrix/policy/v1/sign` before giving up.
+///
+/// Sending an event blocks on this round trip, so it is deliberately much shorter than the
+/// default federation timeout.
+const SIGN_TIMEOUT_SECS: u64 = 30;
+
+/// The error surfaced to clients whose event the Policy Server declined to sign.
+const SPAM_MESSAGE: &str = "This message has been rejected as probable spam";
+
+/// Whether the event configures the room's Policy Server.
+///
+/// Such events are exempt: requiring a signature on them would make it impossible to
+/// remove a Policy Server that has stopped signing.
+pub fn is_policy_config_event(event_ty: &str, state_key: Option<&str>) -> bool {
+    event_ty == RoomPolicyEventContent::TYPE && state_key == Some("")
+}
+
+/// Reads the room's usable Policy Server configuration, if it has one.
+///
+/// `Ok(None)` means "this room does not use a Policy Server", which the MSC says is how an
+/// invalid configuration must behave:
+///
+/// * no `m.room.policy` state event with an empty state key,
+/// * content that does not parse, or that carries no `ed25519` public key,
+/// * `via` is not joined to the room.
+///
+/// An operational failure -- a database error, say -- comes back as an error rather than
+/// as `None`. Reading it as "no Policy Server" would let a transient fault switch off
+/// moderation for its duration, which is the one failure mode this must not have.
+pub async fn policy_server(room_id: &RoomId) -> AppResult<Option<RoomPolicyEventContent>> {
+    let event =
+        match crate::room::get_state(room_id, &RoomPolicyEventContent::TYPE.into(), "", None).await
+        {
+            Ok(event) => event,
+            Err(e) if e.is_not_found() => return Ok(None),
+            Err(e) => return Err(e),
+        };
+
+    let Ok(content) = event.get_content::<RoomPolicyEventContent>() else {
+        debug!(%room_id, "room policy event content is not usable");
+        return Ok(None);
+    };
+
+    if !content
+        .public_keys
+        .contains_key(&SigningKeyAlgorithm::Ed25519)
+    {
+        return Ok(None);
+    }
+    if !crate::room::is_server_joined(&content.via, room_id).await? {
+        return Ok(None);
+    }
+
+    Ok(Some(content))
+}
+
+/// Whether this server is the room's Policy Server.
+///
+/// A room may legitimately name us in `via`: we advertise a policy key at
+/// `/.well-known/matrix/policy_server` and serve `/_matrix/policy/v1/sign`. Signing such an
+/// event is a local operation, so it neither needs nor should make a federation request to
+/// ourselves -- but it does still have to happen, or a room that named us would get no
+/// enforcement at all.
+fn is_local_policy_server(policy: &RoomPolicyEventContent) -> bool {
+    policy.via == *config::server_name()
+}
+
+/// Signs an event with this server's Policy Server key.
+///
+/// Shared with the `/_matrix/policy/v1/sign` endpoint, so a signature we produce for
+/// ourselves is byte-for-byte the one a peer would have been given.
+pub fn sign_locally(pdu_json: &CanonicalJsonObject, rules: &RoomVersionRules) -> AppResult<String> {
+    let redacted = canonical_json::redact(pdu_json.clone(), &rules.redaction, None)
+        .map_err(|e| MatrixError::bad_json(format!("event could not be redacted: {e}")))?;
+    let canonical = to_canonical_json_string_for_signing(&redacted)
+        .map_err(|e| MatrixError::bad_json(format!("event is not canonical JSON: {e}")))?;
+    Ok(config::keypair().sign(canonical.as_bytes()).base64())
+}
+
+/// The event JSON that a Policy Server signature covers.
+///
+/// Signatures are computed over the PDU, which for every room version after v2 does not
+/// carry `event_id`. Palpo keeps `event_id` in the stored JSON, so strip it here rather
+/// than at each call site.
+fn signable_pdu(pdu_json: &CanonicalJsonObject, rules: &RoomVersionRules) -> CanonicalJsonObject {
+    let mut pdu_json = pdu_json.clone();
+    if rules.event_id_format != EventIdFormatVersion::V1 {
+        pdu_json.remove("event_id");
+    }
+    pdu_json
+}
+
+/// Whether `pdu_json` already carries a valid signature from `policy`.
+fn has_valid_signature(
+    policy: &RoomPolicyEventContent,
+    pdu_json: &CanonicalJsonObject,
+    rules: &RoomVersionRules,
+) -> bool {
+    match verify_policy_server_signature(policy, &signable_pdu(pdu_json, rules), rules) {
+        Ok(()) => true,
+        Err(e) => {
+            debug!(
+                policy_server = %policy.via,
+                error = %e,
+                "event is not validly signed by the room's policy server"
+            );
+            false
+        }
+    }
+}
+
+/// Adds the Policy Server's signature for `pdu_json` to its `signatures` block.
+///
+/// Returns an error when the Policy Server refuses to sign (the event is spam), cannot be
+/// reached, or returns a signature that does not verify against the key in the room's
+/// `m.room.policy` event.
+async fn add_signature(
+    policy: &RoomPolicyEventContent,
+    pdu_json: &mut CanonicalJsonObject,
+    rules: &RoomVersionRules,
+) -> AppResult<()> {
+    let signable = signable_pdu(pdu_json, rules);
+    let signature = if is_local_policy_server(policy) {
+        sign_locally(&signable, rules)?
+    } else {
+        let body = PolicySignEventReqBody::new(to_raw_json_value(&signable)?);
+        let request = sign_event_request(&policy.via.origin().await, body)?.into_inner();
+        let res_body =
+            crate::sending::send_federation_request(&policy.via, request, Some(SIGN_TIMEOUT_SECS))
+                .await?
+                .json::<PolicySignEventResBody>()
+                .await?;
+
+        match res_body.ed25519_signature(&policy.via) {
+            Some(signature) => signature.to_owned(),
+            None => return Err(MatrixError::forbidden(SPAM_MESSAGE, None).into()),
+        }
+    };
+
+    // Merge rather than replace: the sender's own signature must survive, otherwise the
+    // event fails authorization everywhere.
+    let signatures = match pdu_json
+        .entry("signatures".to_owned())
+        .or_insert_with(|| CanonicalJsonValue::Object(Default::default()))
+    {
+        CanonicalJsonValue::Object(signatures) => signatures,
+        _ => return Err(MatrixError::bad_json("signatures must be a JSON object").into()),
+    };
+    let entry = match signatures
+        .entry(policy.via.to_string())
+        .or_insert_with(|| CanonicalJsonValue::Object(Default::default()))
+    {
+        CanonicalJsonValue::Object(entry) => entry,
+        _ => return Err(MatrixError::bad_json("signatures must be a JSON object").into()),
+    };
+    entry.insert(
+        PolicySignEventResBody::POLICY_SERVER_ED25519_SIGNING_KEY_ID.to_owned(),
+        CanonicalJsonValue::String(signature),
+    );
+
+    if !has_valid_signature(policy, pdu_json, rules) {
+        return Err(MatrixError::unknown(format!(
+            "policy server {} failed to sign event correctly",
+            policy.via
+        ))
+        .into());
+    }
+
+    Ok(())
+}
+
+fn event_kind_and_state_key(pdu_json: &CanonicalJsonObject) -> AppResult<(&str, Option<&str>)> {
+    let event_ty = match pdu_json.get("type") {
+        Some(CanonicalJsonValue::String(event_ty)) => event_ty.as_str(),
+        _ => return Err(MatrixError::bad_json("pdu has no valid type field").into()),
+    };
+    let state_key = match pdu_json.get("state_key") {
+        Some(CanonicalJsonValue::String(state_key)) => Some(state_key.as_str()),
+        _ => None,
+    };
+    Ok((event_ty, state_key))
+}
+
+async fn check_against_policy(
+    policy: &RoomPolicyEventContent,
+    pdu_json: &mut CanonicalJsonObject,
+    rules: &RoomVersionRules,
+) -> AppResult<()> {
+    if has_valid_signature(policy, pdu_json, rules) {
+        return Ok(());
+    }
+    add_signature(policy, pdu_json, rules).await
+}
+
+/// Read a policy configuration from the full state bundled with a federation invite.
+///
+/// This state is used only when the local server is not joined and consequently has no
+/// trusted current state of its own. The matching state event must itself have a valid
+/// Matrix signature before its public key is used.
+async fn policy_from_invite_state(
+    room_id: &RoomId,
+    invite_room_state: &[Box<RawJsonValue>],
+    room_version: &RoomVersionId,
+) -> AppResult<Option<RoomPolicyEventContent>> {
+    let mut candidate = None;
+    for raw in invite_room_state {
+        let event: CanonicalJsonObject = serde_json::from_str(raw.get())
+            .map_err(|_| MatrixError::invalid_param("invite state event is invalid JSON"))?;
+        let (event_ty, state_key) = event_kind_and_state_key(&event)?;
+        if !is_policy_config_event(event_ty, state_key) {
+            continue;
+        }
+        if let Some(CanonicalJsonValue::String(event_room_id)) = event.get("room_id")
+            && event_room_id != room_id.as_str()
+        {
+            return Err(MatrixError::invalid_param(
+                "invite room policy belongs to a different room",
+            )
+            .into());
+        }
+        if candidate.is_some() {
+            return Err(MatrixError::invalid_param(
+                "invite room state contains multiple policy events",
+            )
+            .into());
+        }
+        match crate::server_key::verify_event(&event, room_version).await {
+            Ok(crate::core::signatures::Verified::All) => {}
+            Ok(crate::core::signatures::Verified::Signatures) => {
+                return Err(MatrixError::invalid_param(
+                    "invite room policy event has an invalid content hash",
+                )
+                .into());
+            }
+            Err(e) => {
+                return Err(MatrixError::invalid_param(format!(
+                    "invite room policy signature verification failed: {e}"
+                ))
+                .into());
+            }
+        }
+        candidate = Some(event);
+    }
+
+    let Some(candidate) = candidate else {
+        return Ok(None);
+    };
+    let Some(content) = candidate.get("content") else {
+        return Ok(None);
+    };
+    let Ok(policy) = serde_json::from_value::<RoomPolicyEventContent>(content.clone().into())
+    else {
+        return Ok(None);
+    };
+    if !policy
+        .public_keys
+        .contains_key(&SigningKeyAlgorithm::Ed25519)
+    {
+        return Ok(None);
+    }
+    // A policy event alone does not prove that its server still participates.
+    // First-time invitees can only use a joined membership bundled with it.
+    for raw in invite_room_state {
+        let event: CanonicalJsonObject = serde_json::from_str(raw.get())?;
+        if invite_proves_joined_server(&event, room_id, &policy.via)
+            && matches!(
+                crate::server_key::verify_event(&event, room_version).await,
+                Ok(crate::core::signatures::Verified::All)
+            )
+        {
+            return Ok(Some(policy));
+        }
+    }
+    Ok(None)
+}
+
+fn invite_proves_joined_server(
+    event: &CanonicalJsonObject,
+    room_id: &RoomId,
+    server: &ServerName,
+) -> bool {
+    if event.get("type").and_then(CanonicalJsonValue::as_str) != Some("m.room.member") {
+        return false;
+    }
+    if let Some(value) = event.get("room_id")
+        && value.as_str() != Some(room_id.as_str())
+    {
+        return false;
+    }
+    let Some(user) = event
+        .get("state_key")
+        .and_then(CanonicalJsonValue::as_str)
+        .and_then(|value| UserId::parse(value).ok())
+    else {
+        return false;
+    };
+    user.server_name() == server
+        && event
+            .get("content")
+            .and_then(CanonicalJsonValue::as_object)
+            .and_then(|content| content.get("membership"))
+            .and_then(CanonicalJsonValue::as_str)
+            == Some("join")
+}
+
+/// Checks `pdu_json` against the room's Policy Server, fetching a signature when needed.
+///
+/// `pdu_json` is updated in place with any signature obtained from the Policy Server so
+/// that callers persist it and pass it on transitively.
+///
+/// Returns `Ok(())` when the room has no usable Policy Server, when the event configures
+/// the Policy Server, or when the event is signed. Any other outcome is an error: callers
+/// on the local send path turn it into a client-visible rejection, callers on the
+/// federation path soft fail the event.
+pub async fn check_event(
+    room_id: &RoomId,
+    pdu_json: &mut CanonicalJsonObject,
+    rules: &RoomVersionRules,
+) -> AppResult<()> {
+    let (event_ty, state_key) = event_kind_and_state_key(pdu_json)?;
+    if is_policy_config_event(event_ty, state_key) {
+        return Ok(());
+    }
+
+    let Some(policy) = policy_server(room_id).await? else {
+        return Ok(());
+    };
+
+    check_against_policy(&policy, pdu_json, rules).await
+}
+
+/// Enforce the policy applicable to an incoming federation invite.
+///
+/// A server already joined to the room uses its trusted current state. On the first invite
+/// there is no local state yet, so the signed `m.room.policy` event supplied in
+/// `invite_room_state` is the only configuration available to the invitee.
+pub async fn check_invite_event(
+    room_id: &RoomId,
+    pdu_json: &mut CanonicalJsonObject,
+    room_version: &RoomVersionId,
+    invite_room_state: &[Box<RawJsonValue>],
+) -> AppResult<()> {
+    let (event_ty, state_key) = event_kind_and_state_key(pdu_json)?;
+    if is_policy_config_event(event_ty, state_key) {
+        return Ok(());
+    }
+
+    let rules = crate::room::get_version_rules(room_version)?;
+    if let Some(policy) = policy_server(room_id).await? {
+        return check_against_policy(&policy, pdu_json, &rules).await;
+    }
+    if crate::room::is_server_joined(config::server_name(), room_id).await? {
+        return Ok(());
+    }
+    let Some(policy) = policy_from_invite_state(room_id, invite_room_state, room_version).await?
+    else {
+        return Ok(());
+    };
+    check_against_policy(&policy, pdu_json, &rules).await
+}
+
+/// Verify an event received by a synchronous federation membership endpoint, then enforce
+/// the room's Policy Server.
+///
+/// The generic transaction path already verifies the sender before reaching the policy
+/// check. The invite/join/leave/knock endpoints need a hard Policy Server error instead of
+/// a soft failure, so they call this earlier and must perform the same verification first;
+/// otherwise an authenticated peer could make us forward unverified events to the Policy
+/// Server.
+pub async fn check_federation_event(
+    room_id: &RoomId,
+    event_id: &EventId,
+    pdu_json: &mut CanonicalJsonObject,
+    room_version: &RoomVersionId,
+) -> AppResult<()> {
+    crate::server_key::verify_event(pdu_json, room_version)
+        .await
+        .map_err(|e| MatrixError::invalid_param(format!("signature verification failed: {e}")))?;
+    let rules = crate::room::get_version_rules(room_version)?;
+    let pdu = crate::event::PduEvent::from_canonical_object(room_id, event_id, pdu_json.clone())
+        .map_err(|_| MatrixError::invalid_param("membership event is not a valid PDU"))?;
+    crate::event::handler::auth_check(&pdu, &rules, None).await?;
+    check_event(room_id, pdu_json, &rules).await
+}
+
+/// Whether the event is allowed into the room by the room's Policy Server.
+///
+/// The federation variant of [`check_event`]: a Policy Server that refuses to sign or
+/// cannot be reached means the event must not reach clients, but it is not a protocol
+/// violation by the sending server, so it is reported as a soft failure rather than an
+/// error.
+pub async fn is_event_allowed(
+    room_id: &RoomId,
+    pdu_json: &mut CanonicalJsonObject,
+    rules: &RoomVersionRules,
+) -> bool {
+    match check_event(room_id, pdu_json, rules).await {
+        Ok(()) => true,
+        Err(e) => {
+            warn!(%room_id, error = %e, "event was not allowed by the room's policy server");
+            false
+        }
+    }
+}
+
+/// Complete a deferred policy check after a recovered outlier passes room auth.
+/// A refusal remains durable even if another recovery path loads the event again.
+pub(crate) async fn check_recovered_event(
+    pdu: &crate::event::SnPduEvent,
+    json_data: &mut CanonicalJsonObject,
+    rules: &RoomVersionRules,
+) -> AppResult<()> {
+    use diesel::prelude::*;
+    use diesel_async::RunQueryDsl;
+
+    use crate::data::schema::events;
+    use crate::event::POLICY_REFUSED_REASON;
+
+    if pdu.rejected() {
+        return Err(crate::AppError::internal(
+            "cannot recover a rejected backfill",
+        ));
+    }
+    if !is_event_allowed(&pdu.room_id, json_data, rules).await {
+        diesel::update(events::table.find(&pdu.event_id))
+            .set((
+                events::is_rejected.eq(true),
+                events::soft_failed.eq(true),
+                events::rejection_reason.eq(POLICY_REFUSED_REASON),
+            ))
+            .execute(&mut crate::data::connect().await?)
+            .await?;
+        return Err(crate::AppError::internal(POLICY_REFUSED_REASON));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_policy_config_event, signable_pdu};
+    use crate::core::room_version_rules::RoomVersionRules;
+    use crate::core::serde::CanonicalJsonObject;
+    use crate::core::state::Event;
+
+    #[test]
+    fn invite_requires_joined_membership_on_the_policy_server() {
+        use super::invite_proves_joined_server;
+        let room = crate::core::RoomId::parse("!room:example.org").unwrap();
+        let server = crate::core::ServerName::parse("policy.example.org").unwrap();
+        let original = serde_json::json!({
+            "type": "m.room.member", "room_id": "!room:example.org",
+            "state_key": "@moderator:policy.example.org", "content": {"membership": "join"}
+        });
+        let parse = |value| serde_json::from_value::<CanonicalJsonObject>(value).unwrap();
+        assert!(invite_proves_joined_server(
+            &parse(original.clone()),
+            &room,
+            &server
+        ));
+        for (key, value) in [
+            ("type", "m.room.policy"),
+            ("room_id", "!other:example.org"),
+            ("state_key", "@user:other.example.org"),
+        ] {
+            let mut event = original.clone();
+            event[key] = value.into();
+            assert!(!invite_proves_joined_server(&parse(event), &room, &server));
+        }
+        for membership in ["leave", "invite", "ban", "knock"] {
+            let mut event = original.clone();
+            event["content"]["membership"] = membership.into();
+            assert!(!invite_proves_joined_server(&parse(event), &room, &server));
+        }
+    }
+
+    #[test]
+    fn policy_configuration_event_is_exempt() {
+        assert!(is_policy_config_event("m.room.policy", Some("")));
+        // A non-empty state key is a different event and is not exempt.
+        assert!(!is_policy_config_event("m.room.policy", Some("@a:b.org")));
+        assert!(!is_policy_config_event("m.room.policy", None));
+        assert!(!is_policy_config_event("m.room.message", Some("")));
+    }
+
+    #[test]
+    fn signable_pdu_drops_event_id_for_hashed_event_ids() {
+        let pdu_json: CanonicalJsonObject = serde_json::from_str(
+            r#"{"event_id": "$abc", "type": "m.room.message", "content": {}}"#,
+        )
+        .unwrap();
+
+        // Room version 1 puts `event_id` in the PDU, so it is part of what gets signed.
+        assert!(signable_pdu(&pdu_json, &RoomVersionRules::V1).contains_key("event_id"));
+        // Every later room version computes the event ID from the event, so palpo's stored
+        // copy of it must not leak into the signature base.
+        assert!(!signable_pdu(&pdu_json, &RoomVersionRules::V11).contains_key("event_id"));
+    }
+    #[tokio::test]
+    #[ignore = "requires an empty dedicated PALPO_TEST_DATABASE_URL"]
+    async fn database_policy_refused_membership_stays_hidden_after_reprocessing() {
+        use diesel::prelude::*;
+        use diesel_async::RunQueryDsl;
+
+        use crate::data::schema::events;
+        use crate::event::{OutlierPdu, PduEvent};
+        crate::test_database::init();
+        let pdu: PduEvent = serde_json::from_value(serde_json::json!({
+            "event_id": "$refused-membership", "room_id": "!policy:example.org",
+            "sender": "@moderator:example.org", "state_key": "@victim:example.org",
+            "type":"m.room.member", "content":{"membership":"ban"},
+            "origin_server_ts":1, "depth":1, "hashes":{"sha256":""}
+        }))
+        .unwrap();
+        let outlier = OutlierPdu {
+            json_data: crate::core::serde::to_canonical_object(&pdu).unwrap(),
+            room_id: pdu.room_id.clone(),
+            pdu,
+            remote_server: "example.org".try_into().unwrap(),
+            room_version: crate::core::RoomVersionId::V11,
+            soft_failed: false,
+            policy_refused: true,
+            event_sn: None,
+        };
+        let (stored, mut json_data, _guard) =
+            outlier.clone().save_to_database(false).await.unwrap();
+        assert!(
+            super::check_recovered_event(&stored, &mut json_data, &RoomVersionRules::V11)
+                .await
+                .is_err()
+        );
+        assert!(
+            crate::event::handler::process_to_timeline_pdu(stored.clone(), json_data.clone(), None)
+                .await
+                .is_err()
+        );
+        let victim = crate::core::UserId::parse("@victim:example.org").unwrap();
+        assert!(!stored.user_can_see(&victim).await.unwrap());
+        let mut conn = crate::data::connect().await.unwrap();
+        assert!(
+            events::table
+                .find(&stored.event_id)
+                .select(events::is_rejected)
+                .first::<bool>(&mut conn)
+                .await
+                .unwrap()
+        );
+        // Missing predecessors are recoverable; they must not inherit the policy
+        // refusal of the first event just because both carry soft_failed=true.
+        let mut recoverable = outlier.clone();
+        recoverable.pdu.event_id = "$recoverable-backfill".try_into().unwrap();
+        recoverable.json_data = crate::core::serde::to_canonical_object(&recoverable.pdu).unwrap();
+        recoverable.event_sn = None;
+        recoverable.policy_refused = false;
+        recoverable.soft_failed = true;
+        let (backfill, mut json_data, _guard) = recoverable.save_to_database(true).await.unwrap();
+        assert!(backfill.soft_failed);
+        assert!(!backfill.rejected());
+        super::check_recovered_event(&backfill, &mut json_data, &RoomVersionRules::V11)
+            .await
+            .unwrap();
+        // Failure of the deferred check must persist rejection before returning;
+        // loading the event again cannot turn that failure into an allowed retry.
+        json_data.remove("type");
+        assert!(
+            super::check_recovered_event(&backfill, &mut json_data, &RoomVersionRules::V11)
+                .await
+                .is_err()
+        );
+        let reloaded = crate::room::timeline::get_pdu(&backfill.event_id)
+            .await
+            .unwrap();
+        assert!(reloaded.rejected());
+        assert!(reloaded.soft_failed);
+        assert!(
+            crate::event::handler::process_to_timeline_pdu(reloaded, json_data, None)
+                .await
+                .is_err()
+        );
+        diesel::update(events::table.find(&stored.event_id))
+            .set(events::is_rejected.eq(false))
+            .execute(&mut conn)
+            .await
+            .unwrap();
+        let mut existing = outlier;
+        existing.event_sn = Some(stored.event_sn);
+        existing.save_to_database(false).await.unwrap();
+        assert!(
+            events::table
+                .find(&stored.event_id)
+                .select(events::is_rejected)
+                .first::<bool>(&mut conn)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires an empty dedicated PALPO_TEST_DATABASE_URL"]
+    async fn database_policy_refusal_survives_a_verdictless_replay() {
+        use diesel::prelude::*;
+        use diesel_async::RunQueryDsl;
+
+        use crate::data::schema::events;
+        use crate::event::{OutlierPdu, POLICY_REFUSED_REASON, PduEvent};
+        crate::test_database::init();
+        let member = |event_id: &str, ts: u64| -> PduEvent {
+            serde_json::from_value(serde_json::json!({
+                "event_id": event_id, "room_id": "!policy-replay:example.org",
+                "sender": "@moderator:example.org", "state_key": "@victim:example.org",
+                "type": "m.room.member", "content": {"membership": "ban"},
+                "origin_server_ts": ts, "depth": ts, "hashes": {"sha256": ""}
+            }))
+            .unwrap()
+        };
+        let outlier = |pdu: PduEvent| OutlierPdu {
+            json_data: crate::core::serde::to_canonical_object(&pdu).unwrap(),
+            room_id: pdu.room_id.clone(),
+            pdu,
+            remote_server: "example.org".try_into().unwrap(),
+            room_version: crate::core::RoomVersionId::V11,
+            soft_failed: false,
+            policy_refused: false,
+            event_sn: None,
+        };
+        let mut conn = crate::data::connect().await.unwrap();
+
+        let mut refused = outlier(member("$replayed-refusal", 1));
+        refused.policy_refused = true;
+        let (stored, ..) = refused.clone().save_to_database(false).await.unwrap();
+        assert!(stored.rejected());
+
+        // A peer can re-offer the same event while its predecessors are momentarily
+        // missing. `process_to_outlier_pdu` then leaves it unauthorised, which skips the
+        // Policy Server request and yields `policy_refused == false` -- the absence of a
+        // verdict, not an allow. The stored refusal has to survive that replay.
+        let mut replay = refused;
+        replay.policy_refused = false;
+        replay.soft_failed = true;
+        let (replayed, ..) = replay.save_to_database(false).await.unwrap();
+        assert!(replayed.rejected(), "a replay promoted a refused event");
+        assert_eq!(
+            replayed.rejection_reason.as_deref(),
+            Some(POLICY_REFUSED_REASON)
+        );
+        assert!(replayed.soft_failed);
+        let (is_rejected, reason) = events::table
+            .find(&replayed.event_id)
+            .select((events::is_rejected, events::rejection_reason))
+            .first::<(bool, Option<String>)>(&mut conn)
+            .await
+            .unwrap();
+        assert!(is_rejected, "a replay cleared is_rejected in the database");
+        assert_eq!(reason.as_deref(), Some(POLICY_REFUSED_REASON));
+        let victim = crate::core::UserId::parse("@victim:example.org").unwrap();
+        assert!(!replayed.user_can_see(&victim).await.unwrap());
+
+        // The opposite direction must keep working: an event first stored without a
+        // verdict is still rejected once a later pass actually obtains one.
+        let mut pending = outlier(member("$refused-on-replay", 2));
+        pending.soft_failed = true;
+        let (undecided, ..) = pending.clone().save_to_database(false).await.unwrap();
+        assert!(!undecided.rejected());
+        pending.soft_failed = false;
+        pending.policy_refused = true;
+        let (now_refused, ..) = pending.save_to_database(false).await.unwrap();
+        assert!(now_refused.rejected());
+        assert!(
+            events::table
+                .find(&now_refused.event_id)
+                .select(events::is_rejected)
+                .first::<bool>(&mut conn)
+                .await
+                .unwrap()
+        );
+    }
+}

--- a/crates/server/src/room/policy.rs
+++ b/crates/server/src/room/policy.rs
@@ -15,8 +15,12 @@ use crate::core::federation::policy::sign_event::{
 };
 use crate::core::identifiers::*;
 use crate::core::room_version_rules::{EventIdFormatVersion, RoomVersionRules};
-use crate::core::serde::{CanonicalJsonObject, CanonicalJsonValue, to_raw_json_value};
-use crate::core::signatures::verify_policy_server_signature;
+use crate::core::serde::{
+    CanonicalJsonObject, CanonicalJsonValue, canonical_json, to_raw_json_value,
+};
+use crate::core::signatures::{
+    KeyPair, to_canonical_json_string_for_signing, verify_policy_server_signature,
+};
 use crate::exts::*;
 use crate::{AppResult, MatrixError, config};
 
@@ -39,41 +43,64 @@ pub fn is_policy_config_event(event_ty: &str, state_key: Option<&str>) -> bool {
 
 /// Reads the room's usable Policy Server configuration, if it has one.
 ///
-/// Returns `None` — meaning "this room does not use a Policy Server" — when the
-/// `m.room.policy` state event is absent or unusable, matching the MSC's requirement that
-/// an invalid configuration behaves as no configuration:
+/// `Ok(None)` means "this room does not use a Policy Server", which the MSC says is how an
+/// invalid configuration must behave:
 ///
 /// * no `m.room.policy` state event with an empty state key,
-/// * no `ed25519` entry in `public_keys`,
-/// * `via` points at this server (we cannot ask ourselves), or
+/// * content that does not parse, or that carries no `ed25519` public key,
 /// * `via` is not joined to the room.
-pub async fn policy_server(room_id: &RoomId) -> Option<RoomPolicyEventContent> {
-    let content = crate::room::get_state_content::<RoomPolicyEventContent>(
-        room_id,
-        &RoomPolicyEventContent::TYPE.into(),
-        "",
-        None,
-    )
-    .await
-    .ok()?;
+///
+/// An operational failure -- a database error, say -- comes back as an error rather than
+/// as `None`. Reading it as "no Policy Server" would let a transient fault switch off
+/// moderation for its duration, which is the one failure mode this must not have.
+pub async fn policy_server(room_id: &RoomId) -> AppResult<Option<RoomPolicyEventContent>> {
+    let event =
+        match crate::room::get_state(room_id, &RoomPolicyEventContent::TYPE.into(), "", None).await
+        {
+            Ok(event) => event,
+            Err(e) if e.is_not_found() => return Ok(None),
+            Err(e) => return Err(e),
+        };
+
+    let Ok(content) = event.get_content::<RoomPolicyEventContent>() else {
+        debug!(%room_id, "room policy event content is not usable");
+        return Ok(None);
+    };
 
     if !content
         .public_keys
         .contains_key(&SigningKeyAlgorithm::Ed25519)
     {
-        return None;
+        return Ok(None);
     }
-    if content.via == *config::server_name() {
-        return None;
-    }
-    if !crate::room::is_server_joined(&content.via, room_id)
-        .await
-        .ok()?
-    {
-        return None;
+    if !crate::room::is_server_joined(&content.via, room_id).await? {
+        return Ok(None);
     }
 
-    Some(content)
+    Ok(Some(content))
+}
+
+/// Whether this server is the room's Policy Server.
+///
+/// A room may legitimately name us in `via`: we advertise a policy key at
+/// `/.well-known/matrix/policy_server` and serve `/_matrix/policy/v1/sign`. Signing such an
+/// event is a local operation, so it neither needs nor should make a federation request to
+/// ourselves -- but it does still have to happen, or a room that named us would get no
+/// enforcement at all.
+fn is_local_policy_server(policy: &RoomPolicyEventContent) -> bool {
+    policy.via == *config::server_name()
+}
+
+/// Signs an event with this server's Policy Server key.
+///
+/// Shared with the `/_matrix/policy/v1/sign` endpoint, so a signature we produce for
+/// ourselves is byte-for-byte the one a peer would have been given.
+pub fn sign_locally(pdu_json: &CanonicalJsonObject, rules: &RoomVersionRules) -> AppResult<String> {
+    let redacted = canonical_json::redact(pdu_json.clone(), &rules.redaction, None)
+        .map_err(|e| MatrixError::bad_json(format!("event could not be redacted: {e}")))?;
+    let canonical = to_canonical_json_string_for_signing(&redacted)
+        .map_err(|e| MatrixError::bad_json(format!("event is not canonical JSON: {e}")))?;
+    Ok(config::keypair().sign(canonical.as_bytes()).base64())
 }
 
 /// The event JSON that a Policy Server signature covers.
@@ -118,16 +145,22 @@ async fn add_signature(
     pdu_json: &mut CanonicalJsonObject,
     rules: &RoomVersionRules,
 ) -> AppResult<()> {
-    let body = PolicySignEventReqBody::new(to_raw_json_value(&signable_pdu(pdu_json, rules))?);
-    let request = sign_event_request(&policy.via.origin().await, body)?.into_inner();
-    let res_body =
-        crate::sending::send_federation_request(&policy.via, request, Some(SIGN_TIMEOUT_SECS))
-            .await?
-            .json::<PolicySignEventResBody>()
-            .await?;
+    let signable = signable_pdu(pdu_json, rules);
+    let signature = if is_local_policy_server(policy) {
+        sign_locally(&signable, rules)?
+    } else {
+        let body = PolicySignEventReqBody::new(to_raw_json_value(&signable)?);
+        let request = sign_event_request(&policy.via.origin().await, body)?.into_inner();
+        let res_body =
+            crate::sending::send_federation_request(&policy.via, request, Some(SIGN_TIMEOUT_SECS))
+                .await?
+                .json::<PolicySignEventResBody>()
+                .await?;
 
-    let Some(signature) = res_body.ed25519_signature(&policy.via) else {
-        return Err(MatrixError::forbidden(SPAM_MESSAGE, None).into());
+        match res_body.ed25519_signature(&policy.via) {
+            Some(signature) => signature.to_owned(),
+            None => return Err(MatrixError::forbidden(SPAM_MESSAGE, None).into()),
+        }
     };
 
     // Merge rather than replace: the sender's own signature must survive, otherwise the
@@ -148,7 +181,7 @@ async fn add_signature(
     };
     entry.insert(
         PolicySignEventResBody::POLICY_SERVER_ED25519_SIGNING_KEY_ID.to_owned(),
-        CanonicalJsonValue::String(signature.to_owned()),
+        CanonicalJsonValue::String(signature),
     );
 
     if !has_valid_signature(policy, pdu_json, rules) {
@@ -188,7 +221,7 @@ pub async fn check_event(
         return Ok(());
     }
 
-    let Some(policy) = policy_server(room_id).await else {
+    let Some(policy) = policy_server(room_id).await? else {
         return Ok(());
     };
 

--- a/crates/server/src/room/state.rs
+++ b/crates/server/src/room/state.rs
@@ -286,17 +286,23 @@ pub async fn summary_stripped(event: &PduEvent) -> AppResult<Vec<RawJson<AnyStri
 ///
 /// Matrix v1.16 requires every entry to be a full PDU in the room version's
 /// wire format and requires the room's create event to be present.
+fn federation_invite_state_cells(sender: &str) -> [(StateEventType, &str); 10] {
+    [
+        (StateEventType::RoomCreate, ""),
+        (StateEventType::RoomJoinRules, ""),
+        (StateEventType::RoomPowerLevels, ""),
+        (StateEventType::RoomCanonicalAlias, ""),
+        (StateEventType::RoomName, ""),
+        (StateEventType::RoomAvatar, ""),
+        (StateEventType::RoomMember, sender),
+        (StateEventType::RoomEncryption, ""),
+        (StateEventType::RoomTopic, ""),
+        (StateEventType::RoomPolicy, ""),
+    ]
+}
+
 pub async fn summary_pdus(event: &PduEvent) -> AppResult<Vec<Box<RawJsonValue>>> {
-    let cells: [(&StateEventType, &str); 8] = [
-        (&StateEventType::RoomCreate, ""),
-        (&StateEventType::RoomJoinRules, ""),
-        (&StateEventType::RoomCanonicalAlias, ""),
-        (&StateEventType::RoomName, ""),
-        (&StateEventType::RoomAvatar, ""),
-        (&StateEventType::RoomMember, event.sender.as_str()),
-        (&StateEventType::RoomEncryption, ""),
-        (&StateEventType::RoomTopic, ""),
-    ];
+    let cells = federation_invite_state_cells(event.sender.as_str());
 
     let create = super::get_state(&event.room_id, &StateEventType::RoomCreate, "", None)
         .await
@@ -304,9 +310,28 @@ pub async fn summary_pdus(event: &PduEvent) -> AppResult<Vec<Box<RawJsonValue>>>
 
     let mut events = vec![create];
     for (event_type, state_key) in cells.into_iter().skip(1) {
-        if let Ok(state_event) = super::get_state(&event.room_id, event_type, state_key, None).await
+        if let Ok(state_event) =
+            super::get_state(&event.room_id, &event_type, state_key, None).await
         {
             events.push(state_event);
+        }
+    }
+
+    // First-time invitees also need signed evidence that the policy server is
+    // joined. Include one current membership from that server, without duplicates.
+    if let Some(policy) = crate::room::policy::policy_server(&event.room_id).await? {
+        let member_id = room_users::table
+            .filter(room_users::room_id.eq(&event.room_id))
+            .filter(room_users::user_server_id.eq(policy.via.as_str()))
+            .filter(room_users::membership.eq("join"))
+            .select(room_users::event_id)
+            .first::<OwnedEventId>(&mut connect().await?)
+            .await
+            .optional()?;
+        if let Some(member_id) = member_id
+            && !events.iter().any(|event| event.event_id == member_id)
+        {
+            events.push(timeline::get_pdu(&member_id).await?);
         }
     }
 
@@ -1167,6 +1192,24 @@ pub fn allowed_room_ids(join_rule: JoinRule) -> Vec<OwnedRoomId> {
         }
     }
     room_ids
+}
+
+#[cfg(test)]
+mod invite_state_tests {
+    use super::federation_invite_state_cells;
+    use crate::core::events::StateEventType;
+
+    #[test]
+    fn federation_invite_state_carries_the_policy_configuration() {
+        let cells = federation_invite_state_cells("@inviter:example.org");
+
+        assert_eq!(cells[0], (StateEventType::RoomCreate, ""));
+        assert!(cells.contains(&(StateEventType::RoomPowerLevels, "")));
+        assert!(
+            cells.contains(&(StateEventType::RoomPolicy, "")),
+            "the invitee needs m.room.policy to verify the invite's policy signature"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/server/src/room/timeline.rs
+++ b/crates/server/src/room/timeline.rs
@@ -820,11 +820,18 @@ pub async fn build_and_append_pdu(
         return Ok(curr_state);
     }
 
-    let (pdu, pdu_json, _event_guard) = pdu_builder
+    let (pdu, mut pdu_json, _event_guard) = pdu_builder
         .hash_sign_save(sender, room_id, room_version, state_lock)
         .await?;
     let room_id = &pdu.room_id;
     crate::room::ensure_room(room_id, room_version).await?;
+
+    // Ask the room's Policy Server (MSC4284) to vouch for the event before it goes
+    // anywhere. A refusal means the policy server considers the event spam, so the client
+    // request fails rather than the event being sent out unsigned. `append_pdu` persists
+    // the signature we obtained, so it travels with the event over federation.
+    let version_rules = crate::room::get_version_rules(room_version)?;
+    crate::room::policy::check_event(room_id, &mut pdu_json, &version_rules).await?;
 
     // let conf = crate::config::get();
     // let admin_room = super::resolve_local_alias(

--- a/crates/server/src/room/timeline.rs
+++ b/crates/server/src/room/timeline.rs
@@ -573,7 +573,10 @@ pub async fn append_pdu(
         .transaction::<_, AppError, _>(async |conn| {
             event_data.save_with_conn(conn).await?;
             diesel::update(events::table.find(&*pdu.event_id))
-                .set(events::is_outlier.eq(false))
+                .set((
+                    events::is_outlier.eq(false),
+                    events::soft_failed.eq(pdu.soft_failed),
+                ))
                 .execute(conn)
                 .await?;
             Ok(())
@@ -864,20 +867,28 @@ async fn build_and_append_pdu_locked(
         return Ok((curr_state, false));
     }
 
-    let (pdu, pdu_json, _event_guard) = pdu_builder
-        .hash_sign_save(sender, room_id, room_version, state_lock)
-        .await?;
-    let room_id = &pdu.room_id;
-    crate::room::ensure_room(room_id, room_version).await?;
+    let (pdu, mut pdu_json) = pdu_builder.hash_sign(sender, room_id, room_version).await?;
+    let room_id = pdu.room_id.clone();
+    crate::room::ensure_room(&room_id, room_version).await?;
+
+    // Ask the room's Policy Server (MSC4284) to vouch for the event before it goes
+    // anywhere. A refusal means the policy server considers the event spam, so the client
+    // request fails rather than the event being sent out unsigned. `append_pdu` persists
+    // the signature we obtained, so it travels with the event over federation.
+    //
+    let version_rules = crate::room::get_version_rules(room_version)?;
+    crate::room::policy::check_event(&room_id, &mut pdu_json, &version_rules).await?;
 
     // let conf = crate::config::get();
     // let admin_room = super::resolve_local_alias(
     //     <&RoomAliasId>::try_from(format!("#admins:{}", &conf.server_name).as_str())
     //         .expect("#admins:server_name is a valid room alias"),
     // )?;
-    if crate::room::is_admin_room(room_id).await? {
+    if crate::room::is_admin_room(&room_id).await? {
         check_pdu_for_admin_room(&pdu, sender).await?;
     }
+
+    let (pdu, pdu_json, _event_guard) = PduBuilder::save_as_outlier(pdu, pdu_json, sender).await?;
 
     append_pdu(&pdu, pdu_json, state_lock).await?;
 

--- a/crates/server/src/room/timeline.rs
+++ b/crates/server/src/room/timeline.rs
@@ -830,8 +830,16 @@ pub async fn build_and_append_pdu(
     // anywhere. A refusal means the policy server considers the event spam, so the client
     // request fails rather than the event being sent out unsigned. `append_pdu` persists
     // the signature we obtained, so it travels with the event over federation.
+    //
+    // `hash_sign_save` has already written the event as an outlier, and a refused event is
+    // never going to be promoted, so it is removed here. Leaving it would accumulate one
+    // dead row per rejected send -- the client retries with a new timestamp and gets a new
+    // event ID each time, since the transaction ID is only recorded on success.
     let version_rules = crate::room::get_version_rules(room_version)?;
-    crate::room::policy::check_event(room_id, &mut pdu_json, &version_rules).await?;
+    if let Err(e) = crate::room::policy::check_event(room_id, &mut pdu_json, &version_rules).await {
+        discard_unsent_event(&pdu.event_id).await;
+        return Err(e);
+    }
 
     // let conf = crate::config::get();
     // let admin_room = super::resolve_local_alias(
@@ -857,6 +865,30 @@ pub async fn build_and_append_pdu(
     crate::sending::send_pdu_servers(servers.into_iter(), &pdu.event_id).await?;
 
     Ok(pdu)
+}
+
+/// Removes an event that was persisted as an outlier but will never be appended.
+///
+/// Best-effort: failing to clean up must not mask the reason the event was rejected.
+async fn discard_unsent_event(event_id: &EventId) {
+    let Ok(mut conn) = connect().await else {
+        return;
+    };
+    for result in [
+        diesel::delete(event_datas::table.filter(event_datas::event_id.eq(event_id)))
+            .execute(&mut conn)
+            .await,
+        diesel::delete(event_points::table.filter(event_points::event_id.eq(event_id)))
+            .execute(&mut conn)
+            .await,
+        diesel::delete(events::table.filter(events::id.eq(event_id)))
+            .execute(&mut conn)
+            .await,
+    ] {
+        if let Err(e) = result {
+            warn!(%event_id, error = ?e, "failed to discard an unsent event");
+        }
+    }
 }
 
 /// Replace a PDU with the redacted form.

--- a/crates/server/src/routing/federation/membership.rs
+++ b/crates/server/src/routing/federation/membership.rs
@@ -11,13 +11,15 @@ use crate::core::events::{AnyStrippedStateEvent, StateEventType, TimelineEventTy
 use crate::core::federation::membership::*;
 use crate::core::identifiers::*;
 use crate::core::room::{JoinRule, RoomEventReqArgs};
+use crate::core::room_version_rules::{EventIdFormatVersion, RoomVersionRules};
 use crate::core::serde::{
     CanonicalJsonObject, CanonicalJsonValue, JsonValue, RawJson, RawJsonValue, to_canonical_object,
 };
+use crate::core::signatures::Verified;
 use crate::data::connect;
 use crate::data::room::NewDbEvent;
 use crate::data::schema::*;
-use crate::event::handler;
+use crate::event::{PduEvent, handler};
 use crate::federation::maybe_strip_event_id;
 use crate::room::{ensure_room, timeline};
 use crate::{
@@ -145,6 +147,176 @@ async fn make_join(args: MakeJoinReqArgs, depot: &mut Depot) -> JsonResult<MakeJ
 
 /// #PUT /_matrix/federation/v2/invite/{room_id}/{event_id}
 /// Invites a remote user to a room.
+fn invite_state_is_full(invite_room_state: &[Box<RawJsonValue>]) -> bool {
+    invite_room_state.iter().all(|raw| {
+        serde_json::from_str::<JsonValue>(raw.get())
+            .ok()
+            .and_then(|event| {
+                Some(
+                    event.get("auth_events")?.is_array()
+                        && event.get("depth")?.is_number()
+                        && event.get("origin_server_ts")?.is_number()
+                        && event.get("signatures")?.is_object(),
+                )
+            })
+            .unwrap_or(false)
+    })
+}
+
+/// Read or recompute an event ID from a PDU in Palpo's stored form.
+///
+/// Room versions 1 and 2 carry an explicit event ID. Later versions derive it from a
+/// reference hash and do not carry `event_id` on the wire, but Palpo adds the field back
+/// before policy processing and persistence. That stored field must not become part of the
+/// reference-hash input when checking that supplementary signatures preserved the ID.
+fn event_id_for_pdu(
+    event: &CanonicalJsonObject,
+    room_version: &RoomVersionId,
+    rules: &RoomVersionRules,
+) -> Result<OwnedEventId, crate::AppError> {
+    if rules.event_id_format == EventIdFormatVersion::V1 {
+        return event
+            .get("event_id")
+            .and_then(CanonicalJsonValue::as_str)
+            .ok_or_else(|| {
+                crate::AppError::from(MatrixError::invalid_param(
+                    "event has no valid event_id field",
+                ))
+            })?
+            .try_into()
+            .map_err(|_| crate::AppError::from(MatrixError::invalid_param("event_id is invalid")));
+    }
+
+    let mut event = event.clone();
+    event.remove("event_id");
+    crate::event::gen_event_id(&event, room_version)
+}
+
+fn requires_full_invite_state(rules: &RoomVersionRules) -> bool {
+    // Room version 12 is the first stable version covered by the mandatory MSC4311
+    // validation. The same authorization flag also identifies its domainless room IDs.
+    rules.authorization.room_create_event_id_as_room_id
+}
+
+async fn authenticate_invite_event(
+    room_id: &RoomId,
+    event_id: &EventId,
+    event: &CanonicalJsonObject,
+    room_version: &RoomVersionId,
+    invite_room_state: &[Box<RawJsonValue>],
+) -> Result<PduEvent, crate::AppError> {
+    let incoming = PduEvent::from_canonical_object(room_id, event_id, event.clone())
+        .map_err(|_| MatrixError::invalid_param("invalid invite event"))?;
+    if incoming.event_ty != TimelineEventType::RoomMember
+        || incoming.state_key.as_deref().is_none()
+        || incoming
+            .get_content::<RoomMemberEventContent>()
+            .map_err(|_| MatrixError::invalid_param("invite has invalid member content"))?
+            .membership
+            != MembershipState::Invite
+    {
+        return Err(MatrixError::invalid_param("event is not a membership invite").into());
+    }
+    let rules = room::get_version_rules(room_version)?;
+    let requires_full_invite_state = requires_full_invite_state(&rules);
+
+    // When we participate in the room, authorise against our trusted event-time state.
+    if room::is_server_joined(config::server_name(), room_id).await? {
+        handler::auth_check(&incoming, &rules, None).await?;
+        return Ok(incoming);
+    }
+
+    // Older servers can still send stripped invite state. It cannot be used as an auth
+    // snapshot because it has neither event IDs nor signatures, but accepting it remains
+    // necessary for federation compatibility through room version 11. Version 12 and
+    // later require full room-version PDUs, including the create event (Matrix v1.16).
+    // The invite event itself was signature-checked by the caller.
+    if !invite_state_is_full(invite_room_state) {
+        if requires_full_invite_state {
+            return Err(MatrixError::invalid_param(
+                "invite room state is not formatted for this room version",
+            )
+            .into());
+        }
+        return Ok(incoming);
+    }
+
+    // Full invite state can be checked for integrity and room binding, but it is not a
+    // trusted current-state snapshot: federation invites do not carry the full auth chain.
+    // Do not use these events to authorise each other.
+    let mut has_create = false;
+    for raw in invite_room_state {
+        let original: CanonicalJsonObject = serde_json::from_str(raw.get())
+            .map_err(|_| MatrixError::invalid_param("invite state event is invalid JSON"))?;
+        if let Some(CanonicalJsonValue::String(event_room_id)) = original.get("room_id")
+            && event_room_id != room_id.as_str()
+        {
+            return Err(MatrixError::invalid_param(
+                "invite state event belongs to a different room",
+            )
+            .into());
+        }
+        let has_declared_room_id =
+            original.get("room_id").and_then(CanonicalJsonValue::as_str) == Some(room_id.as_str());
+        let state_event_id = crate::event::gen_event_id(&original, room_version)?;
+        // The invite itself is commonly included for presentation to the invitee, but it
+        // is not part of the state *before* itself and must never satisfy its own target
+        // membership auth lookup.
+        if state_event_id == event_id {
+            continue;
+        }
+        match crate::server_key::verify_event(&original, room_version).await {
+            Ok(Verified::All) => {}
+            Ok(Verified::Signatures) => {
+                return Err(MatrixError::invalid_param(
+                    "invite state event has an invalid content hash",
+                )
+                .into());
+            }
+            Err(e) => {
+                return Err(MatrixError::invalid_param(format!(
+                    "invite state event signature verification failed: {e}"
+                ))
+                .into());
+            }
+        }
+        let pdu = PduEvent::from_canonical_object(room_id, &state_event_id, original)
+            .map_err(|_| MatrixError::invalid_param("invite state event is not a full PDU"))?;
+        let Some(state_key) = pdu.state_key.as_deref() else {
+            return Err(
+                MatrixError::invalid_param("invite room state contains a non-state event").into(),
+            );
+        };
+        if pdu.event_ty == TimelineEventType::RoomCreate && state_key.is_empty() {
+            if has_create {
+                return Err(MatrixError::invalid_param(
+                    "invite room state contains multiple create events",
+                )
+                .into());
+            }
+            has_create = true;
+            if rules.authorization.room_create_event_id_as_room_id {
+                let derived_room_id = RoomId::new_v2(state_event_id.localpart())?;
+                if derived_room_id != room_id {
+                    return Err(MatrixError::invalid_param(
+                        "invite create event does not match the room ID",
+                    )
+                    .into());
+                }
+            } else if !has_declared_room_id {
+                return Err(MatrixError::invalid_param(
+                    "invite create event has no matching room ID",
+                )
+                .into());
+            }
+        }
+    }
+    if !has_create && requires_full_invite_state {
+        return Err(MatrixError::missing_param("invite room state has no create event").into());
+    }
+    Ok(incoming)
+}
+
 #[endpoint]
 async fn invite_user(
     args: RoomEventReqArgs,
@@ -182,19 +354,53 @@ async fn invite_user(
         .map_err(|_| MatrixError::not_found("invitee user not found"))?;
     handler::acl_check(invitee_id.server_name(), &args.room_id).await?;
 
-    crate::server_key::hash_and_sign_event(&mut signed_event, &body.room_version)
-        .map_err(|e| MatrixError::invalid_param(format!("failed to sign event: {e}")))?;
+    let sender_id: OwnedUserId = serde_json::from_value(
+        signed_event
+            .get("sender")
+            .ok_or(MatrixError::invalid_param("event had no sender field"))?
+            .clone()
+            .into(),
+    )
+    .map_err(|_| MatrixError::invalid_param("sender is not a user id"))?;
+    if sender_id.server_name() != origin {
+        return Err(MatrixError::forbidden(
+            "cannot send an invite on behalf of another server",
+            None,
+        )
+        .into());
+    }
+    if let Some(CanonicalJsonValue::String(event_room_id)) = signed_event.get("room_id")
+        && event_room_id != args.room_id.as_str()
+    {
+        return Err(MatrixError::bad_json("event room ID does not match the request path").into());
+    }
 
-    // Generate event id
-    let event_id = crate::event::gen_event_id(&signed_event, &body.room_version)?;
-
-    // Add event_id back
-    signed_event.insert(
+    // Authenticate the sender's original event before either this server or a Policy
+    // Server adds a supplementary signature.
+    let version_rules = room::get_version_rules(&body.room_version)?;
+    let event_id = event_id_for_pdu(&signed_event, &body.room_version, &version_rules)?;
+    match crate::server_key::verify_event(&signed_event, &body.room_version).await {
+        Ok(Verified::All) => {}
+        Ok(Verified::Signatures) => {
+            return Err(
+                MatrixError::invalid_param("invite event has an invalid content hash").into(),
+            );
+        }
+        Err(e) => {
+            return Err(
+                MatrixError::invalid_param(format!("signature verification failed: {e}")).into(),
+            );
+        }
+    }
+    if event_id != args.event_id {
+        return Err(MatrixError::bad_json("event ID does not match the request path").into());
+    }
+    let mut auth_event = signed_event.clone();
+    auth_event.insert(
         "event_id".to_owned(),
         CanonicalJsonValue::String(event_id.to_string()),
     );
 
-    let state_lock = room::lock_state(&args.room_id).await;
     ensure_room(&args.room_id, &body.room_version).await?;
     if data::room::is_banned(&args.room_id).await? {
         return Err(MatrixError::forbidden("this room is banned on this homeserver", None).into());
@@ -204,9 +410,43 @@ async fn invite_user(
         return Err(MatrixError::forbidden("this server does not allow room invites", None).into());
     }
 
-    let preserve_full_create = crate::room::get_version_rules(&body.room_version)?
-        .authorization
-        .room_create_event_id_as_room_id;
+    authenticate_invite_event(
+        &args.room_id,
+        &event_id,
+        &auth_event,
+        &body.room_version,
+        &body.invite_room_state,
+    )
+    .await?;
+
+    // `auth_check` resolves the event-time state and takes the room state lock internally.
+    // Acquire our write-side lock only after that read-only validation, otherwise invites
+    // to a server which is already participating in the room deadlock on the same mutex.
+    let state_lock = room::lock_state(&args.room_id).await;
+
+    crate::server_key::hash_and_sign_event(&mut signed_event, &body.room_version)
+        .map_err(|e| MatrixError::invalid_param(format!("failed to sign event: {e}")))?;
+    signed_event.insert(
+        "event_id".to_owned(),
+        CanonicalJsonValue::String(event_id.to_string()),
+    );
+
+    // Only contact the Policy Server after room authorization. For a first invite, use
+    // the signed policy state supplied alongside the event because no local state exists.
+    crate::room::policy::check_invite_event(
+        &args.room_id,
+        &mut signed_event,
+        &body.room_version,
+        &body.invite_room_state,
+    )
+    .await?;
+    if event_id_for_pdu(&signed_event, &body.room_version, &version_rules)? != event_id {
+        return Err(
+            MatrixError::bad_json("supplementary invite signatures changed the event ID").into(),
+        );
+    }
+
+    let preserve_full_create = version_rules.authorization.room_create_event_id_as_room_id;
     let mut invite_state = body
         .invite_room_state
         .iter()
@@ -218,11 +458,9 @@ async fn invite_user(
     // record the invited state for client /sync through update_membership(), and
     // send the invite PDU to the relevant appservices.
     // if !room::is_server_joined(&config::get().server_name, &args.room_id)? {
-    let mut event: CanonicalJsonObject = serde_json::from_str(body.event.get())
-        .map_err(|_| MatrixError::invalid_param("invalid invite event bytes"))?;
-
-    // let event_id: OwnedEventId = format!("$dummy_{}", Ulid::generate()).try_into()?;
-    event.insert("event_id".to_owned(), event_id.to_string().into());
+    // Store the same event that is returned to the inviting server. This includes this
+    // server's signature and any Policy Server signature added above.
+    let event = signed_event.clone();
 
     let (event_sn, event_guard) = crate::event::ensure_event_sn(&args.room_id, &event_id).await?;
     let pdu = SnPduEvent::from_canonical_object(
@@ -422,7 +660,7 @@ async fn send_leave(
     // We do not add the event_id field to the pdu here because of signature and hashes checks
     let room_version_id = room::get_version(&args.room_id).await?;
 
-    let Ok((event_id, value)) =
+    let Ok((event_id, mut value)) =
         crate::event::gen_event_id_canonical_json(&body.0, &room_version_id)
     else {
         // Event could not be converted to canonical json
@@ -510,6 +748,17 @@ async fn send_leave(
         return Err(MatrixError::bad_json("state_key does not match sender user").into());
     }
 
+    // A synchronous send_leave must report a Policy Server refusal to the sender. The
+    // normal incoming-PDU path intentionally turns the same refusal into a soft failure
+    // for transaction traffic, which would incorrectly make this endpoint return success.
+    crate::room::policy::check_federation_event(
+        &args.room_id,
+        &event_id,
+        &mut value,
+        &room_version_id,
+    )
+    .await?;
+
     handler::process_incoming_pdu(
         origin,
         &event_id,
@@ -531,7 +780,73 @@ mod tests {
     use serde_json::value::to_raw_value;
     use serde_json::{Value, json};
 
-    use super::stripped_invite_state_event;
+    use super::{
+        event_id_for_pdu, invite_state_is_full, requires_full_invite_state,
+        stripped_invite_state_event,
+    };
+    use crate::core::identifiers::RoomVersionId;
+    use crate::core::room_version_rules::RoomVersionRules;
+    use crate::core::serde::CanonicalJsonObject;
+
+    #[test]
+    fn supplementary_invite_signatures_preserve_reference_hash_event_id() {
+        let room_version = RoomVersionId::V11;
+        let mut event: CanonicalJsonObject = serde_json::from_value(json!({
+            "auth_events": [],
+            "content": { "membership": "invite" },
+            "depth": 1,
+            "hashes": { "sha256": "hash" },
+            "origin_server_ts": 1,
+            "prev_events": [],
+            "room_id": "!room:example.org",
+            "sender": "@alice:example.org",
+            "signatures": { "example.org": { "ed25519:one": "first" } },
+            "state_key": "@bob:remote.example",
+            "type": "m.room.member"
+        }))
+        .unwrap();
+        let event_id = crate::event::gen_event_id(&event, &room_version).unwrap();
+
+        event.insert("event_id".to_owned(), event_id.to_string().into());
+        event
+            .get_mut("signatures")
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .insert(
+                "remote.example".to_owned(),
+                serde_json::from_value(json!({ "ed25519:two": "second" })).unwrap(),
+            );
+
+        assert_eq!(
+            event_id_for_pdu(&event, &room_version, &RoomVersionRules::V11).unwrap(),
+            event_id
+        );
+    }
+
+    #[test]
+    fn legacy_room_versions_use_the_explicit_event_id() {
+        let event_id = "$opaque:example.org";
+        let event: CanonicalJsonObject = serde_json::from_value(json!({
+            "event_id": event_id,
+            "signatures": { "example.org": { "ed25519:one": "first" } },
+            "type": "m.room.member"
+        }))
+        .unwrap();
+
+        assert_eq!(
+            event_id_for_pdu(&event, &RoomVersionId::V1, &RoomVersionRules::V1)
+                .unwrap()
+                .as_str(),
+            event_id
+        );
+    }
+
+    #[test]
+    fn full_invite_state_becomes_mandatory_in_room_version_12() {
+        assert!(!requires_full_invite_state(&RoomVersionRules::V11));
+        assert!(requires_full_invite_state(&RoomVersionRules::V12));
+    }
 
     #[test]
     fn strips_full_federation_pdu_for_client_state() {
@@ -562,6 +877,7 @@ mod tests {
                 "type": "m.room.name"
             })
         );
+        assert!(invite_state_is_full(&[pdu]));
     }
 
     #[test]
@@ -575,6 +891,7 @@ mod tests {
         .unwrap();
 
         assert!(stripped_invite_state_event(&event, false).is_ok());
+        assert!(!invite_state_is_full(&[event]));
     }
 
     #[test]

--- a/crates/server/src/routing/federation/membership.rs
+++ b/crates/server/src/routing/federation/membership.rs
@@ -379,19 +379,27 @@ async fn invite_user(
     // Server adds a supplementary signature.
     let version_rules = room::get_version_rules(&body.room_version)?;
     let event_id = event_id_for_pdu(&signed_event, &body.room_version, &version_rules)?;
-    match crate::server_key::verify_event(&signed_event, &body.room_version).await {
-        Ok(Verified::All) => {}
-        Ok(Verified::Signatures) => {
-            return Err(
-                MatrixError::invalid_param("invite event has an invalid content hash").into(),
-            );
-        }
-        Err(e) => {
-            return Err(
-                MatrixError::invalid_param(format!("signature verification failed: {e}")).into(),
-            );
-        }
-    }
+    let content_was_redacted =
+        match crate::server_key::verify_event(&signed_event, &body.room_version).await {
+            Ok(Verified::All) => false,
+            Ok(Verified::Signatures) => {
+                signed_event = crate::core::serde::canonical_json::redact(
+                    signed_event,
+                    &version_rules.redaction,
+                    None,
+                )
+                .map_err(|e| {
+                    MatrixError::invalid_param(format!("invite event redaction failed: {e}"))
+                })?;
+                true
+            }
+            Err(e) => {
+                return Err(MatrixError::invalid_param(format!(
+                    "signature verification failed: {e}"
+                ))
+                .into());
+            }
+        };
     if event_id != args.event_id {
         return Err(MatrixError::bad_json("event ID does not match the request path").into());
     }
@@ -424,8 +432,15 @@ async fn invite_user(
     // to a server which is already participating in the room deadlock on the same mutex.
     let state_lock = room::lock_state(&args.room_id).await;
 
-    crate::server_key::hash_and_sign_event(&mut signed_event, &body.room_version)
-        .map_err(|e| MatrixError::invalid_param(format!("failed to sign event: {e}")))?;
+    if content_was_redacted {
+        // Keep the sender's original content hash. Re-hashing a redacted copy would make
+        // the sender's otherwise-valid signature cover a different `hashes` block.
+        crate::server_key::sign_json(&mut signed_event)
+            .map_err(|e| MatrixError::invalid_param(format!("failed to sign event: {e}")))?;
+    } else {
+        crate::server_key::hash_and_sign_event(&mut signed_event, &body.room_version)
+            .map_err(|e| MatrixError::invalid_param(format!("failed to sign event: {e}")))?;
+    }
     signed_event.insert(
         "event_id".to_owned(),
         CanonicalJsonValue::String(event_id.to_string()),

--- a/crates/server/src/routing/federation/room.rs
+++ b/crates/server/src/routing/federation/room.rs
@@ -537,7 +537,13 @@ async fn send_knock(
     if let Err(e) = crate::sending::send_pdu_room(&args.room_id, &event_id, &[], &[]).await {
         error!("failed to notify knock event: {e}");
     }
-    json_ok(SendKnockResBody { knock_room_state })
+    let signed_event = Some(to_raw_value(
+        &crate::sending::convert_to_outgoing_federation_event(value).await,
+    )?);
+    json_ok(SendKnockResBody {
+        knock_room_state,
+        signed_event,
+    })
 }
 
 /// # `GET /_matrix/federation/v1/make_knock/{room_id}/{user_id}`

--- a/crates/server/src/routing/federation/room.rs
+++ b/crates/server/src/routing/federation/room.rs
@@ -414,7 +414,7 @@ async fn send_knock(
         return Err(MatrixError::forbidden("room version does not support knocking", None).into());
     }
 
-    let Ok((event_id, value)) = gen_event_id_canonical_json(&body.0, &room_version) else {
+    let Ok((event_id, mut value)) = gen_event_id_canonical_json(&body.0, &room_version) else {
         // Event could not be converted to canonical json
         return Err(MatrixError::invalid_param("could not convert event to canonical json").into());
     };
@@ -502,6 +502,16 @@ async fn send_knock(
 
     let pdu: PduEvent = PduEvent::from_json_value(&args.room_id, &event_id, event.into())
         .map_err(|e| MatrixError::invalid_param(format!("invalid knock event pdu: {e}")))?;
+
+    // send_knock is a synchronous membership request, so a Policy Server refusal must be
+    // returned as an error instead of becoming the generic transaction-path soft failure.
+    crate::room::policy::check_federation_event(
+        &args.room_id,
+        &event_id,
+        &mut value,
+        &room_version,
+    )
+    .await?;
 
     handler::process_incoming_pdu(
         &origin,

--- a/crates/server/src/routing/policy.rs
+++ b/crates/server/src/routing/policy.rs
@@ -2,8 +2,9 @@ use salvo::oapi::extract::*;
 use salvo::prelude::*;
 
 use crate::core::federation::policy::sign_event::{PolicySignEventReqBody, PolicySignEventResBody};
+use crate::core::identifiers::*;
+use crate::core::room_version_rules::{EventIdFormatVersion, RoomVersionRules};
 use crate::core::serde::CanonicalJsonObject;
-use crate::core::signatures::KeyPair;
 use crate::{AppError, AppResult, AuthArgs, JsonResult, MatrixError, config, hoops, json_ok};
 
 pub fn router() -> Router {
@@ -24,11 +25,37 @@ async fn check_policy_server_enabled() -> AppResult<()> {
 }
 
 #[endpoint]
-fn sign_event(
+async fn sign_event(
     _aa: AuthArgs,
     body: JsonBody<PolicySignEventReqBody>,
 ) -> JsonResult<PolicySignEventResBody> {
-    let signature = sign_policy_event(&body.0.0)?;
+    let object: CanonicalJsonObject = serde_json::from_str(body.0.0.get()).map_err(|_| {
+        MatrixError::bad_json("Policy Server signing request must be a JSON object")
+    })?;
+
+    let room_id = object
+        .get("room_id")
+        .and_then(|value| value.as_str())
+        .and_then(|value| RoomId::parse(value).ok())
+        .ok_or_else(|| MatrixError::bad_json("Policy Server signing request has no room_id"))?;
+
+    // MSC4284 has a Policy Server answer 404 for rooms it does not serve. A room record
+    // alone is insufficient: invited/peeked rooms also have one. The current usable policy
+    // configuration must name this server, and its joined-user requirement is enforced by
+    // `policy_server`.
+    let policy = crate::room::policy::policy_server(&room_id).await?;
+    if !matches!(policy, Some(policy) if policy.via == *config::server_name()) {
+        return Err(MatrixError::not_found("Room is not protected by this Policy Server").into());
+    }
+
+    let room_version = match crate::room::get_version(&room_id).await {
+        Ok(room_version) => room_version,
+        Err(e) if e.is_not_found() => return Err(MatrixError::not_found("Unknown room").into()),
+        Err(e) => return Err(e),
+    };
+    let rules = crate::room::get_version_rules(&room_version)?;
+
+    let signature = sign_policy_event(object, &rules)?;
 
     json_ok(PolicySignEventResBody::new(
         config::get().server_name.clone(),
@@ -36,11 +63,16 @@ fn sign_event(
     ))
 }
 
-fn sign_policy_event(pdu: &serde_json::value::RawValue) -> AppResult<String> {
-    let mut object: CanonicalJsonObject = serde_json::from_str(pdu.get()).map_err(|_| {
-        MatrixError::bad_json("Policy Server signing request must be a JSON object")
-    })?;
-
+/// Signs the event the same way a receiver verifies it: over the redacted PDU, with
+/// `signatures` and `unsigned` removed.
+///
+/// Signing the unredacted event instead produces a signature that every implementation --
+/// including palpo's own `verify_policy_server_signature` -- rejects for any event whose
+/// content the redaction algorithm strips.
+fn sign_policy_event(
+    mut object: CanonicalJsonObject,
+    rules: &RoomVersionRules,
+) -> AppResult<String> {
     if object.get("type").and_then(|value| value.as_str()) == Some("m.room.policy")
         && object.get("state_key").and_then(|value| value.as_str()) == Some("")
     {
@@ -51,11 +83,13 @@ fn sign_policy_event(pdu: &serde_json::value::RawValue) -> AppResult<String> {
         .into());
     }
 
-    object.remove("signatures");
-    object.remove("unsigned");
+    // `event_id` is only part of the PDU in room version 1; senders that keep a copy of it
+    // alongside the event must not have it counted towards the signature in later versions.
+    if rules.event_id_format != EventIdFormatVersion::V1 {
+        object.remove("event_id");
+    }
 
-    let canonical_json = serde_json::to_string(&object)?;
-    Ok(config::keypair().sign(canonical_json.as_bytes()).base64())
+    crate::room::policy::sign_locally(&object, rules)
 }
 
 #[cfg(test)]
@@ -63,17 +97,22 @@ mod tests {
     use serde_json::json;
 
     use super::sign_policy_event;
-    use crate::core::serde::to_raw_json_value;
+    use crate::core::room_version_rules::RoomVersionRules;
+    use crate::core::serde::CanonicalJsonObject;
+
+    fn object(value: serde_json::Value) -> CanonicalJsonObject {
+        serde_json::from_value(value).unwrap()
+    }
 
     #[test]
     fn policy_config_event_is_rejected() {
-        let pdu = to_raw_json_value(&json!({
+        let pdu = object(json!({
             "type": "m.room.policy",
             "state_key": "",
+            "room_id": "!room:example.org",
             "content": {}
-        }))
-        .unwrap();
+        }));
 
-        assert!(sign_policy_event(&pdu).is_err());
+        assert!(sign_policy_event(pdu, &RoomVersionRules::V11).is_err());
     }
 }

--- a/crates/server/src/routing/policy.rs
+++ b/crates/server/src/routing/policy.rs
@@ -4,8 +4,7 @@ use salvo::prelude::*;
 use crate::core::federation::policy::sign_event::{PolicySignEventReqBody, PolicySignEventResBody};
 use crate::core::identifiers::*;
 use crate::core::room_version_rules::{EventIdFormatVersion, RoomVersionRules};
-use crate::core::serde::{CanonicalJsonObject, canonical_json};
-use crate::core::signatures::{KeyPair, to_canonical_json_string_for_signing};
+use crate::core::serde::CanonicalJsonObject;
 use crate::{AppError, AppResult, AuthArgs, JsonResult, MatrixError, config, hoops, json_ok};
 
 pub fn router() -> Router {
@@ -81,12 +80,7 @@ fn sign_policy_event(
         object.remove("event_id");
     }
 
-    let redacted = canonical_json::redact(object, &rules.redaction, None)
-        .map_err(|e| MatrixError::bad_json(format!("event could not be redacted: {e}")))?;
-    let canonical_json = to_canonical_json_string_for_signing(&redacted)
-        .map_err(|e| MatrixError::bad_json(format!("event is not canonical JSON: {e}")))?;
-
-    Ok(config::keypair().sign(canonical_json.as_bytes()).base64())
+    crate::room::policy::sign_locally(&object, rules)
 }
 
 #[cfg(test)]

--- a/crates/server/src/routing/policy.rs
+++ b/crates/server/src/routing/policy.rs
@@ -2,8 +2,10 @@ use salvo::oapi::extract::*;
 use salvo::prelude::*;
 
 use crate::core::federation::policy::sign_event::{PolicySignEventReqBody, PolicySignEventResBody};
-use crate::core::serde::CanonicalJsonObject;
-use crate::core::signatures::KeyPair;
+use crate::core::identifiers::*;
+use crate::core::room_version_rules::{EventIdFormatVersion, RoomVersionRules};
+use crate::core::serde::{CanonicalJsonObject, canonical_json};
+use crate::core::signatures::{KeyPair, to_canonical_json_string_for_signing};
 use crate::{AppError, AppResult, AuthArgs, JsonResult, MatrixError, config, hoops, json_ok};
 
 pub fn router() -> Router {
@@ -24,11 +26,28 @@ async fn check_policy_server_enabled() -> AppResult<()> {
 }
 
 #[endpoint]
-fn sign_event(
+async fn sign_event(
     _aa: AuthArgs,
     body: JsonBody<PolicySignEventReqBody>,
 ) -> JsonResult<PolicySignEventResBody> {
-    let signature = sign_policy_event(&body.0.0)?;
+    let object: CanonicalJsonObject = serde_json::from_str(body.0.0.get()).map_err(|_| {
+        MatrixError::bad_json("Policy Server signing request must be a JSON object")
+    })?;
+
+    let room_id = object
+        .get("room_id")
+        .and_then(|value| value.as_str())
+        .and_then(|value| RoomId::parse(value).ok())
+        .ok_or_else(|| MatrixError::bad_json("Policy Server signing request has no room_id"))?;
+
+    // MSC4284 has a Policy Server answer 404 for rooms it does not serve. We only serve
+    // rooms we are in, which is also what tells us the room version to redact against.
+    let rules = match crate::room::get_version(&room_id).await {
+        Ok(room_version) => crate::room::get_version_rules(&room_version)?,
+        Err(_) => return Err(MatrixError::not_found("Unknown room").into()),
+    };
+
+    let signature = sign_policy_event(object, &rules)?;
 
     json_ok(PolicySignEventResBody::new(
         config::get().server_name.clone(),
@@ -36,11 +55,16 @@ fn sign_event(
     ))
 }
 
-fn sign_policy_event(pdu: &serde_json::value::RawValue) -> AppResult<String> {
-    let mut object: CanonicalJsonObject = serde_json::from_str(pdu.get()).map_err(|_| {
-        MatrixError::bad_json("Policy Server signing request must be a JSON object")
-    })?;
-
+/// Signs the event the same way a receiver verifies it: over the redacted PDU, with
+/// `signatures` and `unsigned` removed.
+///
+/// Signing the unredacted event instead produces a signature that every implementation --
+/// including palpo's own `verify_policy_server_signature` -- rejects for any event whose
+/// content the redaction algorithm strips.
+fn sign_policy_event(
+    mut object: CanonicalJsonObject,
+    rules: &RoomVersionRules,
+) -> AppResult<String> {
     if object.get("type").and_then(|value| value.as_str()) == Some("m.room.policy")
         && object.get("state_key").and_then(|value| value.as_str()) == Some("")
     {
@@ -51,10 +75,17 @@ fn sign_policy_event(pdu: &serde_json::value::RawValue) -> AppResult<String> {
         .into());
     }
 
-    object.remove("signatures");
-    object.remove("unsigned");
+    // `event_id` is only part of the PDU in room version 1; senders that keep a copy of it
+    // alongside the event must not have it counted towards the signature in later versions.
+    if rules.event_id_format != EventIdFormatVersion::V1 {
+        object.remove("event_id");
+    }
 
-    let canonical_json = serde_json::to_string(&object)?;
+    let redacted = canonical_json::redact(object, &rules.redaction, None)
+        .map_err(|e| MatrixError::bad_json(format!("event could not be redacted: {e}")))?;
+    let canonical_json = to_canonical_json_string_for_signing(&redacted)
+        .map_err(|e| MatrixError::bad_json(format!("event is not canonical JSON: {e}")))?;
+
     Ok(config::keypair().sign(canonical_json.as_bytes()).base64())
 }
 
@@ -63,17 +94,22 @@ mod tests {
     use serde_json::json;
 
     use super::sign_policy_event;
-    use crate::core::serde::to_raw_json_value;
+    use crate::core::room_version_rules::RoomVersionRules;
+    use crate::core::serde::CanonicalJsonObject;
+
+    fn object(value: serde_json::Value) -> CanonicalJsonObject {
+        serde_json::from_value(value).unwrap()
+    }
 
     #[test]
     fn policy_config_event_is_rejected() {
-        let pdu = to_raw_json_value(&json!({
+        let pdu = object(json!({
             "type": "m.room.policy",
             "state_key": "",
+            "room_id": "!room:example.org",
             "content": {}
-        }))
-        .unwrap();
+        }));
 
-        assert!(sign_policy_event(&pdu).is_err());
+        assert!(sign_policy_event(pdu, &RoomVersionRules::V11).is_err());
     }
 }


### PR DESCRIPTION
Closes #320.

Palpo already modelled `m.room.policy`, advertised a Policy Server, and exposed the signing endpoint, but room events were not consistently checked for a valid Policy Server signature. This PR completes that enforcement and closes the local, federation, invite, and recovery-path bypasses found during review.

## Policy configuration and signatures

- Loads the empty-state-key `m.room.policy` event and requires an `ed25519` public key whose `via` server is joined to the room.
- Supports policies hosted by this Palpo instance by signing locally; remote policies use `POST /_matrix/policy/v1/sign` with a 30-second timeout.
- Verifies signatures over the room-version-redacted event and preserves supplementary signatures without changing the event ID.
- Treats configuration/database failures as enforcement failures instead of silently failing open.
- Exempts the policy configuration event itself so a broken policy can always be replaced or removed.

## Enforcement boundaries

- Local timeline sends and local invite/join/leave/knock membership events fail with `M_FORBIDDEN` when refused.
- Incoming federation events are checked only after normal room authorization, then retained as rejected outliers when refused; they cannot enter the timeline, appear in `/sync`, become predecessors, or be revived by DAG recovery/backfill.
- Federation invite senders include the policy state and signature.
- Federation invite receivers authenticate the sender event, validate trusted/full invite state where required, enforce the advertised policy, add only supplementary signatures, and persist only the accepted invite.

Invite-state handling remains compatible with stripped or partial state in room versions 1–11. Room version 12 enforces the full signed invite-state format and mandatory create event introduced by MSC4311.

## Signing endpoint

`POST /_matrix/policy/v1/sign` now redacts before canonicalising, omits `event_id` for room versions whose wire PDUs do not carry it, and returns `404 M_NOT_FOUND` for rooms this server does not serve.

## Verification

- Full Rust workspace test suite with all targets and features.
- Strict workspace clippy with warnings denied and nightly rustfmt check.
- Unit coverage for redacted signing, event-ID formats, policy refusal persistence, and the room-version 12 invite-state boundary.
- Complement federation coverage for full invite flows (including an already-participating receiver), room-version compatibility, device-list federation, and historical-message/backfill paths.