### PR TITLE
Make local room event appends cluster-safe

### DIFF
--- a/crates/data/src/config.rs
+++ b/crates/data/src/config.rs
@@ -36,6 +36,9 @@ pub struct DbConfig {
     /// some configurations.
     /// An optional follower database. Always read-only.
     pub url: String,
+    /// Maximum number of long-lived PostgreSQL connections used by this process.
+    /// The server divides this budget between ordinary queries and operations which
+    /// hold database-backed coordination locks. Must be at least 2.
     #[serde(default = "default_db_pool_size")]
     pub pool_size: u32,
 

--- a/crates/data/src/config.rs
+++ b/crates/data/src/config.rs
@@ -42,6 +42,12 @@ pub struct DbConfig {
     #[serde(default = "default_db_pool_size")]
     pub pool_size: u32,
 
+    /// Connections carved out of `pool_size` for operations which hold a database-backed
+    /// coordination lock while ordinary queries continue on the remaining connections.
+    /// Leave unset to derive it from `pool_size`.
+    #[serde(default)]
+    pub coordination_pool_size: Option<u32>,
+
     /// Number of seconds to wait for unacknowledged TCP packets before treating the connection as
     /// broken. This value will determine how long crates.io stays unavailable in case of full
     /// packet loss between the application and the database: setting it too high will result in an

--- a/crates/data/src/lib.rs
+++ b/crates/data/src/lib.rs
@@ -39,11 +39,23 @@ pub static REPLICA_POOL: OnceLock<Option<DieselPool>> = OnceLock::new();
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
-pub fn init(config: &DbConfig) {
-    let (query_pool_size, coordination_pool_size) = split_pool_size(config.pool_size);
+/// Largest automatically derived coordination pool.
+///
+/// Coordination connections sit idle inside a transaction while the work they fence runs
+/// on the query pool, so a deployment rarely benefits from more of them than this. An
+/// operator who needs a higher ceiling sets `db.coordination_pool_size` explicitly.
+const MAX_DERIVED_COORDINATION_POOL_SIZE: usize = 16;
 
-    // Migrations use a one-off synchronous connection. Run them before creating the
-    // long-lived pools so startup does not temporarily exceed the configured budget.
+pub fn init(config: &DbConfig) {
+    assert!(
+        config.pool_size >= 2,
+        "db.pool_size must be at least 2 so database-backed coordination cannot starve query work"
+    );
+    let (query_pool_size, coordination_pool_size) = split_pool_size(config);
+
+    // Migrations run on a one-off synchronous connection, and the pools below only open
+    // connections on demand. Migrating first still keeps startup single-connection, which
+    // matters when `db.pool_size` is already sized against `max_connections`.
     migrate(config);
 
     let pool = DieselPool::new(&config.url, config, query_pool_size, "queries")
@@ -57,20 +69,29 @@ pub fn init(config: &DbConfig) {
         .expect("diesel coordination pool should be set");
 }
 
-fn split_pool_size(total: u32) -> (usize, usize) {
-    let coordination = coordination_pool_capacity(total);
-    (total as usize - coordination, coordination)
+fn split_pool_size(config: &DbConfig) -> (usize, usize) {
+    let coordination = coordination_pool_capacity(config.pool_size, config.coordination_pool_size);
+    (
+        (config.pool_size as usize).max(2) - coordination,
+        coordination,
+    )
 }
 
 /// Number of connections reserved for database-backed coordination inside the
 /// configured total pool budget.
-pub fn coordination_pool_capacity(total: u32) -> usize {
-    assert!(
-        total >= 2,
-        "db.pool_size must be at least 2 so database-backed coordination cannot deadlock query work"
-    );
-    let total = total as usize;
-    (total / 2).clamp(1, 8)
+///
+/// `configured` is the operator's explicit `db.coordination_pool_size`. When it is unset
+/// the capacity is derived from the total budget; either way the result is at least 1 and
+/// always leaves at least one connection for ordinary queries, so this never panics on a
+/// hostile configuration. `ServerConfig::check` rejects the invalid combinations up front
+/// with a message an operator can act on.
+pub fn coordination_pool_capacity(total: u32, configured: Option<u32>) -> usize {
+    // A single connection cannot serve both roles; `init` and the server config check
+    // both refuse to start in that case, so only keep this arm self-consistent.
+    let total = (total as usize).max(2);
+    let derived = (total / 4).clamp(1, MAX_DERIVED_COORDINATION_POOL_SIZE);
+    let wanted = configured.map_or(derived, |configured| configured as usize);
+    wanted.clamp(1, total - 1)
 }
 
 /// Run pending migrations using a one-off synchronous connection.
@@ -119,8 +140,18 @@ pub async fn coordination_connect() -> Result<PgPooledConnection, PoolError> {
         }
     }
 }
+/// Status of the query pool. The coordination pool is reported separately by
+/// [`coordination_status`].
 pub fn status() -> deadpool::managed::Status {
     DIESEL_POOL.get().expect("diesel pool should set").status()
+}
+
+/// Status of the pool backing [`coordination_connect`].
+pub fn coordination_status() -> deadpool::managed::Status {
+    COORDINATION_POOL
+        .get()
+        .expect("diesel coordination pool should set")
+        .status()
 }
 
 pub fn connection_url(config: &DbConfig, url: &str) -> String {
@@ -169,33 +200,72 @@ mod migration_tests {
     use diesel::pg::Pg;
     use diesel_migrations::EmbeddedMigrations;
 
-    use super::{MIGRATIONS, coordination_pool_capacity, split_pool_size};
+    use super::{
+        DbConfig, MAX_DERIVED_COORDINATION_POOL_SIZE, MIGRATIONS, coordination_pool_capacity,
+        split_pool_size,
+    };
 
-    #[test]
-    fn coordination_pool_stays_inside_the_configured_budget() {
-        for total in 2..=64 {
-            let (queries, coordination) = split_pool_size(total);
-            assert!(queries > 0);
-            assert!(coordination > 0);
-            assert_eq!(queries + coordination, total as usize);
-            assert!(coordination <= 8);
-            assert_eq!(coordination, coordination_pool_capacity(total));
+    fn db_config(pool_size: u32, coordination_pool_size: Option<u32>) -> DbConfig {
+        DbConfig {
+            url: String::new(),
+            pool_size,
+            coordination_pool_size,
+            tcp_timeout: 0,
+            connection_timeout: 0,
+            statement_timeout: 0,
+            enforce_tls: false,
         }
     }
 
     #[test]
-    fn coordination_capacity_matches_the_pool_split_policy() {
-        assert_eq!(split_pool_size(2), (1, 1));
-        assert_eq!(split_pool_size(3), (2, 1));
-        assert_eq!(split_pool_size(4), (2, 2));
-        assert_eq!(split_pool_size(5), (3, 2));
-        assert_eq!(split_pool_size(20), (12, 8));
+    fn coordination_pool_stays_inside_the_configured_budget() {
+        for total in 2..=256 {
+            for configured in [None, Some(0), Some(1), Some(4), Some(total), Some(u32::MAX)] {
+                let (queries, coordination) = split_pool_size(&db_config(total, configured));
+                assert!(queries > 0, "total={total} configured={configured:?}");
+                assert!(coordination > 0, "total={total} configured={configured:?}");
+                assert_eq!(queries + coordination, total as usize);
+                assert_eq!(
+                    coordination,
+                    coordination_pool_capacity(total, configured),
+                    "total={total} configured={configured:?}"
+                );
+            }
+        }
     }
 
     #[test]
-    #[should_panic(expected = "db.pool_size must be at least 2")]
-    fn a_single_connection_cannot_support_database_coordination() {
-        split_pool_size(1);
+    fn derived_coordination_capacity_leaves_most_connections_for_queries() {
+        assert_eq!(split_pool_size(&db_config(2, None)), (1, 1));
+        assert_eq!(split_pool_size(&db_config(4, None)), (3, 1));
+        // The historical default budget keeps 8 of its 10 connections for queries.
+        assert_eq!(split_pool_size(&db_config(10, None)), (8, 2));
+        assert_eq!(split_pool_size(&db_config(20, None)), (15, 5));
+        assert_eq!(split_pool_size(&db_config(64, None)), (48, 16));
+    }
+
+    #[test]
+    fn derived_coordination_capacity_is_capped() {
+        assert_eq!(
+            coordination_pool_capacity(1_000, None),
+            MAX_DERIVED_COORDINATION_POOL_SIZE
+        );
+    }
+
+    #[test]
+    fn an_explicit_coordination_capacity_overrides_the_derived_one() {
+        assert_eq!(split_pool_size(&db_config(20, Some(2))), (18, 2));
+        // An explicit value may exceed the derived cap.
+        assert_eq!(split_pool_size(&db_config(64, Some(32))), (32, 32));
+    }
+
+    #[test]
+    fn an_out_of_range_coordination_capacity_still_leaves_a_usable_split() {
+        // `ServerConfig::check` rejects these before startup; the split must stay
+        // self-consistent for any other caller.
+        assert_eq!(split_pool_size(&db_config(10, Some(0))), (9, 1));
+        assert_eq!(split_pool_size(&db_config(10, Some(10))), (1, 9));
+        assert_eq!(split_pool_size(&db_config(10, Some(u32::MAX))), (1, 9));
     }
 
     fn validate_index_guard(statement: &str) -> Result<Option<bool>, &'static str> {

--- a/crates/data/src/lib.rs
+++ b/crates/data/src/lib.rs
@@ -34,14 +34,43 @@ use crate::core::Seqnum;
 pub type DataResult<T> = Result<T, DataError>;
 
 pub static DIESEL_POOL: OnceLock<DieselPool> = OnceLock::new();
+pub static COORDINATION_POOL: OnceLock<DieselPool> = OnceLock::new();
 pub static REPLICA_POOL: OnceLock<Option<DieselPool>> = OnceLock::new();
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
 pub fn init(config: &DbConfig) {
-    let pool = DieselPool::new(&config.url, config).expect("diesel pool should be created");
-    DIESEL_POOL.set(pool).expect("diesel pool should be set");
+    let (query_pool_size, coordination_pool_size) = split_pool_size(config.pool_size);
+
+    // Migrations use a one-off synchronous connection. Run them before creating the
+    // long-lived pools so startup does not temporarily exceed the configured budget.
     migrate(config);
+
+    let pool = DieselPool::new(&config.url, config, query_pool_size, "queries")
+        .expect("diesel query pool should be created");
+    DIESEL_POOL.set(pool).expect("diesel pool should be set");
+    let coordination_pool =
+        DieselPool::new(&config.url, config, coordination_pool_size, "coordination")
+            .expect("diesel coordination pool should be created");
+    COORDINATION_POOL
+        .set(coordination_pool)
+        .expect("diesel coordination pool should be set");
+}
+
+fn split_pool_size(total: u32) -> (usize, usize) {
+    let coordination = coordination_pool_capacity(total);
+    (total as usize - coordination, coordination)
+}
+
+/// Number of connections reserved for database-backed coordination inside the
+/// configured total pool budget.
+pub fn coordination_pool_capacity(total: u32) -> usize {
+    assert!(
+        total >= 2,
+        "db.pool_size must be at least 2 so database-backed coordination cannot deadlock query work"
+    );
+    let total = total as usize;
+    (total / 2).clamp(1, 8)
 }
 
 /// Run pending migrations using a one-off synchronous connection.
@@ -66,6 +95,26 @@ pub async fn connect() -> Result<PgPooledConnection, PoolError> {
         Ok(conn) => Ok(conn),
         Err(e) => {
             tracing::error!("db connect error: {e}");
+            Err(e)
+        }
+    }
+}
+
+/// Get a connection reserved for operations which must hold a database lock while
+/// ordinary queries continue on the primary pool.
+///
+/// Both pools are carved out of `db.pool_size`; using this pool never increases the
+/// configured steady-state connection budget.
+pub async fn coordination_connect() -> Result<PgPooledConnection, PoolError> {
+    match COORDINATION_POOL
+        .get()
+        .expect("diesel coordination pool should set")
+        .get()
+        .await
+    {
+        Ok(conn) => Ok(conn),
+        Err(e) => {
+            tracing::error!("db coordination connect error: {e}");
             Err(e)
         }
     }
@@ -120,7 +169,34 @@ mod migration_tests {
     use diesel::pg::Pg;
     use diesel_migrations::EmbeddedMigrations;
 
-    use super::MIGRATIONS;
+    use super::{MIGRATIONS, coordination_pool_capacity, split_pool_size};
+
+    #[test]
+    fn coordination_pool_stays_inside_the_configured_budget() {
+        for total in 2..=64 {
+            let (queries, coordination) = split_pool_size(total);
+            assert!(queries > 0);
+            assert!(coordination > 0);
+            assert_eq!(queries + coordination, total as usize);
+            assert!(coordination <= 8);
+            assert_eq!(coordination, coordination_pool_capacity(total));
+        }
+    }
+
+    #[test]
+    fn coordination_capacity_matches_the_pool_split_policy() {
+        assert_eq!(split_pool_size(2), (1, 1));
+        assert_eq!(split_pool_size(3), (2, 1));
+        assert_eq!(split_pool_size(4), (2, 2));
+        assert_eq!(split_pool_size(5), (3, 2));
+        assert_eq!(split_pool_size(20), (12, 8));
+    }
+
+    #[test]
+    #[should_panic(expected = "db.pool_size must be at least 2")]
+    fn a_single_connection_cannot_support_database_coordination() {
+        split_pool_size(1);
+    }
 
     fn validate_index_guard(statement: &str) -> Result<Option<bool>, &'static str> {
         let tokens = statement

--- a/crates/data/src/pool.rs
+++ b/crates/data/src/pool.rs
@@ -28,7 +28,12 @@ impl std::fmt::Debug for DieselPool {
 }
 
 impl DieselPool {
-    pub(crate) fn new(url: &str, config: &DbConfig) -> Result<DieselPool, PoolError> {
+    pub(crate) fn new(
+        url: &str,
+        config: &DbConfig,
+        max_size: usize,
+        purpose: &str,
+    ) -> Result<DieselPool, PoolError> {
         let conn_url = connection_url(config, url);
 
         // PostgreSQL `SET` does not support bind parameters, so the value is
@@ -57,7 +62,7 @@ impl DieselPool {
 
         let timeout = Duration::from_millis(config.connection_timeout);
         let inner = Pool::builder(manager)
-            .max_size(config.pool_size as usize)
+            .max_size(max_size)
             .runtime(Runtime::Tokio1)
             .timeouts(Timeouts {
                 wait: Some(timeout),
@@ -66,7 +71,7 @@ impl DieselPool {
             })
             .build()?;
 
-        tracing::info!("Database pool is created");
+        tracing::info!(max_size, purpose, "Database pool is created");
         Ok(DieselPool { inner })
     }
 

--- a/crates/data/src/room.rs
+++ b/crates/data/src/room.rs
@@ -1,5 +1,5 @@
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use serde::Deserialize;
 
 use crate::core::events::StateEventType;
@@ -215,12 +215,19 @@ pub struct DbEventData {
 
 impl DbEventData {
     pub async fn save(&self) -> DataResult<()> {
+        let mut conn = connect().await?;
+        self.save_with_conn(&mut conn).await
+    }
+
+    /// Save event JSON using the caller's connection, allowing publication and
+    /// any feature-specific visibility index to share one transaction.
+    pub async fn save_with_conn(&self, conn: &mut AsyncPgConnection) -> DataResult<()> {
         diesel::insert_into(event_datas::table)
             .values(self)
             .on_conflict(event_datas::event_id)
             .do_update()
             .set(self)
-            .execute(&mut connect().await?)
+            .execute(conn)
             .await?;
         Ok(())
     }
@@ -346,12 +353,19 @@ impl NewDbEvent {
     }
 
     pub async fn save(&self) -> DataResult<()> {
+        let mut conn = connect().await?;
+        self.save_with_conn(&mut conn).await
+    }
+
+    /// Save event metadata using the caller's connection so the event row and its
+    /// JSON representation can be created atomically.
+    pub async fn save_with_conn(&self, conn: &mut AsyncPgConnection) -> DataResult<()> {
         diesel::insert_into(events::table)
             .values(self)
             .on_conflict(events::id)
             .do_update()
             .set(self)
-            .execute(&mut connect().await?)
+            .execute(conn)
             .await?;
         Ok(())
     }

--- a/crates/data/src/room/timeline.rs
+++ b/crates/data/src/room/timeline.rs
@@ -1,12 +1,28 @@
 use diesel::prelude::*;
 use diesel::result::Error as DieselError;
-use diesel_async::{AsyncConnection, RunQueryDsl};
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 
 use crate::core::UnixMillis;
 use crate::core::identifiers::*;
 use crate::room::DbEvent;
 use crate::schema::*;
 use crate::{DataResult, connect};
+
+const ROOM_EVENT_APPEND_LOCK_NAMESPACE: i64 = 7_252_664_853;
+
+/// Serialize locally authored events for one room across all server processes.
+///
+/// The caller must keep the surrounding transaction open until the event has been
+/// built and published. A transaction-scoped lock is released automatically on
+/// success, error, cancellation, or connection loss.
+pub async fn lock_event_append(conn: &mut AsyncPgConnection, room_id: &RoomId) -> DataResult<()> {
+    diesel::sql_query("SELECT pg_advisory_xact_lock(hashtextextended($1, $2))")
+        .bind::<diesel::sql_types::Text, _>(room_id.as_str())
+        .bind::<diesel::sql_types::BigInt, _>(ROOM_EVENT_APPEND_LOCK_NAMESPACE)
+        .execute(conn)
+        .await?;
+    Ok(())
+}
 
 /// Get PDUs by room with pagination
 pub async fn get_pdus_by_room(

--- a/crates/data/src/room/timeline.rs
+++ b/crates/data/src/room/timeline.rs
@@ -15,6 +15,15 @@ const ROOM_EVENT_APPEND_LOCK_NAMESPACE: i64 = 7_252_664_853;
 /// The caller must keep the surrounding transaction open until the event has been
 /// built and published. A transaction-scoped lock is released automatically on
 /// success, error, cancellation, or connection loss.
+///
+/// This fences *locally authored* appends against each other. Events received over
+/// federation are appended without it, exactly as before: forks created by a remote
+/// server are ordinary Matrix DAG forks that state resolution already handles, while two
+/// Palpo processes independently authoring an event from the same forward extremity are
+/// not.
+///
+/// The connection's `statement_timeout` also bounds the wait, so a room whose append lock
+/// is held for longer fails the request instead of blocking forever.
 pub async fn lock_event_append(conn: &mut AsyncPgConnection, room_id: &RoomId) -> DataResult<()> {
     diesel::sql_query("SELECT pg_advisory_xact_lock(hashtextextended($1, $2))")
         .bind::<diesel::sql_types::Text, _>(room_id.as_str())

--- a/crates/server/src/config/db.rs
+++ b/crates/server/src/config/db.rs
@@ -9,6 +9,9 @@ pub struct DbConfig {
     /// Settings for the primary database. default reade env var PALPO_DB_URL.
     #[serde(default = "default_db_url")]
     pub url: String,
+    /// Maximum number of long-lived PostgreSQL connections used by this process.
+    /// The budget includes both ordinary queries and database-backed coordination;
+    /// it must be at least 2.
     #[serde(default = "default_db_pool_size")]
     pub pool_size: u32,
 

--- a/crates/server/src/config/db.rs
+++ b/crates/server/src/config/db.rs
@@ -15,6 +15,17 @@ pub struct DbConfig {
     #[serde(default = "default_db_pool_size")]
     pub pool_size: u32,
 
+    /// Connections carved out of `pool_size` for operations which hold a database-backed
+    /// coordination lock (currently building and publishing a locally authored room
+    /// event) while ordinary queries keep using the remaining connections. This caps how
+    /// many locally authored events the process can publish concurrently, so raise it
+    /// together with `pool_size` on a write-heavy deployment.
+    ///
+    /// Leave unset to derive it from `pool_size` as `pool_size / 4`, clamped to 1..=16.
+    /// When set it must be at least 1 and smaller than `pool_size`.
+    #[serde(default)]
+    pub coordination_pool_size: Option<u32>,
+
     /// Number of seconds to wait for unacknowledged TCP packets before treating the connection as
     /// broken. This value will determine how long crates.io stays unavailable in case of full
     /// packet loss between the application and the database: setting it too high will result in an
@@ -42,6 +53,7 @@ impl DbConfig {
         let Self {
             url,
             pool_size,
+            coordination_pool_size,
             tcp_timeout,
             connection_timeout,
             statement_timeout,
@@ -50,6 +62,7 @@ impl DbConfig {
         crate::data::DbConfig {
             url: url.clone(),
             pool_size,
+            coordination_pool_size,
             tcp_timeout,
             connection_timeout,
             statement_timeout,
@@ -63,6 +76,7 @@ impl Default for DbConfig {
         Self {
             url: default_db_url(),
             pool_size: default_db_pool_size(),
+            coordination_pool_size: None,
             tcp_timeout: default_tcp_timeout(),
             connection_timeout: default_connection_timeout(),
             statement_timeout: default_statement_timeout(),

--- a/crates/server/src/config/server.rs
+++ b/crates/server/src/config/server.rs
@@ -878,6 +878,12 @@ impl ServerConfig {
             tracing::warn!("Note: palpo was built without optimisations (i.e. debug build)");
         }
 
+        if self.db.pool_size < 2 {
+            return Err(AppError::internal(
+                "db.pool_size must be at least 2 so query and coordination work cannot deadlock",
+            ));
+        }
+
         // NOTE: `check()` runs *before* `logging::init()` in main, so a
         // `tracing::error!` here would be dropped on the floor. Use
         // `eprintln!` so the banners are always written to stderr regardless

--- a/crates/server/src/config/server.rs
+++ b/crates/server/src/config/server.rs
@@ -883,6 +883,14 @@ impl ServerConfig {
                 "db.pool_size must be at least 2 so query and coordination work cannot deadlock",
             ));
         }
+        if let Some(coordination_pool_size) = self.db.coordination_pool_size
+            && !(1..self.db.pool_size).contains(&coordination_pool_size)
+        {
+            return Err(AppError::internal(format!(
+                "db.coordination_pool_size must be at least 1 and smaller than db.pool_size ({}), but it is {coordination_pool_size}",
+                self.db.pool_size
+            )));
+        }
 
         // NOTE: `check()` runs *before* `logging::init()` in main, so a
         // `tracing::error!` here would be dropped on the floor. Use

--- a/crates/server/src/event/outlier.rs
+++ b/crates/server/src/event/outlier.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncConnection, RunQueryDsl};
 
 use crate::core::events::TimelineEventType;
 use crate::core::identifiers::*;
@@ -143,17 +143,24 @@ impl OutlierPdu {
         db_event.soft_failed = soft_failed;
         db_event.is_rejected = pdu.rejection_reason.is_some();
         db_event.rejection_reason = pdu.rejection_reason.clone();
-        db_event.save().await?;
-        DbEventData {
+        let event_data = DbEventData {
             event_id: pdu.event_id.clone(),
             event_sn,
             room_id: pdu.room_id.clone(),
             internal_metadata: None,
             json_data: serde_json::to_value(&json_data)?,
             format_version: None,
-        }
-        .save()
-        .await?;
+        };
+        // An outlier becomes queryable as soon as its JSON row commits. Keep metadata and
+        // JSON together so feature-specific outlier indexes can share this transaction.
+        connect()
+            .await?
+            .transaction::<_, AppError, _>(async |conn| {
+                db_event.save_with_conn(conn).await?;
+                event_data.save_with_conn(conn).await?;
+                Ok(())
+            })
+            .await?;
         let pdu = SnPduEvent {
             pdu,
             event_sn,

--- a/crates/server/src/event/pdu.rs
+++ b/crates/server/src/event/pdu.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use std::ops::{Deref, DerefMut};
 
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncConnection, RunQueryDsl};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_json::value::to_raw_value;
@@ -856,7 +856,7 @@ impl PduBuilder {
         let (pdu, pdu_json) = self.hash_sign(sender_id, room_id, room_version).await?;
         let (event_sn, event_guard) = crate::event::ensure_event_sn(room_id, &pdu.event_id).await?;
         let content_value: JsonValue = serde_json::from_str(pdu.content.get())?;
-        NewDbEvent {
+        let db_event = NewDbEvent {
             id: pdu.event_id.to_owned(),
             sn: event_sn,
             ty: pdu.event_ty.to_string(),
@@ -875,19 +875,26 @@ impl PduBuilder {
             soft_failed: false,
             is_rejected: false,
             rejection_reason: None,
-        }
-        .save()
-        .await?;
-        DbEventData {
+        };
+        let event_data = DbEventData {
             event_id: pdu.event_id.clone(),
             event_sn,
             room_id: pdu.room_id.to_owned(),
             internal_metadata: None,
             json_data: serde_json::to_value(&pdu_json)?,
             format_version: None,
-        }
-        .save()
-        .await?;
+        };
+        // Store the event metadata and JSON as one unit. Feature-specific indexes which
+        // make an outlier intentionally observable can join this transaction rather than
+        // racing a separately committed event row.
+        connect()
+            .await?
+            .transaction::<_, AppError, _>(async |conn| {
+                db_event.save_with_conn(conn).await?;
+                event_data.save_with_conn(conn).await?;
+                Ok(())
+            })
+            .await?;
 
         Ok((
             SnPduEvent {

--- a/crates/server/src/room/timeline.rs
+++ b/crates/server/src/room/timeline.rs
@@ -17,7 +17,7 @@ use crate::core::serde::{CanonicalJsonObject, CanonicalJsonValue, JsonValue, to_
 use crate::core::state::Event;
 use crate::data::room::{DbEvent, DbEventData, NewDbEventEdge};
 use crate::data::schema::*;
-use crate::data::{connect, diesel_exists};
+use crate::data::{connect, coordination_connect, diesel_exists};
 use crate::event::{PduBuilder, PduEvent};
 use crate::room::{push_action, state, timeline};
 use crate::{
@@ -557,19 +557,27 @@ pub async fn append_pdu(
         _ => {}
     }
 
-    DbEventData {
+    let event_data = DbEventData {
         event_id: pdu.event_id.clone(),
         event_sn: pdu.event_sn,
         room_id: pdu.room_id.to_owned(),
         internal_metadata: None,
         json_data: serde_json::to_value(&pdu_json)?,
         format_version: None,
-    }
-    .save()
-    .await?;
-    diesel::update(events::table.find(&*pdu.event_id))
-        .set(events::is_outlier.eq(false))
-        .execute(&mut connect().await?)
+    };
+    // Event JSON is the timeline's visibility gate. Keep it in the same transaction as
+    // promotion so feature branches can add derived visibility indexes here without
+    // exposing a partially published event to another server process.
+    connect()
+        .await?
+        .transaction::<_, AppError, _>(async |conn| {
+            event_data.save_with_conn(conn).await?;
+            diesel::update(events::table.find(&*pdu.event_id))
+                .set(events::is_outlier.eq(false))
+                .execute(conn)
+                .await?;
+            Ok(())
+        })
         .await?;
 
     for prev_id in &pdu.prev_events {
@@ -800,6 +808,36 @@ pub async fn build_and_append_pdu(
     room_version: &RoomVersionId,
     state_lock: &RoomMutexGuard,
 ) -> AppResult<SnPduEvent> {
+    // The process-local state mutex held by the caller is not sufficient when several
+    // Palpo processes serve the same database. Keep a transaction-scoped PostgreSQL lock
+    // from the first current-state/prev-event read through timeline publication.
+    let (pdu, appended) = coordination_connect()
+        .await?
+        .transaction::<_, AppError, _>(async |conn| {
+            crate::data::room::timeline::lock_event_append(conn, room_id).await?;
+            build_and_append_pdu_locked(pdu_builder, sender, room_id, room_version, state_lock)
+                .await
+        })
+        .await?;
+
+    // Deliver to participating servers only after releasing the append fence. Queueing
+    // unrelated destinations must not prevent another process from building the room's
+    // next event.
+    if appended {
+        let servers = super::participating_servers(room_id, false).await?;
+        crate::sending::send_pdu_servers(servers.into_iter(), &pdu.event_id).await?;
+    }
+
+    Ok(pdu)
+}
+
+async fn build_and_append_pdu_locked(
+    pdu_builder: PduBuilder,
+    sender: &UserId,
+    room_id: &RoomId,
+    room_version: &RoomVersionId,
+    state_lock: &RoomMutexGuard,
+) -> AppResult<(SnPduEvent, bool)> {
     if let Some(state_key) = &pdu_builder.state_key
         && let Ok(curr_state) = super::get_state(
             room_id,
@@ -810,7 +848,7 @@ pub async fn build_and_append_pdu(
         .await
         && curr_state.content.get() == pdu_builder.content.get()
     {
-        return Ok(curr_state);
+        return Ok((curr_state, false));
     }
 
     let (pdu, pdu_json, _event_guard) = pdu_builder
@@ -837,12 +875,7 @@ pub async fn build_and_append_pdu(
     //     crate::room::update_currents(&room_id)?;
     // }
 
-    // Deliver to participating servers. Peeking servers are handled centrally in
-    // `append_pdu` (which also covers events received from other servers).
-    let servers = super::participating_servers(room_id, false).await?;
-    crate::sending::send_pdu_servers(servers.into_iter(), &pdu.event_id).await?;
-
-    Ok(pdu)
+    Ok((pdu, true))
 }
 
 /// Replace a PDU with the redacted form.

--- a/crates/server/src/room/timeline.rs
+++ b/crates/server/src/room/timeline.rs
@@ -811,10 +811,23 @@ pub async fn build_and_append_pdu(
     // The process-local state mutex held by the caller is not sufficient when several
     // Palpo processes serve the same database. Keep a transaction-scoped PostgreSQL lock
     // from the first current-state/prev-event read through timeline publication.
-    let (pdu, appended) = coordination_connect()
-        .await?
+    //
+    // The coordination pool caps how many rooms can be in this section at once, so report
+    // exhaustion as such instead of letting a bare pool timeout reach the operator.
+    let mut fence = coordination_connect().await.map_err(|e| {
+        AppError::internal(format!(
+            "no coordination connection available to fence the event append for room {room_id}; raise db.coordination_pool_size (and db.pool_size with it) if this happens under normal load: {e}"
+        ))
+    })?;
+    let (pdu, appended) = fence
         .transaction::<_, AppError, _>(async |conn| {
-            crate::data::room::timeline::lock_event_append(conn, room_id).await?;
+            crate::data::room::timeline::lock_event_append(conn, room_id)
+                .await
+                .map_err(|e| {
+                    AppError::internal(format!(
+                        "failed to acquire the event append lock for room {room_id}: {e}"
+                    ))
+                })?;
             build_and_append_pdu_locked(pdu_builder, sender, room_id, room_version, state_lock)
                 .await
         })

--- a/palpo-example.toml
+++ b/palpo-example.toml
@@ -776,6 +776,17 @@
 #
 # pool_size =
 
+# Connections carved out of `pool_size` for operations which hold a database-backed
+# coordination lock (currently building and publishing a locally authored room
+# event) while ordinary queries keep using the remaining connections. This caps how
+# many locally authored events the process can publish concurrently, so raise it
+# together with `pool_size` on a write-heavy deployment.
+#
+# Leave unset to derive it from `pool_size` as `pool_size / 4`, clamped to 1..=16.
+# When set it must be at least 1 and smaller than `pool_size`.
+#
+# coordination_pool_size =
+
 # Number of seconds to wait for unacknowledged TCP packets before treating the connection as
 # broken. This value will determine how long crates.io stays unavailable in case of full
 # packet loss between the application and the database: setting it too high will result in an

--- a/palpo-example.toml
+++ b/palpo-example.toml
@@ -770,7 +770,9 @@
 #
 # url =
 
-# This item is undocumented. Please contribute documentation for it.
+# Maximum number of long-lived PostgreSQL connections used by this process.
+# The budget includes both ordinary queries and database-backed coordination;
+# it must be at least 2.
 #
 # pool_size =
 


### PR DESCRIPTION
## Summary

- serialize locally authored room events across Palpo processes with a transaction-scoped PostgreSQL advisory lock
- store event metadata and JSON atomically, and atomically promote final event JSON with the outlier flag
- reserve query and coordination pools inside the existing database connection budget, with reusable capacity accounting

This is a prerequisite for #349 and #374: delayed events can reuse the append fence without creating an extra full-size pool, and sticky-event visibility can join the same event transactions.

Depends on #412. Its prerequisite commit is included in this branch so the combined CI result is meaningful; once #412 lands, it drops out of this PR's diff.

## Verification

- `cargo +nightly fmt --all -- --check`
- `cargo deny check advisories`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-targets --all-features --no-fail-fast`
- Complement: room/state/message transaction, invite, federation, local message, remote message, and remote invite coverage