### PR TITLE
Answer federation media downloads with multipart/mixed

### DIFF
--- a/crates/core/src/federation/media.rs
+++ b/crates/core/src/federation/media.rs
@@ -95,95 +95,95 @@ pub struct ThumbnailResBody {
 }
 
 impl Scribe for ThumbnailResBody {
-    /// Serialize the given metadata and content into a `http::Response`
-    /// `multipart/mixed` body.
-    ///
-    /// Returns a tuple containing the boundary used
     fn render(self, res: &mut Response) {
-        use rand::RngExt as _;
+        render_multipart_mixed(&self.metadata, self.content, res);
+    }
+}
 
-        let mut rng = rand::rng();
-        let boundary = (&mut rng)
-            .sample_iter(rand::distr::Alphanumeric)
-            .map(char::from)
-            .take(GENERATED_BOUNDARY_LENGTH)
-            .collect::<String>();
+/// Serialize the given metadata and content into a `multipart/mixed` response
+/// body, as the authenticated media endpoints answer with.
+fn render_multipart_mixed(metadata: &ContentMetadata, content: FileOrLocation, res: &mut Response) {
+    use rand::RngExt as _;
 
-        let mut body_writer = BytesMut::new();
+    let mut rng = rand::rng();
+    let boundary = (&mut rng)
+        .sample_iter(rand::distr::Alphanumeric)
+        .map(char::from)
+        .take(GENERATED_BOUNDARY_LENGTH)
+        .collect::<String>();
 
-        // Add first boundary separator and header for the metadata.
-        let _ = write!(
-            body_writer,
-            "\r\n--{boundary}\r\n{}: {}\r\n\r\n",
-            http::header::CONTENT_TYPE,
-            mime::APPLICATION_JSON
-        );
+    let mut body_writer = BytesMut::new();
 
-        // Add serialized metadata.
-        match serde_json::to_vec(&self.metadata) {
-            Ok(bytes) => {
-                body_writer.extend_from_slice(&bytes);
-            }
-            Err(e) => {
-                error!("Failed to serialize metadata: {}", e);
-                res.render(
-                    StatusError::internal_server_error().brief("Failed to serialize metadata"),
-                );
-                return;
-            }
+    // Add first boundary separator and header for the metadata.
+    let _ = write!(
+        body_writer,
+        "\r\n--{boundary}\r\n{}: {}\r\n\r\n",
+        http::header::CONTENT_TYPE,
+        mime::APPLICATION_JSON
+    );
+
+    // Add serialized metadata.
+    match serde_json::to_vec(metadata) {
+        Ok(bytes) => {
+            body_writer.extend_from_slice(&bytes);
         }
+        Err(e) => {
+            error!("Failed to serialize metadata: {}", e);
+            res.render(StatusError::internal_server_error().brief("Failed to serialize metadata"));
+            return;
+        }
+    }
 
-        // Add second boundary separator.
-        let _ = write!(body_writer, "\r\n--{boundary}\r\n");
+    // Add second boundary separator.
+    let _ = write!(body_writer, "\r\n--{boundary}\r\n");
 
-        // Add content.
-        match self.content {
-            FileOrLocation::File(content) => {
-                // Add headers.
-                let content_type = content
-                    .content_type
-                    .as_deref()
-                    .unwrap_or(mime::APPLICATION_OCTET_STREAM.as_ref());
+    // Add content.
+    match content {
+        FileOrLocation::File(content) => {
+            // Add headers.
+            let content_type = content
+                .content_type
+                .as_deref()
+                .unwrap_or(mime::APPLICATION_OCTET_STREAM.as_ref());
+            let _ = write!(
+                body_writer,
+                "{}: {content_type}\r\n",
+                http::header::CONTENT_TYPE
+            );
+
+            if let Some(content_disposition) = &content.content_disposition {
                 let _ = write!(
                     body_writer,
-                    "{}: {content_type}\r\n",
-                    http::header::CONTENT_TYPE
-                );
-
-                if let Some(content_disposition) = &content.content_disposition {
-                    let _ = write!(
-                        body_writer,
-                        "{}: {content_disposition}\r\n",
-                        http::header::CONTENT_DISPOSITION
-                    );
-                }
-
-                // Add empty line separator after headers.
-                body_writer.extend_from_slice(b"\r\n");
-
-                // Add bytes.
-                body_writer.extend_from_slice(&content.file);
-            }
-            FileOrLocation::Location(location) => {
-                // Only add location header and empty line separator.
-                let _ = write!(
-                    body_writer,
-                    "{}: {location}\r\n\r\n",
-                    http::header::LOCATION
+                    "{}: {content_disposition}\r\n",
+                    http::header::CONTENT_DISPOSITION
                 );
             }
+
+            // Add empty line separator after headers.
+            body_writer.extend_from_slice(b"\r\n");
+
+            // Add bytes.
+            body_writer.extend_from_slice(&content.file);
         }
-
-        // Add final boundary.
-        let _ = write!(body_writer, "\r\n--{boundary}--");
-
-        let content_type = format!("{MULTIPART_MIXED}; boundary={boundary}");
-
-        let _ = res.add_header(http::header::CONTENT_TYPE, content_type, true);
-        if let Err(e) = res.write_body(body_writer) {
-            res.render(StatusError::internal_server_error().brief("Failed to set response body"));
-            error!("Failed to set response body: {}", e);
+        FileOrLocation::Location(location) => {
+            // Only add location header and empty line separator.
+            let _ = write!(
+                body_writer,
+                "{}: {location}\r\n\r\n",
+                http::header::LOCATION
+            );
         }
+    }
+
+    // Add final boundary.
+    let _ = write!(body_writer, "\r\n--{boundary}--");
+
+    let content_type = format!("{MULTIPART_MIXED}; boundary={boundary}");
+
+    let _ = res.add_header(http::header::CONTENT_TYPE, content_type, true);
+    if let Err(e) = res.write_body(body_writer) {
+        res.render(StatusError::internal_server_error().brief("Failed to set response body"));
+        error!("Failed to set response body: {}", e);
     }
 }
 
@@ -238,6 +238,12 @@ pub struct ContentResBody {
 
     /// The content of the media.
     pub content: FileOrLocation,
+}
+
+impl Scribe for ContentResBody {
+    fn render(self, res: &mut Response) {
+        render_multipart_mixed(&self.metadata, self.content, res);
+    }
 }
 
 /// A file from the content repository or the location where it can be found.

--- a/crates/server/src/routing/federation/media.rs
+++ b/crates/server/src/routing/federation/media.rs
@@ -45,18 +45,31 @@ pub async fn get_content(
                     .as_ref()
                     .map(|name| mime_infer::from_path(name).first_or_octet_stream())
                     .unwrap_or(mime::APPLICATION_OCTET_STREAM)
-            });
+            })
+            .to_string();
 
         let key = media_storage_key(server_name, &args.media_id);
         if storage::exists(&key).await? {
             // Try presigned URL redirect for S3 storage
             if let Some(url) = storage::presign_read(&key).await? {
-                res.render(salvo::prelude::Redirect::found(url));
+                res.render(ContentResBody {
+                    content: FileOrLocation::Location(url),
+                    metadata: ContentMetadata::new(),
+                });
                 return Ok(());
             }
-            let data = storage::read(&key).await?;
-            res.add_header("Content-Type", content_type.to_string(), true)?;
-            res.body = salvo::http::ResBody::Once(data.into());
+            let file = storage::read(&key).await?;
+            let content_disposition =
+                make_content_disposition(None, Some(&content_type), metadata.file_name.as_deref());
+
+            res.render(ContentResBody {
+                content: FileOrLocation::File(Content {
+                    file,
+                    content_type: Some(content_type),
+                    content_disposition: Some(content_disposition),
+                }),
+                metadata: ContentMetadata::new(),
+            });
             Ok(())
         } else {
             Err(MatrixError::not_yet_uploaded("Media has not been uploaded yet").into())


### PR DESCRIPTION
**Merge after #370.** See the compatibility note at the bottom.

`GET /_matrix/federation/v1/media/download/{mediaId}` must answer with a `multipart/mixed` body — a JSON metadata part followed by the file — as [the spec](https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1mediadownloadmediaid) describes and as our own thumbnail endpoint already does.

We answer with the bare file bytes instead, or with a `302` to a presigned URL when media is stored in S3. A server that parses the response the way the spec describes gets neither, so **media hosted on a palpo server does not render on other homeservers.**

This is the other half of the bug #348 fixed: that PR taught us to *read* multipart responses from other servers; this one makes us *write* them. It went unnoticed between palpo servers because both sides speak the same non-compliant dialect, and because the legacy unauthenticated `/_matrix/media/v3/download` endpoint — which palpo tries first — does serve the bare file.

## What this does

- `ContentResBody` gets the `Scribe` impl it was missing, sharing the writer with `ThumbnailResBody` instead of duplicating ~80 lines of multipart assembly.
- The federation download endpoint renders it, with a `Content-Disposition` built by `make_content_disposition` (same as the thumbnail path).
- A presigned S3 URL is handed out as the `Location` part the spec defines for exactly this case, rather than a `302`.

## Compatibility

The file case is safe on its own: the parser on `main` reads what this renders.

The `Location` case is not, which is why this wants #370 first. A palpo peer running the `main` parser turns a `Location` part into an empty `200`; #370 makes it a clear error, and lets the thumbnail path fall back to the legacy endpoint. This only matters for deployments using S3 storage — with local storage no `Location` part is ever produced.

## Testing

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean
- #370 carries a round-trip test over the shared writer this now reuses, so what we render here is covered by what we parse there.