### PR TITLE
Refresh security dependencies and Rust 1.98 lint baseline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,9 +596,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -2086,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5878,9 +5878,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"

--- a/crates/server/src/room/state/diff.rs
+++ b/crates/server/src/room/state/diff.rs
@@ -92,14 +92,18 @@ pub async fn load_state_diff(frame_id: i64) -> AppResult<StateDiff> {
         parent_id,
         appended: Arc::new(
             appended
-                .chunks_exact(size_of::<CompressedEvent>())
-                .map(|chunk| CompressedEvent(chunk.try_into().expect("we checked the size above")))
+                .as_chunks::<{ size_of::<CompressedEvent>() }>()
+                .0
+                .iter()
+                .map(|chunk| CompressedEvent(*chunk))
                 .collect(),
         ),
         disposed: Arc::new(
             disposed
-                .chunks_exact(size_of::<CompressedEvent>())
-                .map(|chunk| CompressedEvent(chunk.try_into().expect("we checked the size above")))
+                .as_chunks::<{ size_of::<CompressedEvent>() }>()
+                .0
+                .iter()
+                .map(|chunk| CompressedEvent(*chunk))
                 .collect(),
         ),
     })


### PR DESCRIPTION
## Summary
- update h2 to 0.4.16 to address RUSTSEC-2026-0258
- refresh the yanked spin and chacha20 lockfile entries without unrelated dependency churn
- replace fixed-size chunks_exact parsing with the Rust 1.98 as_chunks equivalent required by the current CI toolchain

## Validation
- cargo +stable test --workspace --all-features
- cargo +stable clippy --workspace --all-targets --all-features -- -D warnings
- cargo +nightly fmt --all -- --check
- cargo deny check --hide-inclusion-graph
- cargo metadata --locked --format-version 1
- git diff --check