### PR TITLE
Match appservice namespace regexes from the start of identifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3666,6 +3666,7 @@ dependencies = [
  "path-slash",
  "rand 0.10.2",
  "regex",
+ "regex-syntax",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3666,6 +3666,7 @@ dependencies = [
  "path-slash",
  "rand 0.10.2",
  "regex",
+ "regex-automata",
  "regex-syntax",
  "reqwest",
  "reqwest-middleware",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ reqwest-middleware = "0.5.2"
 reqwest-retry = "0.9.1"
 rustyline-async = { version = "0.4.9" }
 regex = "1.12.3"
+regex-syntax = "0.8"
 reqwest = { version = "0.13.4", features = ["json", "form"] }
 ring = "0.17.14"
 salvo = { version = "0.96.0", features = ["rustls"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ reqwest-retry = "0.9.1"
 rustyline-async = { version = "0.4.9" }
 regex = "1.12.3"
 regex-syntax = "0.8"
+regex-automata = "0.4"
 reqwest = { version = "0.13.4", features = ["json", "form"] }
 ring = "0.17.14"
 salvo = { version = "0.96.0", features = ["rustls"]}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -150,6 +150,7 @@ path-slash = { workspace = true }
 rand = { workspace = true }
 rustyline-async = { workspace = true }
 regex = { workspace = true }
+regex-syntax = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 reqwest-middleware = { workspace = true }
 reqwest-retry = { workspace = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -151,6 +151,7 @@ rand = { workspace = true }
 rustyline-async = { workspace = true }
 regex = { workspace = true }
 regex-syntax = { workspace = true }
+regex-automata = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 reqwest-middleware = { workspace = true }
 reqwest-retry = { workspace = true }

--- a/crates/server/src/appservice.rs
+++ b/crates/server/src/appservice.rs
@@ -48,10 +48,16 @@ impl TryFrom<Vec<Namespace>> for NamespaceRegex {
         let mut non_exclusive = vec![];
 
         for namespace in value {
+            // The appservice spec (registration `namespaces[].regex`) requires the
+            // pattern to match the WHOLE identifier. `RegexSet::is_match` is a
+            // substring search, so `@ac_.*` would also claim `@xac_...` and a
+            // rooms pattern `!abc:example.org` would claim `!abc:example.org.evil`.
+            // Anchor every pattern; an already-anchored pattern stays equivalent.
+            let anchored = anchor_namespace_regex(&namespace.regex);
             if namespace.exclusive {
-                exclusive.push(namespace.regex);
+                exclusive.push(anchored);
             } else {
-                non_exclusive.push(namespace.regex);
+                non_exclusive.push(anchored);
             }
         }
 
@@ -70,6 +76,14 @@ impl TryFrom<Vec<Namespace>> for NamespaceRegex {
     }
 
     type Error = regex::Error;
+}
+
+
+/// Wrap a registration namespace pattern so it must match the entire
+/// identifier, as the appservice spec requires. `^(?:re)$` is equivalent
+/// for patterns that already carry their own anchors.
+pub fn anchor_namespace_regex(pattern: &str) -> String {
+    format!("^(?:{pattern})$")
 }
 
 /// Appservice registration combined with its compiled regular expressions.
@@ -354,5 +368,48 @@ mod tests {
         assert!(redacted.contains("foo=bar"));
         assert!(redacted.contains("access_token=REDACTED"));
         assert!(!redacted.contains("secret"));
+    }
+
+    use super::{NamespaceRegex, anchor_namespace_regex};
+    use crate::core::appservice::Namespace;
+
+    fn users(exclusive: bool, pattern: &str) -> NamespaceRegex {
+        NamespaceRegex::try_from(vec![Namespace::new(exclusive, pattern.to_owned())]).unwrap()
+    }
+
+    #[test]
+    fn namespace_regex_matches_the_whole_identifier_not_a_substring() {
+        // Before anchoring, `@ac_.*` also claimed `@xac_...` because RegexSet
+        // searches for a substring anywhere in the haystack.
+        let ns = users(true, "@ac_.*");
+        assert!(ns.is_match("@ac_alice:example.org"));
+        assert!(ns.is_exclusive_match("@ac_alice:example.org"));
+        assert!(!ns.is_match("@xac_alice:example.org"));
+        assert!(!ns.is_match("prefix@ac_alice:example.org"));
+    }
+
+    #[test]
+    fn namespace_regex_room_pattern_does_not_claim_a_longer_server_name() {
+        let ns = users(false, "!abc:example.org");
+        assert!(ns.is_match("!abc:example.org"));
+        assert!(!ns.is_match("!abc:example.org.evil"));
+        assert!(!ns.is_exclusive_match("!abc:example.org"));
+    }
+
+    #[test]
+    fn namespace_regex_keeps_working_for_patterns_that_already_carry_anchors() {
+        let ns = users(true, "^@ac_[^:]+:example\\.org$");
+        assert!(ns.is_match("@ac_alice:example.org"));
+        assert!(!ns.is_match("@ac_alice:example.org.evil"));
+        assert_eq!(anchor_namespace_regex("^a$"), "^(?:^a$)$");
+    }
+
+    #[test]
+    fn namespace_regex_non_exclusive_is_anchored_too() {
+        let ns = users(false, "@bot_.*");
+        assert!(ns.is_match("@bot_x:example.org"));
+        assert!(!ns.is_match("@notbot_x:example.org"));
+        assert!(!ns.is_match("junk@bot_x:example.org")); // substring hit before anchoring
+        assert!(!ns.is_exclusive_match("@bot_x:example.org"));
     }
 }

--- a/crates/server/src/appservice.rs
+++ b/crates/server/src/appservice.rs
@@ -48,12 +48,12 @@ impl TryFrom<Vec<Namespace>> for NamespaceRegex {
         let mut non_exclusive = vec![];
 
         for namespace in value {
-            // The appservice spec (registration `namespaces[].regex`) requires the
-            // pattern to match the WHOLE identifier. `RegexSet::is_match` is a
-            // substring search, so `@ac_.*` would also claim `@xac_...` and a
-            // rooms pattern `!abc:example.org` would claim `!abc:example.org.evil`.
-            // Anchor every pattern; an already-anchored pattern stays equivalent.
-            let anchored = anchor_namespace_regex(&namespace.regex);
+            // A namespace pattern claims an identifier only when it matches the
+            // WHOLE identifier. `RegexSet::is_match` is a substring search, so
+            // `@ac_.*` would also claim `prefix@ac_...` and a rooms pattern
+            // `!abc:example.org` would claim `!abc:example.org.evil`. Anchor
+            // every pattern semantically (see `anchor_namespace_regex`).
+            let anchored = anchor_namespace_regex(&namespace.regex)?;
             if namespace.exclusive {
                 exclusive.push(anchored);
             } else {
@@ -79,11 +79,29 @@ impl TryFrom<Vec<Namespace>> for NamespaceRegex {
 }
 
 
-/// Wrap a registration namespace pattern so it must match the entire
-/// identifier, as the appservice spec requires. `^(?:re)$` is equivalent
-/// for patterns that already carry their own anchors.
-pub fn anchor_namespace_regex(pattern: &str) -> String {
-    format!("^(?:{pattern})$")
+/// Rewrite a registration namespace pattern so it must match the entire
+/// identifier.
+///
+/// The pattern is compiled on its own first, so an invalid pattern fails with
+/// exactly the diagnostic the original text produces. It is then parsed into
+/// `regex-syntax`'s HIR and wrapped in start/end-of-text assertions there,
+/// rather than by pasting `^(?:...)$` around the source text: textual wrapping
+/// changes what parses (an unbalanced `a)|(b` would become valid, and a
+/// verbose-mode pattern ending in a `# comment` would swallow the closing
+/// group). Patterns that already carry anchors stay equivalent.
+pub fn anchor_namespace_regex(pattern: &str) -> Result<String, regex::Error> {
+    // Original diagnostics first: `Regex::new` and the HIR parser agree on
+    // validity, and this is the error a registration author expects to see.
+    regex::Regex::new(pattern)?;
+    let hir = regex_syntax::Parser::new()
+        .parse(pattern)
+        .map_err(|e| regex::Error::Syntax(e.to_string()))?;
+    let anchored = regex_syntax::hir::Hir::concat(vec![
+        regex_syntax::hir::Hir::look(regex_syntax::hir::Look::Start),
+        hir,
+        regex_syntax::hir::Hir::look(regex_syntax::hir::Look::End),
+    ]);
+    Ok(anchored.to_string())
 }
 
 /// Appservice registration combined with its compiled regular expressions.
@@ -379,13 +397,14 @@ mod tests {
 
     #[test]
     fn namespace_regex_matches_the_whole_identifier_not_a_substring() {
-        // Before anchoring, `@ac_.*` also claimed `@xac_...` because RegexSet
-        // searches for a substring anywhere in the haystack.
+        // `RegexSet::is_match` is a substring search: without anchoring
+        // `@ac_.*` also claimed `prefix@ac_alice:example.org`.
         let ns = users(true, "@ac_.*");
         assert!(ns.is_match("@ac_alice:example.org"));
         assert!(ns.is_exclusive_match("@ac_alice:example.org"));
-        assert!(!ns.is_match("@xac_alice:example.org"));
         assert!(!ns.is_match("prefix@ac_alice:example.org"));
+        // Never matched, anchored or not: `@xac_` does not contain `@ac_`.
+        assert!(!ns.is_match("@xac_alice:example.org"));
     }
 
     #[test]
@@ -401,15 +420,42 @@ mod tests {
         let ns = users(true, "^@ac_[^:]+:example\\.org$");
         assert!(ns.is_match("@ac_alice:example.org"));
         assert!(!ns.is_match("@ac_alice:example.org.evil"));
-        assert_eq!(anchor_namespace_regex("^a$"), "^(?:^a$)$");
     }
 
     #[test]
     fn namespace_regex_non_exclusive_is_anchored_too() {
         let ns = users(false, "@bot_.*");
         assert!(ns.is_match("@bot_x:example.org"));
-        assert!(!ns.is_match("@notbot_x:example.org"));
         assert!(!ns.is_match("junk@bot_x:example.org")); // substring hit before anchoring
         assert!(!ns.is_exclusive_match("@bot_x:example.org"));
+    }
+
+    #[test]
+    fn namespace_regex_anchors_every_branch_of_an_alternation() {
+        let ns = users(true, "@a:x|@b:x");
+        assert!(ns.is_match("@a:x"));
+        assert!(ns.is_match("@b:x"));
+        assert!(!ns.is_match("@a:xy"));
+        assert!(!ns.is_match("y@b:x"));
+    }
+
+    #[test]
+    fn namespace_regex_rejects_an_invalid_pattern_with_its_original_diagnostic() {
+        // Pasting `^(?:...)$` around this text would have turned it into the
+        // VALID pattern `^(?:a)|(b)$` — and one that is not anchored at all.
+        let err = NamespaceRegex::try_from(vec![Namespace::new(true, "a)|(b".to_owned())])
+            .expect_err("an unbalanced pattern must not compile");
+        let original = regex::Regex::new("a)|(b").unwrap_err();
+        assert_eq!(err.to_string(), original.to_string());
+    }
+
+    #[test]
+    fn namespace_regex_accepts_a_verbose_pattern_with_a_trailing_comment() {
+        // In `(?x)` mode `#` starts a comment to end of line; textual wrapping
+        // would have put the closing `)$` inside that comment.
+        let ns = users(true, "(?x)^@ac_alice:example\\.org$ # exact user");
+        assert!(ns.is_match("@ac_alice:example.org"));
+        assert!(!ns.is_match("@ac_alice:example.org.evil"));
+        assert!(anchor_namespace_regex("(?x)a # c").is_ok());
     }
 }

--- a/crates/server/src/appservice.rs
+++ b/crates/server/src/appservice.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use regex::RegexSet;
+use regex_automata::meta::Regex as MetaRegex;
 use subtle::ConstantTimeEq;
 
 use crate::core::appservice::{Namespace, Registration};
@@ -10,10 +10,14 @@ pub use crate::data::appservice::DbRegistration;
 use crate::{AppError, AppResult, data, sending};
 
 /// Compiled regular expressions for a namespace.
+///
+/// Each pattern is anchored to the whole identifier (see [`anchored_namespace_hir`])
+/// and the set is compiled straight from the HIR, so the source text is never
+/// rewritten and re-parsed.
 #[derive(Clone, Debug)]
 pub struct NamespaceRegex {
-    pub exclusive: Option<RegexSet>,
-    pub non_exclusive: Option<RegexSet>,
+    pub exclusive: Option<MetaRegex>,
+    pub non_exclusive: Option<MetaRegex>,
 }
 
 impl NamespaceRegex {
@@ -42,6 +46,16 @@ impl NamespaceRegex {
     }
 }
 
+fn compile_set(hirs: Vec<regex_syntax::hir::Hir>) -> Result<Option<MetaRegex>, regex::Error> {
+    if hirs.is_empty() {
+        return Ok(None);
+    }
+    MetaRegex::builder()
+        .build_many_from_hir(&hirs)
+        .map(Some)
+        .map_err(|e| regex::Error::Syntax(e.to_string()))
+}
+
 impl TryFrom<Vec<Namespace>> for NamespaceRegex {
     fn try_from(value: Vec<Namespace>) -> Result<Self, regex::Error> {
         let mut exclusive = vec![];
@@ -49,11 +63,10 @@ impl TryFrom<Vec<Namespace>> for NamespaceRegex {
 
         for namespace in value {
             // A namespace pattern claims an identifier only when it matches the
-            // WHOLE identifier. `RegexSet::is_match` is a substring search, so
-            // `@ac_.*` would also claim `prefix@ac_...` and a rooms pattern
-            // `!abc:example.org` would claim `!abc:example.org.evil`. Anchor
-            // every pattern semantically (see `anchor_namespace_regex`).
-            let anchored = anchor_namespace_regex(&namespace.regex)?;
+            // WHOLE identifier. A plain regex search would let `@ac_.*` claim
+            // `prefix@ac_...` and a rooms pattern `!abc:example.org` claim
+            // `!abc:example.org.evil`. Anchor every pattern in the HIR.
+            let anchored = anchored_namespace_hir(&namespace.regex)?;
             if namespace.exclusive {
                 exclusive.push(anchored);
             } else {
@@ -62,45 +75,35 @@ impl TryFrom<Vec<Namespace>> for NamespaceRegex {
         }
 
         Ok(NamespaceRegex {
-            exclusive: if exclusive.is_empty() {
-                None
-            } else {
-                Some(RegexSet::new(exclusive)?)
-            },
-            non_exclusive: if non_exclusive.is_empty() {
-                None
-            } else {
-                Some(RegexSet::new(non_exclusive)?)
-            },
+            exclusive: compile_set(exclusive)?,
+            non_exclusive: compile_set(non_exclusive)?,
         })
     }
-
     type Error = regex::Error;
 }
 
-/// Rewrite a registration namespace pattern so it must match the entire
-/// identifier.
+/// Parse a registration namespace pattern and anchor it to the whole
+/// identifier, in the regex HIR.
 ///
 /// The pattern is compiled on its own first, so an invalid pattern fails with
 /// exactly the diagnostic the original text produces. It is then parsed into
-/// `regex-syntax`'s HIR and wrapped in start/end-of-text assertions there,
-/// rather than by pasting `^(?:...)$` around the source text: textual wrapping
-/// changes what parses (an unbalanced `a)|(b` would become valid, and a
-/// verbose-mode pattern ending in a `# comment` would swallow the closing
-/// group). Patterns that already carry anchors stay equivalent.
-pub fn anchor_namespace_regex(pattern: &str) -> Result<String, regex::Error> {
-    // Original diagnostics first: `Regex::new` and the HIR parser agree on
-    // validity, and this is the error a registration author expects to see.
+/// `regex-syntax`'s HIR and wrapped in start/end-of-text assertions there. The
+/// anchored HIR is compiled directly (never printed back to text): pasting
+/// `^(?:...)$` around the source changes what parses, and the HIR printer does
+/// not preserve grouping for nested repetitions (`(?:[0-9]{2})?` would come
+/// back as `[0-9]{2}?`). Patterns that already carry anchors stay equivalent.
+pub fn anchored_namespace_hir(pattern: &str) -> Result<regex_syntax::hir::Hir, regex::Error> {
+    // Original diagnostics first: this is the error a registration author
+    // expects to see for an invalid pattern.
     regex::Regex::new(pattern)?;
     let hir = regex_syntax::Parser::new()
         .parse(pattern)
         .map_err(|e| regex::Error::Syntax(e.to_string()))?;
-    let anchored = regex_syntax::hir::Hir::concat(vec![
+    Ok(regex_syntax::hir::Hir::concat(vec![
         regex_syntax::hir::Hir::look(regex_syntax::hir::Look::Start),
         hir,
         regex_syntax::hir::Hir::look(regex_syntax::hir::Look::End),
-    ]);
-    Ok(anchored.to_string())
+    ]))
 }
 
 /// Appservice registration combined with its compiled regular expressions.
@@ -387,7 +390,7 @@ mod tests {
         assert!(!redacted.contains("secret"));
     }
 
-    use super::{NamespaceRegex, anchor_namespace_regex};
+    use super::{NamespaceRegex, anchored_namespace_hir};
     use crate::core::appservice::Namespace;
 
     fn users(exclusive: bool, pattern: &str) -> NamespaceRegex {
@@ -458,6 +461,38 @@ mod tests {
         let ns = users(true, "(?x)^@ac_alice:example\\.org$ # exact user");
         assert!(ns.is_match("@ac_alice:example.org"));
         assert!(!ns.is_match("@ac_alice:example.org.evil"));
-        assert!(anchor_namespace_regex("(?x)a # c").is_ok());
+        assert!(anchored_namespace_hir("(?x)a # c").is_ok());
+    }
+    #[test]
+    fn optional_repeated_suffix_must_remain_optional() {
+        // regex-syntax 0.8's HIR printer renders `(?:[0-9]{2})?` as `[0-9]{2}?`,
+        // which silently requires the two digits. Compiling straight from the
+        // HIR keeps the group optional.
+        let ns = users(true, "^@bot(?:[0-9]{2})?:example\\.org$");
+        assert!(ns.is_match("@bot:example.org"));
+        assert!(ns.is_match("@bot12:example.org"));
+        assert!(!ns.is_match("@bot1:example.org"));
+        assert!(!ns.is_match("@bot123:example.org"));
+        let ns = users(true, "^@bot(?:a+)?:example\\.org$");
+        assert!(ns.is_match("@bot:example.org"));
+        assert!(ns.is_match("@botaaa:example.org"));
+    }
+
+    #[test]
+    fn anchoring_does_not_add_parser_nesting() {
+        // 249 nested groups compile as a plain regex; anchoring in the HIR must
+        // not push the compiled set over the parser's nesting limit.
+        let deep = format!("^@{}a{}:x$", "(".repeat(249), ")".repeat(249));
+        let ns = users(true, &deep);
+        assert!(ns.is_match("@a:x"));
+        assert!(!ns.is_match("@a:xy"));
+    }
+
+    #[test]
+    fn anchors_are_text_boundaries_not_line_boundaries() {
+        let ns = users(true, "(?m)@ac_.*");
+        assert!(ns.is_match("@ac_alice:example.org"));
+        assert!(!ns.is_match("@ac_alice:example.org\n"));
+        assert!(!ns.is_match("x\n@ac_alice:example.org"));
     }
 }

--- a/crates/server/src/appservice.rs
+++ b/crates/server/src/appservice.rs
@@ -78,7 +78,6 @@ impl TryFrom<Vec<Namespace>> for NamespaceRegex {
     type Error = regex::Error;
 }
 
-
 /// Rewrite a registration namespace pattern so it must match the entire
 /// identifier.
 ///
@@ -443,9 +442,12 @@ mod tests {
     fn namespace_regex_rejects_an_invalid_pattern_with_its_original_diagnostic() {
         // Pasting `^(?:...)$` around this text would have turned it into the
         // VALID pattern `^(?:a)|(b)$` — and one that is not anchored at all.
-        let err = NamespaceRegex::try_from(vec![Namespace::new(true, "a)|(b".to_owned())])
+        // Built at runtime so clippy's `invalid_regex` lint does not reject the
+        // literal: the point of this test is that it must NOT compile.
+        let unbalanced = ["a)", "|(b"].concat();
+        let err = NamespaceRegex::try_from(vec![Namespace::new(true, unbalanced.clone())])
             .expect_err("an unbalanced pattern must not compile");
-        let original = regex::Regex::new("a)|(b").unwrap_err();
+        let original = regex::Regex::new(&unbalanced).unwrap_err();
         assert_eq!(err.to_string(), original.to_string());
     }
 

--- a/crates/server/src/appservice.rs
+++ b/crates/server/src/appservice.rs
@@ -11,9 +11,9 @@ use crate::{AppError, AppResult, data, sending};
 
 /// Compiled regular expressions for a namespace.
 ///
-/// Each pattern is anchored to the whole identifier (see [`anchored_namespace_hir`])
-/// and the set is compiled straight from the HIR, so the source text is never
-/// rewritten and re-parsed.
+/// Each pattern is anchored to the start of the identifier, preserving prefix
+/// matches like Synapse. The set is compiled straight from the HIR, so the
+/// source text is never rewritten and re-parsed.
 #[derive(Clone, Debug)]
 pub struct NamespaceRegex {
     pub exclusive: Option<MetaRegex>,
@@ -53,7 +53,10 @@ fn compile_set(hirs: Vec<regex_syntax::hir::Hir>) -> Result<Option<MetaRegex>, r
     MetaRegex::builder()
         .build_many_from_hir(&hirs)
         .map(Some)
-        .map_err(|e| regex::Error::Syntax(e.to_string()))
+        .map_err(|e| match e.size_limit() {
+            Some(limit) => regex::Error::CompiledTooBig(limit),
+            None => regex::Error::Syntax(e.to_string()),
+        })
 }
 
 impl TryFrom<Vec<Namespace>> for NamespaceRegex {
@@ -62,10 +65,10 @@ impl TryFrom<Vec<Namespace>> for NamespaceRegex {
         let mut non_exclusive = vec![];
 
         for namespace in value {
-            // A namespace pattern claims an identifier only when it matches the
-            // WHOLE identifier. A plain regex search would let `@ac_.*` claim
-            // `prefix@ac_...` and a rooms pattern `!abc:example.org` claim
-            // `!abc:example.org.evil`. Anchor every pattern in the HIR.
+            // Match from the start, like Synapse's regex.match, rather than
+            // letting `@ac_.*` claim `prefix@ac_...`. Prefix patterns such as
+            // `@irc_` and empty match-all patterns must keep working; an end
+            // anchor is the registration author's explicit choice.
             let anchored = anchored_namespace_hir(&namespace.regex)?;
             if namespace.exclusive {
                 exclusive.push(anchored);
@@ -82,27 +85,22 @@ impl TryFrom<Vec<Namespace>> for NamespaceRegex {
     type Error = regex::Error;
 }
 
-/// Parse a registration namespace pattern and anchor it to the whole
-/// identifier, in the regex HIR.
+/// Parse a registration namespace pattern and anchor it to the start of the
+/// identifier in the regex HIR.
 ///
-/// The pattern is compiled on its own first, so an invalid pattern fails with
-/// exactly the diagnostic the original text produces. It is then parsed into
-/// `regex-syntax`'s HIR and wrapped in start/end-of-text assertions there. The
-/// anchored HIR is compiled directly (never printed back to text): pasting
-/// `^(?:...)$` around the source changes what parses, and the HIR printer does
-/// not preserve grouping for nested repetitions (`(?:[0-9]{2})?` would come
-/// back as `[0-9]{2}?`). Patterns that already carry anchors stay equivalent.
-pub fn anchored_namespace_hir(pattern: &str) -> Result<regex_syntax::hir::Hir, regex::Error> {
-    // Original diagnostics first: this is the error a registration author
-    // expects to see for an invalid pattern.
-    regex::Regex::new(pattern)?;
+/// Parsing preserves the original syntax diagnostic without compiling the
+/// pattern twice. The anchored HIR is compiled directly (never printed back to
+/// text): pasting `^(?:...)` around the source changes what parses, and the HIR
+/// printer does not preserve grouping for nested repetitions (`(?:[0-9]{2})?`
+/// would come back as `[0-9]{2}?`). Existing end anchors are preserved, while
+/// the added start-of-text assertion is unaffected by multiline mode.
+fn anchored_namespace_hir(pattern: &str) -> Result<regex_syntax::hir::Hir, regex::Error> {
     let hir = regex_syntax::Parser::new()
         .parse(pattern)
         .map_err(|e| regex::Error::Syntax(e.to_string()))?;
     Ok(regex_syntax::hir::Hir::concat(vec![
         regex_syntax::hir::Hir::look(regex_syntax::hir::Look::Start),
         hir,
-        regex_syntax::hir::Hir::look(regex_syntax::hir::Look::End),
     ]))
 }
 
@@ -398,7 +396,7 @@ mod tests {
     }
 
     #[test]
-    fn namespace_regex_matches_the_whole_identifier_not_a_substring() {
+    fn namespace_regex_matches_from_the_start_not_a_substring() {
         // `RegexSet::is_match` is a substring search: without anchoring
         // `@ac_.*` also claimed `prefix@ac_alice:example.org`.
         let ns = users(true, "@ac_.*");
@@ -410,8 +408,8 @@ mod tests {
     }
 
     #[test]
-    fn namespace_regex_room_pattern_does_not_claim_a_longer_server_name() {
-        let ns = users(false, "!abc:example.org");
+    fn namespace_regex_explicit_end_anchor_rejects_a_longer_server_name() {
+        let ns = users(false, "!abc:example\\.org$");
         assert!(ns.is_match("!abc:example.org"));
         assert!(!ns.is_match("!abc:example.org.evil"));
         assert!(!ns.is_exclusive_match("!abc:example.org"));
@@ -437,8 +435,97 @@ mod tests {
         let ns = users(true, "@a:x|@b:x");
         assert!(ns.is_match("@a:x"));
         assert!(ns.is_match("@b:x"));
-        assert!(!ns.is_match("@a:xy"));
+        assert!(ns.is_match("@a:xy"));
+        assert!(ns.is_match("@b:xy"));
+        assert!(!ns.is_match("y@a:x"));
         assert!(!ns.is_match("y@b:x"));
+    }
+
+    #[test]
+    fn namespace_regex_preserves_prefix_patterns() {
+        for exclusive in [true, false] {
+            for (pattern, identifier) in [
+                ("@irc_", "@irc_alice:example.org"),
+                ("#irc_", "#irc_room:example.org"),
+                ("!abc:example\\.org", "!abc:example.org.evil"),
+            ] {
+                let ns = users(exclusive, pattern);
+                assert!(ns.is_match(identifier), "prefix pattern: {pattern}");
+                assert_eq!(ns.is_exclusive_match(identifier), exclusive);
+                assert!(!ns.is_match(&format!("prefix{identifier}")));
+            }
+        }
+    }
+
+    #[test]
+    fn namespace_regex_preserves_empty_match_all_patterns() {
+        for exclusive in [true, false] {
+            let ns = users(exclusive, "");
+            for identifier in [
+                "",
+                "@alice:example.org",
+                "#room:example.org",
+                "!room:example.org",
+            ] {
+                assert!(ns.is_match(identifier));
+                assert_eq!(ns.is_exclusive_match(identifier), exclusive);
+            }
+        }
+    }
+
+    #[test]
+    fn namespace_regex_preserves_prefixes_in_mixed_namespace_sets() {
+        let ns = NamespaceRegex::try_from(vec![
+            Namespace::new(true, "@irc_".to_owned()),
+            Namespace::new(true, "@other_".to_owned()),
+            Namespace::new(false, "@logger_".to_owned()),
+        ])
+        .unwrap();
+        assert!(ns.is_exclusive_match("@irc_alice:example.org"));
+        assert!(ns.is_exclusive_match("@other_alice:example.org"));
+        assert!(ns.is_match("@logger_alice:example.org"));
+        assert!(!ns.is_exclusive_match("@logger_alice:example.org"));
+        assert!(!ns.is_match("prefix@irc_alice:example.org"));
+        assert!(!ns.is_match("prefix@other_alice:example.org"));
+        assert!(!ns.is_match("prefix@logger_alice:example.org"));
+    }
+
+    #[test]
+    fn namespace_regex_preserves_syntax_error_diagnostics() {
+        for pattern in [
+            ")",
+            "(",
+            "[",
+            "a{2,1}",
+            "(?P<x>a)(?P<x>b)",
+            r"\p{Unknown}",
+            "(?P<1>a)",
+        ] {
+            let original = regex::Regex::new(pattern).unwrap_err();
+            let err = NamespaceRegex::try_from(vec![Namespace::new(true, pattern.to_owned())])
+                .expect_err("invalid namespace syntax must fail");
+            assert!(matches!(err, regex::Error::Syntax(_)));
+            assert_eq!(err.to_string(), original.to_string(), "pattern: {pattern}");
+        }
+    }
+
+    #[test]
+    fn namespace_regex_compile_set_preserves_size_limit_error() {
+        // Exercise the set compiler directly, so an earlier standalone compile
+        // cannot mask an incorrect conversion of its error kind.
+        let pattern = "(?:a{1000}){1000}";
+        let hir = regex_syntax::Parser::new().parse(pattern).unwrap();
+        let err = super::compile_set(vec![hir]).expect_err("oversized HIR must fail");
+        let original = regex::Regex::new(pattern).unwrap_err();
+        match (err, original) {
+            (regex::Error::CompiledTooBig(actual), regex::Error::CompiledTooBig(expected)) => {
+                assert_eq!(actual, expected);
+            }
+            (actual, expected) => panic!("expected {expected:?}, got {actual:?}"),
+        }
+        let err = NamespaceRegex::try_from(vec![Namespace::new(true, pattern.to_owned())])
+            .expect_err("oversized namespace must fail");
+        assert!(matches!(err, regex::Error::CompiledTooBig(_)));
     }
 
     #[test]
@@ -489,10 +576,10 @@ mod tests {
     }
 
     #[test]
-    fn anchors_are_text_boundaries_not_line_boundaries() {
-        let ns = users(true, "(?m)@ac_.*");
+    fn start_anchor_is_a_text_boundary_not_a_line_boundary() {
+        let ns = users(true, "(?m)^@ac_.*");
         assert!(ns.is_match("@ac_alice:example.org"));
-        assert!(!ns.is_match("@ac_alice:example.org\n"));
+        assert!(ns.is_match("@ac_alice:example.org\n"));
         assert!(!ns.is_match("x\n@ac_alice:example.org"));
     }
 }


### PR DESCRIPTION
An unanchored namespace search lets a pattern such as `@ac_.*` claim an identifier containing that prefix in the middle. Match each pattern from the start of the identifier, while retaining prefix registrations such as `@irc_` and empty match-all patterns. This uses the same start-position semantics as [Synapse's `re.Pattern.match`](https://github.com/element-hq/synapse/blob/develop/synapse/appservice/__init__.py). The [Matrix namespace definition](https://spec.matrix.org/latest/application-service-api/#registration) does not require a full-identifier match; registrations needing one can specify an explicit `$` or `\z` end anchor.

Parse each pattern once with `regex-syntax`, prepend a start-of-text assertion in the HIR, then compile the set directly with `regex-automata`. Avoiding source-text wrapping and HIR printing preserves verbose trailing comments, alternation, nested repetition and parser nesting limits. Syntax errors retain their original diagnostic, size-limit errors return `regex::Error::CompiledTooBig`, and the HIR helper is private. Registration caching remains separate work.

Validation:

- `cargo test --locked --workspace --all-features --no-fail-fast`: **598 passed, 0 failed, 11 ignored**, including all **16 appservice tests**.
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`: passed.
- `cargo check --locked --all --bins --examples --tests`: passed.
- `cargo +nightly fmt --all -- --check` and the changed-file spelling check: passed.

The appservice regressions cover prefix and empty patterns, mixed exclusive/non-exclusive sets, explicit end anchors, alternation, seven syntax-error diagnostics, compiler size limits, verbose comments, multiline mode, nested repetition and 249-level nesting.
