### PR TITLE
Refresh the CI security baseline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2086,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3363,7 +3363,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5075,7 +5075,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5134,7 +5134,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5873,14 +5873,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"
@@ -6111,7 +6111,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7184,7 +7184,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/server/src/room/state/diff.rs
+++ b/crates/server/src/room/state/diff.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use super::FrameInfo;
 use crate::core::{OwnedEventId, RoomId, Seqnum};
 use crate::data::room::DbRoomStateDelta;
-use crate::{AppResult, data, utils};
+use crate::{AppError, AppResult, data, utils};
 
 pub struct StateDiff {
     pub parent_id: Option<i64>,
@@ -90,19 +90,19 @@ pub async fn load_state_diff(frame_id: i64) -> AppResult<StateDiff> {
     } = data::room::get_state_delta(frame_id).await?;
     Ok(StateDiff {
         parent_id,
-        appended: Arc::new(
-            appended
-                .chunks_exact(size_of::<CompressedEvent>())
-                .map(|chunk| CompressedEvent(chunk.try_into().expect("we checked the size above")))
-                .collect(),
-        ),
-        disposed: Arc::new(
-            disposed
-                .chunks_exact(size_of::<CompressedEvent>())
-                .map(|chunk| CompressedEvent(chunk.try_into().expect("we checked the size above")))
-                .collect(),
-        ),
+        appended: Arc::new(decode_compressed_state(&appended)?),
+        disposed: Arc::new(decode_compressed_state(&disposed)?),
     })
+}
+
+fn decode_compressed_state(bytes: &[u8]) -> AppResult<CompressedState> {
+    let (events, remainder) = bytes.as_chunks::<{ size_of::<CompressedEvent>() }>();
+    if !remainder.is_empty() {
+        return Err(AppError::internal(
+            "stored room state delta has an invalid byte length",
+        ));
+    }
+    Ok(events.iter().copied().map(CompressedEvent).collect())
 }
 
 pub async fn save_state_delta(room_id: &RoomId, frame_id: i64, diff: StateDiff) -> AppResult<()> {
@@ -129,6 +129,7 @@ pub async fn save_state_delta(room_id: &RoomId, frame_id: i64, diff: StateDiff) 
     .await?;
     Ok(())
 }
+
 /// Creates a new state_hash that often is just a diff to an already existing
 /// state_hash and therefore very efficient.
 ///
@@ -251,5 +252,30 @@ pub async fn calc_and_save_state_delta(
             },
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CompressedEvent, decode_compressed_state};
+    use crate::core::Seqnum;
+
+    #[test]
+    fn compressed_state_decoder_round_trips_complete_events() {
+        let first = CompressedEvent::new(1, Seqnum::from(2));
+        let second = CompressedEvent::new(3, Seqnum::from(4));
+        let bytes = [first.as_bytes(), second.as_bytes()].concat();
+
+        let decoded = decode_compressed_state(&bytes).unwrap();
+
+        assert_eq!(decoded.into_iter().collect::<Vec<_>>(), vec![first, second]);
+    }
+
+    #[test]
+    fn compressed_state_decoder_rejects_truncated_rows() {
+        let event = CompressedEvent::new(1, Seqnum::from(2));
+        let bytes = &event.as_bytes()[..3];
+
+        assert!(decode_compressed_state(bytes).is_err());
     }
 }


### PR DESCRIPTION
## Summary

- update `h2` to 0.4.16 to resolve RUSTSEC-2026-0258
- update the yanked `spin` 0.10.0 release to 0.10.1
- decode persisted room-state deltas with fixed-size arrays so current stable Clippy remains clean
- reject truncated persisted state-delta rows instead of silently dropping trailing bytes

## Verification

- `cargo +nightly fmt --all -- --check`
- `cargo deny check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-targets --all-features --no-fail-fast`
- `cargo check --locked --all --bins --examples --tests --release`