### PR TITLE
Fix access-token parsing on mixed-auth routes

### DIFF
--- a/crates/server/src/auth.rs
+++ b/crates/server/src/auth.rs
@@ -52,9 +52,32 @@ pub struct AuthArgs {
 }
 
 impl AuthArgs {
+    /// Whether this request should be authenticated as an access-token request.
+    ///
+    /// An Authorization header takes precedence over the deprecated query-string
+    /// form. HTTP authentication schemes are case-insensitive.
+    pub fn uses_access_token(&self) -> bool {
+        self.authorization.as_deref().map_or_else(
+            || self.access_token.is_some(),
+            |authorization| {
+                authorization
+                    .split_once(' ')
+                    .map_or(authorization, |(scheme, _)| scheme)
+                    .eq_ignore_ascii_case("Bearer")
+            },
+        )
+    }
+
     pub fn require_access_token(&self) -> Result<&str, MatrixError> {
-        if let Some(bearer) = &self.authorization {
-            if let Some(token) = bearer.strip_prefix("Bearer ") {
+        if let Some(authorization) = &self.authorization {
+            let Some((scheme, token)) = authorization.split_once(' ') else {
+                return Err(MatrixError::missing_token("Invalid Bearer token."));
+            };
+            let token = token.trim_start_matches(' ');
+            if scheme.eq_ignore_ascii_case("Bearer")
+                && !token.is_empty()
+                && !token.chars().any(char::is_whitespace)
+            {
                 Ok(token)
             } else {
                 Err(MatrixError::missing_token("Invalid Bearer token."))
@@ -64,5 +87,65 @@ impl AuthArgs {
         } else {
             Err(MatrixError::missing_token("Token not found."))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AuthArgs;
+
+    fn auth_args(authorization: Option<&str>, access_token: Option<&str>) -> AuthArgs {
+        AuthArgs {
+            user_id: None,
+            device_id: None,
+            access_token: access_token.map(ToOwned::to_owned),
+            authorization: authorization.map(ToOwned::to_owned),
+            from_appservice: false,
+        }
+    }
+
+    #[test]
+    fn bearer_scheme_is_case_insensitive() {
+        for scheme in ["Bearer", "bearer", "BEARER", "BeArEr"] {
+            let args = auth_args(Some(&format!("{scheme} token")), None);
+            assert!(args.uses_access_token());
+            assert_eq!(args.require_access_token().unwrap(), "token");
+        }
+    }
+
+    #[test]
+    fn bearer_accepts_multiple_spaces_before_the_token() {
+        let args = auth_args(Some("Bearer   token"), None);
+        assert!(args.uses_access_token());
+        assert_eq!(args.require_access_token().unwrap(), "token");
+    }
+
+    #[test]
+    fn malformed_bearer_credentials_are_rejected() {
+        for authorization in ["Bearer", "Bearer ", "Bearer token suffix", "Bearer\ttoken"] {
+            let args = auth_args(Some(authorization), None);
+            assert!(args.require_access_token().is_err(), "{authorization}");
+        }
+    }
+
+    #[test]
+    fn query_token_is_used_when_authorization_is_absent() {
+        let args = auth_args(None, Some("query-token"));
+        assert!(args.uses_access_token());
+        assert_eq!(args.require_access_token().unwrap(), "query-token");
+    }
+
+    #[test]
+    fn bearer_header_takes_precedence_over_query_token() {
+        let args = auth_args(Some("Bearer header-token"), Some("query-token"));
+        assert!(args.uses_access_token());
+        assert_eq!(args.require_access_token().unwrap(), "header-token");
+    }
+
+    #[test]
+    fn non_bearer_authorization_takes_precedence_over_query_token() {
+        let args = auth_args(Some("X-Matrix origin=example.org"), Some("query-token"));
+        assert!(!args.uses_access_token());
+        assert!(args.require_access_token().is_err());
     }
 }

--- a/crates/server/src/hoops/auth.rs
+++ b/crates/server/src/hoops/auth.rs
@@ -27,12 +27,10 @@ pub async fn auth_by_access_token_or_signatures(
     req: &mut Request,
     depot: &mut Depot,
 ) -> AppResult<()> {
-    if let Some(authorization) = &aa.authorization {
-        if authorization.starts_with("Bearer ") {
-            auth_by_access_token_inner(aa, depot).await
-        } else {
-            auth_by_signatures_inner(req, depot).await
-        }
+    if aa.uses_access_token() {
+        auth_by_access_token_inner(aa, depot).await
+    } else if aa.authorization.is_some() {
+        auth_by_signatures_inner(req, depot).await
     } else {
         Err(MatrixError::missing_token("missing token").into())
     }

--- a/crates/server/src/routing/client/session.rs
+++ b/crates/server/src/routing/client/session.rs
@@ -632,7 +632,7 @@ async fn get_access_token(
 /// - Triggers device list updates
 /// - With delegated auth: revokes the OAuth2 token at the auth provider
 #[endpoint]
-async fn logout(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) -> EmptyResult {
+async fn logout(aa: AuthArgs, depot: &mut Depot) -> EmptyResult {
     let Ok(authed) = depot.authed_info() else {
         return empty_ok();
     };
@@ -641,11 +641,7 @@ async fn logout(_aa: AuthArgs, req: &mut Request, depot: &mut Depot) -> EmptyRes
     // sessions are revoked only from Palpo's local device tables below.
     if authed.is_delegated_auth()
         && let Some(da) = config::get().enabled_delegated_auth()
-        && let Some(token) = req
-            .headers()
-            .get("authorization")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.strip_prefix("Bearer "))
+        && let Ok(token) = aa.require_access_token()
         && let Err(e) = revoke_delegated_token(da, token).await
     {
         tracing::warn!("Failed to revoke delegated auth token: {e}");


### PR DESCRIPTION
## What changed

- accept the deprecated `access_token` query parameter on routes that support either client access-token auth or federation signatures
- match the HTTP `Bearer` authentication scheme case-insensitively and accept the RFC-defined run of spaces before credentials
- keep Authorization-header precedence over query credentials and reject malformed Bearer credentials
- use the same token parser when revoking delegated-auth tokens during logout

## Root cause

The mixed authentication hoop selected access-token authentication only when an Authorization header started with the exact string `Bearer `. A query-only access token was rejected before the normal token parser ran, and differently-cased Bearer schemes were misclassified as federation signatures. Delegated logout separately repeated the same case-sensitive parsing.

## Impact

Authenticated media downloads now support both access-token transport methods required by the Matrix client-server API, while federation `X-Matrix` requests keep their existing path. Delegated logout also revokes the same token that was authenticated.

## Validation

- `cargo test -p palpo auth::tests` — 6 passed
- `cargo test -p palpo` — 131 passed
- `cargo clippy -p palpo --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`