### PR TITLE
Keep transaction IDs private to event senders

### DIFF
--- a/crates/data/src/room/transaction_id.rs
+++ b/crates/data/src/room/transaction_id.rs
@@ -81,3 +81,49 @@ pub async fn get_event_id(
         .map(|v| v.flatten())
         .map_err(Into::into)
 }
+
+/// Recover the originating device using the complete, locally recorded event identity.
+pub async fn get_event_device(
+    txn_id: &TransactionId,
+    user_id: &UserId,
+    room_id: &RoomId,
+    event_id: &EventId,
+) -> DataResult<Option<OwnedDeviceId>> {
+    // New events save trusted provenance in the same transaction as their JSON,
+    // before /sync can see them and before the route records idempotency completion.
+    let metadata = event_datas::table
+        .filter(event_datas::event_id.eq(event_id))
+        .filter(event_datas::room_id.eq(room_id))
+        .select(event_datas::internal_metadata)
+        .first::<Option<serde_json::Value>>(&mut connect().await?)
+        .await
+        .optional()?
+        .flatten();
+    if let Some(metadata) = metadata
+        && metadata
+            .get("transaction_user")
+            .and_then(serde_json::Value::as_str)
+            == Some(user_id.as_str())
+        && metadata
+            .get("transaction_id")
+            .and_then(serde_json::Value::as_str)
+            == Some(txn_id.as_str())
+        && let Some(device) = metadata
+            .get("transaction_device")
+            .and_then(serde_json::Value::as_str)
+    {
+        return Ok(Some(device.into()));
+    }
+    // Existing events predate the provenance field.
+    event_idempotents::table
+        .filter(event_idempotents::txn_id.eq(txn_id))
+        .filter(event_idempotents::user_id.eq(user_id))
+        .filter(event_idempotents::room_id.eq(room_id))
+        .filter(event_idempotents::event_id.eq(event_id))
+        .select(event_idempotents::device_id)
+        .first::<Option<OwnedDeviceId>>(&mut connect().await?)
+        .await
+        .optional()
+        .map(|v| v.flatten())
+        .map_err(Into::into)
+}

--- a/crates/server/src/event/pdu.rs
+++ b/crates/server/src/event/pdu.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::ops::{Deref, DerefMut};
@@ -395,6 +396,10 @@ pub struct PduEvent {
 
     #[serde(skip, default)]
     pub rejection_reason: Option<String>,
+
+    // Trusted local provenance, never accepted from or emitted into event JSON.
+    #[serde(skip)]
+    pub(crate) transaction_device: Option<OwnedDeviceId>,
 }
 
 impl PduEvent {
@@ -463,6 +468,70 @@ impl PduEvent {
         Ok(())
     }
 
+    fn unsigned_for_recipient(
+        &self,
+        recipient: &UserId,
+        device_id: Option<&DeviceId>,
+    ) -> Cow<'_, BTreeMap<String, Box<RawJsonValue>>> {
+        let originating_device = self.sender == recipient
+            && device_id.is_some()
+            && self.transaction_device.as_deref() == device_id;
+        if originating_device
+            && !self.unsigned.contains_key("redacted_because")
+            && !self.unsigned.contains_key("m.relations")
+        {
+            Cow::Borrowed(&self.unsigned)
+        } else {
+            let mut unsigned = self.unsigned_without_transaction_id();
+            if originating_device && let Some(txn) = self.unsigned.get("transaction_id") {
+                unsigned.insert("transaction_id".into(), txn.clone());
+            }
+            Cow::Owned(unsigned)
+        }
+    }
+
+    fn unsigned_without_transaction_id(&self) -> BTreeMap<String, Box<RawJsonValue>> {
+        let mut unsigned = self.unsigned.clone();
+        unsigned.remove("transaction_id");
+        // Embedded events have independent senders and devices. Old stored bundles
+        // may predate the privacy filtering at their creation sites.
+        for key in ["redacted_because", "m.relations"] {
+            if let Some(raw) = unsigned.remove(key)
+                && let Ok(mut value) = serde_json::from_str::<JsonValue>(raw.get())
+            {
+                strip_embedded_transaction_ids(&mut value);
+                unsigned.insert(key.into(), to_raw_value(&value).expect("valid JSON"));
+            }
+        }
+        unsigned
+    }
+
+    fn transaction_metadata(&self) -> Option<JsonValue> {
+        let device = self.transaction_device.as_ref()?;
+        let txn: OwnedTransactionId =
+            serde_json::from_str(self.unsigned.get("transaction_id")?.get()).ok()?;
+        Some(
+            json!({"transaction_device": device, "transaction_id": txn, "transaction_user": self.sender}),
+        )
+    }
+
+    /// Hydrate device provenance only from trusted local metadata or a legacy idempotency record.
+    pub(crate) async fn load_transaction_device(&mut self) -> AppResult<()> {
+        self.transaction_device = None;
+        if let Some(txn_id) = self.unsigned.get("transaction_id")
+            && let Ok(txn_id) = serde_json::from_str::<OwnedTransactionId>(txn_id.get())
+        {
+            self.transaction_device = crate::data::room::transaction_id::get_event_device(
+                &txn_id,
+                &self.sender,
+                &self.room_id,
+                &self.event_id,
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
     pub fn add_age(&mut self) -> AppResult<()> {
         let now: i128 = UnixMillis::now().get().into();
         let then: i128 = self.origin_server_ts.get().into();
@@ -474,8 +543,10 @@ impl PduEvent {
         Ok(())
     }
 
-    #[tracing::instrument]
-    pub fn to_sync_room_event(&self) -> RawJson<AnySyncTimelineEvent> {
+    fn to_sync_room_event_with_unsigned(
+        &self,
+        unsigned: &BTreeMap<String, Box<RawJsonValue>>,
+    ) -> RawJson<AnySyncTimelineEvent> {
         let mut json = json!({
             "content": self.content,
             "type": self.event_ty,
@@ -484,8 +555,8 @@ impl PduEvent {
             "origin_server_ts": self.origin_server_ts,
         });
 
-        if !self.unsigned.is_empty() {
-            json["unsigned"] = json!(self.unsigned);
+        if !unsigned.is_empty() {
+            json["unsigned"] = json!(unsigned);
         }
         if let Some(state_key) = &self.state_key {
             json["state_key"] = json!(state_key);
@@ -497,8 +568,24 @@ impl PduEvent {
         serde_json::from_value(json).expect("RawJson::from_value always works")
     }
 
-    #[tracing::instrument]
-    pub fn to_room_event(&self) -> RawJson<AnyTimelineEvent> {
+    pub fn to_sync_room_event_for(
+        &self,
+        recipient: &UserId,
+        device_id: Option<&DeviceId>,
+    ) -> RawJson<AnySyncTimelineEvent> {
+        self.to_sync_room_event_with_unsigned(
+            self.unsigned_for_recipient(recipient, device_id).as_ref(),
+        )
+    }
+
+    pub fn to_sync_room_event_without_transaction_id(&self) -> RawJson<AnySyncTimelineEvent> {
+        self.to_sync_room_event_with_unsigned(&self.unsigned_without_transaction_id())
+    }
+
+    fn to_room_event_with_unsigned(
+        &self,
+        unsigned: &BTreeMap<String, Box<RawJsonValue>>,
+    ) -> RawJson<AnyTimelineEvent> {
         let age = UnixMillis::now()
             .get()
             .saturating_sub(self.origin_server_ts.get());
@@ -511,12 +598,12 @@ impl PduEvent {
             "room_id": self.room_id,
         });
 
-        if self.unsigned.is_empty() {
+        if unsigned.is_empty() {
             data["unsigned"] = json!({ "age": age });
         } else {
-            let mut unsigned = json!(self.unsigned);
-            unsigned["age"] = json!(age);
-            data["unsigned"] = unsigned;
+            let mut unsigned_json = json!(unsigned);
+            unsigned_json["age"] = json!(age);
+            data["unsigned"] = unsigned_json;
         }
         if let Some(state_key) = &self.state_key {
             data["state_key"] = json!(state_key);
@@ -528,8 +615,22 @@ impl PduEvent {
         serde_json::from_value(data).expect("RawJson::from_value always works")
     }
 
-    #[tracing::instrument]
-    pub fn to_message_like_event(&self) -> RawJson<AnyMessageLikeEvent> {
+    pub fn to_room_event_for(
+        &self,
+        recipient: &UserId,
+        device_id: Option<&DeviceId>,
+    ) -> RawJson<AnyTimelineEvent> {
+        self.to_room_event_with_unsigned(self.unsigned_for_recipient(recipient, device_id).as_ref())
+    }
+
+    pub fn to_room_event_without_transaction_id(&self) -> RawJson<AnyTimelineEvent> {
+        self.to_room_event_with_unsigned(&self.unsigned_without_transaction_id())
+    }
+
+    fn to_message_like_event_with_unsigned(
+        &self,
+        unsigned: &BTreeMap<String, Box<RawJsonValue>>,
+    ) -> RawJson<AnyMessageLikeEvent> {
         let mut data = json!({
             "content": self.content,
             "type": self.event_ty,
@@ -539,8 +640,8 @@ impl PduEvent {
             "room_id": self.room_id,
         });
 
-        if !self.unsigned.is_empty() {
-            data["unsigned"] = json!(self.unsigned);
+        if !unsigned.is_empty() {
+            data["unsigned"] = json!(unsigned);
         }
         if let Some(state_key) = &self.state_key {
             data["state_key"] = json!(state_key);
@@ -552,13 +653,41 @@ impl PduEvent {
         serde_json::from_value(data).expect("RawJson::from_value always works")
     }
 
+    pub fn to_message_like_event_for(
+        &self,
+        recipient: &UserId,
+        device_id: Option<&DeviceId>,
+    ) -> RawJson<AnyMessageLikeEvent> {
+        self.to_message_like_event_with_unsigned(
+            self.unsigned_for_recipient(recipient, device_id).as_ref(),
+        )
+    }
+
+    pub fn to_message_like_event_without_transaction_id(&self) -> RawJson<AnyMessageLikeEvent> {
+        self.to_message_like_event_with_unsigned(&self.unsigned_without_transaction_id())
+    }
+
     #[tracing::instrument]
-    pub fn to_state_event(&self) -> RawJson<AnyStateEvent> {
-        serde_json::from_value(self.to_state_event_value())
+    pub fn to_state_event_with_sender_only_unsigned(&self) -> RawJson<AnyStateEvent> {
+        serde_json::from_value(self.to_state_event_value_with_unsigned(&self.unsigned))
             .expect("RawJson::from_value always works")
     }
-    #[tracing::instrument]
-    pub fn to_state_event_value(&self) -> JsonValue {
+
+    pub fn to_state_event_for(
+        &self,
+        recipient: &UserId,
+        device_id: Option<&DeviceId>,
+    ) -> RawJson<AnyStateEvent> {
+        serde_json::from_value(self.to_state_event_value_with_unsigned(
+            self.unsigned_for_recipient(recipient, device_id).as_ref(),
+        ))
+        .expect("RawJson::from_value always works")
+    }
+
+    fn to_state_event_value_with_unsigned(
+        &self,
+        unsigned: &BTreeMap<String, Box<RawJsonValue>>,
+    ) -> JsonValue {
         let JsonValue::Object(mut data) = json!({
             "content": self.content,
             "type": self.event_ty,
@@ -571,8 +700,8 @@ impl PduEvent {
             panic!("Invalid JSON value, never happened!");
         };
 
-        if !self.unsigned.is_empty() {
-            data.insert("unsigned".into(), json!(self.unsigned));
+        if !unsigned.is_empty() {
+            data.insert("unsigned".into(), json!(unsigned));
         }
 
         for (key, value) in &self.extra_data {
@@ -584,8 +713,20 @@ impl PduEvent {
         JsonValue::Object(data)
     }
 
-    #[tracing::instrument]
-    pub fn to_sync_state_event(&self) -> RawJson<AnySyncStateEvent> {
+    pub fn to_state_event_value_for(
+        &self,
+        recipient: &UserId,
+        device_id: Option<&DeviceId>,
+    ) -> JsonValue {
+        self.to_state_event_value_with_unsigned(
+            self.unsigned_for_recipient(recipient, device_id).as_ref(),
+        )
+    }
+
+    fn to_sync_state_event_with_unsigned(
+        &self,
+        unsigned: &BTreeMap<String, Box<RawJsonValue>>,
+    ) -> RawJson<AnySyncStateEvent> {
         let mut data = json!({
             "content": self.content,
             "type": self.event_ty,
@@ -595,11 +736,21 @@ impl PduEvent {
             "state_key": self.state_key,
         });
 
-        if !self.unsigned.is_empty() {
-            data["unsigned"] = json!(self.unsigned);
+        if !unsigned.is_empty() {
+            data["unsigned"] = json!(unsigned);
         }
 
         serde_json::from_value(data).expect("RawJson::from_value always works")
+    }
+
+    pub fn to_sync_state_event_for(
+        &self,
+        recipient: &UserId,
+        device_id: Option<&DeviceId>,
+    ) -> RawJson<AnySyncStateEvent> {
+        self.to_sync_state_event_with_unsigned(
+            self.unsigned_for_recipient(recipient, device_id).as_ref(),
+        )
     }
 
     #[tracing::instrument]
@@ -639,7 +790,12 @@ impl PduEvent {
     }
 
     #[tracing::instrument]
-    pub fn to_member_event(&self) -> RawJson<StateEvent<RoomMemberEventContent>> {
+    pub fn to_member_event_for(
+        &self,
+        recipient: &UserId,
+        device_id: Option<&DeviceId>,
+    ) -> RawJson<StateEvent<RoomMemberEventContent>> {
+        let unsigned = self.unsigned_for_recipient(recipient, device_id);
         let mut data = json!({
             "content": self.content,
             "type": self.event_ty,
@@ -651,8 +807,8 @@ impl PduEvent {
             "state_key": self.state_key,
         });
 
-        if !self.unsigned.is_empty() {
-            data["unsigned"] = json!(self.unsigned);
+        if !unsigned.is_empty() {
+            data["unsigned"] = json!(unsigned);
         }
 
         serde_json::from_value(data).expect("RawJson::from_value always works")
@@ -818,6 +974,9 @@ pub struct PduBuilder {
     pub state_key: Option<String>,
     pub redacts: Option<OwnedEventId>,
     pub timestamp: Option<UnixMillis>,
+    /// Authenticated local provenance; never accept this field from JSON.
+    #[serde(skip)]
+    pub transaction_device: Option<OwnedDeviceId>,
 }
 
 impl PduBuilder {
@@ -880,7 +1039,7 @@ impl PduBuilder {
             event_id: pdu.event_id.clone(),
             event_sn,
             room_id: pdu.room_id.to_owned(),
-            internal_metadata: None,
+            internal_metadata: pdu.transaction_metadata(),
             json_data: serde_json::to_value(&pdu_json)?,
             format_version: None,
         };
@@ -922,6 +1081,7 @@ impl PduBuilder {
             state_key,
             redacts,
             timestamp,
+            transaction_device,
             ..
         } = self;
 
@@ -1007,6 +1167,7 @@ impl PduBuilder {
             signatures: None,
             extra_data: Default::default(),
             rejection_reason: None,
+            transaction_device,
         };
 
         let fetch_event = async |event_id: OwnedEventId| {
@@ -1124,6 +1285,308 @@ impl Default for PduBuilder {
             state_key: None,
             redacts: None,
             timestamp: None,
+            transaction_device: None,
         }
+    }
+}
+
+/// Only event metadata is private; similarly named fields inside content are user data.
+fn strip_embedded_transaction_ids(value: &mut JsonValue) {
+    match value {
+        JsonValue::Object(object) => {
+            if let Some(JsonValue::Object(unsigned)) = object.get_mut("unsigned") {
+                unsigned.remove("transaction_id");
+            }
+            for (key, value) in object {
+                if key != "content" {
+                    strip_embedded_transaction_ids(value);
+                }
+            }
+        }
+        JsonValue::Array(values) => {
+            for value in values {
+                strip_embedded_transaction_ids(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Federation has no originating-device context, including for embedded events.
+pub(crate) fn sanitize_federation_unsigned(pdu: &mut CanonicalJsonObject) {
+    let Some(CanonicalJsonValue::Object(unsigned)) = pdu.get_mut("unsigned") else {
+        return;
+    };
+    unsigned.remove("transaction_id");
+    for key in ["redacted_because", "m.relations"] {
+        if let Some(value) = unsigned.get_mut(key) {
+            let mut json = serde_json::to_value(&*value).expect("valid canonical JSON");
+            strip_embedded_transaction_ids(&mut json);
+            *value =
+                serde_json::from_value(json).expect("removing fields preserves canonical JSON");
+        }
+    }
+}
+
+#[cfg(test)]
+mod sender_only_unsigned_tests {
+    use serde_json::value::to_raw_value;
+
+    use super::*;
+
+    fn event_with_transaction_id() -> PduEvent {
+        let mut unsigned = BTreeMap::new();
+        unsigned.insert("transaction_id".to_owned(), to_raw_value("txn").unwrap());
+        unsigned.insert("age".to_owned(), to_raw_value(&10_u64).unwrap());
+
+        PduEvent {
+            event_id: "$event:example.org".try_into().unwrap(),
+            sender: "@alice:example.org".try_into().unwrap(),
+            origin_server_ts: UnixMillis(1),
+            event_ty: TimelineEventType::RoomMessage,
+            content: to_raw_value(&json!({"body": "hi", "msgtype": "m.text"})).unwrap(),
+            state_key: None,
+            room_id: "!room:example.org".try_into().unwrap(),
+            prev_events: Vec::new(),
+            depth: 1,
+            auth_events: Vec::new(),
+            redacts: None,
+            hashes: EventHash {
+                sha256: String::new(),
+            },
+            signatures: None,
+            unsigned,
+            extra_data: Default::default(),
+            rejection_reason: None,
+            transaction_device: None,
+        }
+    }
+
+    #[test]
+    fn originating_device_keeps_its_transaction_id() {
+        let mut event = event_with_transaction_id();
+        event.transaction_device = Some("PHONE".into());
+        let sender: OwnedUserId = "@alice:example.org".try_into().unwrap();
+
+        let converted = event.to_room_event_for(&sender, Some("PHONE".into()));
+        let json: JsonValue = serde_json::from_str(converted.as_str()).unwrap();
+
+        assert_eq!(
+            json.pointer("/unsigned/transaction_id"),
+            Some(&json!("txn"))
+        );
+    }
+
+    #[test]
+    fn other_users_do_not_receive_the_transaction_id() {
+        let event = event_with_transaction_id();
+        let recipient: OwnedUserId = "@bob:example.org".try_into().unwrap();
+
+        let converted = event.to_room_event_for(&recipient, Some("PHONE".into()));
+        let json: JsonValue = serde_json::from_str(converted.as_str()).unwrap();
+
+        assert!(json.pointer("/unsigned/transaction_id").is_none());
+        assert!(json.pointer("/unsigned/age").is_some());
+    }
+
+    #[test]
+    fn member_listing_does_not_leak_the_transaction_id() {
+        let mut event = event_with_transaction_id();
+        event.event_ty = TimelineEventType::RoomMember;
+        event.state_key = Some(event.sender.to_string());
+        event.content = to_raw_value(&json!({"membership": "join"})).unwrap();
+        let recipient: OwnedUserId = "@bob:example.org".try_into().unwrap();
+
+        let converted = event.to_member_event_for(&recipient, Some("PHONE".into()));
+        let json: JsonValue = serde_json::from_str(converted.as_str()).unwrap();
+
+        assert!(json.pointer("/unsigned/transaction_id").is_none());
+        assert_eq!(json.pointer("/unsigned/age"), Some(&json!(10)));
+    }
+
+    #[test]
+    fn another_device_and_device_less_consumers_do_not_receive_transaction_ids() {
+        let mut event = event_with_transaction_id();
+        event.transaction_device = Some("PHONE".into());
+        let laptop: &DeviceId = "LAPTOP".into();
+        for device in [Some(laptop), None] {
+            let converted = event.to_room_event_for(&event.sender, device);
+            let json: JsonValue = serde_json::from_str(converted.as_str()).unwrap();
+            assert!(json.pointer("/unsigned/transaction_id").is_none());
+        }
+    }
+
+    #[test]
+    fn event_json_cannot_supply_trusted_device_provenance() {
+        let event = event_with_transaction_id();
+        let mut json = serde_json::to_value(&event).unwrap();
+        json["transaction_device"] = json!("PHONE");
+        let parsed: PduEvent = serde_json::from_value(json).unwrap();
+        assert!(parsed.transaction_device.is_none());
+        let builder: PduBuilder = serde_json::from_value(json!({
+            "type": "m.room.message", "content": {}, "transaction_device": "PHONE"
+        }))
+        .unwrap();
+        assert!(builder.transaction_device.is_none());
+        let converted = parsed.to_room_event_for(&parsed.sender, Some("PHONE".into()));
+        let json: JsonValue = serde_json::from_str(converted.as_str()).unwrap();
+        assert!(json.pointer("/unsigned/transaction_id").is_none());
+    }
+
+    #[test]
+    fn nested_events_never_expose_a_transaction_id() {
+        let event = event_with_transaction_id();
+
+        let converted = event.to_message_like_event_without_transaction_id();
+        let json: JsonValue = serde_json::from_str(converted.as_str()).unwrap();
+
+        assert!(json.pointer("/unsigned/transaction_id").is_none());
+        assert_eq!(json.pointer("/unsigned/age"), Some(&json!(10)));
+    }
+
+    #[test]
+    fn stored_redactions_and_relation_bundles_do_not_leak_device_metadata() {
+        let mut event = event_with_transaction_id();
+        event.transaction_device = Some("PHONE".into());
+        let embedded = json!({
+            "type": "m.room.message", "sender": "@other:example.org",
+            "content": {"unsigned": {"transaction_id": "user content"}},
+            "unsigned": {"transaction_id": "private nested transaction", "age": 12}
+        });
+        event
+            .unsigned
+            .insert("redacted_because".into(), to_raw_value(&embedded).unwrap());
+        event.unsigned.insert(
+            "m.relations".into(),
+            to_raw_value(&json!({
+                "m.thread": {"latest_event": embedded}, "m.replace": embedded
+            }))
+            .unwrap(),
+        );
+        for device in [Some("PHONE".into()), Some("LAPTOP".into()), None] {
+            let converted = event.to_room_event_for(&event.sender, device);
+            let json: JsonValue = serde_json::from_str(converted.as_str()).unwrap();
+            assert_eq!(
+                json.pointer("/unsigned/transaction_id").is_some(),
+                device == Some("PHONE".into())
+            );
+            for path in [
+                "/unsigned/redacted_because",
+                "/unsigned/m.relations/m.thread/latest_event",
+                "/unsigned/m.relations/m.replace",
+            ] {
+                assert!(
+                    json.pointer(&format!("{path}/unsigned/transaction_id"))
+                        .is_none()
+                );
+                assert_eq!(
+                    json.pointer(&format!("{path}/unsigned/age")),
+                    Some(&json!(12))
+                );
+                assert_eq!(
+                    json.pointer(&format!("{path}/content/unsigned/transaction_id")),
+                    Some(&json!("user content"))
+                );
+            }
+        }
+        let mut federation = to_canonical_object(&event).unwrap();
+        sanitize_federation_unsigned(&mut federation);
+        let federation = serde_json::to_value(federation).unwrap();
+        assert!(federation.pointer("/unsigned/transaction_id").is_none());
+        for path in [
+            "/unsigned/redacted_because",
+            "/unsigned/m.relations/m.thread/latest_event",
+            "/unsigned/m.relations/m.replace",
+        ] {
+            assert!(
+                federation
+                    .pointer(&format!("{path}/unsigned/transaction_id"))
+                    .is_none()
+            );
+            assert_eq!(
+                federation.pointer(&format!("{path}/content/unsigned/transaction_id")),
+                Some(&json!("user content"))
+            );
+        }
+    }
+    #[tokio::test]
+    #[ignore = "requires an empty dedicated PALPO_TEST_DATABASE_URL"]
+    async fn database_transaction_device_is_scoped_to_the_event() {
+        crate::test_database::init();
+        let mut event = event_with_transaction_id();
+        let phone: &DeviceId = "PHONE".into();
+        let laptop: &DeviceId = "LAPTOP".into();
+        crate::data::room::transaction_id::add_txn_id(
+            "txn".into(),
+            &event.sender,
+            Some(phone),
+            Some(&event.room_id),
+            Some(&event.event_id),
+        )
+        .await
+        .unwrap();
+        // Another device can reuse the transaction string for a different event.
+        let other = EventId::parse("$other:example.org").unwrap();
+        crate::data::room::transaction_id::add_txn_id(
+            "txn".into(),
+            &event.sender,
+            Some(laptop),
+            Some(&event.room_id),
+            Some(&other),
+        )
+        .await
+        .unwrap();
+        event.load_transaction_device().await.unwrap();
+        assert_eq!(event.transaction_device.as_deref(), Some(phone));
+        for (device, expected) in [(phone, true), (laptop, false)] {
+            let json: JsonValue = serde_json::from_str(
+                event
+                    .to_room_event_for(&event.sender, Some(device))
+                    .as_str(),
+            )
+            .unwrap();
+            assert_eq!(json.pointer("/unsigned/transaction_id").is_some(), expected);
+        }
+        event.event_id = other;
+        event.load_transaction_device().await.unwrap();
+        assert_eq!(event.transaction_device.as_deref(), Some(laptop));
+        event.room_id = "!other:example.org".try_into().unwrap();
+        event.load_transaction_device().await.unwrap();
+        assert!(event.transaction_device.is_none());
+
+        // A newly visible event already has device provenance even while its route
+        // has not yet written the idempotency-completion row.
+        event.event_id = "$before-idempotency:example.org".try_into().unwrap();
+        event.transaction_device = Some(phone.to_owned());
+        let metadata = event.transaction_metadata();
+        let event_data = DbEventData {
+            event_id: event.event_id.clone(),
+            event_sn: 500,
+            room_id: event.room_id.clone(),
+            json_data: serde_json::to_value(&event).unwrap(),
+            internal_metadata: metadata,
+            format_version: None,
+        };
+        event_data.save().await.unwrap();
+        assert!(
+            crate::data::room::transaction_id::get_event_id(
+                "txn".into(),
+                &event.sender,
+                Some(phone),
+                Some(&event.room_id)
+            )
+            .await
+            .unwrap()
+            .is_none()
+        );
+        event.transaction_device = None;
+        event.load_transaction_device().await.unwrap();
+        assert_eq!(event.transaction_device.as_deref(), Some(phone));
+        // Later JSON updates must not clear trusted metadata.
+        let mut update = event_data;
+        update.internal_metadata = None;
+        update.save().await.unwrap();
+        event.load_transaction_device().await.unwrap();
+        assert_eq!(event.transaction_device.as_deref(), Some(phone));
     }
 }

--- a/crates/server/src/event/search.rs
+++ b/crates/server/src/event/search.rs
@@ -38,6 +38,7 @@ fn searchable_events<'a>(
 
 pub async fn search_pdus(
     user_id: &UserId,
+    device_id: Option<&DeviceId>,
     criteria: &Criteria,
     next_batch: Option<&str>,
 ) -> AppResult<ResultRoomEvents> {
@@ -125,11 +126,19 @@ pub async fn search_pdus(
             continue;
         }
         results.push(SearchResult {
-            context: calc_event_context(user_id, &pdu.room_id, pdu.event_sn, 10, 10, false)
-                .await
-                .unwrap_or_default(),
+            context: calc_event_context(
+                user_id,
+                device_id,
+                &pdu.room_id,
+                pdu.event_sn,
+                10,
+                10,
+                false,
+            )
+            .await
+            .unwrap_or_default(),
             rank: Some(rank as f64),
-            result: Some(pdu.to_room_event()),
+            result: Some(pdu.to_room_event_for(user_id, device_id)),
         });
     }
 
@@ -150,6 +159,7 @@ pub async fn search_pdus(
 // Calculates the contextual events for any search results.
 async fn calc_event_context(
     user_id: &UserId,
+    device_id: Option<&DeviceId>,
     room_id: &RoomId,
     event_sn: Seqnum,
     before_limit: usize,
@@ -205,11 +215,11 @@ async fn calc_event_context(
             .map(|(sn, _)| BatchToken::new_live(*sn).to_string()),
         events_before: before_pdus
             .into_iter()
-            .map(|(_, pdu)| pdu.to_room_event())
+            .map(|(_, pdu)| pdu.to_room_event_for(user_id, device_id))
             .collect(),
         events_after: after_pdus
             .into_iter()
-            .map(|(_, pdu)| pdu.to_room_event())
+            .map(|(_, pdu)| pdu.to_room_event_for(user_id, device_id))
             .collect(),
         profile_info: BTreeMap::new(),
     };

--- a/crates/server/src/room/pdu_metadata.rs
+++ b/crates/server/src/room/pdu_metadata.rs
@@ -46,6 +46,7 @@ pub async fn add_relation(
 
 pub async fn paginate_relations_with_filter(
     user_id: &UserId,
+    device_id: Option<&DeviceId>,
     room_id: &RoomId,
     target: &EventId,
     filter_event_type: Option<TimelineEventType>,
@@ -99,7 +100,7 @@ pub async fn paginate_relations_with_filter(
 
     let events: Vec<_> = events
         .into_iter()
-        .map(|(_, pdu)| pdu.to_message_like_event())
+        .map(|(_, pdu)| pdu.to_message_like_event_for(user_id, device_id))
         .collect();
 
     Ok(RelationEventsResBody {

--- a/crates/server/src/room/thread.rs
+++ b/crates/server/src/room/thread.rs
@@ -43,7 +43,7 @@ pub async fn add_to_thread(thread_id: &EventId, pdu: &SnPduEvent) -> AppResult<(
         {
             // Thread already existed
             relations.count += 1;
-            relations.latest_event = pdu.to_message_like_event();
+            relations.latest_event = pdu.to_message_like_event_without_transaction_id();
 
             let content = serde_json::to_value(relations).expect("to_value always works");
 
@@ -56,7 +56,7 @@ pub async fn add_to_thread(thread_id: &EventId, pdu: &SnPduEvent) -> AppResult<(
         } else {
             // New thread
             let relations = BundledThread {
-                latest_event: pdu.to_message_like_event(),
+                latest_event: pdu.to_message_like_event_without_transaction_id(),
                 count: 1,
                 current_user_participated: true,
             };

--- a/crates/server/src/room/timeline.rs
+++ b/crates/server/src/room/timeline.rs
@@ -113,6 +113,7 @@ pub async fn get_non_outlier_pdu(event_id: &EventId) -> AppResult<Option<SnPduEv
         pdu.is_outlier = event.is_outlier;
         pdu.soft_failed = event.soft_failed;
         pdu.rejection_reason = event.rejection_reason;
+        pdu.load_transaction_device().await?;
     }
     Ok(pdu)
 }
@@ -134,6 +135,7 @@ pub async fn get_pdu(event_id: &EventId) -> AppResult<SnPduEvent> {
     let mut pdu = PduEvent::from_json_value(&room_id, event_id, json)
         .map_err(|_e| AppError::internal("invalid pdu in db"))?;
     pdu.rejection_reason = event.rejection_reason;
+    pdu.load_transaction_device().await?;
     Ok(SnPduEvent {
         pdu,
         event_sn,
@@ -162,6 +164,7 @@ pub async fn get_pdu_and_data(event_id: &EventId) -> AppResult<(SnPduEvent, Cano
     let mut pdu = PduEvent::from_json_value(&room_id, event_id, json)
         .map_err(|_e| AppError::internal("invalid pdu in db"))?;
     pdu.rejection_reason = event.rejection_reason;
+    pdu.load_transaction_device().await?;
     Ok((
         SnPduEvent {
             pdu,
@@ -370,7 +373,7 @@ pub async fn append_pdu(
         .await?;
     }
 
-    let sync_pdu = pdu.to_sync_room_event();
+    let sync_pdu = pdu.to_sync_room_event_without_transaction_id();
     let mut notifies = Vec::new();
     let mut highlights = Vec::new();
 

--- a/crates/server/src/routing/admin/debug.rs
+++ b/crates/server/src/routing/admin/debug.rs
@@ -236,7 +236,9 @@ pub async fn get_room_state(room_id: PathParam<OwnedRoomId>) -> JsonResult<RoomS
     let events = state::get_full_state(frame_id)
         .await?
         .values()
-        .map(|pdu| serde_json::to_value(pdu.to_state_event()).unwrap_or_default())
+        .map(|pdu| {
+            serde_json::to_value(pdu.to_state_event_with_sender_only_unsigned()).unwrap_or_default()
+        })
         .collect::<Vec<_>>();
 
     json_ok(RoomStateResponse {

--- a/crates/server/src/routing/admin/server_notice.rs
+++ b/crates/server/src/routing/admin/server_notice.rs
@@ -116,6 +116,7 @@ pub async fn send_server_notice(
             state_key: body.state_key,
             redacts: None,
             timestamp: None,
+            transaction_device: None,
         };
         timeline::build_and_append_pdu(
             pdu_builder,

--- a/crates/server/src/routing/client.rs
+++ b/crates/server/src/routing/client.rs
@@ -146,6 +146,7 @@ async fn search(
     let search_criteria = body.search_categories.room_events.as_ref().unwrap();
     let room_events = crate::event::search::search_pdus(
         authed.user_id(),
+        Some(authed.device_id()),
         search_criteria,
         args.next_batch.as_deref(),
     )

--- a/crates/server/src/routing/client/room.rs
+++ b/crates/server/src/routing/client/room.rs
@@ -176,7 +176,7 @@ async fn initial_sync(
             .server_name()
             .is_ok_and(|server| *server != config::get().server_name)
         {
-            return remote_peek_preview(room_id, args.limit.unwrap_or(20)).await;
+            return remote_peek_preview(sender_id, room_id, args.limit.unwrap_or(20)).await;
         }
         return Err(MatrixError::forbidden("No room preview available.", None).into());
     }
@@ -195,7 +195,7 @@ async fn initial_sync(
         .await
         .unwrap_or_default()
         .into_values()
-        .map(|event| event.to_state_event())
+        .map(|event| event.to_state_event_for(sender_id, Some(authed.device_id())))
         .collect::<Vec<_>>();
 
     let messages = PaginationChunk {
@@ -212,7 +212,7 @@ async fn initial_sync(
             .unwrap_or_default(),
         chunk: events
             .into_iter()
-            .map(|(_sn, event)| event.to_room_event())
+            .map(|(_sn, event)| event.to_room_event_for(sender_id, Some(authed.device_id())))
             .collect(),
     };
 
@@ -241,7 +241,11 @@ async fn initial_sync(
 /// Any failure (room not world-readable, federation disabled, server
 /// unreachable, malformed response) collapses to a clean "no preview" error so
 /// the client falls back to showing the join prompt instead of a hard error.
-async fn remote_peek_preview(room_id: &RoomId, limit: usize) -> JsonResult<InitialSyncResBody> {
+async fn remote_peek_preview(
+    recipient: &UserId,
+    room_id: &RoomId,
+    limit: usize,
+) -> JsonResult<InitialSyncResBody> {
     let no_preview = || MatrixError::forbidden("No room preview available.", None);
 
     let server = room_id.server_name().map_err(|_| no_preview())?;
@@ -278,7 +282,8 @@ async fn remote_peek_preview(room_id: &RoomId, limit: usize) -> JsonResult<Initi
         .pdus
         .iter()
         .filter_map(|raw| {
-            parse_peek_pdu(room_id, &room_version, raw).map(|pdu| pdu.to_state_event())
+            parse_peek_pdu(room_id, &room_version, raw)
+                .map(|pdu| pdu.to_state_event_for(recipient, None))
         })
         .collect();
 
@@ -291,7 +296,8 @@ async fn remote_peek_preview(room_id: &RoomId, limit: usize) -> JsonResult<Initi
         .messages
         .iter()
         .filter_map(|raw| {
-            parse_peek_pdu(room_id, &room_version, raw).map(|pdu| pdu.to_room_event())
+            parse_peek_pdu(room_id, &room_version, raw)
+                .map(|pdu| pdu.to_room_event_for(recipient, None))
         })
         .collect();
 

--- a/crates/server/src/routing/client/room/event.rs
+++ b/crates/server/src/routing/client/room/event.rs
@@ -65,10 +65,9 @@ pub(super) async fn get_room_event(
         return Err(MatrixError::not_found("event not found").into());
     }
 
-    let mut event = event.clone();
-    event.add_age()?;
-
-    json_ok(RoomEventResBody::new(event.to_room_event()))
+    json_ok(RoomEventResBody::new(
+        event.to_room_event_for(authed.user_id(), Some(authed.device_id())),
+    ))
 }
 
 /// #POST /_matrix/client/r0/rooms/{room_id}/report/{event_id}
@@ -198,7 +197,7 @@ pub(super) async fn get_context(
 
     // Use limit with maximum 100
     let limit = args.limit.min(100);
-    let base_event = base_event.to_room_event();
+    let base_event = base_event.to_room_event_for(sender_id, Some(authed.device_id()));
     let events_before_loaded = timeline::stream::load_pdus_backward(
         Some(sender_id),
         &room_id,
@@ -238,7 +237,7 @@ pub(super) async fn get_context(
         .unwrap_or_else(|| base_token);
     let events_before = events_before
         .into_iter()
-        .map(|(_, pdu)| pdu.to_room_event())
+        .map(|(_, pdu)| pdu.to_room_event_for(sender_id, Some(authed.device_id())))
         .collect::<Vec<_>>();
     let events_after = timeline::stream::load_pdus_forward(
         Some(sender_id),
@@ -285,7 +284,7 @@ pub(super) async fn get_context(
         .unwrap_or_else(|| base_token);
     let events_after: Vec<_> = events_after
         .into_iter()
-        .map(|(_, pdu)| pdu.to_room_event())
+        .map(|(_, pdu)| pdu.to_room_event_for(sender_id, Some(authed.device_id())))
         .collect();
     let mut state = Vec::new();
 
@@ -304,7 +303,7 @@ pub(super) async fn get_context(
                     continue;
                 }
             };
-            state.push(pdu.to_state_event());
+            state.push(pdu.to_state_event_for(sender_id, Some(authed.device_id())));
         } else if !lazy_load_enabled || lazy_loaded.contains(&state_key) {
             let pdu = match timeline::get_pdu(&event_id).await {
                 Ok(pdu) => pdu,
@@ -313,7 +312,7 @@ pub(super) async fn get_context(
                     continue;
                 }
             };
-            state.push(pdu.to_state_event());
+            state.push(pdu.to_state_event_for(sender_id, Some(authed.device_id())));
         }
     }
 

--- a/crates/server/src/routing/client/room/membership.rs
+++ b/crates/server/src/routing/client/room/membership.rs
@@ -103,7 +103,7 @@ pub(super) async fn get_members(
         .into_iter()
         .filter(|(key, _)| key.0 == StateEventType::RoomMember)
         .filter_map(|(_, pdu)| membership_filter(pdu, membership, not_membership, until_sn))
-        .map(|pdu| pdu.to_member_event())
+        .map(|pdu| pdu.to_member_event_for(authed.user_id(), Some(authed.device_id())))
         .collect();
 
     json_ok(MembersResBody { chunk: states })

--- a/crates/server/src/routing/client/room/message.rs
+++ b/crates/server/src/routing/client/room/message.rs
@@ -145,7 +145,7 @@ pub(super) async fn get_messages(
 
             let events: Vec<_> = events
                 .into_iter()
-                .map(|(_, pdu)| pdu.to_room_event())
+                .map(|(_, pdu)| pdu.to_room_event_for(sender_id, Some(authed.device_id())))
                 .collect();
 
             resp.start = from_tk.to_string();
@@ -200,7 +200,10 @@ pub(super) async fn get_messages(
             next_token = events.last().map(|(_, pdu)| pdu.prev_historic_token());
             resp.start = from_tk.to_string();
             resp.end = next_token.map(|tk| tk.to_string());
-            resp.chunk = events.values().map(|pdu| pdu.to_room_event()).collect();
+            resp.chunk = events
+                .values()
+                .map(|pdu| pdu.to_room_event_for(sender_id, Some(authed.device_id())))
+                .collect();
         }
     }
 
@@ -214,7 +217,8 @@ pub(super) async fn get_messages(
         )
         .await
         {
-            resp.state.push(member_event.to_state_event());
+            resp.state
+                .push(member_event.to_state_event_for(sender_id, Some(authed.device_id())));
         }
     }
 
@@ -282,6 +286,7 @@ pub(super) async fn send_message(
             event_type: args.event_type.to_string().into(),
             content,
             unsigned,
+            transaction_device: Some(authed.device_id().to_owned()),
             timestamp: if authed.appservice().is_some() {
                 args.timestamp
             } else {

--- a/crates/server/src/routing/client/room/relation.rs
+++ b/crates/server/src/routing/client/room/relation.rs
@@ -17,6 +17,7 @@ pub(super) async fn get_relation(
 
     let body = crate::room::pdu_metadata::paginate_relations_with_filter(
         authed.user_id(),
+        Some(authed.device_id()),
         &args.room_id,
         &args.event_id,
         None,
@@ -42,6 +43,7 @@ pub(super) async fn get_relation_by_rel_type(
 
     let body = crate::room::pdu_metadata::paginate_relations_with_filter(
         authed.user_id(),
+        Some(authed.device_id()),
         &args.room_id,
         &args.event_id,
         None,
@@ -68,6 +70,7 @@ pub(super) async fn get_relation_by_rel_type_and_event_type(
 
     let body = crate::room::pdu_metadata::paginate_relations_with_filter(
         authed.user_id(),
+        Some(authed.device_id()),
         &args.room_id,
         &args.event_id,
         Some(args.event_type.clone()),

--- a/crates/server/src/routing/client/room/state.rs
+++ b/crates/server/src/routing/client/room/state.rs
@@ -50,7 +50,7 @@ pub(super) async fn get_state(
         .await
         .unwrap_or_default()
         .values()
-        .map(|pdu| pdu.to_state_event())
+        .map(|pdu| pdu.to_state_event_for(sender_id, Some(authed.device_id())))
         .collect();
     json_ok(StateEventsResBody::new(room_state))
 }
@@ -166,7 +166,7 @@ pub(super) async fn state_for_key(
     json_ok(StateEventsForKeyResBody {
         content: Some(event.get_content()?),
         event: if event_format {
-            Some(event.to_state_event_value())
+            Some(event.to_state_event_value_for(sender_id, Some(authed.device_id())))
         } else {
             None
         },
@@ -207,7 +207,7 @@ pub(super) async fn state_for_empty_key(
     json_ok(StateEventsForKeyResBody {
         content: Some(event.get_content()?),
         event: if event_format {
-            Some(event.to_state_event_value())
+            Some(event.to_state_event_value_for(sender_id, Some(authed.device_id())))
         } else {
             None
         },

--- a/crates/server/src/routing/client/room/thread.rs
+++ b/crates/server/src/routing/client/room/thread.rs
@@ -42,7 +42,7 @@ pub(super) async fn list_threads(
     json_ok(ThreadsResBody {
         chunk: threads
             .into_iter()
-            .map(|(_, pdu)| pdu.to_room_event())
+            .map(|(_, pdu)| pdu.to_room_event_for(authed.user_id(), Some(authed.device_id())))
             .collect(),
         next_batch: next_batch.map(|b| b.to_string()),
     })

--- a/crates/server/src/sending.rs
+++ b/crates/server/src/sending.rs
@@ -440,7 +440,7 @@ async fn send_events(
                             timeline::get_pdu(event_id)
                                 .await
                                 .map_err(|e| (kind.clone(), e))?
-                                .to_room_event(),
+                                .to_room_event_without_transaction_id(),
                         );
                     }
                     SendingEventType::Edu(_) => {
@@ -1023,12 +1023,7 @@ async fn claim_queued_requests(
 pub async fn convert_to_outgoing_federation_event(
     mut pdu_json: CanonicalJsonObject,
 ) -> Box<RawJsonValue> {
-    if let Some(unsigned) = pdu_json
-        .get_mut("unsigned")
-        .and_then(|val| val.as_object_mut())
-    {
-        unsigned.remove("transaction_id");
-    }
+    crate::event::sanitize_federation_unsigned(&mut pdu_json);
 
     // Determine room version to decide whether to strip event_id.
     // V1/V2 require event_id in federation format; V3+ derive it from content hash.

--- a/crates/server/src/sync_v3.rs
+++ b/crates/server/src/sync_v3.rs
@@ -920,13 +920,13 @@ async fn load_joined_room(
             events: timeline
                 .events
                 .iter()
-                .map(|(_, pdu)| pdu.to_sync_room_event())
+                .map(|(_, pdu)| pdu.to_sync_room_event_for(sender_id, Some(device_id)))
                 .collect(),
         },
         state: State::Before(
             state_events
                 .iter()
-                .map(|pdu| pdu.to_sync_state_event())
+                .map(|pdu| pdu.to_sync_state_event_for(sender_id, Some(device_id)))
                 .collect::<Vec<_>>()
                 .into(),
         ),
@@ -956,7 +956,7 @@ async fn load_joined_room(
 #[tracing::instrument(skip_all)]
 async fn load_left_room(
     sender_id: &UserId,
-    _device_id: &DeviceId,
+    device_id: &DeviceId,
     room_id: &RoomId,
     since_tk: Option<BatchToken>,
     _until_tk: Option<BatchToken>,
@@ -990,6 +990,7 @@ async fn load_left_room(
             signatures: None,
             extra_data: Default::default(),
             rejection_reason: None,
+            transaction_device: None,
         };
         return Ok(LeftRoom {
             account_data: RoomAccountData::default(),
@@ -998,7 +999,9 @@ async fn load_left_room(
                 prev_batch: Some(next_batch.to_string()),
                 events: Vec::new(),
             },
-            state: State::Before(vec![event.to_sync_state_event()].into()),
+            state: State::Before(
+                vec![event.to_sync_state_event_for(sender_id, Some(device_id))].into(),
+            ),
         });
     }
 
@@ -1086,7 +1089,6 @@ async fn load_left_room(
             .map(|(sn, _)| BatchToken::new_live(*sn).to_string())
     };
 
-    // let left_event = timeline::get_pdu(&left_event_id).map(|pdu| pdu.to_sync_room_event());
     Ok(LeftRoom {
         account_data: RoomAccountData { events: Vec::new() },
         timeline: Timeline {
@@ -1095,13 +1097,13 @@ async fn load_left_room(
             events: timeline
                 .events
                 .iter()
-                .map(|(_, pdu)| pdu.to_sync_room_event())
+                .map(|(_, pdu)| pdu.to_sync_room_event_for(sender_id, Some(device_id)))
                 .collect(),
         },
         state: State::Before(
             state_events
                 .iter()
-                .map(|pdu| pdu.to_sync_state_event())
+                .map(|pdu| pdu.to_sync_state_event_for(sender_id, Some(device_id)))
                 .collect::<Vec<_>>()
                 .into(),
         ),

--- a/crates/server/src/sync_v5.rs
+++ b/crates/server/src/sync_v5.rs
@@ -758,7 +758,7 @@ async fn process_rooms(
             .events
             .iter()
             .filter(|item| ignored_filter_with_ignored_users(*item, ignored_users))
-            .map(|(_, pdu)| pdu.to_sync_room_event())
+            .map(|(_, pdu)| pdu.to_sync_room_event_for(sender_id, Some(device_id)))
             .collect();
 
         for (_, pdu) in &timeline.events {
@@ -811,7 +811,8 @@ async fn process_rooms(
                                 pdu.event_sn,
                             )
                             .await;
-                            required_state_events.push(pdu.to_sync_state_event());
+                            required_state_events
+                                .push(pdu.to_sync_state_event_for(sender_id, Some(device_id)));
                         }
                     }
                 }
@@ -837,7 +838,8 @@ async fn process_rooms(
                                     pdu.event_sn,
                                 )
                                 .await;
-                                required_state_events.push(pdu.to_sync_state_event());
+                                required_state_events
+                                    .push(pdu.to_sync_state_event_for(sender_id, Some(device_id)));
                             }
                         }
                     }
@@ -861,7 +863,8 @@ async fn process_rooms(
                             pdu.event_sn,
                         )
                         .await;
-                        required_state_events.push(pdu.to_sync_state_event());
+                        required_state_events
+                            .push(pdu.to_sync_state_event_for(sender_id, Some(device_id)));
                     }
                 }
                 // Specific state key
@@ -882,7 +885,8 @@ async fn process_rooms(
                             pdu.event_sn,
                         )
                         .await;
-                        required_state_events.push(pdu.to_sync_state_event());
+                        required_state_events
+                            .push(pdu.to_sync_state_event_for(sender_id, Some(device_id)));
                     }
                 }
             }

--- a/crates/server/src/user/pusher.rs
+++ b/crates/server/src/user/pusher.rs
@@ -138,7 +138,7 @@ pub async fn send_push_notice(
         user,
         &ruleset,
         &power_levels,
-        &pdu.to_sync_room_event(),
+        &pdu.to_sync_room_event_without_transaction_id(),
         &pdu.room_id,
     )
     .await?


### PR DESCRIPTION
Depends on #412.

## Summary

- make client event serialization recipient-aware so `unsigned.transaction_id` is returned only to the user who sent the event
- cover sync, pagination, direct event/context/state/member/search/thread/relation responses and remote previews
- strip transaction IDs from appservice transactions, embedded thread events, and internal push-rule payloads where there is no sender-client recipient
- remove ambiguous unfiltered conversion entry points to reduce the chance of future leaks

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo clippy --locked -p palpo --bin palpo --all-features -- -D warnings`
- `cargo test --locked --workspace --all-targets --all-features --no-fail-fast`
- `cargo deny check`
- isolated Complement test: sender sees its transaction ID through `/event`; another joined user does not