### PR TITLE
Fix device logout and MSC4133 profile-field routes

### DIFF
--- a/crates/server/src/routing/client.rs
+++ b/crates/server/src/routing/client.rs
@@ -228,6 +228,7 @@ fn supported_versions_body() -> VersionsResBody {
             ("org.matrix.msc3916.stable".to_owned(), true), /* authenticated media (https://github.com/matrix-org/matrix-spec-proposals/pull/3916) */
             ("org.matrix.msc4180".to_owned(), true), /* stable flag for 3916 (https://github.com/matrix-org/matrix-spec-proposals/pull/4180) */
             ("uk.tcpip.msc4133".to_owned(), true), /* Extending User Profile API with Key:Value Pairs (https://github.com/matrix-org/matrix-spec-proposals/pull/4133) */
+            ("uk.tcpip.msc4133.stable".to_owned(), true), /* the profile-field endpoints are served on the stable `/v3` prefix too */
             ("us.cloke.msc4175".to_owned(), true), /* Profile field for user time zone (https://github.com/matrix-org/matrix-spec-proposals/pull/4175) */
             ("org.matrix.simplified_msc3575".to_owned(), true), /* Simplified Sliding sync (https://github.com/matrix-org/matrix-spec-proposals/pull/4186) */
             ("uk.timedout.msc4323".to_owned(), true),           // Account suspension and locking.
@@ -261,6 +262,17 @@ mod supported_versions_tests {
     }
 
     #[test]
+    fn advertises_msc4133_profile_fields_on_the_stable_prefix() {
+        let body = supported_versions_body();
+
+        assert_eq!(body.unstable_features.get("uk.tcpip.msc4133"), Some(&true));
+        assert_eq!(
+            body.unstable_features.get("uk.tcpip.msc4133.stable"),
+            Some(&true)
+        );
+    }
+
+    #[test]
     fn includes_msc4383_server_metadata_and_feature_flag() {
         let body = supported_versions_body();
         let server = body.server.as_ref().unwrap();
@@ -272,6 +284,55 @@ mod supported_versions_tests {
             to_json_value(server).unwrap(),
             json!({ "name": "Palpo", "version": server.version })
         );
+    }
+}
+
+#[cfg(test)]
+mod router_tests {
+    use salvo::http::{Method, Request};
+    use salvo::routing::PathState;
+
+    use super::router;
+
+    /// Resolve `path` against the client router without running any handler.
+    async fn is_routed(method: Method, path: &str) -> bool {
+        let router = router();
+        let mut req = Request::default();
+        *req.method_mut() = method;
+        let mut path_state = PathState::from_owned_path(path.to_owned());
+        router.detect(&mut req, &mut path_state).await.is_some()
+    }
+
+    #[tokio::test]
+    async fn delete_devices_is_a_sibling_of_devices() {
+        for version in ["v3", "r0"] {
+            assert!(is_routed(Method::POST, &format!("/client/{version}/delete_devices")).await);
+        }
+        assert!(!is_routed(Method::POST, "/client/v3/devices/delete_devices").await);
+    }
+
+    #[tokio::test]
+    async fn devices_endpoints_are_still_routed() {
+        assert!(is_routed(Method::GET, "/client/v3/devices").await);
+        assert!(is_routed(Method::GET, "/client/v3/devices/ABCDEF").await);
+        assert!(is_routed(Method::PUT, "/client/v3/devices/ABCDEF").await);
+        assert!(is_routed(Method::DELETE, "/client/v3/devices/ABCDEF").await);
+    }
+
+    #[tokio::test]
+    async fn msc4133_profile_fields_are_served_on_the_unstable_prefix() {
+        const FIELD: &str = "/client/unstable/uk.tcpip.msc4133/profile/@alice:example.org/chat.commet.profile_banner";
+
+        assert!(
+            is_routed(
+                Method::GET,
+                "/client/unstable/uk.tcpip.msc4133/profile/@alice:example.org"
+            )
+            .await
+        );
+        assert!(is_routed(Method::GET, FIELD).await);
+        assert!(is_routed(Method::PUT, FIELD).await);
+        assert!(is_routed(Method::DELETE, FIELD).await);
     }
 }
 

--- a/crates/server/src/routing/client.rs
+++ b/crates/server/src/routing/client.rs
@@ -228,7 +228,9 @@ fn supported_versions_body() -> VersionsResBody {
             ("org.matrix.msc3916.stable".to_owned(), true), /* authenticated media (https://github.com/matrix-org/matrix-spec-proposals/pull/3916) */
             ("org.matrix.msc4180".to_owned(), true), /* stable flag for 3916 (https://github.com/matrix-org/matrix-spec-proposals/pull/4180) */
             ("uk.tcpip.msc4133".to_owned(), true), /* Extending User Profile API with Key:Value Pairs (https://github.com/matrix-org/matrix-spec-proposals/pull/4133) */
-            ("uk.tcpip.msc4133.stable".to_owned(), true), /* the profile-field endpoints are served on the stable `/v3` prefix too */
+            ("uk.tcpip.msc4133.stable".to_owned(), true), /* the profile-field endpoints are
+                                                    * served on the stable `/v3` prefix
+                                                    * too */
             ("us.cloke.msc4175".to_owned(), true), /* Profile field for user time zone (https://github.com/matrix-org/matrix-spec-proposals/pull/4175) */
             ("org.matrix.simplified_msc3575".to_owned(), true), /* Simplified Sliding sync (https://github.com/matrix-org/matrix-spec-proposals/pull/4186) */
             ("uk.timedout.msc4323".to_owned(), true),           // Account suspension and locking.

--- a/crates/server/src/routing/client/device.rs
+++ b/crates/server/src/routing/client/device.rs
@@ -23,20 +23,24 @@ use crate::{
 };
 
 pub fn authed_router() -> Router {
-    Router::with_path("devices")
-        .get(list_devices)
-        // .push(
-        //     Router::with_hoop(hoops::limit_rate)
-        //         .push(Router::new().post(register).push(Router::with_path("available").get(available)))
-        //         .push(Router::with_path("m.login.registration_token/validity").get(validate_token)),
-        // )
-        .push(Router::with_path("delete_devices").post(delete_devices))
+    Router::new()
         .push(
-            Router::with_path("{device_id}")
-                .get(get_device)
-                .delete(delete_device)
-                .put(update_device),
+            Router::with_path("devices")
+                .get(list_devices)
+                // .push(
+                //     Router::with_hoop(hoops::limit_rate)
+                //         .push(Router::new().post(register).push(Router::with_path("available").get(available)))
+                //         .push(Router::with_path("m.login.registration_token/validity").get(validate_token)),
+                // )
+                .push(
+                    Router::with_path("{device_id}")
+                        .get(get_device)
+                        .delete(delete_device)
+                        .put(update_device),
+                ),
         )
+        // `/delete_devices` is a sibling of `/devices`, not a child of it.
+        .push(Router::with_path("delete_devices").post(delete_devices))
 }
 
 /// #GET /_matrix/client/r0/devices/{device_id}
@@ -207,8 +211,8 @@ async fn delete_device(
     empty_ok()
 }
 
-/// #DELETE /_matrix/client/r0/devices/{deviceId}
-/// Deletes the given device.
+/// #POST /_matrix/client/r0/delete_devices
+/// Deletes the given list of devices.
 ///
 /// - Requires UIAA to verify user password
 ///

--- a/crates/server/src/routing/client/profile.rs
+++ b/crates/server/src/routing/client/profile.rs
@@ -48,6 +48,28 @@ pub fn authed_router() -> Router {
         )
 }
 
+/// MSC4133 unstable-prefixed profile reads.
+///
+/// Clients built on matrix-js-sdk only use the stable `/v3` profile-field
+/// endpoints once the server advertises `uk.tcpip.msc4133.stable`; otherwise
+/// they fall back to `/_matrix/client/unstable/uk.tcpip.msc4133/profile/...`.
+/// Serving both keeps older clients working.
+pub(super) fn msc4133_public_router() -> Router {
+    Router::with_path("uk.tcpip.msc4133/profile/{user_id}")
+        .get(get_profile)
+        .push(Router::with_path("{field}").get(get_profile_field))
+}
+
+/// MSC4133 unstable-prefixed profile writes.
+///
+/// Pushed into an already authenticated and rate-limited router, so no hoops
+/// are attached here.
+pub(super) fn msc4133_authed_router() -> Router {
+    Router::with_path("uk.tcpip.msc4133/profile/{user_id}/{field}")
+        .put(set_profile_field)
+        .delete(delete_profile_field)
+}
+
 #[derive(ToSchema, Serialize, Deserialize, Debug, Default)]
 struct ProfileFieldBody {
     #[serde(flatten)]

--- a/crates/server/src/routing/client/unstable.rs
+++ b/crates/server/src/routing/client/unstable.rs
@@ -14,6 +14,7 @@ pub(super) fn router() -> Router {
             Router::with_path("org.matrix.msc2965/auth_metadata").get(auth_metadata),
         )
         .push(Router::with_path("io.element.msc4388/rendezvous").get(discover_rendezvous))
+        .push(super::profile::msc4133_public_router())
         // Authed routes
         .push(
             Router::new()
@@ -58,7 +59,8 @@ pub(super) fn router() -> Router {
                     Router::with_path("uk.timedout.msc4323/admin/suspend/{user_id}")
                         .get(super::admin::is_user_suspended)
                         .put(super::admin::suspend_user),
-                ),
+                )
+                .push(super::profile::msc4133_authed_router()),
         )
 }
 


### PR DESCRIPTION
Fixes both problems reported in #387. They have the same root cause: neither
endpoint was registered, and the root static-file catch-all (`{*path}`, GET
only) matches any otherwise-unrouted path, so the request came back as
`405 M_UNRECOGNIZED` instead of a plain 404.

### 1. Logging other devices out — `POST /_matrix/client/v3/delete_devices`

The route was pushed as a *child* of the `devices` router, so it was actually
served at `/_matrix/client/v3/devices/delete_devices`. The spec path was
unrouted, which is exactly the failure in the screenshot:

```
MatrixError: [405] method not allowed
(https://matrix.example.com/_matrix/client/v3/delete_devices)
```

`delete_devices` is now a sibling of `devices`.

### 2. Setting a profile banner — MSC4133 extended profile fields

Sable/Cinny set the banner with `setExtendedProfileProperty('chat.commet.profile_banner', mxc)`.
matrix-js-sdk picks the request prefix like this:

```ts
if (isVersionSupported("v1.16") || doesServerSupportUnstableFeature("uk.tcpip.msc4133.stable"))
    return ClientPrefix.V3;
return "/_matrix/client/unstable/uk.tcpip.msc4133";
```

Palpo implements the profile-field endpoints on `/v3` and advertises
`uk.tcpip.msc4133`, but not `uk.tcpip.msc4133.stable`, and `/versions` tops out
at `v1.12` — so the SDK addressed the unstable prefix, which no router covered.

This PR:

- serves `GET/PUT/DELETE /_matrix/client/unstable/uk.tcpip.msc4133/profile/{userId}[/{field}]`
  (reads public, writes behind the existing auth + rate-limit hoops), and
- advertises `uk.tcpip.msc4133.stable` so up-to-date clients prefer `/v3`.

### Tests

Added router-resolution tests that check the paths without executing handlers,
plus a `/versions` assertion for the new flag. `cargo test -p palpo --bin palpo`
passes (110 tests); clippy and fmt are clean.

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)
